### PR TITLE
chore: add missing permission description for unused perm

### DIFF
--- a/app/ios/AriesBifold/Info.plist
+++ b/app/ios/AriesBifold/Info.plist
@@ -63,7 +63,7 @@
 	<key>NSFaceIDUsageDescription</key>
 	<string>$(PRODUCT_NAME) wants to use your FaceID/TouchID to authenticate your identity</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
+	<string>Our app does not request this permission or utilize this functionality but it is included in our Info.plist since our app utilizes the react-native-permissions library, which references this permission in its code.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>MaterialIcons.ttf</string>

--- a/app/ios/AriesBifold/Info.plist
+++ b/app/ios/AriesBifold/Info.plist
@@ -63,7 +63,7 @@
 	<key>NSFaceIDUsageDescription</key>
 	<string>$(PRODUCT_NAME) wants to use your FaceID/TouchID to authenticate your identity</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Our app does not request this permission or utilize this functionality but it is included in our Info.plist since our app utilizes the react-native-permissions library, which references this permission in its code.</string>
+	<string>We include this permission because a library our app uses references it, even though we don't use it directly.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>MaterialIcons.ttf</string>


### PR DESCRIPTION
This PR adds a description for an unused permission entry that triggered a warning from the App Store.

Reference: https://github.com/zoontek/react-native-permissions/issues/266#issuecomment-422443290