### PR TITLE
Add AuthProvider

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,6 +1,7 @@
 import {
   Agent,
   AgentProvider,
+  AuthProvider,
   toastConfig,
   initStoredLanguage,
   RootStack,
@@ -9,45 +10,47 @@ import {
   ThemeProvider,
   ConfigurationProvider,
   initLanguages,
-} from 'aries-bifold'
-import React, { useEffect, useState } from 'react'
-import { StatusBar } from 'react-native'
-import SplashScreen from 'react-native-splash-screen'
-import Toast from 'react-native-toast-message'
-import _merge from 'lodash.merge'
-import bcwallet from './src'
-const { theme, localization, configuration } = bcwallet
+} from "aries-bifold";
+import React, { useEffect, useState } from "react";
+import { StatusBar } from "react-native";
+import SplashScreen from "react-native-splash-screen";
+import Toast from "react-native-toast-message";
+import _merge from "lodash.merge";
+import bcwallet from "./src";
+const { theme, localization, configuration } = bcwallet;
 
-initLanguages(localization)
+initLanguages(localization);
 const App = () => {
-  const [agent, setAgent] = useState<Agent | undefined>(undefined)
-  initStoredLanguage()
+  const [agent, setAgent] = useState<Agent | undefined>(undefined);
+  initStoredLanguage();
 
   useEffect(() => {
     // Hide the native splash / loading screen so that our
     // RN version can be displayed.
-    SplashScreen.hide()
-  }, [])
+    SplashScreen.hide();
+  }, []);
 
   return (
     <StoreProvider>
       <AgentProvider agent={agent}>
         <ThemeProvider value={theme}>
           <ConfigurationProvider value={configuration}>
-            <StatusBar
-              barStyle="light-content"
-              hidden={false}
-              backgroundColor={theme.ColorPallet.brand.primary}
-              translucent={false}
-            />
-            <ErrorModal />
-            <RootStack setAgent={setAgent} />
-            <Toast topOffset={15} config={toastConfig} />
+            <AuthProvider>
+              <StatusBar
+                barStyle="light-content"
+                hidden={false}
+                backgroundColor={theme.ColorPallet.brand.primary}
+                translucent={false}
+              />
+              <ErrorModal />
+              <RootStack setAgent={setAgent} />
+              <Toast topOffset={15} config={toastConfig} />
+            </AuthProvider>
           </ConfigurationProvider>
         </ThemeProvider>
       </AgentProvider>
     </StoreProvider>
-  )
-}
+  );
+};
 
-export default App
+export default App;

--- a/app/ios/AriesBifold/Info.plist
+++ b/app/ios/AriesBifold/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSFaceIDUsageDescription</key>
+	<string>$(PRODUCT_NAME) Wants to use your FaceID/TouchID to Authenticate your Identity</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
Add the AuthProvider to our App so we can use the new uber secure wallet mechanics. Looks like our Prettier or lint rules may be different so it updated `'` to be `"` and added `;`. I'd change it but will do a different PR to align our rules with Bifold for simplicity.