### PR TITLE
Added proper direct domains to sauce tunnel in build pipeline smoke test

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -462,7 +462,7 @@ jobs:
         with:
           username: ${{ secrets.SAUCE_USERNAME }}
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-          directDomains: aries-mediator-agent-test.apps.silver.devops.gov.bc.ca
+          directDomains: aries-mediator-agent.vonx.io,apple.com
 
       - name: Fetch mobile test harness repo
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates the direct domains on the Sauce Tunnel. This needed to be changed a while ago and was in the test pipeline but the build pipeline was overlooked. This causes the iOS smoke test to fail on an iOS build. 