### PR TITLE
fix: session id

### DIFF
--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -185,7 +185,7 @@ const translation = {
     "ScreenTitle": "Remote Logging",
     "Paragraph1": "Only turn on remote logging if you are in a debugging session or if you are asked and agree to do so. This action will send logs to Technical Support at the the Government of British Columbia.",
     "Paragraph2": "Logs are automatically deleted after three days. They are kept and used only for debugging, as outlined in our",
-    "Paragraph3": "Provide the debug session id ${sessionId} to technical support.",
+    "Paragraph3": "Provide the debug session id {sessionId} to technical support.",
     "CheckBoxTitle": "I understand and wish to enable remote logging",
     "IAgree": "I Agree",
     "ButtonTitle": "Turn on remote logging",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -184,7 +184,7 @@ const translation = {
     "ScreenTitle": "Remote Logging (FR)",
     "Paragraph1": "Only turn on remote logging if you are in a debugging session or if you are asked and agree to do so. This action will send logs to Technical Support at the the Government of British Columbia. (FR)",
     "Paragraph2": "Logs are automatically deleted after three days. They are kept and used only for debugging, as outlined in our (FR)",
-    "Paragraph3": "Provide the debug session id ${sessionId} to technical support. (FR)",
+    "Paragraph3": "Provide the debug session id {sessionId} to technical support. (FR)",
     "CheckBoxTitle": "I understand and wish to enable remote logging (FR)",
     "IAgree": "I Agree (FR)",
     "ButtonTitle": "Turn on remote logging (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -184,7 +184,7 @@ const translation = {
     "ScreenTitle": "Remote Logging (PT-BR)",
     "Paragraph1": "Only turn on remote logging if you are in a debugging session or if you are asked and agree to do so. This action will send logs to Technical Support at the the Government of British Columbia. (PT-BR)",
     "Paragraph2": "Logs are automatically deleted after three days. They are kept and used only for debugging, as outlined in our (PT-BR)",
-    "Paragraph3": "Provide the debug session id ${sessionId} to technical support. (PT-BR)",
+    "Paragraph3": "Provide the debug session id {sessionId} to technical support. (PT-BR)",
     "CheckBoxTitle": "I understand and wish to enable remote logging (PT-BR)",
     "IAgree": "I Agree (PT-BR)",
     "ButtonTitle": "Turn on remote logging (PT-BR)",

--- a/app/src/screens/RemoteLogWarning.tsx
+++ b/app/src/screens/RemoteLogWarning.tsx
@@ -13,6 +13,7 @@ const RemoteLogWarning: React.FC<RemoteLogWarningProps> = ({ onEnablePressed, se
   const [checked, setChecked] = useState(false)
   const { t } = useTranslation()
   const { TextTheme } = useTheme()
+  const paragraphText = t('RemoteLogging.Paragraph3').replace('{sessionId}', sessionId)
 
   const onSubmitPressed = () => {
     onEnablePressed()
@@ -45,7 +46,7 @@ const RemoteLogWarning: React.FC<RemoteLogWarningProps> = ({ onEnablePressed, se
               {t('RemoteLogging.Paragraph2')}
               <Link onPress={onPressShowcaseLink} linkText={`${'Privacy Policy'}.`} />
             </Text>
-            <Text style={[TextTheme.normal, { marginTop: 10 }]}>{t('RemoteLogging.Paragraph3')}</Text>
+            <Text style={[TextTheme.normal, { marginTop: 10 }]}>{paragraphText}</Text>
           </View>
           <View style={style.controlsContainer}>
             <CheckBoxRow

--- a/devops/README.md
+++ b/devops/README.md
@@ -63,7 +63,8 @@ bcwallet-logstack-proxy   bcwallet-logstack-proxy-abc123-dev.apps.silver.devops.
 
 To use the Loki Logstack, the BC Wallet needs to be configured to send its logs to the Loki Proxy. This is done by setting the following environment variables (in the .env):
 
-| Variable Name | Description |
+| Variable Name      | Description                                                |
+| ------------------ | ---------------------------------------------------------- |
 | REMOTE_LOGGING_URL | The route from above with basic authentication credentials |
 
 For example:


### PR DESCRIPTION
Fix adding the session ID to the remote log warning screen and fix a table in the README docs.