### PR TITLE
fix: bug switching to new verison of bc wallet

### DIFF
--- a/app/container-imp.ts
+++ b/app/container-imp.ts
@@ -67,12 +67,12 @@ export class AppContainer implements Container {
       ])
       const state: BCState = {
         ...initialState,
-        loginAttempt,
-        preferences,
-        migration,
-        tours,
-        onboarding,
-        dismissPersonCredentialOffer: personCredOfferDissmissed,
+        loginAttempt: {...initialState.loginAttempt, ...loginAttempt},
+        preferences:{...initialState.preferences, ...preferences},
+        migration: {...initialState.migration, ...migration},
+        tours: {...initialState.tours, ...tours},
+        onboarding: {...initialState.onboarding, ...onboarding},
+        dismissPersonCredentialOffer: {...initialState.dismissPersonCredentialOffer, ...personCredOfferDissmissed},
         developer: {
           ...initialState.developer,
           environment,


### PR DESCRIPTION
Previously the call in container-imp was using a shallow copy with the initial state, this meant that the new onboarding state wouldn't be copied and would result in postAuthScreens and didCompleteOnboarding to be undefined. I changed the functionality to have a deeper copy and that fixed the issue