### PR TITLE
fix: push environment

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -170,6 +170,10 @@ jobs:
           echo "PROOF_TEMPLATE_URL=${PROOF_TEMPLATE_URL}" >>.env
           echo "REMOTE_LOGGING_URL=${REMOTE_LOGGING_URL}" >>.env
 
+      - name: Update APS environment
+        run: |
+          sed -i '' 's/development/production/g' app/ios/AriesBifold/AriesBifold.entitlements
+
       - name: Archive build
         working-directory: app/ios
         run: |


### PR DESCRIPTION
For TestFlight builds use the production apple push notification environment. 