### PR TITLE
fix: update image assets

### DIFF
--- a/app/src/theme.ts
+++ b/app/src/theme.ts
@@ -767,7 +767,7 @@ const PINInputTheme = {
   },
 }
 
-export const BCImageAssets = {
+export const Assets = {
   ...BifoldImageAssets,
   svg: {
     logo: Logo,
@@ -806,5 +806,5 @@ export const defaultTheme: Theme = {
   DialogTheme,
   LoadingTheme,
   PINInputTheme,
-  Assets: BCImageAssets,
+  Assets,
 }

--- a/app/src/theme.ts
+++ b/app/src/theme.ts
@@ -769,9 +769,7 @@ const PINInputTheme = {
 
 export const Assets = {
   ...BifoldImageAssets,
-  svg: {
-    logo: Logo,
-  },
+  svg: { ...BifoldImageAssets.svg, Logo },
   img: {
     logoSecondary: {
       src: require('./assets/img/logo-large.png'),

--- a/app/src/theme.ts
+++ b/app/src/theme.ts
@@ -1,4 +1,4 @@
-import { Theme } from 'aries-bifold'
+import { ImageAssets as BifoldImageAssets, Theme } from 'aries-bifold'
 import { StyleSheet } from 'react-native'
 
 import Logo from './assets/img/logo-with-text.svg'
@@ -767,7 +767,8 @@ const PINInputTheme = {
   },
 }
 
-export const Assets = {
+export const BCImageAssets = {
+  ...BifoldImageAssets,
   svg: {
     logo: Logo,
   },
@@ -785,7 +786,7 @@ export const Assets = {
       width: 170,
     },
   },
-} as Theme['Assets']
+}
 
 export const defaultTheme: Theme = {
   ColorPallet,
@@ -805,5 +806,5 @@ export const defaultTheme: Theme = {
   DialogTheme,
   LoadingTheme,
   PINInputTheme,
-  Assets,
+  Assets: BCImageAssets,
 }


### PR DESCRIPTION
After some theme changes in Bifold the image assets were not being imported properly to BC Wallet. This fixes the issue.

Fixes #1078