### PR TITLE
chore: credo and oca to gitignore

### DIFF
--- a/.github/workflows/actions/early-exit-check/action.yml
+++ b/.github/workflows/actions/early-exit-check/action.yml
@@ -1,0 +1,27 @@
+name: Check for early exit
+description: |
+  This action checks for changes in specific directories and
+  exits early if there are none
+
+runs:
+  using: composite
+  steps:
+    - name: Check location of changed files
+      shell: bash
+      run: |
+        change_count=$(git diff --name-only origin/main..HEAD | grep -E '^(app/.*)|(.yarn/.*)|(.github/workflows/.*)' | wc -l)
+        echo "$change_count files changed in app, .yarn, or .github/workflows"
+        if [ $change_count -gt 0 ]; then
+          # A result greater than 0 means there are changes
+          # in the specified directories.
+          echo "result=false" >> $GITHUB_OUTPUT
+        else
+          echo "result=true" >> $GITHUB_OUTPUT
+        fi
+
+    # - name: Record output
+    #   if: env.output > 0
+    #   shell: bash
+    #   run: |
+    #     echo "${{ env.output }} files changed in app, .yarn, or .github/workflows"
+    #     echo "result=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,6 @@ on:
       - app/**
       - .yarn/**
       - .github/workflows/**
-      - .gitmodules
       - package.json
       - yarn.lock
       - .yarnrc.yml

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -83,6 +83,17 @@ jobs:
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all branches, main needed.
+
+      - name: Run early exit check
+        id: should_early_exit
+        uses: ./.github/workflows/actions/early-exit-check
+
+      - name: Terminate workflow if early exit check passes
+        if: steps.should_early_exit.outputs.result == 'true'
+        run: |
+          exit 0
 
       - uses: actions/setup-python@v5
         with:
@@ -243,6 +254,15 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+
+      - name: Run early exit check
+        id: should_early_exit
+        uses: ./.github/workflows/actions/early-exit-check
+
+      - name: Terminate workflow if early exit check passes
+        if: steps.should_early_exit.outputs.result == 'true'
+        run: |
+          exit 0
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -254,6 +254,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all branches, main needed.
 
       - name: Run early exit check
         id: should_early_exit

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -80,7 +80,7 @@ jobs:
         id: should_early_exit
         uses: ./.github/workflows/actions/early-exit-check
 
-      - name: Terminate workflow if early exit check passes
+      - name: Exit if no changes in core paths
         if: steps.should_early_exit.outputs.result == 'true'
         run: |
           exit 0
@@ -251,7 +251,7 @@ jobs:
         id: should_early_exit
         uses: ./.github/workflows/actions/early-exit-check
 
-      - name: Terminate workflow if early exit check passes
+      - name: Exit if no changes in core paths
         if: steps.should_early_exit.outputs.result == 'true'
         run: |
           exit 0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,15 +14,6 @@ on:
       - .github/workflows/**
   pull_request:
     branches: [main]
-    paths:
-      - app/**
-      - .yarn/**
-      - .github/workflows/**
-      - package.json
-      - yarn.lock
-      - .yarnrc.yml
-      - .yarn/**
-      - .gitignore
 
 jobs:
   check-secrets:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,6 +23,7 @@ on:
       - yarn.lock
       - .yarnrc.yml
       - .yarn/**
+      - .gitignore
 
 jobs:
   check-secrets:

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ app/vendor/bundle/**
 
 # child packages
 bifold/
+aries-oca-bundles/
+credo-ts/


### PR DESCRIPTION
This PR mages two important changes:

1. Add two additional projects to the `.gitingore` so that local development can follow a similar pattern to Bifold.

- aries-oca-bundles/
- credo-ts/

2. Now that the iOS and Android native build is a required check the PR will do an early exit with success on those workflows if no significant changes were made to the project i.e. no source code files changed.