### PR TITLE
feat: attestation loading hook

### DIFF
--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -24,6 +24,7 @@ import PersonCredential from './screens/PersonCredential'
 import Preface from './screens/Preface'
 import Splash from './screens/Splash'
 import Terms from './screens/Terms'
+import { useAttestation } from './services/attestation'
 import { BCDispatchAction } from './store'
 import { defaultTheme as theme } from './theme'
 
@@ -72,6 +73,7 @@ const configuration: ConfigurationContext = {
   showPreface: true,
   disableOnboardingSkip: true,
   useCustomNotifications: useNotifications,
+  useAttestation: useAttestation,
   whereToUseWalletUrl: 'https://www2.gov.bc.ca/gov/content/governments/government-id/bc-wallet#where',
 }
 

--- a/app/src/screens/Splash.tsx
+++ b/app/src/screens/Splash.tsx
@@ -32,13 +32,6 @@ import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, View, Text, Image, useWindowDimensions, ScrollView } from 'react-native'
 import { Config } from 'react-native-config'
-import { SafeAreaView } from 'react-native-safe-area-context'
-
-import ProgressBar from '../components/ProgressBar'
-import TipCarousel from '../components/TipCarousel'
-import { autoDisableRemoteLoggingIntervalInMinutes } from '../constants'
-import { useAttestation } from '../services/attestation'
-import { BCState, BCDispatchAction, BCLocalStorageKeys } from '../store'
 import {
   getVersion,
   getBuildNumber,
@@ -46,6 +39,13 @@ import {
   getSystemName,
   getSystemVersion,
 } from 'react-native-device-info'
+import { SafeAreaView } from 'react-native-safe-area-context'
+
+import ProgressBar from '../components/ProgressBar'
+import TipCarousel from '../components/TipCarousel'
+import { autoDisableRemoteLoggingIntervalInMinutes } from '../constants'
+import { useAttestation } from '../services/attestation'
+import { BCState, BCDispatchAction, BCLocalStorageKeys } from '../store'
 
 enum InitErrorTypes {
   Onboarding,


### PR DESCRIPTION
The below gif shows the process of getting a proof request that requires an attestation credential first without attestation support enabled and then with it enabled. It takes about 10 seconds so we may want to add a specific message about attestation being in progress but that will be easy.

![attestation](https://github.com/bcgov/bc-wallet-mobile/assets/32586431/7aee40cd-7495-43e1-ae5b-cdf7f440ebe2)
