### PR TITLE
fix: modal covers all

### DIFF
--- a/app/src/screens/WebDisplay.tsx
+++ b/app/src/screens/WebDisplay.tsx
@@ -15,12 +15,12 @@ const WebDisplay: React.FC<WebDisplayProps> = ({ destinationUrl, exitUrl, visibl
       flex: 1,
       justifyContent: 'center',
       alignItems: 'center',
-      marginTop: 54,
+      marginTop: 32,
     },
   })
 
   return (
-    <Modal animationType="slide" transparent={true} visible={visible}>
+    <Modal animationType="slide" transparent={false} visible={visible}>
       <WebView
         style={styles.container}
         source={{ uri: destinationUrl }}


### PR DESCRIPTION
As per the feature feedback the modal now covers the entire screen hiding the top status and nav bars. Users can use the built in EXIT button to return to the home screen.

Fixes #1045

<img width="426" alt="Screenshot 2023-05-15 at 2 35 35 PM" src="https://github.com/bcgov/bc-wallet-mobile/assets/390891/9b63ab59-c27a-4bf9-8789-3f5ee3474f80">


