### PR TITLE
chore: smoke test in parallel

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -407,7 +407,7 @@ jobs:
     needs: [ship-to-saucelabs]
     runs-on: ubuntu-22.04
     strategy:
-      max-parallel: 1
+      max-parallel: 2
       fail-fast: false
       matrix:
         include:


### PR DESCRIPTION
Our account should now support parallel builds in sauce labs. This PR makes the appropriate adjustment to run both iOS and Android smoke tests simultaneously. 

Fixes #1563