### PR TITLE
fix: issue with cicd yaml

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -190,7 +190,7 @@ jobs:
           -scheme AriesBifold \
           -allowProvisioningUpdates \
           -configuration Release \
-          -xcconfig ../../release.xcconfig
+          -xcconfig ../../release.xcconfig \
           -derivedDataPath xbuild \
           -archivePath ../../AriesBifold.xcarchive \
           -sdk iphoneos \

--- a/scripts/makepp.sh
+++ b/scripts/makepp.sh
@@ -7,7 +7,7 @@ echo ">> Build Provisioning Profile... 🤞"
 echo ">> Provisioning Profile Home = ${PP_DIR}"
 
 UUID=$(/usr/libexec/plistbuddy -c Print:UUID /dev/stdin <<< `echo "${PROVISIONING_PROFILE}" | base64 -d | security cms -D`)
-echo "${PROVISIONING_PROFILE}" | base64 -d >${UUID}.mobileprovision
+base64 -d <<< "${PROVISIONING_PROFILE}" >${UUID}.mobileprovision
 md5 "${UUID}.mobileprovision"
 mkdir -p "${PP_DIR}"
 cp ${UUID}.mobileprovision "${PP_DIR}/"


### PR DESCRIPTION
Fix a missing like continuation mark in the yaml and a better way to pipe information between processes.