### PR TITLE
chore: update submodule, i18n, theme, new dep

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission-sdk-23 android:name="android.permission.VIBRATE"/>
+  <uses-permission android:name="android.permission.CAMERA" />
 
   <queries>
     <intent>

--- a/app/ios/Podfile
+++ b/app/ios/Podfile
@@ -22,6 +22,10 @@ end
 target 'AriesBifold' do
   config = use_native_modules!
 
+  permissions_path = '../node_modules/react-native-permissions/ios'
+
+  pod 'Permission-Camera', :path => "#{permissions_path}/Camera"
+
   use_react_native!(
     :path => config[:reactNativePath],
     # to enable hermes on iOS, change `false` to `true` and then install pods

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -57,6 +57,7 @@
         "react-native-inappbrowser-reborn": "^3.7.0",
         "react-native-keychain": "^7.0.0",
         "react-native-localize": "2.1.5",
+        "react-native-permissions": "^3.6.1",
         "react-native-qrcode-svg": "6.1.1",
         "react-native-reanimated": "2.2.4",
         "react-native-safe-area-context": "3.3.2",
@@ -190,6 +191,7 @@
         "react-native-gifted-chat": "^0.16.3",
         "react-native-keychain": "^8.1.1",
         "react-native-localize": "^2.1.5",
+        "react-native-permissions": "^3.6.1",
         "react-native-qrcode-svg": "^6.0.6",
         "react-native-reanimated": "^2.2.4",
         "react-native-safe-area-context": "^3.2.0",
@@ -33808,6 +33810,21 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-permissions": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/react-native-permissions/-/react-native-permissions-3.6.1.tgz",
+      "integrity": "sha512-fzPpPQXeD34inUccqtoResSwYubfrwUguP4qrVUUv8+KSMjYSaHGoS5HaIJLZHlN9gO+TvLJZ2L5ZljTsb6qnQ==",
+      "peerDependencies": {
+        "react": ">=16.13.1",
+        "react-native": ">=0.63.3",
+        "react-native-windows": ">=0.62.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native-windows": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-native-qrcode-svg": {
       "version": "6.1.1",
       "license": "MIT",
@@ -59245,6 +59262,12 @@
       "requires": {
         "prop-types": "^15.7.x"
       }
+    },
+    "react-native-permissions": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/react-native-permissions/-/react-native-permissions-3.6.1.tgz",
+      "integrity": "sha512-fzPpPQXeD34inUccqtoResSwYubfrwUguP4qrVUUv8+KSMjYSaHGoS5HaIJLZHlN9gO+TvLJZ2L5ZljTsb6qnQ==",
+      "requires": {}
     },
     "react-native-qrcode-svg": {
       "version": "6.1.1",

--- a/app/package.json
+++ b/app/package.json
@@ -80,6 +80,7 @@
     "react-native-inappbrowser-reborn": "^3.7.0",
     "react-native-keychain": "^7.0.0",
     "react-native-localize": "2.1.5",
+    "react-native-permissions": "^3.6.1",
     "react-native-qrcode-svg": "6.1.1",
     "react-native-reanimated": "2.2.4",
     "react-native-safe-area-context": "3.3.2",

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -15,6 +15,13 @@ const translation = {
     "Message2025": "There was a problem reported by BCSC.",
     "NoMessage": "No Message",
   },
+  "CameraDisclosure": {
+    "AllowCameraUse": "Allow camera use",
+    "CameraDisclosure": "The camera is used to scan QR codes that initiate a credential offer or credential request. No information about the images is stored, used for analytics, or shared.",
+    "ToContinueUsing": "To continue using the BC Wallet scan feature, please allow camera permissions.",
+    "Allow": "Allow",
+    "OpenSettings": "Open settings",
+  },
   "Biometry": {
     "Toggle": "Toggle Biometrics",
     "EnabledText1": "Log in with your phone's biometrics instead of your wallet PIN.",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -15,6 +15,13 @@ const translation = {
     "Message2025": "There was a problem reported by BCSC. (FR)",
     "NoMessage": "No Message (FR)",
   },
+  "CameraDisclosure": {
+    "AllowCameraUse": "Allow camera use (FR)",
+    "CameraDisclosure": "La caméra est utilisée pour scanner les codes QR pour un traitement immédiat sur l'appareil. Aucune information sur les images n'est stockée, utilisée à des fins d'analyse ou partagée.",
+    "ToContinueUsing": "To continue using the BC Wallet scan feature, please allow camera permissions. (FR)",
+    "Allow": "Allow (FR)",
+    "OpenSettings": "Open settings (FR)",
+  },
   "Biometry": {
     "Toggle": "Toggle Biometrics (FR)",
     "EnabledText1": "Log in with your phone's biometrics instead of your wallet PIN. (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -15,6 +15,13 @@ const translation = {
     "Message2025": "There was a problem reported by BCSC. (PT-BR)",
     "NoMessage": "No Message (PT-BR)",
   },
+  "CameraDisclosure": {
+    "AllowCameraUse": "Allow camera use (PT-BR)",
+    "CameraDisclosure": "A câmera é usada para escanear QR Codes para processamento imediato no dispositivo. Nenhuma informação sobre as imagens é armazenada, usada para análise, ou compartilhada.",
+    "ToContinueUsing": "To continue using the BC Wallet scan feature, please allow camera permissions. (PT-BR)",
+    "Allow": "Allow (PT-BR)",
+    "OpenSettings": "Open settings (PT-BR)",
+  },
   "Biometry": {
     "Toggle": "Toggle Biometrics (PT-BR)",
     "EnabledText1": "Log in with your phone's biometrics instead of your wallet PIN. (PT-BR)",

--- a/app/src/screens/Splash.tsx
+++ b/app/src/screens/Splash.tsx
@@ -19,7 +19,6 @@ import {
   OnboardingState,
   LoginAttemptState,
   PreferencesState,
-  PrivacyState,
   useAuth,
   useTheme,
   useStore,
@@ -108,16 +107,6 @@ const Splash: React.FC = () => {
 
           dispatch({
             type: DispatchAction.PREFERENCES_UPDATED,
-            payload: [dataAsJSON],
-          })
-        }
-
-        const privacyData = await AsyncStorage.getItem(LocalStorageKeys.Privacy)
-        if (privacyData) {
-          const dataAsJSON = JSON.parse(privacyData) as PrivacyState
-
-          dispatch({
-            type: DispatchAction.PRIVACY_UPDATED,
             payload: [dataAsJSON],
           })
         }

--- a/app/src/theme.ts
+++ b/app/src/theme.ts
@@ -87,6 +87,7 @@ interface NotificationColors {
   errorBorder: string
   errorIcon: string
   errorText: string
+  popupOverlay: string
 }
 
 interface GrayscaleColors {
@@ -115,6 +116,7 @@ interface Assets {
 
 export const borderRadius = 4
 export const heavyOpacity = 0.7
+export const mediumOpacity = 0.5
 export const lightOpacity = 0.35
 export const zeroOpacity = 0.0
 export const borderWidth = 2
@@ -155,6 +157,7 @@ const NotificationColors: NotificationColors = {
   errorBorder: '#EBCCD1',
   errorIcon: '#A12622',
   errorText: '#A12622',
+  popupOverlay: `rgba(0, 0, 0, ${mediumOpacity})`,
 }
 
 const GrayscaleColors: GrayscaleColors = {


### PR DESCRIPTION
This is the BC Wallet update for the changes here: https://github.com/hyperledger/aries-mobile-agent-react-native/pull/587

Also cut out the remaining privacy state in our customized Splash screen.

Edit: This change fixes #434 #824 #775

Here is the flow when a user taps scan for the first time:
![bc_first_allowed](https://user-images.githubusercontent.com/32586431/213306832-d7ecaf99-4b7b-4eb2-9517-b5adad67a6e1.gif)

Here is the flow when user hasn't given permission and selects "Not now":
![bc_not_now](https://user-images.githubusercontent.com/32586431/213306909-e2517bfd-ca94-4eec-a19b-29c32a93dada.gif)

Here is the flow when a user has already denied permission:
![bc_already_denied](https://user-images.githubusercontent.com/32586431/213306976-64d83183-269d-4241-ab75-247d9cd35ba6.gif)

