### PR TITLE
fix: onboarding developer mode

### DIFF
--- a/app/__tests__/screens/__snapshots__/Developer.test.tsx.snap
+++ b/app/__tests__/screens/__snapshots__/Developer.test.tsx.snap
@@ -1137,6 +1137,7 @@ exports[`Developer Screen screen renders correctly 1`] = `
         >
           <RCTSwitch
             accessibilityRole="switch"
+            disabled={true}
             onChange={[Function]}
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}

--- a/app/src/screens/Developer.tsx
+++ b/app/src/screens/Developer.tsx
@@ -37,7 +37,6 @@ const Settings: React.FC = () => {
     !!store.developer.attestationSupportEnabled
   )
   const [remoteLoggingEnabled, setRemoteLoggingEnabled] = useState(logger?.remoteLoggingEnabled)
-
   const { start, stop } = useAttestation()
 
   const styles = StyleSheet.create({

--- a/app/src/screens/Developer.tsx
+++ b/app/src/screens/Developer.tsx
@@ -36,7 +36,8 @@ const Settings: React.FC = () => {
   const [attestationSupportEnabled, setAttestationSupportEnabled] = useState(
     !!store.developer.attestationSupportEnabled
   )
-  const [remoteLoggingEnabled, setRemoteLoggingEnabled] = useState(logger.remoteLoggingEnabled)
+  const [remoteLoggingEnabled, setRemoteLoggingEnabled] = useState(logger?.remoteLoggingEnabled)
+
   const { start, stop } = useAttestation()
 
   const styles = StyleSheet.create({
@@ -269,7 +270,7 @@ const Settings: React.FC = () => {
           return
         }}
       >
-        <RemoteLogWarning onEnablePressed={onEnableRemoteLoggingPressed} sessionId={logger.sessionId} />
+        <RemoteLogWarning onEnablePressed={onEnableRemoteLoggingPressed} sessionId={logger?.sessionId} />
       </Modal>
       <Modal
         visible={environmentModalVisible}
@@ -433,6 +434,7 @@ const Settings: React.FC = () => {
             ios_backgroundColor={ColorPallet.grayscale.lightGrey}
             onValueChange={toggleRemoteLoggingWarningSwitch}
             value={remoteLoggingEnabled}
+            disabled={!store.authentication.didAuthenticate}
           />
         </SectionRow>
       </ScrollView>

--- a/app/src/screens/OnboardingPages.tsx
+++ b/app/src/screens/OnboardingPages.tsx
@@ -6,16 +6,11 @@ import {
   createStyles,
   GenericFn,
   testIdWithKey,
-  DispatchAction,
-  Screens,
-  OnboardingStackParams,
   ContentGradient,
 } from '@hyperledger/aries-bifold-core'
-import { useNavigation } from '@react-navigation/native'
-import { StackNavigationProp } from '@react-navigation/stack'
-import React, { useRef } from 'react'
+import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text, TouchableWithoutFeedback, View } from 'react-native'
+import { StyleSheet, Text, View } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
 import { SvgProps } from 'react-native-svg'
 
@@ -84,30 +79,12 @@ const EndPage = (onTutorialCompleted: GenericFn, theme: ITheme['OnboardingTheme'
 const StartPage = (theme: ITheme['OnboardingTheme']) => {
   const { t } = useTranslation()
   const defaultStyle = createStyles(theme)
-  const [store, dispatch] = useStore()
-  const developerOptionCount = useRef(0)
-  const touchCountToEnableBiometrics = 9
-  const navigation = useNavigation<StackNavigationProp<OnboardingStackParams>>()
   const styles = StyleSheet.create({
     imageContainer: {
       alignItems: 'center',
       marginBottom: 10,
     },
   })
-
-  const incrementDeveloperMenuCounter = () => {
-    if (developerOptionCount.current >= touchCountToEnableBiometrics) {
-      developerOptionCount.current = 0
-      dispatch({
-        type: DispatchAction.ENABLE_DEVELOPER_MODE,
-        payload: [true],
-      })
-      navigation.navigate(Screens.Developer)
-      return
-    }
-
-    developerOptionCount.current = developerOptionCount.current + 1
-  }
 
   const imageDisplayOptions = {
     fill: theme.imageDisplayOptions.fill,
@@ -121,12 +98,7 @@ const StartPage = (theme: ITheme['OnboardingTheme']) => {
         <ScanShare {...imageDisplayOptions} />
       </View>
       <View style={{ marginBottom: 20 }}>
-        <TouchableWithoutFeedback
-          onPress={incrementDeveloperMenuCounter}
-          disabled={store.preferences.developerModeEnabled}
-        >
-          <Text style={[defaultStyle.headerText, { fontSize: 26 }]}>{t('Onboarding.DifferentWalletHeading')}</Text>
-        </TouchableWithoutFeedback>
+        <Text style={[defaultStyle.headerText, { fontSize: 26 }]}>{t('Onboarding.DifferentWalletHeading')}</Text>
         <Text style={[defaultStyle.bodyText, { marginTop: 20 }]}>{t('Onboarding.DifferentWalletParagraph')}</Text>
       </View>
     </ScrollView>

--- a/app/src/screens/Preface.tsx
+++ b/app/src/screens/Preface.tsx
@@ -3,37 +3,56 @@ import {
   useStore,
   testIdWithKey,
   DispatchAction,
-  AuthenticateStackParams,
   Screens,
   CheckBoxRow,
   Button,
   ButtonType,
   Link,
+  OnboardingStackParams,
 } from '@hyperledger/aries-bifold-core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Linking, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { Linking, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 const Preface: React.FC = () => {
   const [, dispatch] = useStore()
   const [checked, setChecked] = useState(false)
   const { t } = useTranslation()
-  const navigation = useNavigation<StackNavigationProp<AuthenticateStackParams>>()
+  const developerOptionCount = useRef(0)
+  const touchCountToEnableBiometrics = 9
+  const navigation = useNavigation<StackNavigationProp<OnboardingStackParams>>()
   const { Assets, OnboardingTheme, TextTheme } = useTheme()
+
   const onSubmitPressed = () => {
     dispatch({
       type: DispatchAction.DID_SEE_PREFACE,
     })
     navigation.navigate(Screens.Onboarding)
   }
+
   const onPressInfoLink = () => {
     Linking.openURL('https://www2.gov.bc.ca/gov/content/governments/government-id/bc-wallet#where')
   }
+
   const onPressShowcaseLink = () => {
     Linking.openURL('https://digital.gov.bc.ca/digital-trust/showcase/')
+  }
+
+  const incrementDeveloperMenuCounter = () => {
+    if (developerOptionCount.current >= touchCountToEnableBiometrics) {
+      developerOptionCount.current = 0
+      dispatch({
+        type: DispatchAction.ENABLE_DEVELOPER_MODE,
+        payload: [true],
+      })
+      navigation.navigate(Screens.Developer)
+      return
+    }
+
+    developerOptionCount.current = developerOptionCount.current + 1
   }
 
   const style = StyleSheet.create({
@@ -55,7 +74,9 @@ const Preface: React.FC = () => {
         <View style={style.screenContainer}>
           <View style={style.contentContainer}>
             <Assets.svg.preface style={{ alignSelf: 'center', marginBottom: 20 }} height={200} />
-            <Text style={[TextTheme.headingTwo]}>{t('Preface.PrimaryHeading')}</Text>
+            <Pressable onPress={incrementDeveloperMenuCounter} testID={testIdWithKey('DeveloperCounter')}>
+              <Text style={[TextTheme.headingTwo]}>{t('Preface.PrimaryHeading')}</Text>
+            </Pressable>
             <Text style={[TextTheme.normal, { marginTop: 10, marginBottom: 10 }]}>{t('Preface.Paragraph1')}</Text>
             <Link style={{ marginTop: 10, marginBottom: 10 }} onPress={onPressInfoLink} linkText={t('Preface.Link1')} />
             <Text style={[TextTheme.normal, { marginTop: 10 }]}>{t('Preface.Paragraph2')}</Text>


### PR DESCRIPTION
This PR fixes a bug where attempting to enable developer mode during onboarding would crash the app. It also moves the hidden trigger to the first screen (Preface)

Here's it in action:
![onboarding_developer_mode](https://github.com/bcgov/bc-wallet-mobile/assets/32586431/0001325f-fd32-43ec-94d1-c932d3414040)
