### PR TITLE
fix: profile id

### DIFF
--- a/options.plist
+++ b/options.plist
@@ -17,7 +17,7 @@
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>ca.bc.gov.BCWallet</key>
-		<string>30dd4887-0747-40a7-a519-637253d21fff</string>
+		<string>b2ef928b-6236-4afa-b150-5124e660c775</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Fix the provisioning profile ID. Ealer PR used the development profile rather than the App Store profile.