### PR TITLE
fix: prevent back nav to splash page, run lint

### DIFF
--- a/app/src/assets/branding/credential-branding.ts
+++ b/app/src/assets/branding/credential-branding.ts
@@ -1,6 +1,5 @@
 import { types } from 'aries-bifold'
 
-// type CardLayoutOverlay10 = types.oca.CardLayoutOverlay10
 type CardLayoutOverlay11 = types.oca.CardLayoutOverlay11
 type MetaOverlay = types.oca.MetaOverlay
 type FormatOverlay = types.oca.FormatOverlay

--- a/app/src/assets/branding/credential-branding.ts
+++ b/app/src/assets/branding/credential-branding.ts
@@ -1,6 +1,6 @@
 import { types } from 'aries-bifold'
 
-type CardLayoutOverlay10 = types.oca.CardLayoutOverlay10
+// type CardLayoutOverlay10 = types.oca.CardLayoutOverlay10
 type CardLayoutOverlay11 = types.oca.CardLayoutOverlay11
 type MetaOverlay = types.oca.MetaOverlay
 type FormatOverlay = types.oca.FormatOverlay

--- a/app/src/components/AddCredentialSlider.tsx
+++ b/app/src/components/AddCredentialSlider.tsx
@@ -2,7 +2,7 @@ import { CredentialMetadataKeys, CredentialState } from '@aries-framework/core'
 import { useAgent, useCredentialByState } from '@aries-framework/react-hooks'
 import { useNavigation } from '@react-navigation/core'
 import { useTheme, useStore, Screens, Stacks } from 'aries-bifold'
-import React, { ReducerAction, useEffect, useState, useCallback } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DeviceEventEmitter, Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
@@ -17,7 +17,7 @@ const AddCredentialSlider: React.FC = () => {
   const { ColorPallet, TextTheme } = useTheme()
   const { agent } = useAgent()
   const { t } = useTranslation()
-  const [store, dispatch] = useStore<BCState>()
+  const [store] = useStore<BCState>()
   const [showGetFoundationCredential, setShowGetFoundationCredential] = useState<boolean>(false)
   const [addCredentialPressed, setAddCredentialPressed] = useState<boolean>(false)
   const [workflowInFlight, setWorkflowInFlight] = useState<boolean>(false)

--- a/app/src/helpers/BCIDHelper.ts
+++ b/app/src/helpers/BCIDHelper.ts
@@ -4,7 +4,7 @@ import {
   CredentialMetadataKeys,
 } from '@aries-framework/core'
 import { BifoldError, Agent, EventTypes as BifoldEventTypes } from 'aries-bifold'
-import React, { ReducerAction } from 'react'
+import React from 'react'
 import { TFunction } from 'react-i18next'
 import { Linking, Platform, DeviceEventEmitter } from 'react-native'
 import { InAppBrowser, RedirectResult } from 'react-native-inappbrowser-reborn'

--- a/app/src/screens/PersonCredential.tsx
+++ b/app/src/screens/PersonCredential.tsx
@@ -3,18 +3,7 @@ import { useNavigation } from '@react-navigation/core'
 import { Button, ButtonType, Screens, useStore, useTheme } from 'aries-bifold'
 import React, { useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import {
-  StyleSheet,
-  Text,
-  View,
-  // Image,
-  Dimensions,
-  // ImageBackground,
-  TouchableOpacity,
-  Linking,
-  ScrollView,
-  SafeAreaView,
-} from 'react-native'
+import { StyleSheet, Text, View, Dimensions, TouchableOpacity, Linking, ScrollView, SafeAreaView } from 'react-native'
 
 import LoadingIcon from '../components/LoadingIcon'
 import { startFlow } from '../helpers/BCIDHelper'
@@ -26,7 +15,6 @@ const PersonCredentialScreen: React.FC = () => {
   const navigation = useNavigation()
   const [store, dispatch] = useStore<BCState>()
 
-  // const paddingHorizontal = 10
   const transparent = 'rgba(0,0,0,0)'
   const borderRadius = 15
   const borderPadding = 8
@@ -105,61 +93,6 @@ const PersonCredentialScreen: React.FC = () => {
     <SafeAreaView style={styles.pageContainer}>
       <ScrollView contentContainerStyle={[styles.pageContent]}>
         <View>
-          {/* <View style={[styles.container]}>
-            <View style={[styles.flexGrow]}>
-              <ImageBackground
-                source={require('../assets/branding/service-bc-id-card.png')}
-                style={[styles.flexGrow]}
-                imageStyle={{ borderRadius }}
-              >
-                <View style={[styles.outerHeaderContainer]}>
-                  <View style={[styles.innerHeaderContainer]}>
-                    <Image
-                      source={require('../assets/branding/service-bc-header-logo.png')}
-                      style={{
-                        flex: 1,
-                        resizeMode: 'contain',
-                        maxHeight: styles.outerHeaderContainer.height - borderPadding,
-                      }}
-                    />
-                    <Text
-                      numberOfLines={1}
-                      ellipsizeMode="tail"
-                      style={[
-                        TextTheme.label,
-                        {
-                          color: ColorPallet.grayscale.white,
-                          paddingHorizontal: 0.5 * paddingHorizontal,
-                          flex: 3,
-                          textAlignVertical: 'center',
-                        },
-                      ]}
-                      maxFontSizeMultiplier={1}
-                    >
-                      {t('PersonCredential.Issuer')}
-                    </Text>
-                    <Text
-                      numberOfLines={1}
-                      ellipsizeMode="tail"
-                      style={[
-                        TextTheme.label,
-                        {
-                          color: ColorPallet.grayscale.white,
-                          textAlign: 'right',
-                          paddingHorizontal: 0.5 * paddingHorizontal,
-                          flex: 4,
-                          textAlignVertical: 'center',
-                        },
-                      ]}
-                      maxFontSizeMultiplier={1}
-                    >
-                      {t('PersonCredential.Name')}
-                    </Text>
-                  </View>
-                </View>
-              </ImageBackground>
-            </View>
-          </View> */}
           <View>
             <Text style={TextTheme.normal}>
               {t('PersonCredential.Description') + ' '}

--- a/app/src/screens/PersonCredential.tsx
+++ b/app/src/screens/PersonCredential.tsx
@@ -1,15 +1,15 @@
 import { useAgent } from '@aries-framework/react-hooks'
 import { useNavigation } from '@react-navigation/core'
 import { Button, ButtonType, Screens, useStore, useTheme } from 'aries-bifold'
-import React, { ReducerAction, useState, useCallback } from 'react'
+import React, { useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   StyleSheet,
   Text,
   View,
-  Image,
+  // Image,
   Dimensions,
-  ImageBackground,
+  // ImageBackground,
   TouchableOpacity,
   Linking,
   ScrollView,
@@ -26,7 +26,7 @@ const PersonCredentialScreen: React.FC = () => {
   const navigation = useNavigation()
   const [store, dispatch] = useStore<BCState>()
 
-  const paddingHorizontal = 10
+  // const paddingHorizontal = 10
   const transparent = 'rgba(0,0,0,0)'
   const borderRadius = 15
   const borderPadding = 8

--- a/app/src/screens/Splash.tsx
+++ b/app/src/screens/Splash.tsx
@@ -11,6 +11,7 @@ import { useAgent } from '@aries-framework/react-hooks'
 import { agentDependencies } from '@aries-framework/react-native'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { useNavigation } from '@react-navigation/core'
+import { CommonActions } from '@react-navigation/native'
 import {
   LocalStorageKeys,
   DispatchAction,
@@ -204,22 +205,42 @@ const Splash: React.FC = () => {
           })
 
           if (onboardingComplete(dataAsJSON) && !attemptData?.lockoutDate) {
-            navigation.navigate(Screens.EnterPIN as never)
+            navigation.dispatch(
+              CommonActions.reset({
+                index: 0,
+                routes: [{ name: Screens.EnterPIN }],
+              })
+            )
             return
           } else if (onboardingComplete(dataAsJSON) && attemptData?.lockoutDate) {
             // return to lockout screen if lockout date is set
-            navigation.navigate(Screens.AttemptLockout as never)
+            navigation.dispatch(
+              CommonActions.reset({
+                index: 0,
+                routes: [{ name: Screens.AttemptLockout }],
+              })
+            )
             return
           }
 
           // If onboarding was interrupted we need to pickup from where we left off.
-          navigation.navigate(resumeOnboardingAt(dataAsJSON) as never)
+          navigation.dispatch(
+            CommonActions.reset({
+              index: 0,
+              routes: [{ name: resumeOnboardingAt(dataAsJSON) }],
+            })
+          )
 
           return
         }
 
         // We have no onboarding state, starting from step zero.
-        navigation.navigate(Screens.Onboarding as never)
+        navigation.dispatch(
+          CommonActions.reset({
+            index: 0,
+            routes: [{ name: Screens.Onboarding }],
+          })
+        )
       } catch (e: unknown) {
         setInitError(e as Error)
       }
@@ -276,7 +297,12 @@ const Splash: React.FC = () => {
         setAgent(newAgent)
 
         setStep(9)
-        navigation.navigate(Stacks.TabStack as never)
+        navigation.dispatch(
+          CommonActions.reset({
+            index: 0,
+            routes: [{ name: Stacks.TabStack }],
+          })
+        )
       } catch (e: unknown) {
         setInitError(e as Error)
       }


### PR DESCRIPTION
Resetting the nav stack whenever the splash page is navigated from, this PR in combination with https://github.com/hyperledger/aries-mobile-agent-react-native/pull/647 should fix the majority of the back navigating issues we have been having with the iOS swipe-back and the Android hardware back button.

I also ran the linter and made the changes it demanded. In most cases where there were unused variables/imports I simply commented them out since you may want them for reference.