### PR TITLE
chore: credo and oca to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ app/vendor/bundle/**
 
 # child packages
 bifold/
+aries-oca-bundles/
+credo-ts/


### PR DESCRIPTION
Add credo-ts and aries-oca-bundles to `.gitignore` so they can be located similar to bifold in the project hierarchy.
