### PR TITLE
fix: update ruby version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Configure ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
 
       - name: What XCode are we using?
         run: |


### PR DESCRIPTION
Updating the ruby used by one minor version. Hoping that fixes the cocoapods issue, we'll see once the action runs. Here is the error message from the current cocoapods issue:
<img width="1310" alt="Screenshot 2023-03-06 at 9 15 46 AM" src="https://user-images.githubusercontent.com/32586431/223222322-db280fbb-77ac-455f-97ed-ff6dc0797b6d.png">
