### PR TITLE
fix: no android split screen

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -3,8 +3,8 @@
   <uses-permission android:name="android.permission.USE_FINGERPRINT" />
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
-  <uses-permission-sdk-23 android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.CAMERA" />
+  <uses-permission-sdk-23 android:name="android.permission.VIBRATE"/>
 
   <queries>
     <intent>
@@ -18,6 +18,7 @@
     android:label="@string/app_name" 
     android:icon="@mipmap/ic_launcher" 
     android:allowBackup="false" 
+    android:resizeableActivity="false"
     android:theme="@style/AppTheme" 
     android:usesCleartextTraffic="false">
     <activity 


### PR DESCRIPTION
While the Android version does support tablet we cannot support split screen at this time. This change disables split screen.

Fixes bcgov/bc-wallet-mobile#1277