### PR TITLE
fix: fixed date of birth check in proof template

### DIFF
--- a/app/src/request-templates.ts
+++ b/app/src/request-templates.ts
@@ -1,6 +1,12 @@
 import { PredicateType } from '@aries-framework/core'
 import { ProofRequestTemplate, ProofRequestType } from 'aries-bifold'
 
+const calculatePreviousYear = (yearOffset: number) => {
+  const pastDate = new Date()
+  pastDate.setFullYear(pastDate.getFullYear() - yearOffset)
+  return parseInt(pastDate.toISOString().split('T')[0].replace(/-/g, ''))
+}
+
 export const proofRequestTemplates: Array<ProofRequestTemplate> = [
   {
     id: 'BC:5:FullName:0.0.1:indy',
@@ -70,7 +76,7 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
             {
               name: 'birthdate_dateint',
               predicateType: PredicateType.GreaterThanOrEqualTo,
-              predicateValue: 18,
+              predicateValue: calculatePreviousYear(19),
               restrictions: [
                 // IDIM Person credential
                 { schema_id: 'XpgeQa93eZvGSZBZef3PHn:2:Person:1.0', issuer_did: '7xjfawcnyTUcduWVysLww5' }, // SIT
@@ -100,7 +106,7 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
             {
               name: 'birthdate_dateint',
               predicateType: PredicateType.GreaterThanOrEqualTo,
-              predicateValue: 18,
+              predicateValue: calculatePreviousYear(19),
               restrictions: [
                 // IDIM Person credential
                 { schema_id: 'XpgeQa93eZvGSZBZef3PHn:2:Person:1.0', issuer_did: '7xjfawcnyTUcduWVysLww5' }, // SIT
@@ -201,7 +207,7 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
             {
               name: 'birthdate_dateint',
               predicateType: PredicateType.GreaterThanOrEqualTo,
-              predicateValue: 18,
+              predicateValue: calculatePreviousYear(19),
               parameterizable: true,
               restrictions: [
                 // IDIM Person credential


### PR DESCRIPTION
Previously the request template was checking that the date of birth in a credential was greater than or equal to 18. The date of birth in most credentials uses the `YYYYMMDD` format. This means that the birthdate would always pass the check since any date string will resolve to a number greater than 18.

I changed the request template to calculate the date 19 years before today and to use that in a proof request instead of the number 18

Resolves: #1084 