### PR TITLE
fix: no double tap get person

### DIFF
--- a/app/src/screens/PersonCredential.tsx
+++ b/app/src/screens/PersonCredential.tsx
@@ -135,7 +135,7 @@ export default function PersonCredential() {
                 accessibilityLabel={t('PersonCredential.InstallApp')}
                 testID={testIdWithKey('InstallApp')}
                 title={t('PersonCredential.InstallApp')}
-              ></Button>
+              />
               <TouchableOpacity
                 onPress={() => setAppInstalled(true)}
                 accessibilityLabel={t('PersonCredential.AppOnOtherDevice')}
@@ -167,6 +167,7 @@ export default function PersonCredential() {
           {appInstalled ? (
             <Button
               buttonType={ButtonType.Primary}
+              disabled={workflowInProgress}
               testID={testIdWithKey('StartProcess')}
               accessibilityLabel={t('PersonCredential.StartProcess')}
               title={t('PersonCredential.StartProcess')}


### PR DESCRIPTION
Disable the "Start the process" button if the process has already begun. This prevents people from double tapping the button and potentially getting multiple offers.

Fixes #1835