### PR TITLE
feat: add memcached and expire logs in loki

### DIFF
--- a/devops/charts/loki-logstack/templates/configmap.yaml
+++ b/devops/charts/loki-logstack/templates/configmap.yaml
@@ -31,12 +31,36 @@ data:
         kvstore:
           store: inmemory
 
+    storage_config:
+      index_queries_cache_config:
+        memcached:
+          batch_size: 100
+          parallelism: 100
+        memcached_client:
+          consistent_hash: true
+          {{- range $name := .Values.services.memcached }}
+          {{- if eq .name "client" }}
+          host: {{ include "logstack.fullname" $ }}-memcached.{{ $.Values.namespace }}.svc.cluster.local
+          service: {{ .name }} 
+          {{- end }}
+          {{- end }}
+
     query_range:
+      cache_results: true
       results_cache:
         cache:
-          embedded_cache:
-            enabled: true
-            max_size_mb: 8
+          memcached_client:
+            consistent_hash: true
+            max_idle_conns: 8
+            timeout: 500ms
+            update_interval: 1m
+            {{- range $name := .Values.services.memcached }}
+            {{- if eq .name "client" }}
+            host: {{ include "logstack.fullname" $ }}-memcached.{{ $.Values.namespace }}.svc.cluster.local
+            service: {{ .name }} 
+            {{- end }}
+            {{- end }}
+
 
     schema_config:
       configs:
@@ -54,12 +78,28 @@ data:
     limits_config:
       reject_old_samples: true
       reject_old_samples_max_age: 24h
+      {{- toYaml .Values.loki.retention | nindent 6 }}
 
     chunk_store_config:
       max_look_back_period: 0s
+      chunk_cache_config:
+        memcached:
+          batch_size: 256
+          parallelism: 10
+        memcached_client:
+          {{- range $name := .Values.services.memcached }}
+          {{- if eq .name "client" }}
+          host: {{ include "logstack.fullname" $ }}-memcached.{{ $.Values.namespace }}.svc.cluster.local
+          service: {{ .name }} 
+          {{- end }}
+          {{- end }}
 
-    table_manager:
-      {{- toYaml .Values.loki.retention | nindent 6 }}
+    compactor:
+      retention_enabled: true
+      compaction_interval: 10m
+      retention_delete_delay: 2h
+      retention_delete_worker_count: 33
+
     # By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
     # analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
     #

--- a/devops/charts/loki-logstack/templates/deployment.yaml
+++ b/devops/charts/loki-logstack/templates/deployment.yaml
@@ -144,6 +144,7 @@ spec:
         app.kubernetes.io/component: memcached
         {{- include "logstack.labels" . | nindent 8 }}
     spec:
+      automountServiceAccountToken: false
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       containers:

--- a/devops/charts/loki-logstack/templates/deployment.yaml
+++ b/devops/charts/loki-logstack/templates/deployment.yaml
@@ -120,4 +120,39 @@ spec:
               port: http
             initialDelaySeconds: 60
             timeoutSeconds: 3
-
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "logstack.fullname" . }}-memcached
+  labels: {{- include "logstack.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}  
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: memcached
+      {{- include "logstack.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/component: memcached
+        {{- include "logstack.labels" . | nindent 8 }}
+    spec:
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.images.registry }}/{{ .Values.images.memcached.repository }}:{{ .Values.images.memcached.tag | default .Chart.AppVersion }}"
+          resources:
+            {{- toYaml .Values.resources.memcached | nindent 12 }}
+          ports:
+            {{- range $name, $port := .Values.services.memcached }}
+            - name: {{ .name }}
+              containerPort: {{ .port }}
+            {{- end }}

--- a/devops/charts/loki-logstack/templates/netpol.yaml
+++ b/devops/charts/loki-logstack/templates/netpol.yaml
@@ -43,3 +43,29 @@ spec:
               kubernetes.io/metadata.name: {{ .Values.namespace }}
   policyTypes:
     - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "logstack.fullname" . }}-loki-to-memcached
+  labels: {{- include "logstack.labels" . | nindent 4 }}
+  annotations: {{- toYaml .Values.route.annotations | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: memcached
+      {{- include "logstack.selectorLabels" . | nindent 6 }}
+  ingress:
+    - ports:
+      - protocol: TCP
+        port: 11211
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: loki
+              {{- include "logstack.selectorLabels" . | nindent 14 }}
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.namespace }}
+  policyTypes:
+    - Ingress

--- a/devops/charts/loki-logstack/templates/service.yaml
+++ b/devops/charts/loki-logstack/templates/service.yaml
@@ -32,3 +32,20 @@ spec:
   selector:
     app.kubernetes.io/component: proxy
     {{- include "logstack.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "logstack.fullname" . }}-memcached
+  labels: {{- include "logstack.labels" . | nindent 4 }}
+spec:
+  ports:
+    {{- range $name, $port := .Values.services.memcached }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .port }}
+      protocol: TCP
+    {{- end }}  
+  selector:
+    app.kubernetes.io/component: memcached
+    {{- include "logstack.selectorLabels" . | nindent 4 }}

--- a/devops/charts/loki-logstack/values.yaml
+++ b/devops/charts/loki-logstack/values.yaml
@@ -16,6 +16,10 @@ images:
     repository: caddy/caddy
     # Overrides the image tag whose default is the chart appVersion.
     tag: "latest"
+  memcached:
+    repository: memcached
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "1.6.17-alpine"
 
 imagePullSecrets:
   - name: artifactory-creds
@@ -31,7 +35,7 @@ resources:
       cpu: 10m
     limits:
       memory: 256Mi
-      cpu: 100m
+      cpu: 400m
   proxy:
     requests:
       memory: 32Mi
@@ -39,6 +43,13 @@ resources:
     limits:
       memory: 64Mi
       cpu: 60m
+  memcached:
+    limits:
+      cpu: 50m
+      memory: 32Mi
+    requests:
+      cpu: 10m
+      memory: 32Mi
 
 persistentVolumeClaim:
   mountPath: /data
@@ -56,6 +67,9 @@ services:
   proxy:
     - name: http
       port: 2015
+  memcached:
+    - name: client
+      port: 11211
 
 route:
   host: ""
@@ -100,7 +114,6 @@ volumeMounts: []
 # deployments
 loki:
   retention:
-    retention_deletes_enabled: true
     retention_period: 3d
 
 #


### PR DESCRIPTION
Integrate memcached into the Loki logging stack to enhance performance and enable its use in low-resource environments and expire Loki logs after a specified (default 3 days) time.