### PR TITLE
fix: verifier notifications

### DIFF
--- a/app/src/hooks/notifications.ts
+++ b/app/src/hooks/notifications.ts
@@ -8,6 +8,7 @@ import {
 import { useCredentialByState, useProofByState } from '@aries-framework/react-hooks'
 import { useStore } from 'aries-bifold'
 import { CredentialMetadata, customMetadata } from 'aries-bifold/App/types/metadata'
+import { ProofCustomMetadata, ProofMetadata } from 'aries-bifold/verifier'
 
 import { getInvitationCredentialDate, showBCIDSelector } from '../helpers/BCIDHelper'
 import { BCState } from '../store'
@@ -27,6 +28,14 @@ export const useNotifications = (): Notifications => {
   const [store] = useStore<BCState>()
   const offers = useCredentialByState(CredentialState.OfferReceived)
   const proofsRequested = useProofByState(ProofState.RequestReceived)
+  const proofsDone = useProofByState([ProofState.Done, ProofState.PresentationReceived]).filter(
+    (proof: ProofExchangeRecord) => {
+      if (proof.isVerified === undefined) return false
+
+      const metadata = proof.metadata.get(ProofMetadata.customMetadata) as ProofCustomMetadata
+      return !metadata?.details_seen
+    }
+  )
   const revoked = useCredentialByState(CredentialState.Done).filter((cred: CredentialRecord) => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const metadata = cred!.metadata.get(CredentialMetadata.customMetadata) as customMetadata
@@ -50,7 +59,7 @@ export const useNotifications = (): Notifications => {
       ? [{ type: 'CustomNotification', createdAt: invitationDate, id: 'custom' }]
       : []
 
-  const notifications = [...offers, ...proofsRequested, ...revoked, ...custom].sort(
+  const notifications = [...offers, ...proofsRequested, ...proofsDone, ...revoked, ...custom].sort(
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
   )
 


### PR DESCRIPTION
Previously I removed mobile verifier notifications in the home screen. This change adds them back in as well as fixes bugs while viewing or deleting the notification.

Depends on: https://github.com/hyperledger/aries-mobile-agent-react-native/pull/874
<img width="389" alt="image" src="https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/6a43b5b7-6d9d-471c-98a4-a2e69ab95cff">
<img width="389" alt="image" src="https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/7cd2e0ef-20f1-4c4f-ae21-15b178e6e136">