### PR TITLE
feat: use button loading animation component from bifold

### DIFF
--- a/app/src/components/BCIDView.tsx
+++ b/app/src/components/BCIDView.tsx
@@ -10,16 +10,14 @@ import {
   Screens,
   DispatchAction,
   useStore,
-  useTheme
 } from 'aries-bifold'
-import React, { useEffect, useState, useRef } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { View, Linking, Platform, Animated } from 'react-native'
-import { Config } from 'react-native-config'
+import { View, Linking, Platform } from 'react-native'
 import { InAppBrowser, RedirectResult } from 'react-native-inappbrowser-reborn'
+import ButtonLoading from 'aries-bifold/App/components/animated/ButtonLoading'
 
-import { BCState, BCDispatchAction } from '../store'
-import Icon from 'react-native-vector-icons/MaterialIcons'
+import { BCState } from '../store'
 
 import CredentialIcon from '../assets/img/credentialIcon.svg'
 
@@ -67,7 +65,6 @@ const BCIDView: React.FC = () => {
   ]
   const navigation = useNavigation()
   const [canUseLSBCredential] = useState<boolean>(true)
-  const { ColorPallet } = useTheme()
 
   useEffect(() => {
     for (const o of offers) {
@@ -180,7 +177,7 @@ const BCIDView: React.FC = () => {
     }
   }
 
-  const onGetIdTouched = async () => {
+  async function onGetIdTouched(){
     try {
       setWorkflowInFlight(true)
 
@@ -251,27 +248,6 @@ const BCIDView: React.FC = () => {
     }
   }
 
-  const rotationAnim = useRef(new Animated.Value(0)).current
-  const timing: Animated.TimingAnimationConfig = {
-    toValue: 1,
-    duration: 2000,
-    useNativeDriver: true,
-  }
-  const rotation = rotationAnim.interpolate({
-    inputRange: [0, 1],
-    outputRange: ['0deg', '360deg'],
-  })
-
-  useEffect(() => {
-    const animation = Animated.loop(Animated.timing(rotationAnim, timing))
-    if (workflowInFlight) {
-      animation.start()
-    } else {
-      animation.reset()
-      animation.stop()
-    }
-  }, [rotationAnim, workflowInFlight])
-
   return (
     <HomeContentView>
       {showGetFoundationCredential && (
@@ -286,9 +262,7 @@ const BCIDView: React.FC = () => {
           >
             {
               workflowInFlight ? (
-                <Animated.View style={[{ transform: [{ rotate: rotation }] }]}>
-                  <Icon style={{ color: ColorPallet.grayscale.white }} size={35} name="refresh" />
-                </Animated.View>
+                <ButtonLoading/>
               ) : <CredentialIcon style={{ marginRight: 10 }} />
             }
           </Button>


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>
Replace the active button loading animation on  the get BCID button with an equivalent animation from a bifold component
Depends on: https://github.com/hyperledger/aries-mobile-agent-react-native/pull/556