### PR TITLE
fix: api clarity

### DIFF
--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -252,14 +252,12 @@ class BcscCore: NSObject {
     let storage = StorageService()
       
     // Extract required fields from the dictionary
-    guard let issuer = account["issuer"] as? String, let clientID = account["clientID"] as? String  else {
-      reject("E_INVALID_ACCOUNT_DATA", "Account must have an 'issuer' and 'clientID' fields", nil)
+    guard let issuer = account["issuer"] as? String, let clientID = account["clientID"] as? String,
+      let securityMethod = account["securityMethod"] as? String else {
+      reject("E_INVALID_ACCOUNT_DATA", "Account must have an 'issuer', 'clientID' and 'securityMethod' fields", nil)
       return
     }
-    
-    // Extract optional security method, default to pin without device auth
-    let securityMethod = account["_securityMethod"] as? String ?? "app_pin_no_device_authn"
-    
+        
     // Create Account object with required fields
     let newAccount = Account(id: accountID, clientID: clientID, issuer: issuer, securityMethod: securityMethod)
     

--- a/packages/bcsc-core/src/NativeBcscCore.ts
+++ b/packages/bcsc-core/src/NativeBcscCore.ts
@@ -27,14 +27,24 @@ export type NativeToken = {
   expiry?: number | null; // Timestamp or null
 };
 
+export enum AccountSecurityMethod {
+  PinNoDeviceAuth = 'app_pin_no_device_authn',
+  PinWithDeviceAuth = 'app_pin_has_device_authn',
+  DeviceAuth = 'device_authentication',
+}
+
 export type NativeAccount = {
   readonly id: string;
   issuer: string;
-  clientID?: string;
+  clientID: string;
+  securityMethod: AccountSecurityMethod;
   displayName?: string;
-  didPostNicknameToServer: boolean;
+  didPostNicknameToServer?: boolean;
   nickname?: string;
-  failedAttemptCount: number;
+  failedAttemptCount?: number;
+  // lastAttemptDate?: number; // Timestamp
+  // Penalties are not directly included as it's a computed property
+  // with complex structure
 };
 
 export interface Spec extends TurboModule {

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -1,6 +1,6 @@
 import { NativeModules, Platform } from 'react-native';
-import NativeBcscCoreSpec from './NativeBcscCore';
-
+import NativeBcscCoreSpec, { type NativeAccount } from './NativeBcscCore';
+export type { NativeAccount, AccountSecurityMethod } from './NativeBcscCore';
 export interface TokenInfo {
   id: string;
   type: TokenType;
@@ -31,21 +31,6 @@ export interface KeyPair {
   privateKeyAvailable: string; // Indicates if the private key exists,
   // even if not extractable
 }
-
-export interface Account {
-  id: string;
-  issuer: string;
-  clientID?: string;
-  // _securityMethod: string; // Consider if this should be exposed or mapped to a more friendly type
-  displayName?: string;
-  didPostNicknameToServer: boolean;
-  nickname?: string;
-  failedAttemptCount: number;
-  // lastAttemptDate?: number; // Timestamp
-  // Penalties are not directly included as it's a computed property
-  // with complex structure
-}
-
 export interface ProviderInfo {
   // Assuming Provider can be represented like this
   issuer: string;
@@ -132,7 +117,7 @@ export const getToken = async (
  * @param account The Account object to set as the current account.
  * @returns A promise that resolves when the account has been successfully set.
  */
-export const setAccount = async (account: Account): Promise<void> => {
+export const setAccount = async (account: NativeAccount): Promise<void> => {
   return BcscCore.setAccount(account);
 };
 
@@ -140,7 +125,7 @@ export const setAccount = async (account: Account): Promise<void> => {
  * Retrieves the current account information.
  * @returns A promise that resolves to an Account object if an account exists, otherwise null.
  */
-export const getAccount = async (): Promise<Account | null> => {
+export const getAccount = async (): Promise<NativeAccount | null> => {
   return BcscCore.getAccount();
 };
 


### PR DESCRIPTION
Improve the API of setAccount to make it more usable and clear.

Code: 

```TypeScript
       const status = await setAccount({
          issuer: 'https://example.com',
          clientID: 'test-client-id',
          securityMethod: AccountSecurityMethod.DeviceAuth,
          displayName: 'Test Account',
          didPostNicknameToServer: false,
          nickname: 'Test Nickname',
          failedAttemptCount: 0,
        })
        console.log('***** jsSetAccountStatus:', status)

        const account = await getAccount()
        console.log('***** jsGetAccount:', account)
```

Results:

```console
setAccount called with account: {
    clientID = "test-client-id";
    didPostNicknameToServer = 0;
    displayName = "Test Account";
    failedAttemptCount = 0;
    issuer = "https://example.com";
    nickname = "Test Nickname";
    securityMethod = "device_authentication";
}


'***** jsSetAccountStatus:', undefined

Data read from file: 707 bytes
Decoding classx: bc_services_card_dev.Account
Decoded object: <BcscCore.Account: 0x15dff4900>
'***** jsGetAccount:', { clientID: 'test-client-id',
  failedAttemptCount: 0,
  id: 'D41F1D79-8AF2-4543-9647-6F73EF49D9FC',
  nickname: 'Test Nickname',
  displayName: 'Test Account',
  didPostNicknameToServer: false,
  issuer: 'https://example.com' }
```
