### PR TITLE
fix: correct spaces urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@aries-framework/core": "0.4.0",
     "@aries-framework/anoncreds-rs": "0.4.0",
     "@aries-framework/askar": "0.4.0",
-    "@aries-framework/react-native": "0.4.0",
+    "@aries-framework/react-native": "0.4.2",
     "@aries-framework/indy-sdk-to-askar-migration": "0.4.0",
     "@aries-framework/react-hooks": "patch:@aries-framework/react-hooks@npm:0.4.2#./.yarn/patches/@aries-framework-react-hooks-npm-0.4.2-84b7eb8764.patch",
     "@aries-framework/anoncreds": "patch:@aries-framework/anoncreds@npm%3A0.4.0#./.yarn/patches/@aries-framework-anoncreds-npm-0.4.0-4d3b4e769d.patch",


### PR DESCRIPTION
This pulls in a fix to an AFJ package where URLs with spaces in them are properly decoded when fetched. This can occurs because some schemas have spaces in the names which fails when fetching the associated tails file. This is an example of the error:

```
  "message": "Error while retrieving tails file from URL https://tails-test.vonx.io/TeT8SJGHruVL9up3Erp4o:4:TeT8SJGHruVL9up3Erp4o:3:CL:224665:Selling It Right:CL_ACCUM:6d6f660b-7b89-4812-87fe-5d286e7dd63c",
```

I checked the difference between 0.4.0 and 0.4.2 of the `@aries-framework/react-native` package and this is the only change:

```console
➜  vc-wallet-mobile git:(main) ✗ diff app/node_modules/@aries-framework/react-native/build/ReactNativeFileSystem.js /tmp/ReactNativeFileSystem.js
79a80
>         const fromUrl = this.encodeUriIfRequired(url);
81c82
<             fromUrl: url,
---
>             fromUrl,
95a97,101
>     encodeUriIfRequired(uri) {
>         // Some characters in the URL might be invalid for
>         // the native os to handle. Only encode if necessary.
>         return uri === decodeURI(uri) ? encodeURI(uri) : uri;
>     }
➜  vc-wallet-mobile git:(main) ✗
```