### PR TITLE
fix: offer being dismissed

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,17 @@
 ## v1.0.3
 
-Build 3xx
+Build 40x
+
+fix: closing offer screen when it should not be. #585
+
+Build 404
+
+feat: use secure browser tab for authentication with BCSC #585
+feat: handle callback (redirect) URLs from BCSC #587
+chore: update Android SDK to API 31 (was 30)
+fix: numerous biometrics improvements
+
+Build 318
 
 feat: use secure browser tab for authentication with BCSC #585
 feat: handle callback (redirect) URLs from BCSC #587

--- a/app/src/components/BCIDView.tsx
+++ b/app/src/components/BCIDView.tsx
@@ -155,10 +155,6 @@ const BCIDView: React.FC = () => {
     if (status === AuthenticationResultType.Cancel) {
       setWorkflowInFlight(false);
     }
-
-    if (navigation.canGoBack()) {
-      navigation.goBack();
-    }
   };
 
   const authenticateWithServiceCard = async (did: string): Promise<void> => {
@@ -202,7 +198,7 @@ const BCIDView: React.FC = () => {
           );
         }
       } else {
-        Linking.openURL(url);
+        await Linking.openURL(url);
       }
 
       cleanupAfterServiceCardAuthentication(AuthenticationResultType.Success);


### PR DESCRIPTION
Stale code left over from the use of a WebView was causing the credential offer screen to be dismissed. This PR removes the code.