### PR TITLE
fix: set min android sdk ver

### DIFF
--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "33.0.2"
-        minSdkVersion = 21
+        minSdkVersion = 23
         compileSdkVersion = 33
         targetSdkVersion = 33
         ndkVersion = "25.1.8937393"


### PR DESCRIPTION
Fix builds that are failing because the current android min SDK (21) is too low.

```console
Uploading bundle data to Edit.
error =  GaxiosError: Automatic integrity protection (version: dynamite) requires a minimum SDK version of 23 or higher. Please update your minSdkVersion in your app's Android manifest.
    at Gaxios._request (/home/runner/.npm/_npx/62ba049eca7ed435/node_modules/gaxios/build/src/gaxios.js:129:23)
...
```

Fixes #1709