### PR TITLE
feat: use secure browser tab for auth

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,7 +1,7 @@
 name: Native Build & Test
 
 env:
-  cacheId: "10" # increment to expire the cache
+  cacheId: "11" # increment to expire the cache
   appBuildNumber: ${{ github.run_number }}
   appBuildVersion: "1.0.3"
 
@@ -244,50 +244,21 @@ jobs:
     # if: ${{ false }}  # disable for now
     needs: [check-android-secrets]
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        compile-sdk: [30]
-        build-tools: [30.0.2]
-        sdk-tools: [4333796]
+    # container:
+    #   image: docker.io/fullboar/android-builder:latest
     steps:
       - uses: actions/checkout@v1
 
       - name: Pull & update submodules recursively
         run: |
+          git config --global --add safe.directory '*'
           git submodule update --init --recursive
-
-      - name: Setup ubuntu
-        run: |
-          sudo apt-get --quiet update --yes
-          sudo apt-get --quiet install --yes wget tar unzip lib32stdc++6 lib32z1
 
       - name: Configure node
         uses: actions/setup-node@v1
         with:
           node-version: "16.15.0"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Setup JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
-      - name: Download Android SDK
-        working-directory: app/android
-        run: |
-          wget --quiet --output-document=android-sdk.zip https://dl.google.com/android/repository/sdk-tools-linux-${{ matrix.sdk-tools }}.zip
-          unzip -d android-sdk-linux android-sdk.zip
-          sudo mkdir -p /root/.android
-          sudo touch /root/.android/repositories.cfg
-          echo y | android-sdk-linux/tools/bin/sdkmanager "platforms;android-${{ matrix.compile-sdk }}" >/dev/null
-          echo y | android-sdk-linux/tools/bin/sdkmanager "platform-tools" >/dev/null
-          echo y | android-sdk-linux/tools/bin/sdkmanager "build-tools;${{ matrix.build-tools }}" >/dev/null
-          export ANDROID_HOME=$PWD/android-sdk-linux
-          export PATH=$PATH:$PWD/android-sdk-linux/platform-tools/
-          chmod +x ./gradlew
-          set +o pipefail
-          yes | android-sdk-linux/tools/bin/sdkmanager --licenses
-          set -o pipefail
 
       - name: Cache node modules
         uses: actions/cache@v1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,17 @@
 ## v1.0.3
 
+Build 3xx
+
+feat: use secure browser tab for authentication with BCSC #585
+feat: handle callback (redirect) URLs from BCSC #587
+
+Build 330
+
+- feat: work on bcsc / idim foundation credential #407
+- feat: make biometrics optional during onboarding #578
+- fix: biometrics on android #519
+- fix: disappearing image on proof screen #553
+
 Build 318
 
 - fix: secondary message on some proofs #553

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -12,12 +12,27 @@
     </intent>
   </queries>
   
-  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:allowBackup="false" android:theme="@style/AppTheme" android:usesCleartextTraffic="false">
-    <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:screenOrientation="portrait">
+  <application 
+    android:name=".MainApplication" 
+    android:label="@string/app_name" 
+    android:icon="@mipmap/ic_launcher" 
+    android:allowBackup="false" 
+    android:theme="@style/AppTheme" 
+    android:usesCleartextTraffic="false">
+    <activity 
+        android:name=".MainActivity"
+        android:label="@string/app_name" 
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode" 
+        android:launchMode="singleTask" 
+        android:windowSoftInputMode="adjustResize" 
+        android:screenOrientation="portrait"
+        android:exported="true">
+
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
+      
       <intent-filter>
         <action android:name="android.intent.action.VIEW"/>
         <category android:name="android.intent.category.DEFAULT"/>

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext {
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 30
+        compileSdkVersion = 31
         targetSdkVersion = 30
         ndkVersion = "21.4.7075529"
     }

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -395,6 +395,8 @@ PODS:
     - React
   - RNGestureHandler (1.10.3):
     - React-Core
+  - RNInAppBrowser (3.7.0):
+    - React-Core
   - RNKeychain (7.0.0):
     - React-Core
   - RNLocalize (2.1.5):
@@ -510,6 +512,7 @@ DEPENDENCIES:
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNFS (from `../node_modules/react-native-fs`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
+  - RNInAppBrowser (from `../node_modules/react-native-inappbrowser-reborn`)
   - RNKeychain (from `../node_modules/react-native-keychain`)
   - RNLocalize (from `../node_modules/react-native-localize`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
@@ -628,6 +631,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-fs"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
+  RNInAppBrowser:
+    :path: "../node_modules/react-native-inappbrowser-reborn"
   RNKeychain:
     :path: "../node_modules/react-native-keychain"
   RNLocalize:
@@ -704,6 +709,7 @@ SPEC CHECKSUMS:
   RNDeviceInfo: 4944cf8787b9c5bffaf301fda68cc1a2ec003341
   RNFS: 3ab21fa6c56d65566d1fb26c2228e2b6132e5e32
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
+  RNInAppBrowser: e36d6935517101ccba0e875bac8ad7b0cb655364
   RNKeychain: f75b8c8b2f17d3b2aa1f25b4a0ac5b83d947ff8f
   RNLocalize: 74b82db20cc3895ccc25af992c644879bcec2815
   RNReanimated: 65583befd5706cc9c86ae9a081786181ced37b93

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -53,6 +53,7 @@
         "react-native-gesture-handler": "1.10.3",
         "react-native-get-random-values": "1.7.0",
         "react-native-gifted-chat": "0.16.3",
+        "react-native-inappbrowser-reborn": "^3.7.0",
         "react-native-keychain": "^7.0.0",
         "react-native-localize": "2.1.5",
         "react-native-qrcode-svg": "6.1.1",
@@ -9463,6 +9464,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "bin": {
+        "opencollective-postinstall": "index.js"
+      }
+    },
     "node_modules/options": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
@@ -10411,6 +10420,19 @@
       "peer": true,
       "dependencies": {
         "react-native-codegen": "*"
+      }
+    },
+    "node_modules/react-native-inappbrowser-reborn": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/react-native-inappbrowser-reborn/-/react-native-inappbrowser-reborn-3.7.0.tgz",
+      "integrity": "sha512-Ia53jYNtFcbNaX5W3QfOmN25I7bcvuDiQmSY5zABXjy4+WI20bPc9ua09li55F8yDCjv3C99jX6vKms68mBV7g==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "opencollective-postinstall": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.56"
       }
     },
     "node_modules/react-native-iphone-x-helper": {
@@ -21278,6 +21300,11 @@
         "is-wsl": "^2.1.1"
       }
     },
+    "opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="
+    },
     "options": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
@@ -21966,6 +21993,15 @@
       "peer": true,
       "requires": {
         "react-native-codegen": "*"
+      }
+    },
+    "react-native-inappbrowser-reborn": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/react-native-inappbrowser-reborn/-/react-native-inappbrowser-reborn-3.7.0.tgz",
+      "integrity": "sha512-Ia53jYNtFcbNaX5W3QfOmN25I7bcvuDiQmSY5zABXjy4+WI20bPc9ua09li55F8yDCjv3C99jX6vKms68mBV7g==",
+      "requires": {
+        "invariant": "^2.2.4",
+        "opencollective-postinstall": "^2.0.3"
       }
     },
     "react-native-iphone-x-helper": {

--- a/app/package.json
+++ b/app/package.json
@@ -72,6 +72,7 @@
     "react-native-gesture-handler": "1.10.3",
     "react-native-get-random-values": "1.7.0",
     "react-native-gifted-chat": "0.16.3",
+    "react-native-inappbrowser-reborn": "^3.7.0",
     "react-native-keychain": "^7.0.0",
     "react-native-localize": "2.1.5",
     "react-native-qrcode-svg": "6.1.1",

--- a/app/src/components/BCIDView.tsx
+++ b/app/src/components/BCIDView.tsx
@@ -54,6 +54,22 @@ const BCIDView: React.FC = () => {
   const receivedProofs = useProofByState(ProofState.RequestReceived);
   const proof = useProofById(agentDetails.invitationProofId ?? "");
   const navigation = useNavigation();
+  const blarb: Array<NavigationHandler> = [
+    {
+      url: "bcwallet://bcsc/v1/dids/<did>/success",
+      callback: () => {
+        console.log("success");
+        // navigation.pop()
+      },
+    },
+    {
+      url: "bcwallet://bcsc/v1/dids/<did>/cancel",
+      callback: () => {
+        console.log("cancel");
+        // navigation.pop()
+      },
+    },
+  ];
 
   useEffect(() => {
     for (const p of receivedProofs) {
@@ -87,7 +103,14 @@ const BCIDView: React.FC = () => {
 
       console.log("target URL = ", destUrl);
 
-      navigation.navigate(Screens.WebDisplay, { destUrl });
+      blarb.forEach((item) => {
+        item.url = item.url.replace("<did>", agentDetails?.legacyConnectionDid);
+      });
+
+      navigation.navigate(Screens.WebDisplay, {
+        targetUrl: destUrl,
+        navigationHandlers: blarb,
+      });
 
       setWorkflowInFlight(false);
     }

--- a/app/src/components/BCIDView.tsx
+++ b/app/src/components/BCIDView.tsx
@@ -26,6 +26,7 @@ import { useNavigation } from "@react-navigation/core";
 import { Screens } from "aries-bifold";
 import { Config } from "react-native-config";
 import { InAppBrowser, RedirectResult } from "react-native-inappbrowser-reborn";
+import { Linking } from "react-native";
 
 const legacyDidKey = "_internal/legacyDid"; // TODO:(jl) Waiting for AFJ export of this.
 const trustedInvitationIssueRe =
@@ -200,6 +201,8 @@ const BCIDView: React.FC = () => {
             ErrorCodes.ServiceCardError
           );
         }
+      } else {
+        Linking.openURL(url);
       }
 
       cleanupAfterServiceCardAuthentication(AuthenticationResultType.Success);

--- a/app/src/components/BCIDView.tsx
+++ b/app/src/components/BCIDView.tsx
@@ -30,10 +30,10 @@ import { Linking } from "react-native";
 
 const legacyDidKey = "_internal/legacyDid"; // TODO:(jl) Waiting for AFJ export of this.
 const trustedInvitationIssueRe =
-  /3Lbd5wSSSBv1xtjwsQ36sj:[0-9]{1,1}:CL:[0-9]{5,}:default/i;
+  /^3Lbd5wSSSBv1xtjwsQ36sj:[0-9]{1,1}:CL:[0-9]{5,}:default$/i;
 const trustedFoundationCredentialIssuerRe =
-  /7xjfawcnyTUcduWVysLww5:[0-9]{1,1}:CL:[0-9]{5,}:Person\s\(SIT\)/i;
-const redirectUrlTemplate = "bcwallet://ServiceCard/v1/dids/<did>";
+  /^7xjfawcnyTUcduWVysLww5:[0-9]{1,1}:CL:[0-9]{5,}:Person\s\(SIT\)$/i;
+const redirectUrlTemplate = "bcwallet://bcsc/v1/dids/<did>";
 
 enum AuthenticationResultType {
   Success = "success",
@@ -165,7 +165,7 @@ const BCIDView: React.FC = () => {
     try {
       const url = `${Config.IDIM_PORTAL_URL}/${did}`;
 
-      console.log("target URL = ", url);
+      // console.log("target URL = ", url);
 
       if (await InAppBrowser.isAvailable()) {
         const result = await InAppBrowser.openAuth(
@@ -209,7 +209,7 @@ const BCIDView: React.FC = () => {
     } catch (error: unknown) {
       const code = (error as BifoldError).code;
 
-      console.log(`message = ${(error as Error).message}, code = ${code}`);
+      // console.log(`message = ${(error as Error).message}, code = ${code}`);
 
       cleanupAfterServiceCardAuthentication(
         code === ErrorCodes.CanceledByUser

--- a/app/src/components/BCIDView.tsx
+++ b/app/src/components/BCIDView.tsx
@@ -46,6 +46,8 @@ const BCIDView: React.FC = () => {
   ];
   const { agent } = useAgent();
   const { t } = useTranslation();
+  const [workflowInFlight, setWorkflowInFlight] =
+    React.useState<boolean>(false);
   const [agentDetails, setAgentDetails] = React.useState<WellKnownAgentDetails>(
     {}
   );
@@ -86,6 +88,8 @@ const BCIDView: React.FC = () => {
       console.log("target URL = ", destUrl);
 
       navigation.navigate(Screens.WebDisplay, { destUrl });
+
+      setWorkflowInFlight(false);
     }
   }, [proof]);
 
@@ -113,6 +117,8 @@ const BCIDView: React.FC = () => {
 
   const onGetIdTouched = async () => {
     try {
+      setWorkflowInFlight(true);
+
       // If something fails before we get the credential we need to
       // cleanup the old invitation before it can be used again.
       const oldInvitation = await agent?.oob.findByInvitationId(
@@ -175,7 +181,8 @@ const BCIDView: React.FC = () => {
         legacyConnectionDid: did,
       });
     } catch (error: unknown) {
-      // TODO:(jl) useless try-catch. cleanup.
+      setWorkflowInFlight(false);
+
       throw error;
     }
   };
@@ -190,6 +197,7 @@ const BCIDView: React.FC = () => {
             testID={testIdWithKey("GetBCID")}
             onPress={onGetIdTouched}
             buttonType={ButtonType.Secondary}
+            disabled={workflowInFlight}
           />
         </View>
       )}


### PR DESCRIPTION
This PR adds support for a secure authentication tab on iOS and Android API => 31. For Android API 30 or lower it will trigger the built in Web browser to open the URL, once authentication is completed it will hand back to the BC Wallet. The API updates are not common to Bifold so no changes in support levels there.

- feat: use secure browser tab for authentication with BCSC.
- feat: handle callback (redirect) URLs from BCSC.
- chore: update Android SDK to API 31 (was 30).
- chore: updated cicd pipeline to be more simple for Android builds and use API 31.

Fixed #585
Fixed #587