### PR TITLE
chore: fix path in build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -217,7 +217,7 @@ jobs:
           APP_STORE_CONNECT_KEY_IDENTIFIER: ${{ secrets.APP_STORE_CONNECT_KEY_IDENTIFIER }}
           APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY_95 }}
         run: |
-          app-store-connect publish \
+          /usr/local/bin/app-store-connect publish \
           --apple-id ${{ secrets.APPLE_ID }} \
           --password ${{ secrets.APPLE_ID_PASSWD }} \
           --enable-package-validation \


### PR DESCRIPTION
Fist pass at fixing publishing to the app store. I tried installing the tools on my mac and they work as expected. Hoping using the full path will fix the issue. 