### PR TITLE
changed sauce tunnel settings for app to hit mediator directly

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -327,6 +327,15 @@ jobs:
 
       - name: run-aath-agents
         uses: ./.github/workflows/actions/run-aath-agents
+        with:
+          USE_NGROK: ""
+
+      - name: run-sauce-connect-tunnel
+        uses: saucelabs/sauce-connect-action@v2
+        with:
+          username: ${{ secrets.SAUCE_USERNAME }}
+          accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
+          directDomains: aries-mediator-agent-test.apps.silver.devops.gov.bc.ca
 
       - name: Fetch mobile test harness repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This is a change to the main build pipeline for the smoke test execution. The android app was having issues connecting with the mediator through the Sauce Tunnel and NGROK, it now will force the app in SL to hit the mediator directly. 