### PR TITLE
fix: change product name to BCWallet from AriesBifold

### DIFF
--- a/app/ios/AriesBifold.xcodeproj/project.pbxproj
+++ b/app/ios/AriesBifold.xcodeproj/project.pbxproj
@@ -52,7 +52,7 @@
 		00E356EE1AD99517003FC87E /* AriesBifoldTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AriesBifoldTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* AriesBifoldTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AriesBifoldTests.m; sourceTree = "<group>"; };
-		13B07F961A680F5B00A75B9A /* AriesBifold.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AriesBifold.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07F961A680F5B00A75B9A /* BCWallet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BCWallet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = AriesBifold/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = AriesBifold/AppDelegate.m; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = AriesBifold/Images.xcassets; sourceTree = "<group>"; };
@@ -177,7 +177,7 @@
 		83CBBA001A601CBA00E9B192 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				13B07F961A680F5B00A75B9A /* AriesBifold.app */,
+				13B07F961A680F5B00A75B9A /* BCWallet.app */,
 				00E356EE1AD99517003FC87E /* AriesBifoldTests.xctest */,
 			);
 			name = Products;
@@ -238,7 +238,7 @@
 			);
 			name = AriesBifold;
 			productName = AriesBifold;
-			productReference = 13B07F961A680F5B00A75B9A /* AriesBifold.app */;
+			productReference = 13B07F961A680F5B00A75B9A /* BCWallet.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -561,7 +561,7 @@
 					"-lc++",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = ca.bc.gov.BCWallet;
-				PRODUCT_NAME = AriesBifold;
+				PRODUCT_NAME = BCWallet;
 				PROVISIONING_PROFILE_SPECIFIER = "BC Secure Wallet - 2023";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -599,7 +599,7 @@
 					"-lc++",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = ca.bc.gov.BCWallet;
-				PRODUCT_NAME = AriesBifold;
+				PRODUCT_NAME = BCWallet;
 				PROVISIONING_PROFILE_SPECIFIER = "BC Secure Wallet - 2023";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/app/ios/AriesBifold.xcodeproj/xcshareddata/xcschemes/AriesBifold.xcscheme
+++ b/app/ios/AriesBifold.xcodeproj/xcshareddata/xcschemes/AriesBifold.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-               BuildableName = "AriesBifold.app"
+               BuildableName = "BCWallet.app"
                BlueprintName = "AriesBifold"
                ReferencedContainer = "container:AriesBifold.xcodeproj">
             </BuildableReference>
@@ -55,7 +55,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-            BuildableName = "AriesBifold.app"
+            BuildableName = "BCWallet.app"
             BlueprintName = "AriesBifold"
             ReferencedContainer = "container:AriesBifold.xcodeproj">
          </BuildableReference>
@@ -72,7 +72,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-            BuildableName = "AriesBifold.app"
+            BuildableName = "BCWallet.app"
             BlueprintName = "AriesBifold"
             ReferencedContainer = "container:AriesBifold.xcodeproj">
          </BuildableReference>

--- a/app/ios/AriesBifold/Info.plist
+++ b/app/ios/AriesBifold/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 	<dict>
 		<key>NSFaceIDUsageDescription</key>
-		<string>$(PRODUCT_NAME) Wants to use your FaceID/TouchID to Authenticate your Identity</string>
+		<string>$(PRODUCT_NAME) wants to use your FaceID/TouchID to authenticate your identity</string>
 		<key>CFBundleDevelopmentRegion</key>
 		<string>en</string>
 		<key>CFBundleDisplayName</key>


### PR DESCRIPTION
I didn't change all references to `AriesBifold` in the repo, because that ended up just being too hairy of a job, but all instances where users will see the name (in prompts and such) are now changed to either `BC Wallet` or `BCWallet`. I also fixed the sentence casing of the faceID usage description (pre-screenshot unfortunately). Here are some pics:
![IMG_0013](https://user-images.githubusercontent.com/32586431/227081634-943fdae2-ec5e-4c15-bf9c-fc1cd87a2d54.PNG)
![IMG_0014](https://user-images.githubusercontent.com/32586431/227081644-3d9f8efe-184d-478b-835f-84755c5d0b53.PNG)
![IMG_0015](https://user-images.githubusercontent.com/32586431/227081649-dfcd8e96-3e51-49db-8a78-a4d7a27c0e7a.PNG)


