### PR TITLE
fix: i18n support

### DIFF
--- a/app/src/assets/branding/credential-branding.ts
+++ b/app/src/assets/branding/credential-branding.ts
@@ -115,7 +115,7 @@ const createMemberCardBundle = (demo = false) => {
         language: 'en',
         name: 'Member Card',
         issuerName: demo ? 'Law Society of BC DEMO' : 'Law Society of BC',
-        watermark: demo ? "NON-PRODUCTION" : undefined
+        watermark: demo ? 'NON-PRODUCTION' : undefined,
       } as MetaOverlay,
       memberCardOverlay,
     ],
@@ -131,7 +131,7 @@ const createPersonCredentialBundle = (backgroundImageSource: string, verified = 
       language: 'en',
       name: 'Person',
       issuerName: demo ? 'Service BC DEMO' : 'Service BC',
-      watermark: demo ? "NON-PRODUCTION" : undefined,
+      watermark: demo ? 'NON-PRODUCTION' : undefined,
     })
     metaOverlays.push({
       captureBase: '',
@@ -139,7 +139,7 @@ const createPersonCredentialBundle = (backgroundImageSource: string, verified = 
       language: 'fr',
       name: 'Personne',
       issuerName: demo ? 'Service BC DEMO' : 'Service BC',
-      watermark: demo ? "NON-PRODUCTION (FR)" : undefined
+      watermark: demo ? 'NON-PRODUCTION (FR)' : undefined,
     })
   } else {
     metaOverlays.push({
@@ -197,7 +197,7 @@ const createPersonCredentialBundle = (backgroundImageSource: string, verified = 
         language: 'en',
         attributeFormats: {
           birthdate_dateint: 'YYYYMMDD',
-          picture: 'image/jpeg'
+          picture: 'image/jpeg',
         },
       } as FormatOverlay,
       {
@@ -205,7 +205,7 @@ const createPersonCredentialBundle = (backgroundImageSource: string, verified = 
         type: 'spec/overlays/character_encoding/1.0',
         language: 'en',
         attributeCharacterEncoding: {
-          picture: 'base64'
+          picture: 'base64',
         },
       } as CharacterEncodingOverlay,
       {
@@ -229,8 +229,8 @@ const createPersonCredentialBundle = (backgroundImageSource: string, verified = 
       } as LabelOverlay,
     ],
   }
-  if (demo && overlay.captureBase.attributes){
-    overlay.captureBase.attributes.picture = 'Binary' 
+  if (demo && overlay.captureBase.attributes) {
+    overlay.captureBase.attributes.picture = 'Binary'
   }
   return overlay
 }

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -16,6 +16,8 @@ import EmptyList from './components/EmptyList'
 import HomeContentView from './components/HomeContentView'
 import { useNotifications } from './hooks/notifications'
 import en from './localization/en'
+import fr from './localization/fr'
+import ptBr from './localization/pt-br'
 import { proofRequestTemplates } from './request-templates'
 import Developer from './screens/Developer'
 import { pages } from './screens/OnboardingPages'
@@ -27,6 +29,8 @@ import { defaultTheme as theme } from './theme'
 
 const localization = merge({}, translationResources, {
   en: { translation: en },
+  fr: { translation: fr },
+  'pt-BR': { translation: ptBr },
 })
 
 const selectedLedgers = indyLedgers.filter((item) => !item.id.startsWith('Indicio'))

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -39,6 +39,19 @@ const translation = {
     "EmptyList": "Your wallet is empty.",
     "AddFirstCredential": "Add your first credential"
   },
+  "Onboarding": {
+    "Welcome": "Welcome",
+    "WelcomeParagraph1": "BC Wallet lets you receive, store and use digital credentials.",
+    "WelcomeParagraph2": "It is highly secure, and helps protect your privacy online.",
+    "WelcomeParagraph3": "BC Wallet is currently in its early stages and the technology is being explored. Most people will not have a use for BC Wallet yet, because very few digital credentials are available.",
+    "StoredSecurelyTitle": "Digital credentials, stored securely",
+    "StoredSecurelyBody": "BC Wallet holds digital credentials—the digital versions of things like licenses, identities and permits.\n\nThey are stored securely, only on this device.",
+    "UsingCredentialsTitle": "Receiving and using credentials",
+    "UsingCredentialsBody": "To receive and use credentials you use the “Scan” feature in the app to scan a special QR code.\n\nInformation is sent and received over a private, encrypted connection.",
+    "PrivacyConfidentiality": "Privacy and confidentiality",
+    "PrivacyParagraph": "You approve every use of information from your BC Wallet. You also only share what is needed for a situation.\n\nThe Government of British Columbia is not told when you use your digital credentials.",
+    "GetStarted": "Get Started",
+  },
   "Screens": {
     "Onboarding": "BC Wallet",
     "Settings": "Menu",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -39,6 +39,19 @@ const translation = {
     "EmptyList": "Your wallet is empty. (FR)",
     "AddFirstCredential": "Add your first credential (FR)"
   },
+  "Onboarding": {
+    "Welcome": "Welcome (FR)",
+    "WelcomeParagraph1": "BC Wallet lets you receive, store and use digital credentials. (FR)",
+    "WelcomeParagraph2": "It is highly secure, and helps protect your privacy online. (FR)",
+    "WelcomeParagraph3": "BC Wallet is currently in its early stages and the technology is being explored. Most people will not have a use for BC Wallet yet, because very few digital credentials are available. (FR)",
+    "StoredSecurelyTitle": "Digital credentials, stored securely (FR)",
+    "StoredSecurelyBody": "BC Wallet holds digital credentials—the digital versions of things like licenses, identities and permits.\n\nThey are stored securely, only on this device. (FR)",
+    "UsingCredentialsTitle": "Receiving and using credentials (FR)",
+    "UsingCredentialsBody": "To receive and use credentials you use the “Scan” feature in the app to scan a special QR code.\n\nInformation is sent and received over a private, encrypted connection. (FR)",
+    "PrivacyConfidentiality": "Privacy and confidentiality (FR)",
+    "PrivacyParagraph": "You approve every use of information from your BC Wallet. You also only share what is needed for a situation.\n\nThe Government of British Columbia is not told when you use your digital credentials. (FR)",
+    "GetStarted": "Get Started (FR)",
+  },
   "Screens": {
     "Onboarding": "BC Wallet (FR)",
     "Settings": "Menu (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -39,6 +39,19 @@ const translation = {
     "EmptyList": "Your wallet is empty. (PT-BR)",
     "AddFirstCredential": "Add your first credential (PT-BR)"
   },
+  "Onboarding": {
+    "Welcome": "Welcome (PT-BR)",
+    "WelcomeParagraph1": "BC Wallet lets you receive, store and use digital credentials. (PT-BR)",
+    "WelcomeParagraph2": "It is highly secure, and helps protect your privacy online. (PT-BR)",
+    "WelcomeParagraph3": "BC Wallet is currently in its early stages and the technology is being explored. Most people will not have a use for BC Wallet yet, because very few digital credentials are available. (PT-BR)",
+    "StoredSecurelyTitle": "Digital credentials, stored securely (PT-BR)",
+    "StoredSecurelyBody": "BC Wallet holds digital credentials—the digital versions of things like licenses, identities and permits.\n\nThey are stored securely, only on this device. (PT-BR)",
+    "UsingCredentialsTitle": "Receiving and using credentials (PT-BR)",
+    "UsingCredentialsBody": "To receive and use credentials you use the “Scan” feature in the app to scan a special QR code.\n\nInformation is sent and received over a private, encrypted connection. (PT-BR)",
+    "PrivacyConfidentiality": "Privacy and confidentiality (PT-BR)",
+    "PrivacyParagraph": "You approve every use of information from your BC Wallet. You also only share what is needed for a situation.\n\nThe Government of British Columbia is not told when you use your digital credentials. (PT-BR)",
+    "GetStarted": "Get Started (PT-BR)",
+  },
   "Screens": {
     "Onboarding": "BC Wallet (PT-BR)",
     "Settings": "Menu (PT-BR)",

--- a/app/src/screens/OnboardingPages.tsx
+++ b/app/src/screens/OnboardingPages.tsx
@@ -1,5 +1,6 @@
 import { useStore, Button, ButtonType, ITheme, createStyles, GenericFn, testIdWithKey } from 'aries-bifold'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { Text, View } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
 import { SvgProps } from 'react-native-svg'
@@ -10,6 +11,7 @@ import SecureImage from '../assets/img/secure-image.svg'
 
 const EndPage = (onTutorialCompleted: GenericFn, theme: ITheme['OnboardingTheme']) => {
   const [store] = useStore()
+  const { t } = useTranslation()
   const defaultStyle = createStyles(theme)
   const imageDisplayOptions = {
     fill: theme.imageDisplayOptions.fill,
@@ -23,13 +25,8 @@ const EndPage = (onTutorialCompleted: GenericFn, theme: ITheme['OnboardingTheme'
           <SecureImage {...imageDisplayOptions} />
         </View>
         <View style={{ marginBottom: 20 }}>
-          <Text style={[defaultStyle.headerText, { fontSize: 18 }]}>Privacy and confidentiality</Text>
-          <Text style={[defaultStyle.bodyText, { marginTop: 25 }]}>
-            You approve every use of information from your BC Wallet. You also only share what is needed for a
-            situation.
-            {'\n\n'}
-            The Government of British Columbia is not told when you use your digital credentials.
-          </Text>
+          <Text style={[defaultStyle.headerText, { fontSize: 18 }]}>{t('Onboarding.PrivacyConfidentiality')}</Text>
+          <Text style={[defaultStyle.bodyText, { marginTop: 25 }]}>{t('Onboarding.PrivacyParagraph')}</Text>
         </View>
       </ScrollView>
       {!(store.onboarding.didCompleteTutorial && store.authentication.didAuthenticate) && (
@@ -40,8 +37,8 @@ const EndPage = (onTutorialCompleted: GenericFn, theme: ITheme['OnboardingTheme'
           }}
         >
           <Button
-            title={'Get Started'}
-            accessibilityLabel={'Get Started'}
+            title={t('Onboarding.GetStarted')}
+            accessibilityLabel={t('Onboarding.GetStarted')}
             testID={testIdWithKey('GetStarted')}
             onPress={onTutorialCompleted}
             buttonType={ButtonType.Primary}
@@ -53,20 +50,14 @@ const EndPage = (onTutorialCompleted: GenericFn, theme: ITheme['OnboardingTheme'
 }
 
 const StartPages = (theme: ITheme) => {
+  const { t } = useTranslation()
   const defaultStyle = createStyles(theme)
   return (
     <ScrollView style={{ padding: 20, paddingTop: 30 }}>
-      <Text style={[defaultStyle.headerText]}>Welcome</Text>
-      <Text style={[defaultStyle.bodyText, { marginTop: 25 }]}>
-        BC Wallet lets you receive, store and use digital credentials.
-      </Text>
-      <Text style={[defaultStyle.bodyText, { marginTop: 25 }]}>
-        It is highly secure, and helps protect your privacy online.
-      </Text>
-      <Text style={[defaultStyle.bodyText, { marginTop: 25 }]}>
-        BC Wallet is currently in its early stages and the technology is being explored. Most people will not have a use
-        for BC Wallet yet, because very few digital credentials are available.
-      </Text>
+      <Text style={[defaultStyle.headerText]}>{t('Onboarding.Welcome')}</Text>
+      <Text style={[defaultStyle.bodyText, { marginTop: 25 }]}>{t('Onboarding.WelcomeParagraph1')}</Text>
+      <Text style={[defaultStyle.bodyText, { marginTop: 25 }]}>{t('Onboarding.WelcomeParagraph2')}</Text>
+      <Text style={[defaultStyle.bodyText, { marginTop: 25 }]}>{t('Onboarding.WelcomeParagraph3')}</Text>
     </ScrollView>
   )
 }
@@ -78,17 +69,18 @@ const guides: Array<{
 }> = [
   {
     image: CredentialList,
-    title: 'Digital credentials, stored securely',
-    body: 'BC Wallet holds digital credentials—the digital versions of things like licenses, identities and permits.\n\nThey are stored securely, only on this device.',
+    title: 'Onboarding.StoredSecurelyTitle',
+    body: 'Onboarding.StoredSecurelyBody',
   },
   {
     image: ScanShare,
-    title: 'Receiving and using credentials',
-    body: 'To receive and use credentials you use the “Scan” feature in the app to scan a special QR code.\n\nInformation is sent and received over a private, encrypted connection.',
+    title: 'Onboarding.UsingCredentialsTitle',
+    body: 'Onboarding.UsingCredentialsBody',
   },
 ]
 
 const CreatePageWith = (image: React.FC<SvgProps>, title: string, body: string, theme: ITheme['OnboardingTheme']) => {
+  const { t } = useTranslation()
   const defaultStyle = createStyles(theme)
   const imageDisplayOptions = {
     fill: theme.imageDisplayOptions.fill,
@@ -99,8 +91,8 @@ const CreatePageWith = (image: React.FC<SvgProps>, title: string, body: string, 
     <ScrollView style={{ padding: 20 }}>
       <View style={{ alignItems: 'center' }}>{image(imageDisplayOptions)}</View>
       <View style={{ marginBottom: 20 }}>
-        <Text style={[defaultStyle.headerText, { fontSize: 18 }]}>{title}</Text>
-        <Text style={[defaultStyle.bodyText, { marginTop: 25 }]}>{body}</Text>
+        <Text style={[defaultStyle.headerText, { fontSize: 18 }]}>{t(title)}</Text>
+        <Text style={[defaultStyle.bodyText, { marginTop: 25 }]}>{t(body)}</Text>
       </View>
     </ScrollView>
   )


### PR DESCRIPTION
Took me a long time to find the root cause of this issue. Turns out none of the BC Wallet French or Portuguese translations were being applied anywhere. This PR fixes that as well as adds some i18n for the onboarding pages.

![i18n](https://github.com/bcgov/bc-wallet-mobile/assets/32586431/922ea839-f414-4b0f-89ab-ae5d9f82bfe3)
