### PR TITLE
chore: vscode ignore symlink

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/bifold-core": true,
+  }
+}


### PR DESCRIPTION
As a work arround for a yarn issue we added a symlink to bifold/core in the root of the project. This works well but causes VSCode to find duplicate files. This fix, in combination with the instrucitons below, fixes this problem.

Make sure you clear your editor history. Here is a command built in to do this CMD-SHIFT-P then choose "Clear Editor History".

