### PR TITLE
chore: upgrade indy vdr to latest

### DIFF
--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -134,7 +134,7 @@ PODS:
   - hermes-engine (0.72.5):
     - hermes-engine/Pre-built (= 0.72.5)
   - hermes-engine/Pre-built (0.72.5)
-  - indy-vdr (0.2.0):
+  - indy-vdr (0.2.2):
     - React
     - React-callinvoker
     - React-Core
@@ -445,7 +445,7 @@ PODS:
   - React-jsinspector (0.72.5)
   - React-logger (0.72.5):
     - glog
-  - "react-native-attestation (1.0.0-alpha.222+818ae7f1)":
+  - "react-native-attestation (1.0.0-alpha.230+e96a7c3e)":
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - react-native-config (1.5.0):
@@ -912,7 +912,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
   GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
   hermes-engine: f6cf92a471053245614d9d8097736f6337d5b86c
-  indy-vdr: 3d43949ef94eb3912f5b382bc9d7af5692f5e4e1
+  indy-vdr: 790ab1fd9b12ad5adfce4905c327f5902253eeeb
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
@@ -931,7 +931,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: ff70a72027dea5cc7d71cfcc6fad7f599f63987a
   React-jsinspector: aef73cbd43b70675f572214d10fa438c89bf11ba
   React-logger: 2e4aee3e11b3ec4fa6cfd8004610bbb3b8d6cca4
-  react-native-attestation: ce96e2066ec880e1ca00baddfff4b06992fb0f86
+  react-native-attestation: 8f34ccd6262dff8e2766b542da4b5de22e604dbb
   react-native-config: 5330c8258265c1e5fdb8c009d2cabd6badd96727
   react-native-encrypted-storage: db300a3f2f0aba1e818417c1c0a6be549038deb7
   react-native-get-random-values: a6ea6a8a65dc93e96e24a11105b1a9c8cfe1d72a

--- a/app/package.json
+++ b/app/package.json
@@ -66,7 +66,7 @@
     "@hyperledger/aries-bifold-verifier": "1.0.0-alpha.230",
     "@hyperledger/aries-oca": "1.0.0-alpha.230",
     "@hyperledger/aries-react-native-attestation": "1.0.0-alpha.230",
-    "@hyperledger/indy-vdr-react-native": "0.2.0",
+    "@hyperledger/indy-vdr-react-native": "0.2.2",
     "@react-native-async-storage/async-storage": "1.15.11",
     "@react-native-community/masked-view": "0.1.11",
     "@react-native-community/netinfo": "9.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4409,23 +4409,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperledger/indy-vdr-react-native@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@hyperledger/indy-vdr-react-native@npm:0.2.0"
+"@hyperledger/indy-vdr-react-native@npm:0.2.2":
+  version: 0.2.2
+  resolution: "@hyperledger/indy-vdr-react-native@npm:0.2.2"
   dependencies:
-    "@hyperledger/indy-vdr-shared": "npm:0.2.0"
+    "@hyperledger/indy-vdr-shared": "npm:0.2.2"
     "@mapbox/node-pre-gyp": "npm:^1.0.10"
   peerDependencies:
     react: ">= 16"
     react-native: ">= 0.66.0"
-  checksum: 03acda2a2b7c4396c5245d6b4062df3532885503443bf6d69701688a9973366ca333ed8c9317aab461acc23dd180c1dcec198001117168ee101ea831cf5f76e3
+  checksum: 7a924099b7baeb7384ecd96bb1a5751e5bbc07871288f883ca1f9789d23be478c63ebca66082e090a8b1ef90f40dbbe3ccaf0b67246fbfe125a8b9997fecb871
   languageName: node
   linkType: hard
 
-"@hyperledger/indy-vdr-shared@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@hyperledger/indy-vdr-shared@npm:0.2.0"
-  checksum: 729760438fbc6b7b98686fa654384a517645463106e747560564f6cbe4e702b52cd2996983b5d23551d29eac58c21beaf889f6195313ccdd7ea07c115fd19a25
+"@hyperledger/indy-vdr-shared@npm:0.2.2":
+  version: 0.2.2
+  resolution: "@hyperledger/indy-vdr-shared@npm:0.2.2"
+  checksum: 5bfa1b87b1eca1e5775da1451d9260177a66932765f1276bff4ff5746665dd0060771341490f69d694c80b97e45fdddf7b98e9c01849f58c51482271ec46ce6f
   languageName: node
   linkType: hard
 
@@ -8905,7 +8905,7 @@ __metadata:
     "@hyperledger/aries-bifold-verifier": "npm:1.0.0-alpha.230"
     "@hyperledger/aries-oca": "npm:1.0.0-alpha.230"
     "@hyperledger/aries-react-native-attestation": "npm:1.0.0-alpha.230"
-    "@hyperledger/indy-vdr-react-native": "npm:0.2.0"
+    "@hyperledger/indy-vdr-react-native": "npm:0.2.2"
     "@react-native-async-storage/async-storage": "npm:1.15.11"
     "@react-native-community/masked-view": "npm:0.1.11"
     "@react-native-community/netinfo": "npm:9.3.7"


### PR DESCRIPTION
This seems to fix the majority of the issues with the Person credential flow. There are some more cutting edge changes that have yet to be published that also seem to help with occasional non-blocking error messages but for 0.2.2 seems to get the flow working.