### PR TITLE
fix: fixed bug where done proof appears in home screen of verifier

### DIFF
--- a/app/src/hooks/notifications.ts
+++ b/app/src/hooks/notifications.ts
@@ -8,7 +8,6 @@ import {
 import { useCredentialByState, useProofByState } from '@aries-framework/react-hooks'
 import { useStore } from 'aries-bifold'
 import { CredentialMetadata, customMetadata } from 'aries-bifold/App/types/metadata'
-import { ProofCustomMetadata, ProofMetadata } from 'aries-bifold/verifier'
 
 import { getInvitationCredentialDate, showBCIDSelector } from '../helpers/BCIDHelper'
 import { BCState } from '../store'
@@ -28,14 +27,6 @@ export const useNotifications = (): Notifications => {
   const [store] = useStore<BCState>()
   const offers = useCredentialByState(CredentialState.OfferReceived)
   const proofsRequested = useProofByState(ProofState.RequestReceived)
-  const proofsDone = useProofByState([ProofState.Done, ProofState.PresentationReceived]).filter(
-    (proof: ProofExchangeRecord) => {
-      if (proof.isVerified === undefined) return false
-
-      const metadata = proof.metadata.get(ProofMetadata.customMetadata) as ProofCustomMetadata
-      return !metadata?.details_seen
-    }
-  )
   const revoked = useCredentialByState(CredentialState.Done).filter((cred: CredentialRecord) => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const metadata = cred!.metadata.get(CredentialMetadata.customMetadata) as customMetadata
@@ -59,7 +50,7 @@ export const useNotifications = (): Notifications => {
       ? [{ type: 'CustomNotification', createdAt: invitationDate, id: 'custom' }]
       : []
 
-  const notifications = [...offers, ...proofsRequested, ...proofsDone, ...revoked, ...custom].sort(
+  const notifications = [...offers, ...proofsRequested, ...revoked, ...custom].sort(
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
   )
 


### PR DESCRIPTION
Previously the notification functionality was listing any proof record that was in the done state. This doesn't really make sense since the notification list is supposed to contain proofs and credential offers that haven't been completed yet. The functionality to list completed proof requests in the notification list has been removed