### PR TITLE
feat: enable wallet naming via onboarding dev mode

### DIFF
--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -67,7 +67,6 @@ const configuration: ConfigurationContext = {
   useCustomNotifications: useNotifications,
   proofRequestTemplates,
   enableTours: true,
-  enableWalletNaming: false,
 }
 
 export default { theme, localization, configuration }

--- a/app/src/screens/Developer.tsx
+++ b/app/src/screens/Developer.tsx
@@ -36,6 +36,7 @@ const Settings: React.FC = () => {
     !!store.preferences.useConnectionInviterCapability
   )
   const [useDevVerifierTemplates, setDevVerifierTemplates] = useState(!!store.preferences.useDevVerifierTemplates)
+  const [enableWalletNaming, setEnableWalletNaming] = useState(!!store.preferences.enableWalletNaming)
 
   const styles = StyleSheet.create({
     container: {
@@ -193,6 +194,14 @@ const Settings: React.FC = () => {
     setDevVerifierTemplates((previousState) => !previousState)
   }
 
+  const toggleWalletNamingSwitch = () => {
+    dispatch({
+      type: DispatchAction.ENABLE_WALLET_NAMING,
+      payload: [!enableWalletNaming],
+    })
+    setEnableWalletNaming((previousState) => !previousState)
+  }
+
   return (
     <SafeAreaView edges={['bottom', 'left', 'right']}>
       <Modal
@@ -286,6 +295,21 @@ const Settings: React.FC = () => {
             value={useDevVerifierTemplates}
           />
         </SectionRow>
+        {!store.onboarding.didCreatePIN && (
+          <SectionRow
+            title={t('NameWallet.EnableWalletNaming')}
+            accessibilityLabel={t('NameWallet.ToggleWalletNaming')}
+            testID={testIdWithKey('ToggleWalletNamingSwitch')}
+          >
+            <Switch
+              trackColor={{ false: ColorPallet.grayscale.lightGrey, true: ColorPallet.brand.primaryDisabled }}
+              thumbColor={enableWalletNaming ? ColorPallet.brand.primary : ColorPallet.grayscale.mediumGrey}
+              ios_backgroundColor={ColorPallet.grayscale.lightGrey}
+              onValueChange={toggleWalletNamingSwitch}
+              value={enableWalletNaming}
+            />
+          </SectionRow>
+        )}
       </View>
     </SafeAreaView>
   )

--- a/app/src/screens/Splash.tsx
+++ b/app/src/screens/Splash.tsx
@@ -96,7 +96,7 @@ const Splash: React.FC = () => {
   const navigation = useNavigation()
   const { getWalletCredentials } = useAuth()
   const { ColorPallet, Assets } = useTheme()
-  const { indyLedgers, enableWalletNaming } = useConfiguration()
+  const { indyLedgers } = useConfiguration()
   const [stepText, setStepText] = useState<string>(t('Init.Starting'))
   const [progressPercent, setProgressPercent] = useState(0)
   const [initOnboardingCount, setInitOnboardingCount] = useState(0)
@@ -258,22 +258,29 @@ const Splash: React.FC = () => {
             payload: [dataAsJSON],
           })
 
-          if (onboardingComplete(dataAsJSON) && !attemptData?.lockoutDate) {
-            navigation.dispatch(
-              CommonActions.reset({
-                index: 0,
-                routes: [{ name: Screens.EnterPIN }],
-              })
-            )
-            return
-          } else if (onboardingComplete(dataAsJSON) && attemptData?.lockoutDate) {
-            // return to lockout screen if lockout date is set
-            navigation.dispatch(
-              CommonActions.reset({
-                index: 0,
-                routes: [{ name: Screens.AttemptLockout }],
-              })
-            )
+          if (onboardingComplete(dataAsJSON)) {
+            // if they previously completed onboarding before wallet naming was enabled, mark complete
+            if (!store.onboarding.didNameWallet) {
+              dispatch({ type: DispatchAction.DID_NAME_WALLET, payload: [true] })
+            }
+
+            if (!attemptData?.lockoutDate) {
+              navigation.dispatch(
+                CommonActions.reset({
+                  index: 0,
+                  routes: [{ name: Screens.EnterPIN }],
+                })
+              )
+            } else {
+              // return to lockout screen if lockout date is set
+              navigation.dispatch(
+                CommonActions.reset({
+                  index: 0,
+                  routes: [{ name: Screens.AttemptLockout }],
+                })
+              )
+            }
+
             return
           }
 
@@ -281,7 +288,7 @@ const Splash: React.FC = () => {
           navigation.dispatch(
             CommonActions.reset({
               index: 0,
-              routes: [{ name: resumeOnboardingAt(dataAsJSON, enableWalletNaming) }],
+              routes: [{ name: resumeOnboardingAt(dataAsJSON, store.preferences.enableWalletNaming) }],
             })
           )
 


### PR DESCRIPTION
Depends on: https://github.com/hyperledger/aries-mobile-agent-react-native/pull/933

Here's what it looks like:
![wallet_naming_onboarding](https://github.com/bcgov/bc-wallet-mobile/assets/32586431/41136636-6b2b-4640-a5b1-c13bf5adc7d8)
