### PR TITLE
fix: fixed notifications on home screen when returning from mob verifier

### DIFF
--- a/app/src/hooks/notifications.ts
+++ b/app/src/hooks/notifications.ts
@@ -71,7 +71,10 @@ export const useNotifications = (): Array<BasicMessageRecord | CredentialRecord 
         ? [{ type: 'CustomNotification', createdAt: invitationDate, id: 'custom' }]
         : []
 
-    const notif = [...messagesToShow, ...offers, ...nonAttestationProofs, ...revoked].sort(
+    const proofs = nonAttestationProofs.filter((proof) => {
+      return !(proof.metadata.data[ProofMetadata.customMetadata] as ProofCustomMetadata)?.details_seen
+    })
+    const notif = [...messagesToShow, ...offers, ...proofs, ...revoked].sort(
       (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
     )
 
@@ -81,10 +84,7 @@ export const useNotifications = (): Array<BasicMessageRecord | CredentialRecord 
 
   useEffect(() => {
     const validProofsDone = proofsDone.filter((proof: ProofExchangeRecord) => {
-      if (proof.isVerified === undefined) return false
-
-      const metadata = proof.metadata.get(ProofMetadata.customMetadata) as ProofCustomMetadata
-      return !metadata?.details_seen
+      return proof.isVerified !== undefined
     })
     Promise.all(
       [...proofsRequested, ...validProofsDone].map(async (proof: ProofExchangeRecord) => {


### PR DESCRIPTION
Previously when exiting the mobile verifier page and returning to the home screen the notification state wouldn't update, This would mean that there were two notifications on the home page, one from the person credential, and one from the proof request that had already been viewed. Once you navigate away and then back to the home screen the erroneous notification would be removed, but the notification bubble on the tabstack would still say there's 2 notifications.

This change fixes the useNotifications hook so that the notifications hook is updated whenever the proof request is marked as seen. This ensures we don't get an erroneous proof notification on the home screen 