### PR TITLE
Changed tag in CI for smoke tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -349,7 +349,7 @@ jobs:
           DEVICE_CLOUD_KEY: "-k ${{ secrets.SAUCE_ACCESS_KEY }}"
           MOBILE_PLATFORM: ${{ matrix.mobile-platform }}
           APP_FILE_NAME: ${{ matrix.app-file-name }}
-          TEST_SCOPE: "-t @bc_wallet -t @T002-Proof"
+          TEST_SCOPE: "-t @bc_wallet -t @SmokeTest"
           REPORT_PROJECT: ${{ matrix.report-project }}
         continue-on-error: true
 


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Minor change to the CI test runs. Changed the tag to run smoke tests to `@SmokeTest` instead of test id(s). This way all we have to do is tag any test scenario with `@SmokeTest` in AMTH BC Wallet tests, and they all will run as part of the build pipeline verification. Right now there will be one test that runs in the build pipeline, which is [T002.1-Proof](https://github.com/hyperledger/aries-mobile-test-harness/blob/697215262a072d0481efa9a40c4bc3f5d9c19a47/aries-mobile-tests/features/bc_wallet/proof.feature#L46), it pretty much runs through the full app workflow. 