### PR TITLE
chore: update RN to 0.66.5 and latest bifold

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -40,7 +40,7 @@
         "query-string": "7.0.1",
         "react": "17.0.2",
         "react-i18next": "11.13.0",
-        "react-native": "^0.66.5",
+        "react-native": "0.66.5",
         "react-native-animated-pagination-dots": "0.1.72",
         "react-native-argon2": "2.0.1",
         "react-native-bouncy-checkbox": "^3.0.5",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -40,7 +40,7 @@
         "query-string": "7.0.1",
         "react": "17.0.2",
         "react-i18next": "11.13.0",
-        "react-native": "0.66.1",
+        "react-native": "^0.66.5",
         "react-native-animated-pagination-dots": "0.1.72",
         "react-native-argon2": "2.0.1",
         "react-native-bouncy-checkbox": "^3.0.5",
@@ -173,7 +173,7 @@
         "query-string": "^7.0.1",
         "react": "17.0.2",
         "react-i18next": "^11.13.0",
-        "react-native": "0.66.1",
+        "react-native": "0.66.5",
         "react-native-animated-pagination-dots": "^0.1.72",
         "react-native-argon2": "^2.0.1",
         "react-native-bouncy-checkbox": "^3.0.5",
@@ -33724,8 +33724,9 @@
       "license": "MIT"
     },
     "node_modules/react-native": {
-      "version": "0.66.1",
-      "license": "MIT",
+      "version": "0.66.5",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.66.5.tgz",
+      "integrity": "sha512-dC5xmE1anT+m8eGU0N/gv2XUWZygii6TTqbwZPsN+uMhVvjxt4FsTqpZOFFvA5sxLPR/NDEz8uybTvItNBMClw==",
       "dependencies": {
         "@jest/create-cache-key-function": "^27.0.1",
         "@react-native-community/cli": "^6.0.0",
@@ -59304,7 +59305,9 @@
       "version": "16.13.1"
     },
     "react-native": {
-      "version": "0.66.1",
+      "version": "0.66.5",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.66.5.tgz",
+      "integrity": "sha512-dC5xmE1anT+m8eGU0N/gv2XUWZygii6TTqbwZPsN+uMhVvjxt4FsTqpZOFFvA5sxLPR/NDEz8uybTvItNBMClw==",
       "requires": {
         "@jest/create-cache-key-function": "^27.0.1",
         "@react-native-community/cli": "^6.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -63,7 +63,7 @@
     "query-string": "7.0.1",
     "react": "17.0.2",
     "react-i18next": "11.13.0",
-    "react-native": "0.66.1",
+    "react-native": "^0.66.5",
     "react-native-animated-pagination-dots": "0.1.72",
     "react-native-argon2": "2.0.1",
     "react-native-bouncy-checkbox": "^3.0.5",

--- a/app/package.json
+++ b/app/package.json
@@ -63,7 +63,7 @@
     "query-string": "7.0.1",
     "react": "17.0.2",
     "react-i18next": "11.13.0",
-    "react-native": "^0.66.5",
+    "react-native": "0.66.5",
     "react-native-animated-pagination-dots": "0.1.72",
     "react-native-argon2": "2.0.1",
     "react-native-bouncy-checkbox": "^3.0.5",


### PR DESCRIPTION
As noted in [517](https://github.com/hyperledger/aries-mobile-agent-react-native/pull/517) we need to update to RN 0.66.5 to fix an android package issue that breaks the build. This PR makes said change.