### PR TITLE
feat: add progress ui features to initialization screen

### DIFF
--- a/app/src/components/ProgressBar.tsx
+++ b/app/src/components/ProgressBar.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from 'aries-bifold'
 import React, { useEffect, useState } from 'react'
-import { StyleSheet, View, LayoutChangeEvent, Animated } from 'react-native'
+import { StyleSheet, View, Animated, useWindowDimensions } from 'react-native'
 
 export interface ProgressBarProps {
   progressPercent: number
@@ -8,7 +8,7 @@ export interface ProgressBarProps {
 
 const ProgressBar: React.FC<ProgressBarProps> = ({ progressPercent }) => {
   const { ColorPallet } = useTheme()
-  const [progressBarWidth, setProgressBarWidth] = useState(700)
+  const { width: windowWidth } = useWindowDimensions()
   const [progressBarScale] = useState(new Animated.Value(0))
 
   useEffect(() => {
@@ -38,18 +38,11 @@ const ProgressBar: React.FC<ProgressBarProps> = ({ progressPercent }) => {
   })
   const animatedBarStyle = {
     // without these two translates, the progress would start from the center and expand outward, rather than start from the left
-    transform: [{ translateX: -(progressBarWidth / 2) }, { scaleX }, { translateX: progressBarWidth / 2 }],
-  }
-
-  const onLayout = (event: LayoutChangeEvent) => {
-    const { width } = event.nativeEvent.layout
-    if (width) {
-      setProgressBarWidth(width)
-    }
+    transform: [{ translateX: -(windowWidth / 2) }, { scaleX }, { translateX: windowWidth / 2 }],
   }
 
   return (
-    <View onLayout={onLayout} style={styles.progressBarContainer}>
+    <View style={styles.progressBarContainer}>
       <Animated.View style={[StyleSheet.absoluteFill, styles.progressBar, animatedBarStyle]} />
     </View>
   )

--- a/app/src/components/ProgressBar.tsx
+++ b/app/src/components/ProgressBar.tsx
@@ -1,0 +1,58 @@
+import { useTheme } from 'aries-bifold'
+import React, { useEffect, useState } from 'react'
+import { StyleSheet, View, LayoutChangeEvent, Animated } from 'react-native'
+
+export interface ProgressBarProps {
+  progressPercent: number
+}
+
+const ProgressBar: React.FC<ProgressBarProps> = ({ progressPercent }) => {
+  const { ColorPallet } = useTheme()
+  const [progressBarWidth, setProgressBarWidth] = useState(700)
+  const [progressBarScale] = useState(new Animated.Value(0))
+
+  useEffect(() => {
+    Animated.timing(progressBarScale, {
+      toValue: progressPercent,
+      duration: 300,
+      useNativeDriver: true, // allows for much smoother animation
+    }).start()
+  }, [progressPercent])
+
+  const styles = StyleSheet.create({
+    progressBarContainer: {
+      width: '100%',
+      height: 11,
+      backgroundColor: '#001e3d',
+    },
+    progressBar: {
+      height: '100%',
+      width: '100%',
+      backgroundColor: ColorPallet.brand.highlight,
+    },
+  })
+  // scaleX rather than width is used for the progress bar as this allows useNativeDriver to be true
+  const scaleX = progressBarScale.interpolate({
+    inputRange: [0, 100],
+    outputRange: [0, 1],
+  })
+  const animatedBarStyle = {
+    // without these two translates, the progress would start from the center and expand outward, rather than start from the left
+    transform: [{ translateX: -(progressBarWidth / 2) }, { scaleX }, { translateX: progressBarWidth / 2 }],
+  }
+
+  const onLayout = (event: LayoutChangeEvent) => {
+    const { width } = event.nativeEvent.layout
+    if (width) {
+      setProgressBarWidth(width)
+    }
+  }
+
+  return (
+    <View onLayout={onLayout} style={styles.progressBarContainer}>
+      <Animated.View style={[StyleSheet.absoluteFill, styles.progressBar, animatedBarStyle]} />
+    </View>
+  )
+}
+
+export default ProgressBar

--- a/app/src/components/TipCarousel.tsx
+++ b/app/src/components/TipCarousel.tsx
@@ -17,14 +17,14 @@ const shuffleArray = (arr: number[]) => {
 // increase / decrease the count in this array if you remove or add tips from the i18n files
 const tipOrder: number[] = shuffleArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14])
 
-interface ITip {
+interface TipItem {
   id: string
   showHeader: boolean
   text: string
 }
 
 export interface TipProps {
-  item: ITip
+  item: TipItem
   width: number
   header: string
 }
@@ -125,8 +125,8 @@ const TipCarousel: React.FC = () => {
 
   // translating once here to prevent many repeated translations for each tip item
   const tipHeader = t('Tips.Header')
-  const keyExtractor = (item: ITip) => item.id
-  const renderItem: ListRenderItem<ITip> = ({ item }) => {
+  const keyExtractor = (item: TipItem) => item.id
+  const renderItem: ListRenderItem<TipItem> = ({ item }) => {
     return <Tip item={item} width={width} header={tipHeader} />
   }
 

--- a/app/src/components/TipCarousel.tsx
+++ b/app/src/components/TipCarousel.tsx
@@ -1,0 +1,151 @@
+import React, { memo, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, View, Text, useWindowDimensions, FlatList, ListRenderItem } from 'react-native'
+
+// used for randomizng tip order
+const shuffleArray = (arr: number[]) => {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    const temp = arr[i]
+    arr[i] = arr[j]
+    arr[j] = temp
+  }
+
+  return arr
+}
+
+// increase / decrease the count in this array if you remove or add tips from the i18n files
+const tipOrder: number[] = shuffleArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14])
+
+interface ITip {
+  id: string
+  showHeader: boolean
+  text: string
+}
+
+export interface TipProps {
+  item: ITip
+  width: number
+  header: string
+}
+
+// memo used here to optimize for FlatList rendering
+const Tip: React.FC<TipProps> = memo(({ item, width, header }) => {
+  // not making use of useTheme here to optimize FlatList rendering
+  const tipStyles = StyleSheet.create({
+    tipContainer: {
+      paddingHorizontal: 20,
+      height: '100%',
+      width,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    tipHeaderContainer: {
+      borderBottomWidth: 1,
+      borderBottomColor: '#FCBA19',
+    },
+    tipHeader: {
+      paddingBottom: 3,
+      fontSize: 26,
+      fontFamily: 'BCSans-Regular',
+      fontWeight: 'bold',
+      color: 'white',
+    },
+    tipText: {
+      fontSize: 26,
+      fontFamily: 'BCSans-Regular',
+      fontWeight: 'bold',
+      color: 'white',
+      marginTop: 10,
+      textAlign: 'center',
+    },
+  })
+
+  return (
+    <View style={tipStyles.tipContainer}>
+      {item.showHeader && (
+        <View style={tipStyles.tipHeaderContainer}>
+          <Text style={tipStyles.tipHeader}>{header}</Text>
+        </View>
+      )}
+      <Text style={tipStyles.tipText}>{item.text}</Text>
+    </View>
+  )
+})
+
+const TipCarousel: React.FC = () => {
+  const flatListRef = useRef<FlatList>(null)
+  const { width } = useWindowDimensions()
+  const [currentPosition, setCurrentPosition] = useState(0)
+  const { t } = useTranslation()
+  const delay = 5000 // ms
+  const tips = [
+    {
+      id: '0',
+      showHeader: false,
+      text: t('Tips.GettingReady'),
+    },
+    ...tipOrder.map((num, index) => {
+      return {
+        id: `${index + 1}`,
+        showHeader: true,
+        text: t(`Tips.Tip${num}`),
+      }
+    }),
+  ]
+
+  const scrolling = () => {
+    if (flatListRef.current) {
+      const newOffset = (currentPosition + 1) * width
+      const maxOffset = tips.length * width
+      if (newOffset >= maxOffset) {
+        flatListRef.current.scrollToOffset({ offset: 0, animated: false })
+        setCurrentPosition(0)
+      } else {
+        flatListRef.current.scrollToOffset({ offset: newOffset, animated: true })
+        setCurrentPosition(currentPosition + 1)
+      }
+    }
+  }
+
+  // ref used here to prevent interval from using old (initial) state values
+  const callbackRef = useRef(scrolling)
+  useEffect(() => {
+    callbackRef.current = scrolling
+  }, [scrolling])
+
+  useEffect(() => {
+    const timer = setInterval(() => callbackRef.current(), delay)
+    return () => {
+      if (timer) {
+        clearInterval(timer)
+      }
+    }
+  }, [])
+
+  // translating once here to prevent many repeated translations for each tip item
+  const tipHeader = t('Tips.Header')
+  const keyExtractor = (item: ITip) => item.id
+  const renderItem: ListRenderItem<ITip> = ({ item }) => {
+    return <Tip item={item} width={width} header={tipHeader} />
+  }
+
+  return (
+    <FlatList
+      ref={flatListRef}
+      data={tips}
+      getItemLayout={(_, index) => ({
+        length: tips.length,
+        offset: width * index,
+        index,
+      })}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      scrollEnabled={false}
+    />
+  )
+}
+
+export default TipCarousel

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -13,6 +13,8 @@ const translation = {
     "Message2022": "There was a problem extracting the did repository.",
     "Title2025": "BCSC Authentication",
     "Message2025": "There was a problem reported by BCSC.",
+    "Title2026": "Oops! Something went wrong",
+    "Message2026": "The app has encountered a problem. Try restarting the app.",
     "NoMessage": "No Message",
   },
   "CameraDisclosure": {
@@ -76,6 +78,36 @@ const translation = {
     "Test": "Test",
     "DeveloperMode": "Developer mode",
     "Toggle": "Toggle Developer Mode"
+  },
+  "Tips": {
+    "Header": "Tips",
+    "GettingReady": "Getting your wallet ready...",
+    "Tip1": "For extra security, BC Wallet locks the app after 5 minutes of inactivity",
+    "Tip2": "Unlike showing physical cards, you share only what is necessary from your credentials",
+    "Tip3": "Your credentials are stored only on this phone, nowhere else",
+    "Tip4": "Information is sent and received over an untraceable encrypted connection",
+    "Tip5": "Remember your PIN. If you forget it, you'll need to reinstall and re-add your credentials",
+    "Tip6": "Skip the PIN and unlock your wallet using your biometrics for a faster experience",
+    "Tip7": "Your most recently added credentials are placed at the top",
+    "Tip8": "Remove credentials in your wallet from the credential details screen",
+    "Tip9": "You can dismiss notifications without opening them by tapping “X” in the top right corner",
+    "Tip10": "Need help? Find answers in the help section within the “☰” button on the top left corner",
+    "Tip11": "You can turn on the camera flash if the QR code is hard to see",
+    "Tip12": "If the QR code isn't scanning, try increasing the screen's brightness",
+    "Tip13": "Information sent via your wallet is trusted by you and your Contacts you interact with",
+    "Tip14": "Even revoked or expired credentials can be usable if the organisation doesn't request for it",
+  },
+  "Init": {
+    "Starting": "Starting...",
+    "CheckingAuth": "Checking authentication...",
+    "FetchingPreferences": "Fetching preferences...",
+    "VerifyingOnboarding": "Verifying onboarding...",
+    "GettingCredentials": "Getting wallet credentials...",
+    "RegisteringTransports": "Registering transports...",
+    "InitializingAgent": "Initializing agent...",
+    "ConnectingLedgers": "Connecting to ledgers...",
+    "SettingAgent": "Setting agent...",
+    "Finishing": "Finishing..."
   }
 }
 

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -13,6 +13,8 @@ const translation = {
     "Message2022": "There was a problem extracting the did repository. (FR)",
     "Title2025": "BCSC Authentication (FR)",
     "Message2025": "There was a problem reported by BCSC. (FR)",
+    "Title2026": "Oops! Something went wrong (FR)",
+    "Message2026": "The app has encountered a problem. Try restarting the app. (FR)",
     "NoMessage": "No Message (FR)",
   },
   "CameraDisclosure": {
@@ -75,6 +77,36 @@ const translation = {
     "Test": "Test (FR)",
     "DeveloperMode": "Developer mode",
     "Toggle": "Toggle Developer Mode"
+  },
+  "Tips": {
+    "Header": "Tips (FR)",
+    "GettingReady": "Getting your wallet ready... (FR)",
+    "Tip1": "For extra security, BC Wallet locks the app after 5 minutes of inactivity (FR)",
+    "Tip2": "Unlike showing physical cards, you share only what is necessary from your credentials (FR)",
+    "Tip3": "Your credentials are stored only on this phone, nowhere else (FR)",
+    "Tip4": "Information is sent and received over an untraceable encrypted connection (FR)",
+    "Tip5": "Remember your PIN. If you forget it, you'll need to reinstall and re-add your credentials (FR)",
+    "Tip6": "Skip the PIN and unlock your wallet using your biometrics for a faster experience (FR)",
+    "Tip7": "Your most recently added credentials are placed at the top (FR)",
+    "Tip8": "Remove credentials in your wallet from the credential details screen (FR)",
+    "Tip9": "You can dismiss notifications without opening them by tapping “X” in the top right corner (FR)",
+    "Tip10": "Need help? Find answers in the help section within the “☰” button on the top left corner (FR)",
+    "Tip11": "You can turn on the camera flash if the QR code is hard to see (FR)",
+    "Tip12": "If the QR code isn't scanning, try increasing the screen's brightness (FR)",
+    "Tip13": "Information sent via your wallet is trusted by you and your Contacts you interact with (FR)",
+    "Tip14": "Even revoked or expired credentials can be usable if the organisation doesn't request for it (FR)",
+  },
+  "Init": {
+    "Starting": "Starting... (FR)",
+    "CheckingAuth": "Checking authentication... (FR)",
+    "FetchingPreferences": "Fetching preferences... (FR)",
+    "VerifyingOnboarding": "Verifying onboarding... (FR)",
+    "GettingCredentials": "Getting wallet credentials... (FR)",
+    "RegisteringTransports": "Registering transports... (FR)",
+    "InitializingAgent": "Initializing agent... (FR)",
+    "ConnectingLedgers": "Connecting to ledgers... (FR)",
+    "SettingAgent": "Setting agent... (FR)",
+    "Finishing": "Finishing... (FR)",
   }
 }
 

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -13,6 +13,8 @@ const translation = {
     "Message2022": "There was a problem extracting the did repository. (PT-BR)",
     "Title2025": "BCSC Authentication (PT-BR)",
     "Message2025": "There was a problem reported by BCSC. (PT-BR)",
+    "Title2026": "Oops! Something went wrong (PT-BR)",
+    "Message2026": "The app has encountered a problem. Try restarting the app. (PT-BR)",
     "NoMessage": "No Message (PT-BR)",
   },
   "CameraDisclosure": {
@@ -75,6 +77,36 @@ const translation = {
     "Test": "Test (PT-BR)",
     "DeveloperMode": "Developer mode",
     "Toggle": "Toggle Developer Mode"
+  },
+  "Tips": {
+    "Header": "Tips (PT-BR)",
+    "GettingReady": "Getting your wallet ready... (PT-BR)",
+    "Tip1": "For extra security, BC Wallet locks the app after 5 minutes of inactivity (PT-BR)",
+    "Tip2": "Unlike showing physical cards, you share only what is necessary from your credentials (PT-BR)",
+    "Tip3": "Your credentials are stored only on this phone, nowhere else (PT-BR)",
+    "Tip4": "Information is sent and received over an untraceable encrypted connection (PT-BR)",
+    "Tip5": "Remember your PIN. If you forget it, you'll need to reinstall and re-add your credentials (PT-BR)",
+    "Tip6": "Skip the PIN and unlock your wallet using your biometrics for a faster experience (PT-BR)",
+    "Tip7": "Your most recently added credentials are placed at the top (PT-BR)",
+    "Tip8": "Remove credentials in your wallet from the credential details screen (PT-BR)",
+    "Tip9": "You can dismiss notifications without opening them by tapping “X” in the top right corner (PT-BR)",
+    "Tip10": "Need help? Find answers in the help section within the “☰” button on the top left corner (PT-BR)",
+    "Tip11": "You can turn on the camera flash if the QR code is hard to see (PT-BR)",
+    "Tip12": "If the QR code isn't scanning, try increasing the screen's brightness (PT-BR)",
+    "Tip13": "Information sent via your wallet is trusted by you and your Contacts you interact with (PT-BR)",
+    "Tip14": "Even revoked or expired credentials can be usable if the organisation doesn't request for it (PT-BR)",
+  },
+  "Init": {
+    "Starting": "Starting... (PT-BR)",
+    "CheckingAuth": "Checking authentication... (PT-BR)",
+    "FetchingPreferences": "Fetching preferences... (PT-BR)",
+    "VerifyingOnboarding": "Verifying onboarding... (PT-BR)",
+    "GettingCredentials": "Getting wallet credentials... (PT-BR)",
+    "RegisteringTransports": "Registering transports... (PT-BR)",
+    "InitializingAgent": "Initializing agent... (PT-BR)",
+    "ConnectingLedgers": "Connecting to ledgers... (PT-BR)",
+    "SettingAgent": "Setting agent... (PT-BR)",
+    "Finishing": "Finishing... (PT-BR)",
   }
 }
 

--- a/app/src/screens/Splash.tsx
+++ b/app/src/screens/Splash.tsx
@@ -72,8 +72,22 @@ const Splash: React.FC = () => {
   const [stepText, setStepText] = useState<string>(t('Init.Starting'))
   const [progressPercent, setProgressPercent] = useState(0)
   const [initError, setInitError] = useState<Error | null>(null)
-  const setProgress = (text: string, percent: number) => {
-    setStepText(text)
+  const steps: string[] = [
+    t('Init.Starting'),
+    t('Init.CheckingAuth'),
+    t('Init.FetchingPreferences'),
+    t('Init.VerifyingOnboarding'),
+    t('Init.GettingCredentials'),
+    t('Init.RegisteringTransports'),
+    t('Init.InitializingAgent'),
+    t('Init.ConnectingLedgers'),
+    t('Init.SettingAgent'),
+    t('Init.Finishing'),
+  ]
+
+  const setStep = (stepIdx: number) => {
+    setStepText(steps[stepIdx])
+    const percent = Math.floor(((stepIdx + 1) / steps.length) * 100)
     setProgressPercent(percent)
   }
 
@@ -148,14 +162,14 @@ const Splash: React.FC = () => {
 
     const initOnboarding = async (): Promise<void> => {
       try {
-        setProgress(t('Init.CheckingAuth'), 3)
+        setStep(1)
         // load authentication attempts from storage
         const attemptData = await loadAuthAttempts()
 
         // load BCID person credential notification dismissed state from storage
         await loadPersonNotificationDismissed()
 
-        setProgress(t('Init.FetchingPreferences'), 7)
+        setStep(2)
         const preferencesData = await AsyncStorage.getItem(LocalStorageKeys.Preferences)
 
         if (preferencesData) {
@@ -167,7 +181,7 @@ const Splash: React.FC = () => {
           })
         }
 
-        setProgress(t('Init.VerifyingOnboarding'), 10)
+        setStep(3)
         const data = await AsyncStorage.getItem(LocalStorageKeys.Onboarding)
         if (data) {
           const dataAsJSON = JSON.parse(data) as OnboardingState
@@ -207,7 +221,7 @@ const Splash: React.FC = () => {
 
     const initAgent = async (): Promise<void> => {
       try {
-        setProgress(t('Init.GettingCredentials'), 20)
+        setStep(4)
         const credentials = await getWalletCredentials()
 
         if (!credentials?.id || !credentials.key) {
@@ -215,7 +229,7 @@ const Splash: React.FC = () => {
           return
         }
 
-        setProgress(t('Init.RegisteringTransports'), 35)
+        setStep(5)
         const options = {
           config: {
             label: 'BC Wallet',
@@ -239,16 +253,16 @@ const Splash: React.FC = () => {
         newAgent.registerOutboundTransport(wsTransport)
         newAgent.registerOutboundTransport(httpTransport)
 
-        setProgress(t('Init.InitializingAgent'), 55)
+        setStep(6)
         await newAgent.initialize()
 
-        setProgress(t('Init.ConnectingLedgers'), 80)
+        setStep(7)
         await newAgent.ledger.connectToPools()
 
-        setProgress(t('Init.SettingAgent'), 95)
+        setStep(8)
         setAgent(newAgent)
 
-        setProgress(t('Init.Finishing'), 100)
+        setStep(9)
         navigation.navigate(Stacks.TabStack as never)
       } catch (e: unknown) {
         setInitError(e as Error)


### PR DESCRIPTION
Resolves #829

Here is the new flow when a user starts the app:
![initialization](https://user-images.githubusercontent.com/32586431/214981157-cec8b6f0-d1ce-48a9-b902-7a9ad8d365b2.gif)

Here is the flow when an error occurs during initialization (manually thrown in this case):
![manual_error](https://user-images.githubusercontent.com/32586431/214981244-8041c05a-b4c6-4196-8a0c-ce5e56f3e82e.gif)

Here is the XD flow for reference:
https://xd.adobe.com/view/1fa13810-e597-4029-8e89-7643ee880a4b-4af2/

Things to note:
- The Splash screen remains mounted before and after a user has to enter their PIN, so the tip carousel continues scrolling in the background while they enter it. Not really a big issue imo but worth noting