### PR TITLE
fix: bash shell logic

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -98,7 +98,7 @@ jobs:
           echo "Comparing ${parent_ref} with ${child_ref}"
 
           diff_output=$(git diff --name-only ${parent_ref}..${child_ref})
-          change_count=$(echo "$diff_output" | grep -E '^(app/.*)|(.yarn/.*)|(.github/workflows/.*)' || true | wc -l | awk '{$1=$1};1')
+          change_count=$(echo "$diff_output" | (grep -E '^(app/.*)|(.yarn/.*)|(.github/workflows/.*)' || true) | wc -l | awk '{$1=$1};1')
 
           echo "$change_count files changed in app, .yarn, or .github/workflows"
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -98,7 +98,7 @@ jobs:
           echo "Comparing ${parent_ref} with ${child_ref}"
 
           diff_output=$(git diff --name-only ${parent_ref}..${child_ref})
-          change_count=$(echo "$diff_output" | grep -E '^(app/.*)|(.yarn/.*)|(.github/workflows/.*)' | wc -l | awk '{$1=$1};1' || true)
+          change_count=$(echo "$diff_output" | grep -E '^(app/.*)|(.yarn/.*)|(.github/workflows/.*)' || true | wc -l | awk '{$1=$1};1')
 
           echo "$change_count files changed in app, .yarn, or .github/workflows"
 


### PR DESCRIPTION
Rework the chained command so that only if the grep fails it will continue. Grep will return "1" if no match is found which cases the pipe to fail. It should continue so that `wc` can return 0 count.