### PR TITLE
fix: patch for revocation interval

### DIFF
--- a/.yarn/patches/@aries-framework-anoncreds-npm-0.4.0-4d3b4e769d.patch
+++ b/.yarn/patches/@aries-framework-anoncreds-npm-0.4.0-4d3b4e769d.patch
@@ -1,0 +1,18 @@
+diff --git a/build/utils/revocationInterval.js b/build/utils/revocationInterval.js
+index 728732d5119b879a2a2399eab6e6430b62796106..5c69ea0731c0fbdc0ff4820891d67773c7105b3b 100644
+--- a/build/utils/revocationInterval.js
++++ b/build/utils/revocationInterval.js
+@@ -7,9 +7,9 @@ function assertBestPracticeRevocationInterval(revocationInterval) {
+     if (!revocationInterval.to) {
+         throw new core_1.AriesFrameworkError(`Presentation requests proof of non-revocation with no 'to' value specified`);
+     }
+-    if ((revocationInterval.from || revocationInterval.from === 0) && revocationInterval.to !== revocationInterval.from) {
+-        throw new core_1.AriesFrameworkError(`Presentation requests proof of non-revocation with an interval from: '${revocationInterval.from}' that does not match the interval to: '${revocationInterval.to}', as specified in Aries RFC 0441`);
+-    }
++    // if ((revocationInterval.from || revocationInterval.from === 0) && revocationInterval.to !== revocationInterval.from) {
++    //     throw new core_1.AriesFrameworkError(`Presentation requests proof of non-revocation with an interval from: '${revocationInterval.from}' that does not match the interval to: '${revocationInterval.to}', as specified in Aries RFC 0441`);
++    // }
+ }
+ exports.assertBestPracticeRevocationInterval = assertBestPracticeRevocationInterval;
+ //# sourceMappingURL=revocationInterval.js.map
+\ No newline at end of file

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "react-native-gifted-chat@0.16.3": "patch:react-native-gifted-chat@npm:0.16.3#./.yarn/patches/react-native-gifted-chat-npm-0.16.3-9cbc12a602.patch",
     "@aries-framework/core@0.3.3": "patch:@aries-framework/core@npm:0.3.3#./.yarn/patches/@aries-framework-core-npm-0.3.3-dd6486de3d.patch",
     "@aries-framework/react-hooks@^0.4.2": "patch:@aries-framework/react-hooks@npm:0.4.2#./.yarn/patches/@aries-framework-react-hooks-npm-0.4.2-84b7eb8764.patch",
-    "@aries-framework/react-native@0.4.0": "patch:@aries-framework/react-native@npm:0.3.3#./.yarn/patches/@aries-framework-react-native-npm-0.3.3-bb75ece22d.patch"
+    "@aries-framework/react-native@0.4.0": "patch:@aries-framework/react-native@npm:0.3.3#./.yarn/patches/@aries-framework-react-native-npm-0.3.3-bb75ece22d.patch",
+    "@aries-framework/anoncreds@^0.4.0": "patch:@aries-framework/anoncreds@npm%3A0.4.0#./.yarn/patches/@aries-framework-anoncreds-npm-0.4.0-4d3b4e769d.patch",
+    "@aries-framework/anoncreds@0.4.0": "patch:@aries-framework/anoncreds@npm%3A0.4.0#./.yarn/patches/@aries-framework-anoncreds-npm-0.4.0-4d3b4e769d.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,7 +31,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aries-framework/anoncreds@npm:0.4.0, @aries-framework/anoncreds@npm:^0.4.0":
+"@aries-framework/anoncreds@npm:0.4.0":
   version: 0.4.0
   resolution: "@aries-framework/anoncreds@npm:0.4.0"
   dependencies:
@@ -41,6 +41,19 @@ __metadata:
     class-validator: 0.14.0
     reflect-metadata: ^0.1.13
   checksum: 006761a28946e1ddab6fdf877ced98dd39e13624cc444bac5ceafd6a9376308d27054bda8bb8c53d83f29c3f96c03ceb0ffb669d9d2391fad4cbfecea26cd0f8
+  languageName: node
+  linkType: hard
+
+"@aries-framework/anoncreds@patch:@aries-framework/anoncreds@npm%3A0.4.0#./.yarn/patches/@aries-framework-anoncreds-npm-0.4.0-4d3b4e769d.patch::locator=bc-wallet-mobile%40workspace%3A.":
+  version: 0.4.0
+  resolution: "@aries-framework/anoncreds@patch:@aries-framework/anoncreds@npm%3A0.4.0#./.yarn/patches/@aries-framework-anoncreds-npm-0.4.0-4d3b4e769d.patch::version=0.4.0&hash=effd16&locator=bc-wallet-mobile%40workspace%3A."
+  dependencies:
+    "@aries-framework/core": 0.4.0
+    bn.js: ^5.2.1
+    class-transformer: 0.5.1
+    class-validator: 0.14.0
+    reflect-metadata: ^0.1.13
+  checksum: 7f4d2e15f86ce64a402c65436f05d9a9a66e7b8dcaf50b9206985f8e5a4544ca1a4a1bbda0a6c953fc683859e2ba270464ece54b0f323fc6c10498cadc67f610
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
After the update to AFJ 0.4.0 one of our patches was not applying because the underlying AFJ files have been restructured. This PR rebuilds the patch and applies it to the correct file.

Fixes #1301
