### PR TITLE
feat: added automatic screen reading for tips on loading

### DIFF
--- a/app/src/components/TipCarousel.tsx
+++ b/app/src/components/TipCarousel.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, View, Text, useWindowDimensions, FlatList, ListRenderItem } from 'react-native'
+import { StyleSheet, View, Text, useWindowDimensions, FlatList, ListRenderItem, AccessibilityInfo } from 'react-native'
 
 // used for randomizng tip order
 const shuffleArray = (arr: number[]) => {
@@ -126,6 +126,20 @@ const TipCarousel: React.FC = () => {
       }
     }
   }, [])
+
+  useEffect(() => {
+    // Function to announce the current item to VoiceOver
+    const currentTip = tipOrder[currentPosition - 1]
+    if (currentTip) {
+      const tipBody = t(`Tips.Tip${tipOrder[currentPosition - 1]}`)
+      const tipHeader = t('Tips.Header')
+      AccessibilityInfo.announceForAccessibility(
+        `${tipHeader}, ${tipBody}`
+      )
+    } else if (currentPosition === 0) {
+      AccessibilityInfo.announceForAccessibility(t('Tips.GettingReady'))
+    }
+  }, [currentPosition])
 
   // translating once here to prevent many repeated translations for each tip item
   const tipHeader = t('Tips.Header')


### PR DESCRIPTION
Added support for screen readers on the tips while on the loading splash screen.
The tips are now read automatically as they appear on the splash screen.
Resolves: #861

https://github.com/bcgov/bc-wallet-mobile/assets/36937407/fe9f05d8-5a0b-4acf-a8f2-02bbb28eabdf

