### PR TITLE
feat: revocation improvement

### DIFF
--- a/app/src/request-templates.ts
+++ b/app/src/request-templates.ts
@@ -66,7 +66,11 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
           {
             schema: personSchema,
             requestedAttributes: [
-              { names: ['given_names', 'family_name', 'picture'], restrictions: verifiedPersonRestrictions },
+              {
+                names: ['given_names', 'family_name', 'picture'],
+                restrictions: verifiedPersonRestrictions,
+                nonRevoked: { to: 1694794371 },
+              },
             ],
           },
           {
@@ -75,6 +79,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 names: ['Given Name', 'Surname', 'Member Status', 'Member Status Code'],
                 restrictions: memberCardCodeRestrictions,
+                nonRevoked: { to: 1694794371 },
               },
             ],
           },

--- a/app/src/request-templates.ts
+++ b/app/src/request-templates.ts
@@ -54,6 +54,8 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
     return { ...restriction }
   })
 
+  const now = Math.floor(new Date().getTime() / 1000)
+
   const proofRequestTemplates: Array<ProofRequestTemplate> = [
     {
       id: 'BC:5:PracticingLawyerAndPhoto:0.0.1:indy',
@@ -69,7 +71,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 names: ['given_names', 'family_name', 'picture'],
                 restrictions: verifiedPersonRestrictions,
-                nonRevoked: { to: 1694794371 },
+                nonRevoked: { to: now },
               },
             ],
           },
@@ -79,7 +81,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 names: ['Given Name', 'Surname', 'Member Status', 'Member Status Code'],
                 restrictions: memberCardCodeRestrictions,
-                nonRevoked: { to: 1694794371 },
+                nonRevoked: { to: now },
               },
             ],
           },
@@ -100,10 +102,12 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 name: 'given_names',
                 restrictions: useDevRestrictions ? personRestrictions : verifiedPersonRestrictions,
+                nonRevoked: { to: now },
               },
               {
                 name: 'family_name',
                 restrictions: useDevRestrictions ? personRestrictions : verifiedPersonRestrictions,
+                nonRevoked: { to: now },
               },
             ],
           },
@@ -124,6 +128,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 names: ['given_names', 'family_name'],
                 restrictions: verifiedPersonRestrictions,
+                nonRevoked: { to: now },
               },
             ],
             requestedPredicates: [
@@ -132,6 +137,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
                 predicateType: '<=',
                 predicateValue: calculatePreviousYear(19),
                 restrictions: verifiedPersonRestrictions,
+                nonRevoked: { to: now },
               },
             ],
           },
@@ -154,6 +160,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
                 predicateType: '<=',
                 predicateValue: calculatePreviousYear(19),
                 restrictions: verifiedPersonRestrictions,
+                nonRevoked: { to: now },
               },
             ],
           },
@@ -174,6 +181,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 names: ['Given Name', 'Surname', 'PPID', 'Member Status'],
                 restrictions: memberCardRestrictions,
+                nonRevoked: { to: now },
               },
             ],
           },
@@ -194,6 +202,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 names: ['given_names', 'family_name'],
                 restrictions: useDevRestrictions ? personRestrictions : verifiedPersonRestrictions,
+                nonRevoked: { to: now },
               },
             ],
           },
@@ -203,6 +212,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 names: ['Given Name', 'Surname', 'PPID', 'Member Status'],
                 restrictions: memberCardRestrictions,
+                nonRevoked: { to: now },
               },
             ],
           },
@@ -226,6 +236,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
                 predicateValue: calculatePreviousYear(19),
                 parameterizable: true,
                 restrictions: verifiedPersonRestrictions,
+                nonRevoked: { to: now },
               },
             ],
           },
@@ -247,14 +258,17 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 name: 'given_names',
                 restrictions: verifiedPersonRestrictions,
+                nonRevoked: { to: now },
               },
               {
                 name: 'family_name',
                 restrictions: verifiedPersonRestrictions,
+                nonRevoked: { to: now },
               },
               {
                 name: 'picture',
                 restrictions: verifiedPersonRestrictions,
+                nonRevoked: { to: now },
               },
             ],
           },
@@ -276,10 +290,12 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 name: 'given_names',
                 restrictions: openvpRestrictions,
+                nonRevoked: { to: now },
               },
               {
                 name: 'family_name',
                 restrictions: openvpRestrictions,
+                nonRevoked: { to: now },
               },
             ],
           },
@@ -301,14 +317,17 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 name: 'given_names',
                 restrictions: openvpRestrictions,
+                nonRevoked: { to: now },
               },
               {
                 name: 'family_name',
                 restrictions: openvpRestrictions,
+                nonRevoked: { to: now },
               },
               {
                 name: 'birthdate',
                 restrictions: openvpRestrictions,
+                nonRevoked: { to: now },
               },
             ],
           },

--- a/app/src/request-templates.ts
+++ b/app/src/request-templates.ts
@@ -54,7 +54,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
     return { ...restriction }
   })
 
-  const now = Math.floor(new Date().getTime() / 1000)
+  const now = () => Math.floor(new Date().getTime() / 1000)
 
   const proofRequestTemplates: Array<ProofRequestTemplate> = [
     {
@@ -71,7 +71,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 names: ['given_names', 'family_name', 'picture'],
                 restrictions: verifiedPersonRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
             ],
           },
@@ -81,7 +81,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 names: ['Given Name', 'Surname', 'Member Status', 'Member Status Code'],
                 restrictions: memberCardCodeRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
             ],
           },
@@ -102,12 +102,12 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 name: 'given_names',
                 restrictions: useDevRestrictions ? personRestrictions : verifiedPersonRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
               {
                 name: 'family_name',
                 restrictions: useDevRestrictions ? personRestrictions : verifiedPersonRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
             ],
           },
@@ -128,7 +128,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 names: ['given_names', 'family_name'],
                 restrictions: verifiedPersonRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
             ],
             requestedPredicates: [
@@ -137,7 +137,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
                 predicateType: '<=',
                 predicateValue: calculatePreviousYear(19),
                 restrictions: verifiedPersonRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
             ],
           },
@@ -160,7 +160,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
                 predicateType: '<=',
                 predicateValue: calculatePreviousYear(19),
                 restrictions: verifiedPersonRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
             ],
           },
@@ -181,7 +181,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 names: ['Given Name', 'Surname', 'PPID', 'Member Status'],
                 restrictions: memberCardRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
             ],
           },
@@ -202,7 +202,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 names: ['given_names', 'family_name'],
                 restrictions: useDevRestrictions ? personRestrictions : verifiedPersonRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
             ],
           },
@@ -212,7 +212,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 names: ['Given Name', 'Surname', 'PPID', 'Member Status'],
                 restrictions: memberCardRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
             ],
           },
@@ -236,7 +236,7 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
                 predicateValue: calculatePreviousYear(19),
                 parameterizable: true,
                 restrictions: verifiedPersonRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
             ],
           },
@@ -258,17 +258,17 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 name: 'given_names',
                 restrictions: verifiedPersonRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
               {
                 name: 'family_name',
                 restrictions: verifiedPersonRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
               {
                 name: 'picture',
                 restrictions: verifiedPersonRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
             ],
           },
@@ -290,12 +290,12 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 name: 'given_names',
                 restrictions: openvpRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
               {
                 name: 'family_name',
                 restrictions: openvpRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
             ],
           },
@@ -317,17 +317,17 @@ export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
               {
                 name: 'given_names',
                 restrictions: openvpRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
               {
                 name: 'family_name',
                 restrictions: openvpRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
               {
                 name: 'birthdate',
                 restrictions: openvpRestrictions,
-                nonRevoked: { to: now },
+                nonRevoked: { to: now() },
               },
             ],
           },


### PR DESCRIPTION
Added revocation intervals to proof templates to ensure that mobile verifiers don't accept revoked credentials.
Depends on: https://github.com/hyperledger/aries-mobile-agent-react-native/pull/972
Resolves: https://github.com/bcgov/bc-wallet-mobile/issues/1439