### PR TITLE
feat: added issuer_did restriction to request template

### DIFF
--- a/app/src/request-templates.ts
+++ b/app/src/request-templates.ts
@@ -15,11 +15,11 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
           requestedAttributes: [
             {
               name: 'given_names',
-              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0' }],
+              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }],
             },
             {
               name: 'family_name',
-              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0' }],
+              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0', issuer_did: 'XUxBrVSALWHLeycAUhrNr9'}],
             },
           ],
         },
@@ -39,7 +39,7 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
           requestedAttributes: [
             {
               names: ['given_names', 'family_name'],
-              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0' }],
+              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }],
             },
           ],
           requestedPredicates: [
@@ -47,7 +47,7 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
               name: 'birthdate_dateint',
               predicateType: PredicateType.GreaterThanOrEqualTo,
               predicateValue: 18,
-              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0' }],
+              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }],
             },
           ],
         },
@@ -69,7 +69,7 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
               name: 'birthdate_dateint',
               predicateType: PredicateType.GreaterThanOrEqualTo,
               predicateValue: 18,
-              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0' }],
+              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }],
             },
           ],
         },
@@ -89,7 +89,7 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
           requestedAttributes: [
             {
               names: ['Given Name', 'Surname', 'PPID', 'Member Status'],
-              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Member Card:1.5.1' }],
+              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Member Card:1.5.1', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }],
             },
           ],
         },
@@ -109,7 +109,7 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
           requestedAttributes: [
             {
               names: ['given_names', 'family_name'],
-              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0' }],
+              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }],
             },
           ],
         },
@@ -118,7 +118,7 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
           requestedAttributes: [
             {
               names: ['Given Name', 'Surname', 'PPID', 'Member Status'],
-              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Member Card:1.5.1' }],
+              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Member Card:1.5.1', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }],
             },
           ],
         },
@@ -141,7 +141,7 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
               predicateType: PredicateType.GreaterThanOrEqualTo,
               predicateValue: 18,
               parameterizable: true,
-              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0' }],
+              restrictions: [{ schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }],
             },
           ],
         },


### PR DESCRIPTION
only restricting by the schema name allows users to issue themselves a credential that uses the specified schema. This credential would satisfy the proof request even though it was not issued by the intended issuer. I added the issuer_did restriction to ensure that the credential was issued by LSBC or IDIM