### PR TITLE
fix: get settings icons to show up again

### DIFF
--- a/app/src/theme.ts
+++ b/app/src/theme.ts
@@ -496,7 +496,7 @@ export const SettingsTheme = {
     marginBottom: 8,
   },
   groupBackground: ColorPallet.brand.secondaryBackground,
-  iconColor: ColorPallet.grayscale.white,
+  iconColor: ColorPallet.grayscale.darkGrey,
   text: {
     ...TextTheme.caption,
     color: ColorPallet.grayscale.darkGrey,


### PR DESCRIPTION
Was a theming issue. Here's what Settings looks like now:
![settings](https://github.com/bcgov/bc-wallet-mobile/assets/32586431/7809f44f-22d2-4b0f-91a5-418a100d92c4)
