### PR TITLE
feat: no backup afj folder

### DIFF
--- a/app/ios/AriesBifold/AppDelegate.m
+++ b/app/ios/AriesBifold/AppDelegate.m
@@ -48,19 +48,28 @@
 
 // The .afj folder from Credo cannot be restored.
 - (void)excludeDotAFJFolderFromBackup {
-  NSString *fileName = @".afj";
-  NSURL *documentsURL = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory
-                                                                inDomains:NSUserDomainMask] firstObject];
-  NSURL *folderURL = [documentsURL URLByAppendingPathComponent:fileName];
+    NSString *folderName = @".afj";
+    NSURL *documentsURL = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory
+                                                                  inDomains:NSUserDomainMask] firstObject];
+    NSURL *folderURL = [documentsURL URLByAppendingPathComponent:folderName];
 
-  NSError *error = nil;
-  BOOL success = [folderURL setResourceValue:@YES
-                                      forKey:NSURLIsExcludedFromBackupKey
-                                       error:&error];
-  
-  if (!success) {
-      NSLog(@"Error excluding folder %@ from backup: %@", fileName, error);
-  }
+    // Check if the directory exists
+    BOOL isDir;
+    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:[folderURL path]
+                                                           isDirectory:&isDir];
+    if (!fileExists || !isDir) {
+        NSLog(@"Directory %@ does not exist. Skipping backup exclusion.", folderName);
+      return;
+    }
+
+    NSError *error = nil;
+    BOOL success = [folderURL setResourceValue:@YES 
+                                        forKey:NSURLIsExcludedFromBackupKey 
+                                         error:&error];
+
+    if (!success) {
+        NSLog(@"Error excluding folder %@ from backup: %@", folderName, error);
+    }
 }
 
 @end

--- a/app/ios/AriesBifold/AppDelegate.m
+++ b/app/ios/AriesBifold/AppDelegate.m
@@ -17,6 +17,8 @@
   // They will be passed down to the ViewController used by React Native.
   self.initialProps = @{};
 
+  [self excludeDotAFJFolderFromBackup];
+  
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 
@@ -42,6 +44,23 @@
 
 - (UIInterfaceOrientationMask)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window {
   return [Orientation getOrientation];
+}
+
+// The .afj folder from Credo cannot be restored.
+- (void)excludeDotAFJFolderFromBackup {
+  NSString *fileName = @".afj";
+  NSURL *documentsURL = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory
+                                                                inDomains:NSUserDomainMask] firstObject];
+  NSURL *folderURL = [documentsURL URLByAppendingPathComponent:fileName];
+
+  NSError *error = nil;
+  BOOL success = [folderURL setResourceValue:@YES
+                                      forKey:NSURLIsExcludedFromBackupKey
+                                       error:&error];
+  
+  if (!success) {
+      NSLog(@"Error excluding folder %@ from backup: %@", fileName, error);
+  }
 }
 
 @end

--- a/app/ios/AriesBifold/AppDelegate.m
+++ b/app/ios/AriesBifold/AppDelegate.m
@@ -58,7 +58,7 @@
     BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:[folderURL path]
                                                            isDirectory:&isDir];
     if (!fileExists || !isDir) {
-        NSLog(@"Directory %@ does not exist. Skipping backup exclusion.", folderName);
+      NSLog(@"Directory %@ does not exist. Skipping backup exclusion.", folderName);
       return;
     }
 

--- a/app/ios/AriesBifold/AppDelegate.m
+++ b/app/ios/AriesBifold/AppDelegate.m
@@ -62,6 +62,7 @@
       return;
     }
 
+    // Exclude the folder from backup
     NSError *error = nil;
     BOOL success = [folderURL setResourceValue:@YES 
                                         forKey:NSURLIsExcludedFromBackupKey 


### PR DESCRIPTION
Signal to iOS that it should not backup the `.afj` folder in the applications Documents so that it cannot be restored to alternative devices which can cause errors. Also, this is not meant to be backed up.