### PR TITLE
fix: debug android manifest to work with metro

### DIFF
--- a/app/android/app/src/debug/AndroidManifest.xml
+++ b/app/android/app/src/debug/AndroidManifest.xml
@@ -5,9 +5,10 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
     <application
-        android:usesCleartextTraffic="false"
+        android:usesCleartextTraffic="true"
         tools:targetApi="28"
-        tools:ignore="GoogleAppIndexingWarning">
+        tools:ignore="GoogleAppIndexingWarning"
+        tools:replace="android:usesCleartextTraffic">
         <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>
 </manifest>


### PR DESCRIPTION
Changed `android:usesCleartextTraffic` to `true` in the manifest. It seems like metro needs the attribute to be set to true. This change only affects the debug/development environment
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>