### PR TITLE
chore: update to 2023/24 certificate

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -177,8 +177,8 @@ jobs:
         if: github.ref_name == 'main' && needs.check-ios-secrets.outputs.isReleaseBuild == 'true'
         uses: ./.github/workflows/actions/export-ios-archive
         with:
-          certificate: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-          certificate_password: ${{ secrets.KEYCHIAN_PASSWD }}
+          certificate: ${{ secrets.APPLE_APP_STORE_BUILD_CERTIFICATE_BASE64 }}
+          certificate_password: ${{ secrets.APPLE_APP_STORE_BUILD_CERTIFICATE_PASSWD }}
           provisioning_profile: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
           export_options: options.plist
           ouput_artifact_ref: ios-artifact

--- a/options.plist
+++ b/options.plist
@@ -17,7 +17,7 @@
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>ca.bc.gov.BCWallet</key>
-		<string>294e3c78-8b6d-4a39-8f23-8eebb8ba0cac</string>
+		<string>b2ef928b-6236-4afa-b150-5124e660c775</string>
 	</dict>
 </dict>
 </plist>

--- a/options.plist
+++ b/options.plist
@@ -17,11 +17,7 @@
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>ca.bc.gov.BCWallet</key>
-<<<<<<< HEAD
-		<string>b2ef928b-6236-4afa-b150-5124e660c775</string>
-=======
 		<string>30dd4887-0747-40a7-a519-637253d21fff</string>
->>>>>>> 7554c39 (fix: profile ID)
 	</dict>
 </dict>
 </plist>

--- a/options.plist
+++ b/options.plist
@@ -17,7 +17,11 @@
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>ca.bc.gov.BCWallet</key>
+<<<<<<< HEAD
 		<string>b2ef928b-6236-4afa-b150-5124e660c775</string>
+=======
+		<string>30dd4887-0747-40a7-a519-637253d21fff</string>
+>>>>>>> 7554c39 (fix: profile ID)
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Updated CICD pipline to use 2023/24 release certificates for the Apple App Store.