### PR TITLE
fix: typo in AndroidManifest permission USE_BIOMETRIC

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="ca.bc.gov.BCWallet"
   xmlns:tools="http://schemas.android.com/tools">
-  <uses-permission android:name="android.permission.USE_BIOMETRICS" />
+  <uses-permission android:name="android.permission.USE_BIOMETRIC" />
   <uses-permission android:name="android.permission.USE_FINGERPRINT" />
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.VIBRATE" />


### PR DESCRIPTION
Related issues:
openwallet-foundation/bifold-wallet#999