### PR TITLE
chore: remove cpu limit

### DIFF
--- a/devops/README.md
+++ b/devops/README.md
@@ -101,5 +101,5 @@ Get and updated timestamp:
 Send a sample log with the updated timestamp:
 
 ```bash
-curl -v -H "Content-Type: application/json" -H "Authorization: Basic Base64-Encoded-USERNAME:PASSWORD" -X POST "https://bcwallet-logstack-proxy-caZZZZ-dev.apps.silver.devops.gov.bc.ca/loki/api/v1/push" --data-raw '{"streams":[{"stream":{"job":"react-native-logs","level":"debug","application":"bc wallet","version":"1.0.1-444","system":"iOS v16.7.4","session_id":"463217"},"values":[["1734028898448000000","{\"message\":\"Successfully connected to WebSocket wss://aries-mediator-agent.blah.gov.bc.ca\"}"]]}]}'
+curl -v -H "Content-Type: application/json" -u $PROXY_USER_NAME:$PROXY_PASSWORD -X POST "https://bcwallet-logstack-proxy-caZZZZ-dev.apps.silver.devops.gov.bc.ca/loki/api/v1/push" --data-raw '{"streams":[{"stream":{"job":"react-native-logs","level":"debug","application":"bc wallet","version":"1.0.1-444","system":"iOS v16.7.4","session_id":"463217"},"values":[["1734028898448000000","{\"message\":\"Successfully connected to WebSocket wss://aries-mediator-agent.blah.gov.bc.ca\"}"]]}]}'
 ```

--- a/devops/charts/loki-logstack/values_dev.yaml
+++ b/devops/charts/loki-logstack/values_dev.yaml
@@ -48,17 +48,14 @@ resources:
       cpu: 10m
     limits:
       memory: 256Mi
-      cpu: 400m
   proxy:
     requests:
       memory: 32Mi
       cpu: 10m
     limits:
       memory: 64Mi
-      cpu: 60m
   memcached:
     limits:
-      cpu: 50m
       memory: 32Mi
     requests:
       cpu: 10m
@@ -69,7 +66,6 @@ resources:
       cpu: 20m
     limits:
       memory: 128Mi
-      cpu: 40m
 
 services:
   loki:

--- a/devops/charts/loki-logstack/values_test.yaml
+++ b/devops/charts/loki-logstack/values_test.yaml
@@ -42,17 +42,14 @@ resources:
       cpu: 10m
     limits:
       memory: 256Mi
-      cpu: 400m
   proxy:
     requests:
       memory: 64Mi
       cpu: 10m
     limits:
       memory: 92Mi
-      cpu: 60m
   memcached:
     limits:
-      cpu: 50m
       memory: 32Mi
     requests:
       cpu: 10m
@@ -63,7 +60,6 @@ resources:
       cpu: 20m
     limits:
       memory: 192Mi
-      cpu: 80m
 
 services:
   loki:


### PR DESCRIPTION
This PR removes the CPU limit on our deployments. As of some time ago we no longer need to set them. This will allow a pod to utilize and available resources on the node.