### PR TITLE
feat: add stale check

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -5,9 +5,10 @@ on:
   schedule:
     - cron: "0 12 * * *" # Runs every day at 12 PM (noon) UTC, which is 4 AM PST
 jobs:
-  lint:
+  prune:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
-    name: Issue Mgmt.
+    name: Issue and PR maintenance
     steps:
       - name: Prune stale issues
         uses: actions/stale@v5

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,28 +1,27 @@
 name: Maintenance
 
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened, labeled]
-
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * *" # Runs every day at 12 PM (noon) UTC, which is 4 AM PST
 jobs:
   lint:
     runs-on: ubuntu-22.04
-    name: Issue and PR maintenance
+    name: Issue Mgmt.
     steps:
-      - name: Close stale issues
+      - name: Prune stale issues
         uses: actions/stale@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 90
           days-before-close: 14
-          stale-issue-label: "stale"
+          stale-issue-label: stale
           exempt-issue-labels: bug,help wanted
-          stale-issue-message:
+          stale-issue-message: |
             This issue has been automatically closed because it has been
             inactive for a while. Feel free to reopen it if you still have
             this problem.
-          stale-pr-message:
+          stale-pr-message: |
             This pull request has been automatically closed because it has been
             inactive for a while. Feel free to reopen it if you still want
             to continue with this work.

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -18,6 +18,7 @@ jobs:
           days-before-close: 30
           stale-issue-label: stale
           exempt-issue-labels: bug,help wanted
+          exempt-pr-labels: external-dependency
           stale-issue-message: |
             This issue has been automatically closed because it has been
             inactive for a while. Feel free to reopen it if you still have

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -13,8 +13,8 @@ jobs:
         uses: actions/stale@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 90
-          days-before-close: 14
+          days-before-stale: 270
+          days-before-close: 30
           stale-issue-label: stale
           exempt-issue-labels: bug,help wanted
           stale-issue-message: |

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -14,8 +14,8 @@ jobs:
         uses: actions/stale@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 270
-          days-before-close: 30
+          days-before-stale: 270 # 9 months
+          days-before-close: 30 # 1 month
           stale-issue-label: stale
           exempt-issue-labels: bug,help wanted
           exempt-pr-labels: external-dependency

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,4 +1,4 @@
-name: Maintenance
+name: Backlog Maintenance
 
 on:
   workflow_dispatch:
@@ -12,7 +12,7 @@ jobs:
       # contents: write # only for delete-branch option
       issues: write
       pull-requests: write
-    name: Issue and PR maintenance
+    name: Issue and PR
     steps:
       - name: Prune stale issues
         uses: actions/stale@v5
@@ -21,13 +21,24 @@ jobs:
           days-before-stale: 270 # 9 months
           days-before-close: 30 # 1 month
           stale-issue-label: stale
-          exempt-issue-labels: bug,help wanted
+          exempt-issue-labels: help wanted
           exempt-pr-labels: external-dependency
           stale-issue-message: |
-            This issue has been automatically closed because it has been
-            inactive for a while. Feel free to reopen it if you still have
-            this problem.
+            This issue has been inactive for a while, so it's
+            been marked as "stale." If you're still working on
+            it or it's still important, please leave a comment
+            to keep it open and remove the "stale" label. Thanks!
           stale-pr-message: |
-            This pull request has been automatically closed because it has been
-            inactive for a while. Feel free to reopen it if you still want
-            to continue with this work.
+            This pull request hasn't had any recent activity,
+            so it's been marked as "stale."  If you're still
+            working on it or if it's still important, just keep
+            making commits (code changes) and remove the "stale"
+            label. Thanks!
+          close-issue-message: |
+            This issue has been automatically closed because
+            there hasn't been any recent activity. If it's
+            still relevant, please feel free to reopen it.
+          close-pr-message: |
+            This pull request has been automatically closed due
+            to inactivity. If it's still relevant, please
+            feel free to reopen it.

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -8,6 +8,10 @@ jobs:
   prune:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
+    permissions:
+      # contents: write # only for delete-branch option
+      issues: write
+      pull-requests: write
     name: Issue and PR maintenance
     steps:
       - name: Prune stale issues

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,28 @@
+name: Maintenance
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled]
+
+jobs:
+  lint:
+    runs-on: ubuntu-22.04
+    name: Issue and PR maintenance
+    steps:
+      - name: Close stale issues
+        uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 90
+          days-before-close: 14
+          stale-issue-label: "stale"
+          exempt-issue-labels: bug,help wanted
+          stale-issue-message:
+            This issue has been automatically closed because it has been
+            inactive for a while. Feel free to reopen it if you still have
+            this problem.
+          stale-pr-message:
+            This pull request has been automatically closed because it has been
+            inactive for a while. Feel free to reopen it if you still want
+            to continue with this work.


### PR DESCRIPTION
This PR add the ability to run periodic maintenance on the repository. It will label stale issues after ~9 months and then close them 30 days later. This will age out issues after ~10 months.