### PR TITLE
Reverted to ngrok for android to sl tunnel

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -362,11 +362,19 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: run-aath-agents
+        if: ${{ matrix.mobile-platform=='-p iOS' }}
         uses: ./.github/workflows/actions/run-aath-agents
         with:
           USE_NGROK: ""
 
+      - name: run-aath-agents-ngrok
+        if: ${{ matrix.mobile-platform=='-p Android' }}
+        uses: ./.github/workflows/run-aath-agents
+        with:
+          USE_NGROK: "-n"
+
       - name: run-sauce-connect-tunnel
+        if: ${{ matrix.mobile-platform=='-p iOS' }}
         uses: saucelabs/sauce-connect-action@v2
         with:
           username: ${{ secrets.SAUCE_USERNAME }}
@@ -396,9 +404,9 @@ jobs:
           APP_FILE_NAME: ${{ matrix.app-file-name }}
           TEST_SCOPE: "-t @bc_wallet -t @SmokeTest"
           REPORT_PROJECT: ${{ matrix.report-project }}
-        continue-on-error: true
 
       - name: Upload smoke-test results to Allure
+        if: ${{ always() }}
         uses: ./.github/workflows/actions/run-send-gen-test-results-secure
         with:
           REPORT_PROJECT: ${{ matrix.report-project }}


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This PR changes the tunnel back to NGROK from the Sauce Tunnel that is not working for Android. 
It also changes the push to allure logic if the test run fails. It now follows a better convention than continue-on-error. 