### PR TITLE
fix: pp id

### DIFF
--- a/options.plist
+++ b/options.plist
@@ -17,7 +17,7 @@
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>ca.bc.gov.BCWallet</key>
-		<string>b2ef928b-6236-4afa-b150-5124e660c775</string>
+		<string>84752b1c-8c7c-4afc-8a0b-fffbf56cd390</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
The provisioning profile has been updated to include the proper entitlements for push notifications. This change updates the provisioning profile ID accordingly.