### PR TITLE
fix failing early navigation on biometrics screen

### DIFF
--- a/app/src/screens/Splash.tsx
+++ b/app/src/screens/Splash.tsx
@@ -135,7 +135,7 @@ const Splash: React.FC = () => {
   }, [store.authentication.didAuthenticate])
 
   useEffect(() => {
-    if (!store.authentication.didAuthenticate) {
+    if (!store.authentication.didAuthenticate || !store.onboarding.didConsiderBiometry) {
       return
     }
 
@@ -188,7 +188,7 @@ const Splash: React.FC = () => {
     }
 
     initAgent()
-  }, [store.authentication.didAuthenticate])
+  }, [store.authentication.didAuthenticate, store.onboarding.didConsiderBiometry])
 
   return (
     <SafeAreaView style={styles.container}>


### PR DESCRIPTION
On the biometrics screen, if the user waits 5-10 seconds until the agent has finished initialization, the app will attempt to navigate to the tab stack. The tab stack doesn't exist yet so the navigation will fail. Then when the user clicks continue, the navigation function won't be called again and the user will be stuck on the navigation screen.

This fix ensures that the agent is initialized and the navigation function is called after the user clicks "Continue" on the biometrics screen.
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>