### PR TITLE
feat: update lsbc cred info

### DIFF
--- a/proof-templates.json
+++ b/proof-templates.json
@@ -108,9 +108,6 @@
                      "restrictions": [
                         {
                            "schema_id": "RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0",
-                           "issuer_did": "RGjWbW1eycP7FrMf4QJvX8"
-                        },
-                        {
                            "cred_def_id": "RGjWbW1eycP7FrMf4QJvX8:3:CL:13:Person"
                         }
                      ],

--- a/proof-templates.json
+++ b/proof-templates.json
@@ -107,8 +107,8 @@
                      ],
                      "restrictions": [
                         {
-                           "schema_id": "RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0",
-                           "cred_def_id": "RGjWbW1eycP7FrMf4QJvX8:3:CL:13:Person"
+                           "cred_def_id": "RGjWbW1eycP7FrMf4QJvX8:3:CL:13:Person",
+                           "issuer_did": "RGjWbW1eycP7FrMf4QJvX8"
                         }
                      ],
                      "devRestrictions": [

--- a/proof-templates.json
+++ b/proof-templates.json
@@ -58,7 +58,7 @@
                ]
             },
             {
-               "schema": "4xE68b6S5VRFrKMMG1U95M:2:Member Card:1.5.1",
+               "schema": "QzLYGuAebsy3MXQ6b1sFiT:2:legal-professional:1.0",
                "requestedAttributes": [
                   {
                      "names": [
@@ -74,35 +74,12 @@
                         },
                         {
                            "cred_def_id": "QzLYGuAebsy3MXQ6b1sFiT:3:CL:2351:lawyer"
-                        },
-                        {
-                           "schema_id": "4xE68b6S5VRFrKMMG1U95M:2:Member Card:1.5.1",
-                           "issuer_did": "4xE68b6S5VRFrKMMG1U95M"
-                        },
-                        {
-                           "cred_def_id": "4xE68b6S5VRFrKMMG1U95M:3:CL:59232:default"
                         }
                      ],
                      "devRestrictions": [
                         {
                            "schema_id": "MLvtJW6pFuYu4NnMB14d29:2:legal-professional:1.0",
                            "issuer_did": "MLvtJW6pFuYu4NnMB14d29"
-                        },
-                        {
-                           "schema_id": "AuJrigKQGRLJajKAebTgWu:2:Member Card:1.5.1",
-                           "issuer_did": "AuJrigKQGRLJajKAebTgWu"
-                        },
-                        {
-                           "schema_id": "QEquAHkM35w4XVT3Ku5yat:2:member_card:1.54",
-                           "issuer_did": "QEquAHkM35w4XVT3Ku5yat"
-                        },
-                        {
-                           "schema_id": "M6dhuFj5UwbhWkSLmvYSPc:2:member_card:1.54",
-                           "issuer_did": "M6dhuFj5UwbhWkSLmvYSPc"
-                        },
-                        {
-                           "schema_id": "L6ASjmDDbDH7yPL1t2yFj9:2:member_card:1.53",
-                           "issuer_did": "L6ASjmDDbDH7yPL1t2yFj9"
                         }
                      ],
                      "nonRevoked": {
@@ -347,7 +324,7 @@
          "type": "anoncreds",
          "data": [
             {
-               "schema": "4xE68b6S5VRFrKMMG1U95M:2:Member Card:1.5.1",
+               "schema": "QzLYGuAebsy3MXQ6b1sFiT:2:legal-professional:1.0",
                "requestedAttributes": [
                   {
                      "names": [
@@ -363,35 +340,12 @@
                         },
                         {
                            "cred_def_id": "QzLYGuAebsy3MXQ6b1sFiT:3:CL:2351:lawyer"
-                        },
-                        {
-                           "schema_id": "4xE68b6S5VRFrKMMG1U95M:2:Member Card:1.5.1",
-                           "issuer_did": "4xE68b6S5VRFrKMMG1U95M"
-                        },
-                        {
-                           "cred_def_id": "4xE68b6S5VRFrKMMG1U95M:3:CL:59232:default"
                         }
                      ],
                      "devRestrictions": [
                         {
                            "schema_id": "MLvtJW6pFuYu4NnMB14d29:2:legal-professional:1.0",
                            "issuer_did": "MLvtJW6pFuYu4NnMB14d29"
-                        },
-                        {
-                           "schema_id": "AuJrigKQGRLJajKAebTgWu:2:Member Card:1.5.1",
-                           "issuer_did": "AuJrigKQGRLJajKAebTgWu"
-                        },
-                        {
-                           "schema_id": "QEquAHkM35w4XVT3Ku5yat:2:member_card:1.54",
-                           "issuer_did": "QEquAHkM35w4XVT3Ku5yat"
-                        },
-                        {
-                           "schema_id": "M6dhuFj5UwbhWkSLmvYSPc:2:member_card:1.54",
-                           "issuer_did": "M6dhuFj5UwbhWkSLmvYSPc"
-                        },
-                        {
-                           "schema_id": "L6ASjmDDbDH7yPL1t2yFj9:2:member_card:1.53",
-                           "issuer_did": "L6ASjmDDbDH7yPL1t2yFj9"
                         }
                      ],
                      "nonRevoked": {
@@ -470,7 +424,7 @@
                ]
             },
             {
-               "schema": "4xE68b6S5VRFrKMMG1U95M:2:Member Card:1.5.1",
+               "schema": "QzLYGuAebsy3MXQ6b1sFiT:2:legal-professional:1.0",
                "requestedAttributes": [
                   {
                      "names": [
@@ -486,35 +440,12 @@
                         },
                         {
                            "cred_def_id": "QzLYGuAebsy3MXQ6b1sFiT:3:CL:2351:lawyer"
-                        },
-                        {
-                           "schema_id": "4xE68b6S5VRFrKMMG1U95M:2:Member Card:1.5.1",
-                           "issuer_did": "4xE68b6S5VRFrKMMG1U95M"
-                        },
-                        {
-                           "cred_def_id": "4xE68b6S5VRFrKMMG1U95M:3:CL:59232:default"
                         }
                      ],
                      "devRestrictions": [
                         {
                            "schema_id": "MLvtJW6pFuYu4NnMB14d29:2:legal-professional:1.0",
                            "issuer_did": "MLvtJW6pFuYu4NnMB14d29"
-                        },
-                        {
-                           "schema_id": "AuJrigKQGRLJajKAebTgWu:2:Member Card:1.5.1",
-                           "issuer_did": "AuJrigKQGRLJajKAebTgWu"
-                        },
-                        {
-                           "schema_id": "QEquAHkM35w4XVT3Ku5yat:2:member_card:1.54",
-                           "issuer_did": "QEquAHkM35w4XVT3Ku5yat"
-                        },
-                        {
-                           "schema_id": "M6dhuFj5UwbhWkSLmvYSPc:2:member_card:1.54",
-                           "issuer_did": "M6dhuFj5UwbhWkSLmvYSPc"
-                        },
-                        {
-                           "schema_id": "L6ASjmDDbDH7yPL1t2yFj9:2:member_card:1.53",
-                           "issuer_did": "L6ASjmDDbDH7yPL1t2yFj9"
                         }
                      ],
                      "nonRevoked": {

--- a/proof-templates.json
+++ b/proof-templates.json
@@ -107,8 +107,7 @@
                      ],
                      "restrictions": [
                         {
-                           "cred_def_id": "RGjWbW1eycP7FrMf4QJvX8:3:CL:13:Person",
-                           "issuer_did": "RGjWbW1eycP7FrMf4QJvX8"
+                           "cred_def_id": "RGjWbW1eycP7FrMf4QJvX8:3:CL:13:Person"
                         }
                      ],
                      "devRestrictions": [

--- a/proof-templates.json
+++ b/proof-templates.json
@@ -69,7 +69,6 @@
                      ],
                      "restrictions": [
                         {
-                           "schema_id": "QzLYGuAebsy3MXQ6b1sFiT:2:legal-professional:1.0",
                            "cred_def_id": "QzLYGuAebsy3MXQ6b1sFiT:3:CL:2351:lawyer"
                         }
                      ],
@@ -328,7 +327,6 @@
                      ],
                      "restrictions": [
                         {
-                           "schema_id": "QzLYGuAebsy3MXQ6b1sFiT:2:legal-professional:1.0",
                            "cred_def_id": "QzLYGuAebsy3MXQ6b1sFiT:3:CL:2351:lawyer"
                         }
                      ],
@@ -425,7 +423,6 @@
                      ],
                      "restrictions": [
                         {
-                           "schema_id": "QzLYGuAebsy3MXQ6b1sFiT:2:legal-professional:1.0",
                            "cred_def_id": "QzLYGuAebsy3MXQ6b1sFiT:3:CL:2351:lawyer"
                         }
                      ],

--- a/proof-templates.json
+++ b/proof-templates.json
@@ -69,6 +69,13 @@
                      ],
                      "restrictions": [
                         {
+                           "schema_id": "QzLYGuAebsy3MXQ6b1sFiT:2:legal-professional:1.0",
+                           "issuer_did": "QzLYGuAebsy3MXQ6b1sFiT"
+                        },
+                        {
+                           "cred_def_id": "QzLYGuAebsy3MXQ6b1sFiT:3:CL:2351:lawyer"
+                        },
+                        {
                            "schema_id": "4xE68b6S5VRFrKMMG1U95M:2:Member Card:1.5.1",
                            "issuer_did": "4xE68b6S5VRFrKMMG1U95M"
                         },
@@ -77,6 +84,10 @@
                         }
                      ],
                      "devRestrictions": [
+                        {
+                           "schema_id": "MLvtJW6pFuYu4NnMB14d29:2:legal-professional:1.0",
+                           "issuer_did": "MLvtJW6pFuYu4NnMB14d29"
+                        },
                         {
                            "schema_id": "AuJrigKQGRLJajKAebTgWu:2:Member Card:1.5.1",
                            "issuer_did": "AuJrigKQGRLJajKAebTgWu"
@@ -347,6 +358,13 @@
                      ],
                      "restrictions": [
                         {
+                           "schema_id": "QzLYGuAebsy3MXQ6b1sFiT:2:legal-professional:1.0",
+                           "issuer_did": "QzLYGuAebsy3MXQ6b1sFiT"
+                        },
+                        {
+                           "cred_def_id": "QzLYGuAebsy3MXQ6b1sFiT:3:CL:2351:lawyer"
+                        },
+                        {
                            "schema_id": "4xE68b6S5VRFrKMMG1U95M:2:Member Card:1.5.1",
                            "issuer_did": "4xE68b6S5VRFrKMMG1U95M"
                         },
@@ -355,6 +373,10 @@
                         }
                      ],
                      "devRestrictions": [
+                        {
+                           "schema_id": "MLvtJW6pFuYu4NnMB14d29:2:legal-professional:1.0",
+                           "issuer_did": "MLvtJW6pFuYu4NnMB14d29"
+                        },
                         {
                            "schema_id": "AuJrigKQGRLJajKAebTgWu:2:Member Card:1.5.1",
                            "issuer_did": "AuJrigKQGRLJajKAebTgWu"
@@ -459,6 +481,13 @@
                      ],
                      "restrictions": [
                         {
+                           "schema_id": "QzLYGuAebsy3MXQ6b1sFiT:2:legal-professional:1.0",
+                           "issuer_did": "QzLYGuAebsy3MXQ6b1sFiT"
+                        },
+                        {
+                           "cred_def_id": "QzLYGuAebsy3MXQ6b1sFiT:3:CL:2351:lawyer"
+                        },
+                        {
                            "schema_id": "4xE68b6S5VRFrKMMG1U95M:2:Member Card:1.5.1",
                            "issuer_did": "4xE68b6S5VRFrKMMG1U95M"
                         },
@@ -467,6 +496,10 @@
                         }
                      ],
                      "devRestrictions": [
+                        {
+                           "schema_id": "MLvtJW6pFuYu4NnMB14d29:2:legal-professional:1.0",
+                           "issuer_did": "MLvtJW6pFuYu4NnMB14d29"
+                        },
                         {
                            "schema_id": "AuJrigKQGRLJajKAebTgWu:2:Member Card:1.5.1",
                            "issuer_did": "AuJrigKQGRLJajKAebTgWu"

--- a/proof-templates.json
+++ b/proof-templates.json
@@ -70,9 +70,6 @@
                      "restrictions": [
                         {
                            "schema_id": "QzLYGuAebsy3MXQ6b1sFiT:2:legal-professional:1.0",
-                           "issuer_did": "QzLYGuAebsy3MXQ6b1sFiT"
-                        },
-                        {
                            "cred_def_id": "QzLYGuAebsy3MXQ6b1sFiT:3:CL:2351:lawyer"
                         }
                      ],
@@ -336,9 +333,6 @@
                      "restrictions": [
                         {
                            "schema_id": "QzLYGuAebsy3MXQ6b1sFiT:2:legal-professional:1.0",
-                           "issuer_did": "QzLYGuAebsy3MXQ6b1sFiT"
-                        },
-                        {
                            "cred_def_id": "QzLYGuAebsy3MXQ6b1sFiT:3:CL:2351:lawyer"
                         }
                      ],
@@ -436,9 +430,6 @@
                      "restrictions": [
                         {
                            "schema_id": "QzLYGuAebsy3MXQ6b1sFiT:2:legal-professional:1.0",
-                           "issuer_did": "QzLYGuAebsy3MXQ6b1sFiT"
-                        },
-                        {
                            "cred_def_id": "QzLYGuAebsy3MXQ6b1sFiT:3:CL:2351:lawyer"
                         }
                      ],


### PR DESCRIPTION
Update the proof templates to support the latest LSB credential.


Image below shows the format:

```
{
   "schema_id": "RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0",
   "cred_def_id": "RGjWbW1eycP7FrMf4QJvX8:3:CL:13:Person"
}
```

Works as expected. Branding shows up in the verifier, correct proof / credential is requested.

![markup_1000003073](https://github.com/user-attachments/assets/a4dee3b7-8262-41b5-96b9-e8c12ea4ecc7)




Fixes #2339