### PR TITLE
fix: add kotlinstdlib dep resolution to build.gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ node_modules
 .gradle
 lib
 yarn.lock
+local.properties
 
 # aries-bifold should be cloned separately
 aries-bifold/

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -77,6 +77,17 @@ import com.android.build.OutputFile
  * ]
  */
 
+// added 1/26/2023 by BM, when our builds suddenly started failing due to conflicting kotlin stdlib versions
+configurations.all {
+    resolutionStrategy {
+        eachDependency {
+            if ((requested.group == "org.jetbrains.kotlin") && (requested.name.startsWith("kotlin-stdlib"))) {
+                useVersion("1.8.0")
+            }
+        }
+    }
+}
+
 project.ext.react = [
     enableHermes: true,  // clean and rebuild if changing
 ]


### PR DESCRIPTION
Resolves #851 

Not an ideal solution, but seems to work until we can figure out why (without this) bifold will build but bc wallet won't. In future, locking deps like these seems like a good idea

