### PR TITLE
fix: build and probes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -160,7 +160,7 @@ jobs:
           IAS_AGENT_INVITE_URL: ${{ secrets.IAS_AGENT_INVITE_URL }}
           OCA_URL: ${{ vars.OCA_URL }}
           PROOF_TEMPLATE_URL: ${{ vars.PROOF_TEMPLATE_URL }}
-          REMOTE_LOGGING_URL: ${{ secrets.REMOTE_LOGGING_URL }}}
+          REMOTE_LOGGING_URL: ${{ secrets.REMOTE_LOGGING_URL }}
         run: |
           echo "MEDIATOR_USE_PUSH_NOTIFICATIONS=${MEDIATOR_USE_PUSH_NOTIFICATIONS}" >.env
           echo "MEDIATOR_URL=${MEDIATOR_URL}" >>.env

--- a/devops/README.md
+++ b/devops/README.md
@@ -1,0 +1,73 @@
+# TL;DR
+
+This directory contains the source code for supporting infrastructure components for the project.
+
+# Overview
+
+## Loki Logstack
+
+The Loki Logstack is a set of components for gathering and storing logs temporarily, which helps with troubleshooting and analyzing issues for the BC Wallet's advanced support team.
+
+When turned on, the BC Wallet sends its logs to the Loki Logstack through the Loki Proxy. This proxy then forwards the logs to Loki for safekeeping. To ensure security, the Loki Proxy needs proper login details. It will only accept logs from the BC Wallet if the correct credentials are provided.
+
+The components to the Loki Logstack deployment are as follows:
+
+1. Loki - a log aggregation system
+
+Read more about Loki [here](https://grafana.com/oss/loki/).
+
+2. Proxy - a gatekeeper for the Loki system
+
+The current proxy implementation is Caddy. Read more about Caddy [here](https://caddyserver.com/).
+
+### Deployment
+
+Deploy the Loki Logstack using the following command:
+
+```bash
+helm template bcwallet ./devops/charts/loki-logstack \
+--set-string namespace=abc123-dev \
+--set-string proxyUserName=<USER_NAME> \
+--set-string proxyPassword=<PASSWORD> | \
+oc apply -n e79518-dev -f -
+```
+
+The parameters passed in via the `--set-string` argument for this command are as follows:
+
+| Value         | Description                                                                                         |
+| ------------- | --------------------------------------------------------------------------------------------------- |
+| namespace     | The namespace in which to deploy the Loki Logstack. This is used by Caddy to find the Loki service. |
+| proxyUserName | The username for the Loki Proxy. This is part of the authentication credentials.                    |
+| proxyPassword | The password for the Loki Proxy.This is part of the authentication credentials.                     |
+
+Once deployed there will be two pods running that can be verified with the following command:
+
+```console
+➜  vc-wallet-mobile ✗ oc get pods -l "app.kubernetes.io/name=logstack"
+
+NAME                                       READY   STATUS    RESTARTS   AGE
+bcwallet-logstack-loki-78867f88c8-zpm74    1/1     Running   0          39m
+bcwallet-logstack-proxy-54977bb56b-jrnd9   1/1     Running   0          70m
+```
+
+In addition to the pods, there will be a route created for the Loki Proxy. This route is used by the BC Wallet to send its logs to the Loki Proxy. The route can be verified with the following command:
+
+```console
+➜  vc-wallet-mobile oc get routes -l "app.kubernetes.io/name=logstack"
+
+NAME                      HOST/PORT                                                         PATH   SERVICES                  PORT   TERMINATION     WILDCARD
+bcwallet-logstack-proxy   bcwallet-logstack-proxy-abc123-dev.apps.silver.devops.gov.bc.ca          bcwallet-logstack-proxy   2015   edge/Redirect   None
+```
+
+### Usage
+
+To use the Loki Logstack, the BC Wallet needs to be configured to send its logs to the Loki Proxy. This is done by setting the following environment variables (in the .env):
+
+| Variable Name | Description |
+| REMOTE_LOGGING_URL | The route from above with basic authentication credentials |
+
+For example:
+
+```console
+REMOTE_LOGGING_URL=https://<USERNAME>:<PASSWORD>@bcwallet-logstack-proxy-ab123-dev.apps.silver.devops.gov.bc.ca/loki/api/v1/push
+```

--- a/devops/README.md
+++ b/devops/README.md
@@ -71,3 +71,18 @@ For example:
 ```console
 REMOTE_LOGGING_URL=https://<USERNAME>:<PASSWORD>@bcwallet-logstack-proxy-ab123-dev.apps.silver.devops.gov.bc.ca/loki/api/v1/push
 ```
+
+You can use the following cURL command to the entire log stack. Loki does not accept outdated logs, so you will need to change the timestamp `1705256799868099100` to the current time.
+
+Get and updated timestamp:
+
+```console
+➜  vc-wallet-mobile git:(fix/build-and-probe) ✗ node -e "console.log(Date.now() + '099100')"
+1705256928213099100
+```
+
+Send a sample log with the updated timestamp:
+
+```bash
+curl -v -H "Content-Type: application/json" -X POST "https://<USERNAME>:<PASSWORD>@bcwallet-logstack-proxy-abc123-dev.apps.silver.devops.gov.bc.ca/loki/api/v1/push" --data-raw '{"streams": [{ "stream": { "bcwallet": "00123", "level": "debug" }, "values": [ [ "1705256928213099100", "fizbuzz" ] ] }]}'
+```

--- a/devops/charts/loki-logstack/templates/configmap.yaml
+++ b/devops/charts/loki-logstack/templates/configmap.yaml
@@ -95,6 +95,13 @@ data:
       }
     }
 
+    (logging) {
+      log {
+        level {{ .Values.caddy.logLevel }}
+        output stdout
+      }
+    }
+
     {{- range $name, $port := .Values.services.proxy }}
     {{- if eq .name "http" }}
     :{{ .port }} {
@@ -107,4 +114,5 @@ data:
       }
 
       import revpx
+      import logging
     }

--- a/devops/charts/loki-logstack/templates/deployment.yaml
+++ b/devops/charts/loki-logstack/templates/deployment.yaml
@@ -50,18 +50,20 @@ spec:
               subPath: {{ .Values.env.LOKI_CONFIG_PATH | base}}
             - name: loki-log-data
               mountPath: {{ .Values.persistentVolumeClaim.mountPath }}
-          # livenessProbe:
-          #   httpGet:
-          #     path: /api/v1/ehlo
-          #     port: http
-          #   initialDelaySeconds: 60
-          #   periodSeconds: 3
-          # readinessProbe:
-          #   httpGet:
-          #     path: /api/v1/ehlo
-          #     port: http
-          #   initialDelaySeconds: 60
-          #   timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 90
+            timeoutSeconds: 3
+            failureThreshold: 3
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -106,16 +108,16 @@ spec:
             - name: loki-proxy-config
               mountPath: {{.Values.env.CADDY_CONFIG_PATH }} 
               subPath: {{.Values.env.CADDY_CONFIG_PATH | base}}
-          # livenessProbe:
-          #   httpGet:
-          #     path: /api/v1/ehlo
-          #     port: http
-          #   initialDelaySeconds: 60
-          #   periodSeconds: 3
-          # readinessProbe:
-          #   httpGet:
-          #     path: /api/v1/ehlo
-          #     port: http
-          #   initialDelaySeconds: 60
-          #   timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /ehlo
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ehlo
+              port: http
+            initialDelaySeconds: 60
+            timeoutSeconds: 3
 

--- a/devops/charts/loki-logstack/values.yaml
+++ b/devops/charts/loki-logstack/values.yaml
@@ -27,10 +27,10 @@ env:
 resources:
   loki:
     requests:
-      memory: 48Mi
+      memory: 92Mi
       cpu: 10m
     limits:
-      memory: 64Mi
+      memory: 128Mi
       cpu: 100m
   proxy:
     requests:
@@ -102,3 +102,10 @@ loki:
   retention:
     retention_deletes_enabled: true
     retention_period: 3d
+
+#
+# Caddy configuration
+#
+
+caddy:
+  logLevel: DEBUG

--- a/devops/charts/loki-logstack/values.yaml
+++ b/devops/charts/loki-logstack/values.yaml
@@ -108,4 +108,4 @@ loki:
 #
 
 caddy:
-  logLevel: DEBUG
+  logLevel: INFO


### PR DESCRIPTION
The following changes are part of this PR:

- Fix an erosions `{` in the cicd pipeline workflow;
- Enable k8s probes.
- Caddy logging.
- Add documentation
- Fix session Id not showing up in remote log warning screen