### PR TITLE
fix: no error on user cancel

### DIFF
--- a/app/src/components/BCIDView.tsx
+++ b/app/src/components/BCIDView.tsx
@@ -131,14 +131,9 @@ const BCIDView: React.FC = () => {
         })
 
         if (result.type === AuthenticationResultType.Cancel) {
+          // The user hit cancel in the Web view to end the
+          // authentication attempt.
           setWorkflowInFlight(false)
-
-          throw new BifoldError(
-            t('Error.Title2024'),
-            t('Error.Description2024'),
-            t('Error.NoMessage'),
-            ErrorCodes.CanceledByUser
-          )
         }
 
         if (

--- a/app/src/components/BCIDView.tsx
+++ b/app/src/components/BCIDView.tsx
@@ -131,8 +131,8 @@ const BCIDView: React.FC = () => {
         })
 
         if (result.type === AuthenticationResultType.Cancel) {
-          // The user hit cancel in the Web view to end the
-          // authentication attempt.
+          // Cancel in the Web view to end the authentication
+          // propels the user Home.
           setWorkflowInFlight(false)
         }
 

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -11,8 +11,6 @@ const translation = {
     "Message2021": "There was a problem receiving the invitation to connect.",
     "Title2022": "Unable to find legacy DID",
     "Message2022": "There was a problem extracting the did repository.",
-    "Title2024": "BCSC Authentication",
-    "Message2024": "The authentication request was canceled.",
     "Title2025": "BCSC Authentication",
     "Message2025": "There was a problem reported by BCSC.",
     "NoMessage": "No Message",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -11,8 +11,6 @@ const translation = {
     "Message2021": "There was a problem receiving the invitation to connect. (FR)",
     "Title2022": "Unable to find legacy DID (FR)",
     "Message2022": "There was a problem extracting the did repository. (FR)",
-    "Title2024": "BCSC Authentication (FR)",
-    "Message2024": "The authentication request was canceled. (FR)",
     "Title2025": "BCSC Authentication (FR)",
     "Message2025": "There was a problem reported by BCSC. (FR)",
     "NoMessage": "No Message (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -11,8 +11,6 @@ const translation = {
     "Message2021": "There was a problem receiving the invitation to connect. (PT-BR)",
     "Title2022": "Unable to find legacy DID (PT-BR)",
     "Message2022": "There was a problem extracting the did repository. (PT-BR)",
-    "Title2024": "BCSC Authentication (PT-BR)",
-    "Message2024": "The authentication request was canceled. (PT-BR)",
     "Title2025": "BCSC Authentication (PT-BR)",
     "Message2025": "There was a problem reported by BCSC. (PT-BR)",
     "NoMessage": "No Message (PT-BR)",


### PR DESCRIPTION
Fix an issue where when the user cancels BSCS authentication the app interprites it as a error. With his change it just returns the user to the home screen allowing them to try agains when convenient.