### PR TITLE
feat: enable remote logging before login in dev settings

### DIFF
--- a/app/__mocks__/helpers/app.tsx
+++ b/app/__mocks__/helpers/app.tsx
@@ -1,0 +1,12 @@
+import 'reflect-metadata'
+import React, { PropsWithChildren, useMemo } from 'react'
+
+import { container } from 'tsyringe'
+import { MainContainer, ContainerProvider } from '@hyperledger/aries-bifold-core'
+
+export const BasicAppContext: React.FC<PropsWithChildren> = ({ children }) => {
+  const context = useMemo(() => new MainContainer(container.createChildContainer()).init(), [])
+  return (
+    <ContainerProvider value={context}>{children}</ContainerProvider>
+  )
+}

--- a/app/__tests__/screens/Developer.test.tsx
+++ b/app/__tests__/screens/Developer.test.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 
 import Developer from '../../src/screens/Developer'
 import { initialState, reducer } from '../../src/store'
+import { BasicAppContext } from '../../__mocks__/helpers/app'
 
 const mockNavigation = jest.fn()
 jest.mock('@react-navigation/native', () => ({
@@ -28,9 +29,11 @@ describe('Developer Screen', () => {
 
   test('screen renders correctly', () => {
     const tree = render(
-      <StoreProvider initialState={initialState} reducer={reducer}>
-        <Developer />
-      </StoreProvider>
+      <BasicAppContext>
+        <StoreProvider initialState={initialState} reducer={reducer}>
+          <Developer />
+        </StoreProvider>
+      </BasicAppContext>
     )
 
     expect(tree).toMatchSnapshot()

--- a/app/__tests__/screens/__snapshots__/Developer.test.tsx.snap
+++ b/app/__tests__/screens/__snapshots__/Developer.test.tsx.snap
@@ -1014,7 +1014,6 @@ exports[`Developer Screen screen renders correctly 1`] = `
           >
             <RCTSwitch
               accessibilityRole="switch"
-              disabled={true}
               onChange={[Function]}
               onResponderTerminationRequest={[Function]}
               onStartShouldSetResponder={[Function]}

--- a/app/src/screens/Developer.tsx
+++ b/app/src/screens/Developer.tsx
@@ -1,5 +1,4 @@
-import { useAgent } from '@credo-ts/react-hooks'
-import { useTheme, useStore, testIdWithKey, DispatchAction, Screens } from '@hyperledger/aries-bifold-core'
+import { useTheme, useStore, testIdWithKey, DispatchAction, Screens, useServices, TOKENS } from '@hyperledger/aries-bifold-core'
 import { RemoteLogger, RemoteLoggerEventTypes } from '@hyperledger/aries-bifold-remote-logs'
 import { useNavigation } from '@react-navigation/native'
 import React, { useState } from 'react'
@@ -14,11 +13,10 @@ import IASEnvironment from './IASEnvironment'
 import RemoteLogWarning from './RemoteLogWarning'
 
 const Settings: React.FC = () => {
-  const { agent } = useAgent()
-  const logger = agent?.config.logger as RemoteLogger
   const { t } = useTranslation()
   const [store, dispatch] = useStore<BCState>()
   const { SettingsTheme, TextTheme, ColorPallet } = useTheme()
+  const [logger] = useServices([TOKENS.UTIL_LOGGER]) as [RemoteLogger]
   const [environmentModalVisible, setEnvironmentModalVisible] = useState<boolean>(false)
   const [devMode, setDevMode] = useState<boolean>(true)
   const [useVerifierCapability, setUseVerifierCapability] = useState<boolean>(!!store.preferences.useVerifierCapability)
@@ -229,7 +227,10 @@ const Settings: React.FC = () => {
     setRemoteLoggingEnabled(remoteLoggingEnabled)
 
     setRemoteLoggingWarningModalVisible(false)
-    navigation.navigate(Screens.Home as never)
+
+    if (store.authentication.didAuthenticate) {
+      navigation.navigate(Screens.Home as never)
+    }
   }
 
   const onRemoteLoggingBackPressed = () => {
@@ -427,7 +428,6 @@ const Settings: React.FC = () => {
             ios_backgroundColor={ColorPallet.grayscale.lightGrey}
             onValueChange={toggleRemoteLoggingSwitch}
             value={remoteLoggingEnabled}
-            disabled={!store.authentication.didAuthenticate}
           />
         </SectionRow>
 


### PR DESCRIPTION
This PR allows users to enable remote logging from developer mode before they have finished onboarding. Tested and logs seem to be coming in, see here:
<img width="952" alt="Screenshot 2024-12-20 at 3 53 14 PM" src="https://github.com/user-attachments/assets/34daaf37-1d18-4ea4-a2fa-b8a8f3425a3f" />
