### PR TITLE
Fix splash screen override

### DIFF
--- a/app/ios/AriesBifold/LaunchScreen.storyboard
+++ b/app/ios/AriesBifold/LaunchScreen.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,7 +16,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>
-                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.94901960784313721" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -39,11 +39,6 @@ const App = () => {
     SplashScreen.hide();
   }, []);
 
-  console.log(
-    "13y82y4823y48i23y4i234yi23u4y2u34y2i3u4y23iu4yi2u34",
-    Terms,
-    Splash
-  );
   const defaultConfiguration: ConfigurationContext = {
     pages: OnboardingPages,
     splash: Splash,

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -1,13 +1,13 @@
 import {
     translationResources,
     ConfigurationContext,
-    Splash,
 } from 'aries-bifold'
 import _merge from 'lodash.merge'
 import  {defaultTheme as theme} from './theme'
 import en from './localization/en'
 import { pages }  from './screens/OnboardingPages'
 import Terms from './screens/Terms'
+import Splash from './screens/Splash'
 
 const localization = _merge({}, translationResources, {en:{translation:en}})
 const configuration: ConfigurationContext = {


### PR DESCRIPTION
Change the background color of the iOS launch screen from black to the BC themed color `#F2F2F2` and add in our cusotm splash screen.