### PR TITLE
chore: smoke test in parallel

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -407,7 +407,7 @@ jobs:
     needs: [ship-to-saucelabs]
     runs-on: ubuntu-22.04
     strategy:
-      max-parallel: 1
+      max-parallel: 2
       fail-fast: false
       matrix:
         include:


### PR DESCRIPTION
Our SauceLabs account should be able to run the smoke tests in parallel now. This PR attempts to this.

Fixes #1563