### PR TITLE
fix: set account param

### DIFF
--- a/packages/bcsc-core/src/NativeBcscCore.ts
+++ b/packages/bcsc-core/src/NativeBcscCore.ts
@@ -52,6 +52,7 @@ export interface Spec extends TurboModule {
   getKeyPair(label: string): Promise<KeyPair>;
   getToken(tokenType: number): Promise<NativeToken | null>;
   getAccount(): Promise<NativeAccount | null>;
+  setAccount(account: Omit<NativeAccount, 'id'>): Promise<void>;
   getRefreshTokenRequestBody(
     issuer: string,
     clientID: string

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -115,10 +115,12 @@ export const getToken = async (
 
 /**
  * Sets the current account information.
- * @param account The Account object to set as the current account.
+ * @param account The Account object to set as the current account (without id, which will be generated).
  * @returns A promise that resolves when the account has been successfully set.
  */
-export const setAccount = async (account: NativeAccount): Promise<void> => {
+export const setAccount = async (
+  account: Omit<NativeAccount, 'id'>
+): Promise<void> => {
   return BcscCore.setAccount(account);
 };
 


### PR DESCRIPTION
Remove the `id` prop from NativeAccout when used in `setAccount`.