### PR TITLE
fix: add labels to logging

### DIFF
--- a/app/src/screens/Splash.tsx
+++ b/app/src/screens/Splash.tsx
@@ -39,6 +39,13 @@ import TipCarousel from '../components/TipCarousel'
 import { autoDisableRemoteLoggingIntervalInMinutes } from '../constants'
 import { useAttestation } from '../services/attestation'
 import { BCState, BCDispatchAction, BCLocalStorageKeys } from '../store'
+import {
+  getVersion,
+  getBuildNumber,
+  getApplicationName,
+  getSystemName,
+  getSystemVersion,
+} from 'react-native-device-info'
 
 enum InitErrorTypes {
   Onboarding,
@@ -394,8 +401,10 @@ const Splash = () => {
         const logOptions: RemoteLoggerOptions = {
           lokiUrl: Config.REMOTE_LOGGING_URL,
           lokiLabels: {
-            application: 'bcwallet',
+            application: getApplicationName().toLowerCase(),
             job: 'react-native-logs',
+            version: `${getVersion()}-${getBuildNumber()}`,
+            system: `${getSystemName()} v${getSystemVersion()}`,
           },
           autoDisableRemoteLoggingIntervalInMinutes,
         }


### PR DESCRIPTION
Add additional log labels to remote logging.

![Screenshot 2024-01-22 at 4 47 26 PM](https://github.com/bcgov/bc-wallet-mobile/assets/390891/31ad5999-5d75-447b-9d10-9d3e1bbdafb5)


Fixes #1727 