### PR TITLE
chore: bump version number to 1.0.22

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,7 +2,7 @@ name: Native Build & Test
 
 env:
   appBuildNumber: ${{ github.run_number }}
-  appBuildVersion: "1.0.21"
+  appBuildVersion: "1.0.22"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
bump version number to 1.0.22