### PR TITLE
feat: dev only verifier templates

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -187,7 +187,9 @@ jobs:
           -archivePath AriesBifold.xcarchive \
           -sdk iphoneos \
           -verbose \
-          archive
+          archive \
+          CODE_SIGNING_ALLOWED=NO \
+          CODE_SIGNING_REQUIRED=NO
 
       - name: Debug build
         if: github.ref_name != 'main' || needs.check-ios-secrets.outputs.isReleaseBuild != 'true'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -187,9 +187,7 @@ jobs:
           -archivePath AriesBifold.xcarchive \
           -sdk iphoneos \
           -verbose \
-          archive \
-          CODE_SIGNING_ALLOWED=NO \
-          CODE_SIGNING_REQUIRED=NO
+          archive
 
       - name: Debug build
         if: github.ref_name != 'main' || needs.check-ios-secrets.outputs.isReleaseBuild != 'true'

--- a/app/src/request-templates.ts
+++ b/app/src/request-templates.ts
@@ -6,6 +6,36 @@ const calculatePreviousYear = (yearOffset: number) => {
   return parseInt(pastDate.toISOString().split('T')[0].replace(/-/g, ''))
 }
 
+const personSchema = 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0'
+const personRestrictions = [
+  // IDIM Person credential
+  { schema_id: 'XpgeQa93eZvGSZBZef3PHn:2:Person:1.0', issuer_did: '7xjfawcnyTUcduWVysLww5' }, // SIT
+  { schema_id: 'KCxVC8GkKywjhWJnUfCmkW:2:Person:1.0', issuer_did: 'KCxVC8GkKywjhWJnUfCmkW' }, // QA
+  { schema_id: 'RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0', issuer_did: 'RGjWbW1eycP7FrMf4QJvX8' }, // Prod
+  // BC Wallet Showcase
+  { schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }, // Prod
+  { schema_id: '2K2h7kf8VGTLtfoxJgWazf:2:Person:1.1', issuer_did: '2K2h7kf8VGTLtfoxJgWazf' }, // Dev & Test
+  // openvp candy
+  { schema_id: 'Ui6HA36FvN83cEtmYYHxrn:2:unverified_person:0.1.0', issuer_did: 'Ui6HA36FvN83cEtmYYHxrn' },
+]
+
+const openvpSchema = '9wVuYYDEDtpZ6CYMqSiWop:2:unverified_person:0.1.0'
+const openvpRestrictions = [
+  { schema_id: '9wVuYYDEDtpZ6CYMqSiWop:2:unverified_person:0.1.0', issuer_did: '9wVuYYDEDtpZ6CYMqSiWop' },
+  { schema_id: 'XZQpyaFa9hBUdJXfKHUvVg:2:unverified_person:0.1.0', issuer_did: 'XZQpyaFa9hBUdJXfKHUvVg' },
+  { schema_id: 'Ui6HA36FvN83cEtmYYHxrn:2:unverified_person:0.1.0', issuer_did: 'Ui6HA36FvN83cEtmYYHxrn' },
+]
+
+const memberCardSchema = 'XUxBrVSALWHLeycAUhrNr9:2:Member Card:1.5.1'
+const memberCardRestrictions = [
+  // LSBC Member Card
+  { schema_id: '4xE68b6S5VRFrKMMG1U95M:2:Member Card:1.5.1', issuer_did: '4xE68b6S5VRFrKMMG1U95M' }, // Prod
+  { schema_id: 'AuJrigKQGRLJajKAebTgWu:2:Member Card:1.5.1', issuer_did: 'AuJrigKQGRLJajKAebTgWu' }, // Test
+  // BC Wallet Showcase
+  { schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Member Card:1.5.1', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }, // Prod
+  { schema_id: '2K2h7kf8VGTLtfoxJgWazf:2:Member Card:1.1', issuer_did: '2K2h7kf8VGTLtfoxJgWazf' }, // Dev & Test
+]
+
 export const proofRequestTemplates: Array<ProofRequestTemplate> = [
   {
     id: 'BC:5:FullName:0.0.1:indy',
@@ -16,31 +46,15 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
       type: ProofRequestType.AnonCreds,
       data: [
         {
-          schema: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0',
+          schema: personSchema,
           requestedAttributes: [
             {
               name: 'given_names',
-              restrictions: [
-                // IDIM Person credential
-                { schema_id: 'XpgeQa93eZvGSZBZef3PHn:2:Person:1.0', issuer_did: '7xjfawcnyTUcduWVysLww5' }, // SIT
-                { schema_id: 'KCxVC8GkKywjhWJnUfCmkW:2:Person:1.0', issuer_did: 'KCxVC8GkKywjhWJnUfCmkW' }, // QA
-                { schema_id: 'RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0', issuer_did: 'RGjWbW1eycP7FrMf4QJvX8' }, // Prod
-                // BC Wallet Showcase
-                { schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }, // Prod
-                { schema_id: '2K2h7kf8VGTLtfoxJgWazf:2:Person:1.1', issuer_did: '2K2h7kf8VGTLtfoxJgWazf' }, // Dev & Test
-              ],
+              restrictions: personRestrictions,
             },
             {
               name: 'family_name',
-              restrictions: [
-                // IDIM Person credential
-                { schema_id: 'XpgeQa93eZvGSZBZef3PHn:2:Person:1.0', issuer_did: '7xjfawcnyTUcduWVysLww5' }, // SIT
-                { schema_id: 'KCxVC8GkKywjhWJnUfCmkW:2:Person:1.0', issuer_did: 'KCxVC8GkKywjhWJnUfCmkW' }, // QA
-                { schema_id: 'RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0', issuer_did: 'RGjWbW1eycP7FrMf4QJvX8' }, // Prod
-                // BC Wallet Showcase
-                { schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }, // Prod
-                { schema_id: '2K2h7kf8VGTLtfoxJgWazf:2:Person:1.1', issuer_did: '2K2h7kf8VGTLtfoxJgWazf' }, // Dev & Test
-              ],
+              restrictions: personRestrictions,
             },
           ],
         },
@@ -50,41 +64,25 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
   {
     id: 'BC:5:19+AndFullName:0.0.1:indy',
     name: '19+ and Full name',
-    description: 'Verify if a person is 19 years end up and full name.',
+    description: 'Verify if a person is 19 years and up and full name.',
     version: '0.0.1',
     payload: {
       type: ProofRequestType.AnonCreds,
       data: [
         {
-          schema: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0',
+          schema: personSchema,
           requestedAttributes: [
             {
               names: ['given_names', 'family_name'],
-              restrictions: [
-                // IDIM Person credential
-                { schema_id: 'XpgeQa93eZvGSZBZef3PHn:2:Person:1.0', issuer_did: '7xjfawcnyTUcduWVysLww5' }, // SIT
-                { schema_id: 'KCxVC8GkKywjhWJnUfCmkW:2:Person:1.0', issuer_did: 'KCxVC8GkKywjhWJnUfCmkW' }, // QA
-                { schema_id: 'RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0', issuer_did: 'RGjWbW1eycP7FrMf4QJvX8' }, // Prod
-                // BC Wallet Showcase
-                { schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }, // Prod
-                { schema_id: '2K2h7kf8VGTLtfoxJgWazf:2:Person:1.1', issuer_did: '2K2h7kf8VGTLtfoxJgWazf' }, // Dev & Test
-              ],
+              restrictions: personRestrictions,
             },
           ],
           requestedPredicates: [
             {
               name: 'birthdate_dateint',
-              predicateType: '>=',
+              predicateType: '<=',
               predicateValue: calculatePreviousYear(19),
-              restrictions: [
-                // IDIM Person credential
-                { schema_id: 'XpgeQa93eZvGSZBZef3PHn:2:Person:1.0', issuer_did: '7xjfawcnyTUcduWVysLww5' }, // SIT
-                { schema_id: 'KCxVC8GkKywjhWJnUfCmkW:2:Person:1.0', issuer_did: 'KCxVC8GkKywjhWJnUfCmkW' }, // QA
-                { schema_id: 'RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0', issuer_did: 'RGjWbW1eycP7FrMf4QJvX8' }, // Prod
-                // BC Wallet Showcase
-                { schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }, // Prod
-                { schema_id: '2K2h7kf8VGTLtfoxJgWazf:2:Person:1.1', issuer_did: '2K2h7kf8VGTLtfoxJgWazf' }, // Dev & Test
-              ],
+              restrictions: personRestrictions,
             },
           ],
         },
@@ -94,27 +92,19 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
   {
     id: 'BC:5:Over19YearsOfAge:0.0.1:indy',
     name: 'Over 19 years of age',
-    description: 'Verify if a person is 19 years end up.',
+    description: 'Verify if a person is 19 years and up.',
     version: '0.0.1',
     payload: {
       type: ProofRequestType.AnonCreds,
       data: [
         {
-          schema: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0',
+          schema: personSchema,
           requestedPredicates: [
             {
               name: 'birthdate_dateint',
-              predicateType: '>=',
+              predicateType: '<=',
               predicateValue: calculatePreviousYear(19),
-              restrictions: [
-                // IDIM Person credential
-                { schema_id: 'XpgeQa93eZvGSZBZef3PHn:2:Person:1.0', issuer_did: '7xjfawcnyTUcduWVysLww5' }, // SIT
-                { schema_id: 'KCxVC8GkKywjhWJnUfCmkW:2:Person:1.0', issuer_did: 'KCxVC8GkKywjhWJnUfCmkW' }, // QA
-                { schema_id: 'RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0', issuer_did: 'RGjWbW1eycP7FrMf4QJvX8' }, // Prod
-                // BC Wallet Showcase
-                { schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }, // Prod
-                { schema_id: '2K2h7kf8VGTLtfoxJgWazf:2:Person:1.1', issuer_did: '2K2h7kf8VGTLtfoxJgWazf' }, // Dev & Test
-              ],
+              restrictions: personRestrictions,
             },
           ],
         },
@@ -124,24 +114,17 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
   {
     id: 'BC:5:PractisingLawyer:0.0.1:indy',
     name: 'Practising lawyer',
-    description: 'Verify if a person`is a practicing lawyer.',
+    description: 'Verify if a person is a practicing lawyer.',
     version: '0.0.1',
     payload: {
       type: ProofRequestType.AnonCreds,
       data: [
         {
-          schema: 'XUxBrVSALWHLeycAUhrNr9:2:Member Card:1.5.1',
+          schema: memberCardSchema,
           requestedAttributes: [
             {
               names: ['Given Name', 'Surname', 'PPID', 'Member Status'],
-              restrictions: [
-                // LSBC Member Card
-                { schema_id: '4xE68b6S5VRFrKMMG1U95M:2:Member Card:1.5.1', issuer_did: '4xE68b6S5VRFrKMMG1U95M' }, // Prod
-                { schema_id: 'AuJrigKQGRLJajKAebTgWu:2:Member Card:1.5.1', issuer_did: 'AuJrigKQGRLJajKAebTgWu' }, // Test
-                // BC Wallet Showcase
-                { schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Member Card:1.5.1', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }, // Prod
-                { schema_id: '2K2h7kf8VGTLtfoxJgWazf:2:Member Card:1.1', issuer_did: '2K2h7kf8VGTLtfoxJgWazf' }, // Dev & Test
-              ],
+              restrictions: memberCardRestrictions,
             },
           ],
         },
@@ -151,41 +134,26 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
   {
     id: 'BC:5:PractisingLawyerAndFullName:0.0.1:indy',
     name: 'Practising lawyer and full name',
-    description: 'Verify if a person`is a practicing lawyer using two different credentials for extra assurance',
+    description: 'Verify if a person is a practicing lawyer using two different credentials for extra assurance',
     version: '0.0.1',
     payload: {
       type: ProofRequestType.AnonCreds,
       data: [
         {
-          schema: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0',
+          schema: personSchema,
           requestedAttributes: [
             {
               names: ['given_names', 'family_name'],
-              restrictions: [
-                // IDIM Person credential
-                { schema_id: 'XpgeQa93eZvGSZBZef3PHn:2:Person:1.0', issuer_did: '7xjfawcnyTUcduWVysLww5' }, // SIT
-                { schema_id: 'KCxVC8GkKywjhWJnUfCmkW:2:Person:1.0', issuer_did: 'KCxVC8GkKywjhWJnUfCmkW' }, // QA
-                { schema_id: 'RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0', issuer_did: 'RGjWbW1eycP7FrMf4QJvX8' }, // Prod
-                // BC Wallet Showcase
-                { schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }, // Prod
-                { schema_id: '2K2h7kf8VGTLtfoxJgWazf:2:Person:1.1', issuer_did: '2K2h7kf8VGTLtfoxJgWazf' }, // Dev & Test
-              ],
+              restrictions: personRestrictions,
             },
           ],
         },
         {
-          schema: 'XUxBrVSALWHLeycAUhrNr9:2:Member Card:1.5.1',
+          schema: memberCardSchema,
           requestedAttributes: [
             {
               names: ['Given Name', 'Surname', 'PPID', 'Member Status'],
-              restrictions: [
-                // LSBC Member Card
-                { schema_id: '4xE68b6S5VRFrKMMG1U95M:2:Member Card:1.5.1', issuer_did: '4xE68b6S5VRFrKMMG1U95M' }, // Prod
-                { schema_id: 'AuJrigKQGRLJajKAebTgWu:2:Member Card:1.5.1', issuer_did: 'AuJrigKQGRLJajKAebTgWu' }, // Test
-                // BC Wallet Showcase
-                { schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Member Card:1.5.1', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }, // Prod
-                { schema_id: '2K2h7kf8VGTLtfoxJgWazf:2:Member Card:1.1', issuer_did: '2K2h7kf8VGTLtfoxJgWazf' }, // Dev & Test
-              ],
+              restrictions: memberCardRestrictions,
             },
           ],
         },
@@ -195,28 +163,74 @@ export const proofRequestTemplates: Array<ProofRequestTemplate> = [
   {
     id: 'BC:5:OverSomeYearsOfAge:0.0.1:indy',
     name: 'Over some years of age',
-    description: 'Verify if a person is over some years ends up.',
+    description: 'Verify if a person is over some years and up.',
     version: '0.0.1',
     payload: {
       type: ProofRequestType.AnonCreds,
       data: [
         {
-          schema: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0',
+          schema: personSchema,
           requestedPredicates: [
             {
               name: 'birthdate_dateint',
-              predicateType: '>=',
+              predicateType: '<=',
               predicateValue: calculatePreviousYear(19),
               parameterizable: true,
-              restrictions: [
-                // IDIM Person credential
-                { schema_id: 'XpgeQa93eZvGSZBZef3PHn:2:Person:1.0', issuer_did: '7xjfawcnyTUcduWVysLww5' }, // SIT
-                { schema_id: 'KCxVC8GkKywjhWJnUfCmkW:2:Person:1.0', issuer_did: 'KCxVC8GkKywjhWJnUfCmkW' }, // QA
-                { schema_id: 'RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0', issuer_did: 'RGjWbW1eycP7FrMf4QJvX8' }, // Prod
-                // BC Wallet Showcase
-                { schema_id: 'XUxBrVSALWHLeycAUhrNr9:2:Person:1.0', issuer_did: 'XUxBrVSALWHLeycAUhrNr9' }, // Prod
-                { schema_id: '2K2h7kf8VGTLtfoxJgWazf:2:Person:1.1', issuer_did: '2K2h7kf8VGTLtfoxJgWazf' }, // Dev & Test
-              ],
+              restrictions: personRestrictions,
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    id: 'BC:5:OpenvpFullName:0.0.1:indy',
+    name: 'Unverified Person Full name',
+    description: 'Verify the full name of a person',
+    devOnly: true,
+    version: '0.0.1',
+    payload: {
+      type: ProofRequestType.AnonCreds,
+      data: [
+        {
+          schema: openvpSchema,
+          requestedAttributes: [
+            {
+              name: 'given_names',
+              restrictions: openvpRestrictions,
+            },
+            {
+              name: 'family_name',
+              restrictions: openvpRestrictions,
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    id: 'BC:5:Openvp19+:0.0.1:indy',
+    name: 'Unverified Person Full name and Birth Date',
+    description: 'Verify the full name and birth date of a person',
+    devOnly: true,
+    version: '0.0.1',
+    payload: {
+      type: ProofRequestType.AnonCreds,
+      data: [
+        {
+          schema: openvpSchema,
+          requestedAttributes: [
+            {
+              name: 'given_names',
+              restrictions: openvpRestrictions,
+            },
+            {
+              name: 'family_name',
+              restrictions: openvpRestrictions,
+            },
+            {
+              name: 'birthdate',
+              restrictions: openvpRestrictions,
             },
           ],
         },

--- a/app/src/screens/Developer.tsx
+++ b/app/src/screens/Developer.tsx
@@ -154,6 +154,14 @@ const Settings: React.FC = () => {
   }
 
   const toggleVerifierCapabilitySwitch = () => {
+    // if verifier feature is switched off then also turn off the dev templates
+    if (useVerifierCapability) {
+      dispatch({
+        type: DispatchAction.USE_DEV_VERIFIER_TEMPLATES,
+        payload: [false],
+      })
+      setDevVerifierTemplates(false)
+    }
     dispatch({
       type: DispatchAction.USE_VERIFIER_CAPABILITY,
       payload: [!useVerifierCapability],
@@ -170,6 +178,14 @@ const Settings: React.FC = () => {
   }
 
   const toggleDevVerifierTemplatesSwitch = () => {
+    // if we switch on dev templates we can assume the user also wants to enable the verifier capability
+    if (!useDevVerifierTemplates) {
+      dispatch({
+        type: DispatchAction.USE_VERIFIER_CAPABILITY,
+        payload: [true],
+      })
+      setUseVerifierCapability(true)
+    }
     dispatch({
       type: DispatchAction.USE_DEV_VERIFIER_TEMPLATES,
       payload: [!useDevVerifierTemplates],

--- a/app/src/screens/Developer.tsx
+++ b/app/src/screens/Developer.tsx
@@ -35,6 +35,7 @@ const Settings: React.FC = () => {
   const [useConnectionInviterCapability, setConnectionInviterCapability] = useState(
     !!store.preferences.useConnectionInviterCapability
   )
+  const [useDevVerifierTemplates, setDevVerifierTemplates] = useState(!!store.preferences.useDevVerifierTemplates)
 
   const styles = StyleSheet.create({
     container: {
@@ -168,6 +169,14 @@ const Settings: React.FC = () => {
     setConnectionInviterCapability((previousState) => !previousState)
   }
 
+  const toggleDevVerifierTemplatesSwitch = () => {
+    dispatch({
+      type: DispatchAction.USE_DEV_VERIFIER_TEMPLATES,
+      payload: [!useDevVerifierTemplates],
+    })
+    setDevVerifierTemplates((previousState) => !previousState)
+  }
+
   return (
     <SafeAreaView edges={['bottom', 'left', 'right']}>
       <Modal
@@ -246,6 +255,19 @@ const Settings: React.FC = () => {
             ios_backgroundColor={ColorPallet.grayscale.lightGrey}
             onValueChange={toggleConnectionInviterCapabilitySwitch}
             value={useConnectionInviterCapability}
+          />
+        </SectionRow>
+        <SectionRow
+          title={t('Verifier.UseDevVerifierTemplates')}
+          accessibilityLabel={t('Verifier.ToggleDevTemplates')}
+          testID={testIdWithKey('ToggleDevVerifierTemplatesSwitch')}
+        >
+          <Switch
+            trackColor={{ false: ColorPallet.grayscale.lightGrey, true: ColorPallet.brand.primaryDisabled }}
+            thumbColor={useDevVerifierTemplates ? ColorPallet.brand.primary : ColorPallet.grayscale.mediumGrey}
+            ios_backgroundColor={ColorPallet.grayscale.lightGrey}
+            onValueChange={toggleDevVerifierTemplatesSwitch}
+            value={useDevVerifierTemplates}
           />
         </SectionRow>
       </View>


### PR DESCRIPTION
Sheldon asked for Unverified Person templates for ease of testing, Decided to make them development only templates so they don't end up in prod.
- Added extra toggle on developer menu to include development templates
- Bound inputs so that when the dev templates toggle is on, verifier feature must be enabled. Conversely when the verifier feature is turned off, dev template must also be turned off 

Resolves: #1213 

https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/d2910669-c842-4501-b2da-3d351cb80ed2