### PR TITLE
feat: app to app toggle and pin content

### DIFF
--- a/app/__tests__/screens/__snapshots__/Developer.test.tsx.snap
+++ b/app/__tests__/screens/__snapshots__/Developer.test.tsx.snap
@@ -1318,6 +1318,100 @@ exports[`Developer Screen screen renders correctly 1`] = `
           </View>
         </View>
       </View>
+      <View
+        style={
+          {
+            "backgroundColor": "#FFFFFF",
+            "padding": 24,
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Text
+            style={
+              {
+                "color": "#313132",
+                "flex": 1,
+                "flexWrap": "wrap",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 21,
+                "fontWeight": "normal",
+              }
+            }
+          >
+            Developer.EnableAppToAppPersonFlow
+          </Text>
+          <View
+            accessibilityLabel="Developer.EnableAppToAppPersonFlow"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+              }
+            }
+            testID="com.ariesbifold:id/ToggleEnableAppToAppPersonFlow"
+          >
+            <RCTSwitch
+              accessibilityRole="switch"
+              onChange={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              onTintColor="#757575"
+              style={
+                [
+                  {
+                    "height": 31,
+                    "width": 51,
+                  },
+                  {
+                    "backgroundColor": "#D3D3D3",
+                    "borderRadius": 16,
+                  },
+                ]
+              }
+              thumbTintColor="#606060"
+              tintColor="#D3D3D3"
+              value={false}
+            />
+          </View>
+        </View>
+      </View>
     </View>
   </RCTScrollView>
 </RNCSafeAreaView>

--- a/app/container-imp.ts
+++ b/app/container-imp.ts
@@ -359,7 +359,8 @@ export class AppContainer implements Container {
       let tours = initialState.tours
       let onboarding = initialState.onboarding
       let personCredOfferDissmissed = initialState.dismissPersonCredentialOffer
-      let { environment, remoteDebugging, enableProxy, enableAltPersonFlow } = initialState.developer
+      let { environment, remoteDebugging, enableProxy, enableAltPersonFlow, enableAppToAppPersonFlow } =
+        initialState.developer
       let unified = initialState.unified
 
       await Promise.all([
@@ -380,6 +381,7 @@ export class AppContainer implements Container {
         loadState<RemoteDebuggingState>(BCLocalStorageKeys.RemoteDebugging, (val) => (remoteDebugging = val)),
         loadState<boolean>(BCLocalStorageKeys.EnableProxy, (val) => (enableProxy = val)),
         loadState<boolean>(BCLocalStorageKeys.EnableAltPersonFlow, (val) => (enableAltPersonFlow = val)),
+        loadState<boolean>(BCLocalStorageKeys.EnableAppToAppPersonFlow, (val) => (enableAppToAppPersonFlow = val)),
         loadState<Unified>(BCLocalStorageKeys.Unified, (val) => (unified = val)),
       ])
 
@@ -404,6 +406,7 @@ export class AppContainer implements Container {
           },
           enableProxy,
           enableAltPersonFlow,
+          enableAppToAppPersonFlow,
         },
         unified: { ...initialState.unified, ...unified },
       } as BCState

--- a/app/container-imp.ts
+++ b/app/container-imp.ts
@@ -61,6 +61,7 @@ import Developer from './src/screens/Developer'
 import { pages } from './src/screens/OnboardingPages'
 import PersonCredential from './src/screens/PersonCredential'
 import PersonCredentialLoading from './src/screens/PersonCredentialLoading'
+import PINExplainer from './src/screens/PINExplainer'
 import Preface from './src/screens/Preface'
 import Splash from './src/screens/Splash'
 import Terms, { TermsVersion } from './src/screens/Terms'
@@ -306,6 +307,7 @@ export class AppContainer implements Container {
     ])
     this._container.registerInstance(TOKENS.INLINE_ERRORS, { enabled: true, position: InlineErrorPosition.Below })
     this._container.registerInstance(TOKENS.SCREEN_TERMS, { screen: Terms, version: TermsVersion })
+    this._container.registerInstance(TOKENS.SCREEN_PIN_EXPLAINER, PINExplainer)
     this._container.registerInstance(TOKENS.SCREEN_DEVELOPER, Developer)
 
     const resolver = new RemoteOCABundleResolver(Config.OCA_URL ?? '', {

--- a/app/eslint.config.mjs
+++ b/app/eslint.config.mjs
@@ -41,6 +41,7 @@ export default [
     rules: {
       ...reactHooks.configs.recommended.rules,
       ...reactPlugin.configs.flat.recommended.rules,
+      'no-console': 'error',
       'react/react-in-jsx-scope': 'off',
       'react-hooks/exhaustive-deps': 'error',
       '@typescript-eslint/no-explicit-any': 'off',

--- a/app/src/assets/img/secure-pin.svg
+++ b/app/src/assets/img/secure-pin.svg
@@ -1,0 +1,38 @@
+<svg width="107" height="120" viewBox="0 0 107 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Layer_1" clip-path="url(#clip0_3706_428)">
+<path id="Vector" d="M101.369 1.4043H5.63122C3.29675 1.4043 1.4043 3.29692 1.4043 5.63158V21.677C1.4043 24.0117 3.29675 25.9043 5.63122 25.9043H101.369C103.703 25.9043 105.596 24.0117 105.596 21.677V5.63158C105.596 3.29692 103.703 1.4043 101.369 1.4043Z" fill="#8099B3" stroke="#003366" stroke-width="4" stroke-linejoin="round"/>
+<path id="Vector_2" d="M16.4653 9.29736V18.0117" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_3" d="M12.6948 11.4741L20.2359 15.8348" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_4" d="M20.2359 11.4741L12.6948 15.8348" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_5" d="M31.2805 9.29736V18.0117" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_6" d="M27.5029 11.4741L35.051 15.8348" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_7" d="M35.051 11.4741L27.5029 15.8348" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_8" d="M46.0959 9.29736V18.0117" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_9" d="M42.3184 11.4741L49.8664 15.8348" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_10" d="M49.8664 11.4741L42.3184 15.8348" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_11" d="M60.9041 9.29736V18.0117" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_12" d="M57.1335 11.4741L64.6816 15.8348" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_13" d="M64.6816 11.4741L57.1335 15.8348" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_14" d="M75.7195 9.29736V18.0117" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_15" d="M71.949 11.4741L79.49 15.8348" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_16" d="M79.49 11.4741L71.949 15.8348" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_17" d="M90.5347 9.29736V18.0117" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_18" d="M86.7642 11.4741L94.3052 15.8348" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_19" d="M94.3052 11.4741L86.7642 15.8348" stroke="#FCBA19" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_20" d="M29.2795 48.0027C33.1884 48.0027 36.3572 44.8336 36.3572 40.9244C36.3572 37.0152 33.1884 33.8462 29.2795 33.8462C25.3707 33.8462 22.2019 37.0152 22.2019 40.9244C22.2019 44.8336 25.3707 48.0027 29.2795 48.0027Z" fill="#8099B3" stroke="#003366" stroke-width="4" stroke-linejoin="round"/>
+<path id="Vector_21" d="M53.4966 48.0027C57.4054 48.0027 60.5742 44.8336 60.5742 40.9244C60.5742 37.0152 57.4054 33.8462 53.4966 33.8462C49.5877 33.8462 46.4189 37.0152 46.4189 40.9244C46.4189 44.8336 49.5877 48.0027 53.4966 48.0027Z" fill="#8099B3" stroke="#003366" stroke-width="4" stroke-linejoin="round"/>
+<path id="Vector_22" d="M77.7134 48.0027C81.6222 48.0027 84.791 44.8336 84.791 40.9244C84.791 37.0152 81.6222 33.8462 77.7134 33.8462C73.8045 33.8462 70.6357 37.0152 70.6357 40.9244C70.6357 44.8336 73.8045 48.0027 77.7134 48.0027Z" fill="#8099B3" stroke="#003366" stroke-width="4" stroke-linejoin="round"/>
+<path id="Vector_23" d="M29.2795 71.5339C33.1884 71.5339 36.3572 68.3649 36.3572 64.4557C36.3572 60.5465 33.1884 57.3774 29.2795 57.3774C25.3707 57.3774 22.2019 60.5465 22.2019 64.4557C22.2019 68.3649 25.3707 71.5339 29.2795 71.5339Z" fill="#8099B3" stroke="#003366" stroke-width="4" stroke-linejoin="round"/>
+<path id="Vector_24" d="M53.4966 71.5339C57.4054 71.5339 60.5742 68.3649 60.5742 64.4557C60.5742 60.5465 57.4054 57.3774 53.4966 57.3774C49.5877 57.3774 46.4189 60.5465 46.4189 64.4557C46.4189 68.3649 49.5877 71.5339 53.4966 71.5339Z" fill="#8099B3" stroke="#003366" stroke-width="4" stroke-linejoin="round"/>
+<path id="Vector_25" d="M77.7134 71.5339C81.6222 71.5339 84.791 68.3649 84.791 64.4557C84.791 60.5465 81.6222 57.3774 77.7134 57.3774C73.8045 57.3774 70.6357 60.5465 70.6357 64.4557C70.6357 68.3649 73.8045 71.5339 77.7134 71.5339Z" fill="#8099B3" stroke="#003366" stroke-width="4" stroke-linejoin="round"/>
+<path id="Vector_26" d="M29.2795 95.0647C33.1884 95.0647 36.3572 91.8956 36.3572 87.9864C36.3572 84.0772 33.1884 80.9082 29.2795 80.9082C25.3707 80.9082 22.2019 84.0772 22.2019 87.9864C22.2019 91.8956 25.3707 95.0647 29.2795 95.0647Z" fill="#8099B3" stroke="#003366" stroke-width="4" stroke-linejoin="round"/>
+<path id="Vector_27" d="M53.4966 95.0647C57.4054 95.0647 60.5742 91.8956 60.5742 87.9864C60.5742 84.0772 57.4054 80.9082 53.4966 80.9082C49.5877 80.9082 46.4189 84.0772 46.4189 87.9864C46.4189 91.8956 49.5877 95.0647 53.4966 95.0647Z" fill="#8099B3" stroke="#003366" stroke-width="4" stroke-linejoin="round"/>
+<path id="Vector_28" d="M77.7134 95.0647C81.6222 95.0647 84.791 91.8956 84.791 87.9864C84.791 84.0772 81.6222 80.9082 77.7134 80.9082C73.8045 80.9082 70.6357 84.0772 70.6357 87.9864C70.6357 91.8956 73.8045 95.0647 77.7134 95.0647Z" fill="#8099B3" stroke="#003366" stroke-width="4" stroke-linejoin="round"/>
+<path id="Vector_29" d="M53.4966 118.595C57.4054 118.595 60.5742 115.426 60.5742 111.517C60.5742 107.608 57.4054 104.439 53.4966 104.439C49.5877 104.439 46.4189 107.608 46.4189 111.517C46.4189 115.426 49.5877 118.595 53.4966 118.595Z" fill="#8099B3" stroke="#003366" stroke-width="4" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_3706_428">
+<rect width="107" height="120" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/app/src/helpers/BCIDHelper.ts
+++ b/app/src/helpers/BCIDHelper.ts
@@ -120,6 +120,19 @@ export const cleanupAfterServiceCardAuthentication = (status: AuthenticationResu
   }
 }
 
+export const initiateAppToAppFlow = async (url: string) => {
+  try {
+    if (await Linking.canOpenURL(url)) {
+      await Linking.openURL(url)
+    } else {
+      throw new Error()
+    }
+  } catch {
+    const error = new BifoldError('Error.Title2032', 'Error.Message2032', 'Error.NoMessage', 2032)
+    DeviceEventEmitter.emit(BifoldEventTypes.ERROR_ADDED, error)
+  }
+}
+
 export const authenticateWithServiceCard = async (
   legacyConnectionDid: string,
   iasPortalUrl: string,

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -25,6 +25,8 @@ const translation = {
     "Message2030": "There was a problem while initializing the app.",
     "Title2031": "Unable to complete agent initialization",
     "Message2031": "There was a problem while initializing the agent.",
+    "Title2032": "Unable to open app-to-app URL",
+    "Message2032": "There was a problem while opening the app-to-app URL.",
     "NoMessage": "No Message",
   },
   "CameraDisclosure": {
@@ -161,6 +163,7 @@ const translation = {
     "AttestationSupport": "Attestation support",
     "EnableProxy": "Enable proxy",
     "EnableAltPersonFlow": "Alt Person flow",
+    "EnableAppToAppPersonFlow": "App-to-app Person flow",
   },
   "Tips": {
     "Header": "Tips",

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -87,6 +87,13 @@ const translation = {
       "Stage1": "TODO",
     },
   },
+  "PINCreate": {
+    "Explainer": {
+      "PrimaryHeading": "Create a PIN that is:",
+      "Bullet1": "<b>Memorable.</b> If you forget your PIN, you can't recover it. You will need to reinstall and set up your wallet again.",
+      "Bullet2": "<b>Unique.</b> Your PIN prevents people from accessing your digital credentials. Do not share it with anyone.",
+    }
+  },
   "PersonCredentialNotification": {
     "Title": "Get your Person credential",
     "Description": "Add your Person credential to your wallet and use it to get access to services online.",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -87,6 +87,13 @@ const translation = {
       "Stage1": "TODO",
     },
   },
+  "PINCreate": {
+    "Explainer": {
+      "PrimaryHeading": "Create a PIN that is: (FR)",
+      "Bullet1": "<b>Memorable.</b> If you forget your PIN, you can't recover it. You will need to reinstall and set up your wallet again. (FR)",
+      "Bullet2": "<b>Unique.</b> Your PIN prevents people from accessing your digital credentials. Do not share it with anyone. (FR)",
+    }
+  },
   "PersonCredentialNotification": {
     "Title": "Obtener votre carte d'identité",
     "Description": "Ajouter votre carte d'identité à votre portefeuille et utilisez-la pour accéder aux services en ligne."

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -25,6 +25,8 @@ const translation = {
     "Message2030": "There was a problem while initializing the app. (FR)",
     "Title2031": "Unable to complete agent initialization (FR)",
     "Message2031": "There was a problem while initializing the agent. (FR)",
+    "Title2032": "Unable to open app-to-app URL (FR)",
+    "Message2032": "There was a problem while opening the app-to-app URL. (FR)",
     "NoMessage": "Aucun message",
   },
   "CameraDisclosure": {
@@ -160,6 +162,7 @@ const translation = {
     "AttestationSupport": "Soutien d'attestation",
     "EnableProxy": "Enable proxy (FR)",
     "EnableAltPersonFlow": "Alt Person flow (FR)",
+    "EnableAppToAppPersonFlow": "App-to-app Person flow (FR)",
   },
   "Tips": {
     "Header": "Conseils",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -25,6 +25,8 @@ const translation = {
     "Message2030": "There was a problem while initializing the app. (PT-BR)",
     "Title2031": "Unable to complete agent initialization (PT-BR)",
     "Message2031": "There was a problem while initializing the agent. (PT-BR)",
+    "Title2032": "Unable to open app-to-app URL (PT-BR)",
+    "Message2032": "There was a problem while opening the app-to-app URL. (PT-BR)",
     "NoMessage": "No Message (PT-BR)",
   },
   "CameraDisclosure": {
@@ -160,6 +162,7 @@ const translation = {
     "AttestationSupport": "Attestation support (PT-BR)",
     "EnableProxy": "Enable proxy (PT-BR)",
     "EnableAltPersonFlow": "Alt Person flow (PT-BR)",
+    "EnableAppToAppPersonFlow": "App-to-app Person flow (PT-BR)",
   },
   "Tips": {
     "Header": "Tips (PT-BR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -87,6 +87,13 @@ const translation = {
       "Stage1": "TODO",
     },
   },
+  "PINCreate": {
+    "Explainer": {
+      "PrimaryHeading": "Create a PIN that is: (PT-BR)",
+      "Bullet1": "<b>Memorable.</b> If you forget your PIN, you can't recover it. You will need to reinstall and set up your wallet again. (PT-BR)",
+      "Bullet2": "<b>Unique.</b> Your PIN prevents people from accessing your digital credentials. Do not share it with anyone. (PT-BR)",
+    }
+  },
   "PersonCredentialNotification": {
     "Title": "Get your Person credential (PT-BR)",
     "Description": "Add your Person credential to your wallet and use it to get access to services online. (PT-BR)"

--- a/app/src/screens/Developer.tsx
+++ b/app/src/screens/Developer.tsx
@@ -41,6 +41,7 @@ const Settings: React.FC = () => {
   const [enableShareableLink, setEnableShareableLink] = useState(!!store.preferences.enableShareableLink)
   const [enableProxy, setEnableProxy] = useState(!!store.developer.enableProxy)
   const [enableAltPersonFlow, setEnableAltPersonFlow] = useState(!!store.developer.enableAltPersonFlow)
+  const [enableAppToAppPersonFlow, setEnableAppToAppPersonFlow] = useState(!!store.developer.enableAppToAppPersonFlow)
   const navigation = useNavigation()
 
   const styles = StyleSheet.create({
@@ -279,6 +280,14 @@ const Settings: React.FC = () => {
     setEnableAltPersonFlow((previousState) => !previousState)
   }
 
+  const toggleEnableAppToAppPersonFlowSwitch = () => {
+    dispatch({
+      type: BCDispatchAction.TOGGLE_APP_TO_APP_PERSON_FLOW,
+      payload: [!enableAppToAppPersonFlow],
+    })
+    setEnableAppToAppPersonFlow((previousState) => !previousState)
+  }
+
   return (
     <SafeAreaView edges={['bottom', 'left', 'right']}>
       <SafeAreaModal
@@ -480,6 +489,20 @@ const Settings: React.FC = () => {
             ios_backgroundColor={ColorPallet.grayscale.lightGrey}
             onValueChange={toggleEnableAltPersonFlowSwitch}
             value={enableAltPersonFlow}
+          />
+        </SectionRow>
+
+        <SectionRow
+          title={t('Developer.EnableAppToAppPersonFlow')}
+          accessibilityLabel={t('Developer.EnableAppToAppPersonFlow')}
+          testID={testIdWithKey('ToggleEnableAppToAppPersonFlow')}
+        >
+          <Switch
+            trackColor={{ false: ColorPallet.grayscale.lightGrey, true: ColorPallet.brand.primaryDisabled }}
+            thumbColor={enableAppToAppPersonFlow ? ColorPallet.brand.primary : ColorPallet.grayscale.mediumGrey}
+            ios_backgroundColor={ColorPallet.grayscale.lightGrey}
+            onValueChange={toggleEnableAppToAppPersonFlowSwitch}
+            value={enableAppToAppPersonFlow}
           />
         </SectionRow>
       </ScrollView>

--- a/app/src/screens/PINExplainer.tsx
+++ b/app/src/screens/PINExplainer.tsx
@@ -1,0 +1,102 @@
+import { useTheme, testIdWithKey, ThemedText, Button, ButtonType } from '@hyperledger/aries-bifold-core'
+import React from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+import { ScrollView, StyleSheet, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import Icon from 'react-native-vector-icons/MaterialIcons'
+
+interface BoldedBulletPointProps {
+  i18nKey: string
+}
+
+const BoldedBulletPoint: React.FC<BoldedBulletPointProps> = ({ i18nKey }) => {
+  const { t } = useTranslation()
+  const { ColorPallet, Spacing } = useTheme()
+
+  const styles = StyleSheet.create({
+    container: {
+      marginVertical: Spacing.sm,
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+    },
+    iconContainer: {
+      margin: Spacing.sm,
+    },
+  })
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.iconContainer}>
+        <Icon name={'circle'} size={Spacing.sm} color={ColorPallet.brand.modalIcon} />
+      </View>
+      <ThemedText style={{ flexShrink: 1 }}>
+        <Trans
+          i18nKey={i18nKey}
+          components={{
+            b: <ThemedText variant="bold" />,
+          }}
+          t={t}
+        />
+      </ThemedText>
+    </View>
+  )
+}
+
+export interface PINExplainerProps {
+  continueCreatePIN: () => void
+}
+
+const PINExplainer: React.FC<PINExplainerProps> = ({ continueCreatePIN }) => {
+  const { t } = useTranslation()
+  const { ColorPallet, Assets, Spacing } = useTheme()
+
+  const style = StyleSheet.create({
+    safeAreaView: {
+      flex: 1,
+      backgroundColor: ColorPallet.brand.primaryBackground,
+      padding: Spacing.lg,
+    },
+    scrollViewContentContainer: {
+      flexGrow: 1,
+    },
+    imageContainer: {
+      alignItems: 'center',
+      marginBottom: Spacing.xxl,
+    },
+    footer: {
+      paddingTop: 10,
+    },
+  })
+
+  const imageDisplayOptions = {
+    fill: ColorPallet.notification.infoText,
+    height: 150,
+    width: 150,
+  }
+
+  return (
+    <SafeAreaView style={style.safeAreaView} edges={['bottom', 'left', 'right']}>
+      <ScrollView contentContainerStyle={style.scrollViewContentContainer}>
+        <View style={style.imageContainer}>
+          <Assets.svg.secureCheck {...imageDisplayOptions} />
+        </View>
+        <ThemedText style={{ marginBottom: Spacing.md }} variant="headingThree">
+          {t('PINCreate.Explainer.PrimaryHeading')}
+        </ThemedText>
+        <BoldedBulletPoint i18nKey={'PINCreate.Explainer.Bullet1'} />
+        <BoldedBulletPoint i18nKey={'PINCreate.Explainer.Bullet2'} />
+      </ScrollView>
+      <View style={style.footer}>
+        <Button
+          title={t('Global.Continue')}
+          accessibilityLabel={t('Global.Continue')}
+          testID={testIdWithKey('ContinueCreatePIN')}
+          onPress={continueCreatePIN}
+          buttonType={ButtonType.Primary}
+        />
+      </View>
+    </SafeAreaView>
+  )
+}
+
+export default PINExplainer

--- a/app/src/screens/PersonCredentialLoading.tsx
+++ b/app/src/screens/PersonCredentialLoading.tsx
@@ -153,7 +153,6 @@ const PersonCredentialLoading: React.FC<PersonProps> = ({ navigation }) => {
       store.developer.enableAppToAppPersonFlow &&
       ['Development', 'Test'].includes(store.developer.environment.name)
     ) {
-      console.log('PERU')
       initiateAppToAppFlow(store.developer.environment.appToAppUrl)
         .then(() => {
           logger.info('Initiated app-to-app flow')

--- a/app/src/store.tsx
+++ b/app/src/store.tsx
@@ -13,6 +13,7 @@ export interface IASEnvironment {
   name: string
   iasAgentInviteUrl: string
   iasPortalUrl: string
+  appToAppUrl: string
 }
 
 export type RemoteDebuggingState = {
@@ -25,6 +26,7 @@ export interface Developer {
   remoteDebugging: RemoteDebuggingState
   enableProxy: boolean
   enableAltPersonFlow: boolean
+  enableAppToAppPersonFlow: boolean
 }
 
 export interface DismissPersonCredentialOffer {
@@ -47,6 +49,7 @@ enum DeveloperDispatchAction {
   UPDATE_ENVIRONMENT = 'developer/updateEnvironment',
   TOGGLE_PROXY = 'developer/toggleProxy',
   TOGGLE_ALT_PERSON_FLOW = 'developer/toggleAltPersonFlow',
+  TOGGLE_APP_TO_APP_PERSON_FLOW = 'developer/toggleAppToAppPersonFlow',
 }
 
 enum DismissPersonCredentialOfferDispatchAction {
@@ -82,18 +85,21 @@ export const iasEnvironments: Array<IASEnvironment> = [
     iasAgentInviteUrl:
       'https://idim-agent.apps.silver.devops.gov.bc.ca?c_i=eyJAdHlwZSI6ICJkaWQ6c292OkJ6Q2JzTlloTXJqSGlxWkRUVUFTSGc7c3BlYy9jb25uZWN0aW9ucy8xLjAvaW52aXRhdGlvbiIsICJAaWQiOiAiNWY2NTYzYWItNzEzYi00YjM5LWI5MTUtNjY2YjJjNDc4M2U2IiwgImxhYmVsIjogIlNlcnZpY2UgQkMiLCAicmVjaXBpZW50S2V5cyI6IFsiN2l2WVNuN3NocW8xSkZyYm1FRnVNQThMNDhaVnh2TnpwVkN6cERSTHE4UmoiXSwgInNlcnZpY2VFbmRwb2ludCI6ICJodHRwczovL2lkaW0tYWdlbnQuYXBwcy5zaWx2ZXIuZGV2b3BzLmdvdi5iYy5jYSIsICJpbWFnZVVybCI6ICJodHRwczovL2lkLmdvdi5iYy5jYS9zdGF0aWMvR292LTIuMC9pbWFnZXMvZmF2aWNvbi5pY28ifQ==',
     iasPortalUrl: 'https://id.gov.bc.ca/issuer/v1/dids',
+    appToAppUrl: 'ca.bc.gov.id.servicescard.v2://credentials/person/v1',
   },
   {
     name: 'Development',
     iasAgentInviteUrl:
       'https://idim-agent-dev.apps.silver.devops.gov.bc.ca?c_i=eyJAdHlwZSI6ICJkaWQ6c292OkJ6Q2JzTlloTXJqSGlxWkRUVUFTSGc7c3BlYy9jb25uZWN0aW9ucy8xLjAvaW52aXRhdGlvbiIsICJAaWQiOiAiY2U1NWFiZDctNWRmYy00YjQ5LWExODYtOWUzMzQ1ZjEyZThkIiwgImxhYmVsIjogIlNlcnZpY2UgQkMgKERldikiLCAicmVjaXBpZW50S2V5cyI6IFsiM0I0bnlDMVg4R1E0M0NLczR4clVXOFdnbWE5MUpMem50cVVYdlo0UjQ4TXQiXSwgInNlcnZpY2VFbmRwb2ludCI6ICJodHRwczovL2lkaW0tYWdlbnQtZGV2LmFwcHMuc2lsdmVyLmRldm9wcy5nb3YuYmMuY2EiLCAiaW1hZ2VVcmwiOiAiaHR0cHM6Ly9pZC5nb3YuYmMuY2Evc3RhdGljL0dvdi0yLjAvaW1hZ2VzL2Zhdmljb24uaWNvIn0=',
     iasPortalUrl: 'https://iddev.gov.bc.ca/issuer/v1/dids',
+    appToAppUrl: 'ca.bc.gov.iddev.servicescard.v2://credentials/person/v1',
   },
   {
     name: 'Test',
     iasAgentInviteUrl:
       'https://idim-sit-agent-dev.apps.silver.devops.gov.bc.ca?c_i=eyJAdHlwZSI6ICJkaWQ6c292OkJ6Q2JzTlloTXJqSGlxWkRUVUFTSGc7c3BlYy9jb25uZWN0aW9ucy8xLjAvaW52aXRhdGlvbiIsICJAaWQiOiAiZDFkMDk5MDQtN2ZlOC00YzlkLTk4YjUtZmNmYmEwODkzZTAzIiwgImxhYmVsIjogIlNlcnZpY2UgQkMgKFNJVCkiLCAicmVjaXBpZW50S2V5cyI6IFsiNVgzblBoZkVIOU4zb05kcHdqdUdjM0ZhVzNQbmhiY05QemRGbzFzS010dEoiXSwgInNlcnZpY2VFbmRwb2ludCI6ICJodHRwczovL2lkaW0tc2l0LWFnZW50LWRldi5hcHBzLnNpbHZlci5kZXZvcHMuZ292LmJjLmNhIiwgImltYWdlVXJsIjogImh0dHBzOi8vaWQuZ292LmJjLmNhL3N0YXRpYy9Hb3YtMi4wL2ltYWdlcy9mYXZpY29uLmljbyJ9',
     iasPortalUrl: 'https://idsit.gov.bc.ca/issuer/v1/dids',
+    appToAppUrl: 'ca.bc.gov.iddev.servicescard.v2://credentials/person/v1',
   },
 ]
 
@@ -107,6 +113,7 @@ const developerState: Developer = {
   environment: iasEnvironments[0],
   remoteDebugging: remoteDebuggingState,
   enableAltPersonFlow: false,
+  enableAppToAppPersonFlow: false,
 }
 
 const dismissPersonCredentialOfferState: DismissPersonCredentialOffer = {
@@ -126,6 +133,7 @@ export enum BCLocalStorageKeys {
   RemoteDebugging = 'RemoteDebugging',
   EnableProxy = 'EnableProxy',
   EnableAltPersonFlow = 'EnableAltPersonFlow',
+  EnableAppToAppPersonFlow = 'EnableAppToAppPersonFlow',
   UserDeniedPushNotifications = 'userDeniedPushNotifications',
   DeviceToken = 'deviceToken',
   Unified = 'Unified',
@@ -179,6 +187,17 @@ const bcReducer = (state: BCState, action: ReducerAction<BCDispatchAction>): BCS
       const developer = { ...state.developer, enableAltPersonFlow }
 
       PersistentStorage.storeValueForKey<boolean>(BCLocalStorageKeys.EnableAltPersonFlow, developer.enableAltPersonFlow)
+
+      return { ...state, developer }
+    }
+    case DeveloperDispatchAction.TOGGLE_APP_TO_APP_PERSON_FLOW: {
+      const enableAppToAppPersonFlow: boolean = (action?.payload || []).pop() || false
+      const developer = { ...state.developer, enableAppToAppPersonFlow }
+
+      PersistentStorage.storeValueForKey<boolean>(
+        BCLocalStorageKeys.EnableAppToAppPersonFlow,
+        developer.enableAppToAppPersonFlow
+      )
 
       return { ...state, developer }
     }

--- a/app/src/theme.ts
+++ b/app/src/theme.ts
@@ -16,6 +16,7 @@ import React from 'react'
 import { StyleSheet, ViewStyle } from 'react-native'
 
 import Logo from './assets/img/logo-with-text.svg'
+import SecurePIN from './assets/img/secure-pin.svg'
 
 export const maxFontSizeMultiplier = 2
 export const borderRadius = 4
@@ -734,7 +735,11 @@ const PINInputTheme = {
 
 export const Assets: IAssets = {
   ...BifoldImageAssets,
-  svg: { ...BifoldImageAssets.svg, logo: Logo as React.FC },
+  svg: {
+    ...BifoldImageAssets.svg,
+    logo: Logo as React.FC,
+    secureCheck: SecurePIN as React.FC,
+  },
   img: {
     logoSecondary: {
       src: require('./assets/img/logo-large.png'),


### PR DESCRIPTION
This PR adds the app-to-app person flow, default off and gated behind a developer mode toggle and IAS environment setting. To try it out, you need the BCSC Dev app setup on your device, then enable the toggle, and switch IAS environments to "Test".
Here's a video of it:
https://github.com/user-attachments/assets/0cb75e6e-9c68-4825-ba25-d580c3f709a1

It also adds BC Wallet-specific content for the PINExplainer that pops up just before the create PIN screen during onboarding.

Here is the before and after of that: 
![explainer_before](https://github.com/user-attachments/assets/b71dce04-5bd5-4cfb-9b38-7ad9beee122e)
![explainer_after](https://github.com/user-attachments/assets/9e9d7ff4-744c-4e5a-a298-f7c614dddddd)
