### PR TITLE
fix: align versions of upload / download artifact gha

### DIFF
--- a/.github/workflows/actions/export-ios-archive/action.yml
+++ b/.github/workflows/actions/export-ios-archive/action.yml
@@ -6,12 +6,12 @@ inputs:
     description: |
       The file containing the export options to use 
       for signing the archive.
-    requred: true
+    required: true
   ouput_artifact_ref:
     description: |
       The reference ID / name of the uploaded GitHub artifact
       stored in GitHub by the upload action.
-    requred: true
+    required: true
 
 runs:
   using: composite
@@ -27,7 +27,7 @@ runs:
         -verbose
 
     - name: Upload signed artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.ouput_artifact_ref }}
         path: export/BCWallet.ipa

--- a/.github/workflows/actions/ship-to-saucelabs/action.yml
+++ b/.github/workflows/actions/ship-to-saucelabs/action.yml
@@ -11,7 +11,7 @@ inputs:
   sauce_labs_name:
     description: |
       The name of the artifact shown in SauceLabs
-    requred: true
+    required: true
   sauce_labs_description:
     description: |
       The description of the artifact show in SauceLabs.
@@ -20,7 +20,7 @@ inputs:
     description: |
       The referene ID / name of the uploaded GitHub artifact
       stored in GitHub by the upload action. i.e my-artifact
-    requred: true
+    required: true
   artifact_name:
     description: |
       The actual name of the artifact that would be
@@ -31,7 +31,7 @@ runs:
   using: composite
   steps:
     - name: Download artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact_ref }}
 


### PR DESCRIPTION
A recent dependabot PR updated some but not all of our upload-artifact / download-artifact GHAs from `@v3` to `@v4`. `@v3` and `@v4` are uncompatible which I believe was causing the pipeline failures 