### PR TITLE
chore: allow provisioning updates in gha pipeline for ios

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -174,6 +174,7 @@ jobs:
           xcodebuild \
           -workspace AriesBifold.xcworkspace \
           -scheme AriesBifold \
+          -allowProvisioningUpdates \
           -configuration Release \
           -derivedDataPath xbuild \
           -xcconfig ../../release.xcconfig \


### PR DESCRIPTION
This should hopefully fix the error we are getting from the app store re: push notification provisioning profile.
See here: https://github.com/invertase/react-native-firebase/discussions/6450