### PR TITLE
chore: bumb version number

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,7 +3,7 @@ name: Native Build & Test
 env:
   cacheId: "11" # increment to expire the cache
   appBuildNumber: ${{ github.run_number }}
-  appBuildVersion: "1.0.4"
+  appBuildVersion: "1.0.5"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Need to bump the version number now that we have a version queued for approval.