### PR TITLE
fix: android build error

### DIFF
--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -7,6 +7,10 @@ buildscript {
         compileSdkVersion = 31
         targetSdkVersion = 30
         ndkVersion = "21.4.7075529"
+        // The setting `androidXBrowser` is temporary until it can be fixed in 
+        // the npm package `react-native-inappbrowser-reborn` v3.7.0.
+        // Ref. https://github.com/proyecto26/react-native-inappbrowser/issues/386
+        androidXBrowser = "1.4.0"
     }
     repositories {
         google()


### PR DESCRIPTION
Fix android build issue by pegging `androidXBrowser` to v1.4.0. This is a dependency for the npm package react-native-inappbrowser-reborn v3.7.0