### PR TITLE
feat: refresh pool on connect

### DIFF
--- a/.yarn/patches/@aries-framework-indy-vdr-npm-0.4.0-b01067562c.patch
+++ b/.yarn/patches/@aries-framework-indy-vdr-npm-0.4.0-b01067562c.patch
@@ -1,0 +1,49 @@
+diff --git a/build/pool/IndyVdrPool.d.ts b/build/pool/IndyVdrPool.d.ts
+index cff86a7a020c7c6152a7c08f4ce0cb4e83b3838d..8b2cde35e778b85d7d76c6d32c2c636751718bcb 100644
+--- a/build/pool/IndyVdrPool.d.ts
++++ b/build/pool/IndyVdrPool.d.ts
+@@ -30,7 +30,7 @@ export declare class IndyVdrPool {
+     constructor(poolConfig: IndyVdrPoolConfig);
+     get indyNamespace(): string;
+     get config(): IndyVdrPoolConfig;
+-    connect(): void;
++    connect(): Promise<void>;
+     private get pool();
+     close(): void;
+     prepareWriteRequest<Request extends IndyVdrRequest>(agentContext: AgentContext, request: Request, signingKey: Key, endorserDid?: string): Promise<Request>;
+diff --git a/build/pool/IndyVdrPool.js b/build/pool/IndyVdrPool.js
+index 0ec57415429a0b97844b2d65a8ee83f68ad10466..1c693e7381dc19209ec928d26a05eb65b2e8d9f5 100644
+--- a/build/pool/IndyVdrPool.js
++++ b/build/pool/IndyVdrPool.js
+@@ -15,7 +15,7 @@ class IndyVdrPool {
+     get config() {
+         return this.poolConfig;
+     }
+-    connect() {
++    async connect() {
+         if (this._pool) {
+             throw new error_1.IndyVdrError('Cannot connect to pool, already connected.');
+         }
+@@ -24,10 +24,11 @@ class IndyVdrPool {
+                 transactions: this.config.genesisTransactions,
+             },
+         });
++        await this._pool.refresh()
+     }
+-    get pool() {
++    async pool() {
+         if (!this._pool)
+-            this.connect();
++            await this.connect();
+         if (!this._pool)
+             throw new error_1.IndyVdrError('Pool is not connected.');
+         return this._pool;
+@@ -60,7 +61,7 @@ class IndyVdrPool {
+      * @param writeRequest
+      */
+     async submitRequest(writeRequest) {
+-        return await this.pool.submitRequest(writeRequest);
++        return await (await this.pool()).submitRequest(writeRequest);
+     }
+     async appendTaa(request) {
+         const authorAgreement = await this.getTransactionAuthorAgreement();

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@aries-framework/react-hooks@^0.4.2": "patch:@aries-framework/react-hooks@npm:0.4.2#./.yarn/patches/@aries-framework-react-hooks-npm-0.4.2-84b7eb8764.patch",
     "@aries-framework/react-native@0.4.0": "patch:@aries-framework/react-native@npm:0.3.3#./.yarn/patches/@aries-framework-react-native-npm-0.3.3-bb75ece22d.patch",
     "@aries-framework/anoncreds@^0.4.0": "patch:@aries-framework/anoncreds@npm%3A0.4.0#./.yarn/patches/@aries-framework-anoncreds-npm-0.4.0-4d3b4e769d.patch",
-    "@aries-framework/anoncreds@0.4.0": "patch:@aries-framework/anoncreds@npm%3A0.4.0#./.yarn/patches/@aries-framework-anoncreds-npm-0.4.0-4d3b4e769d.patch"
+    "@aries-framework/anoncreds@0.4.0": "patch:@aries-framework/anoncreds@npm%3A0.4.0#./.yarn/patches/@aries-framework-anoncreds-npm-0.4.0-4d3b4e769d.patch",
+    "@aries-framework/indy-vdr@^0.4.0": "patch:@aries-framework/indy-vdr@npm%3A0.4.0#./.yarn/patches/@aries-framework-indy-vdr-npm-0.4.0-b01067562c.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -129,7 +129,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aries-framework/indy-vdr@npm:^0.4.0":
+"@aries-framework/indy-vdr@npm:0.4.0":
   version: 0.4.0
   resolution: "@aries-framework/indy-vdr@npm:0.4.0"
   dependencies:
@@ -138,6 +138,18 @@ __metadata:
   peerDependencies:
     "@hyperledger/indy-vdr-shared": ^0.1.0
   checksum: 9ba82aa3994a1774f186fafbe793384ce42af9dfd5604189ac7786f0e31dc9ca1eba70e8b2e4aab474889775264d39a1e4c3bce997dd446f81f49b16ca2191a5
+  languageName: node
+  linkType: hard
+
+"@aries-framework/indy-vdr@patch:@aries-framework/indy-vdr@npm%3A0.4.0#./.yarn/patches/@aries-framework-indy-vdr-npm-0.4.0-b01067562c.patch::locator=bc-wallet-mobile%40workspace%3A.":
+  version: 0.4.0
+  resolution: "@aries-framework/indy-vdr@patch:@aries-framework/indy-vdr@npm%3A0.4.0#./.yarn/patches/@aries-framework-indy-vdr-npm-0.4.0-b01067562c.patch::version=0.4.0&hash=69134c&locator=bc-wallet-mobile%40workspace%3A."
+  dependencies:
+    "@aries-framework/anoncreds": 0.4.0
+    "@aries-framework/core": 0.4.0
+  peerDependencies:
+    "@hyperledger/indy-vdr-shared": ^0.1.0
+  checksum: baa7245703045d08fc0ca159cde9232421ec2b343457232f9fcbe355920a66f279bff4739ac34dadfecced5b0a758f52490a2c034e1c0531f9b1398084e9c651
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Added a patch to refresh the pool when connecting, solves the slowness issue with lsbc credential
together with: https://github.com/hyperledger/aries-mobile-agent-react-native/pull/1015 this should speed up the wallet quite a bit