### PR TITLE
refactor: accept refresh token as parameter

### DIFF
--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -218,13 +218,19 @@ class BcscCoreModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  override fun getRefreshTokenRequestBody(issuer: String, clientID: String, promise: Promise) {
+  override fun getRefreshTokenRequestBody(issuer: String, clientID: String, refreshToken: String, promise: Promise) {
+    // Validate all parameters are provided
+    if (issuer.isEmpty() || clientID.isEmpty() || refreshToken.isEmpty()) {
+      promise.reject("E_INVALID_PARAMETERS", "All parameters (issuer, clientID, refreshToken) are required and cannot be empty.")
+      return
+    }
+    
     // Mock implementation - returns null for now
     // In a real implementation, this would:
     // 1. Create and sign a JWT assertion using provided issuer and clientID
-    // 2. Retrieve the refresh token
+    // 2. Use the provided refreshToken parameter instead of retrieving it
     // 3. Format the OAuth request body
-    Log.d(NAME, "getRefreshTokenRequestBody called with issuer: $issuer, clientID: $clientID")
+    Log.d(NAME, "getRefreshTokenRequestBody called with issuer: $issuer, clientID: $clientID, refreshToken: [REDACTED]")
     promise.resolve("getRefreshTokenRequestBody-mock-return-value")
   }
 

--- a/packages/bcsc-core/android/src/oldarch/BcscCoreSpec.kt
+++ b/packages/bcsc-core/android/src/oldarch/BcscCoreSpec.kt
@@ -12,7 +12,7 @@ abstract class BcscCoreSpec internal constructor(context: ReactApplicationContex
   abstract fun getToken(tokenType: Int, promise: Promise)
   abstract fun setAccount(account: com.facebook.react.bridge.ReadableMap, promise: Promise)
   abstract fun getAccount(promise: Promise)
-  abstract fun getRefreshTokenRequestBody(issuer: String, clientID: String, promise: Promise)
+  abstract fun getRefreshTokenRequestBody(issuer: String, clientID: String, refreshToken: String, promise: Promise)
   abstract fun signPairingCode(code: String, issuer: String, clientID: String, fcmDeviceToken: String, deviceToken: String?, promise: Promise)
   abstract fun getDynamicClientRegistrationBody(fcmDeviceToken: String, deviceToken: String?, promise: Promise)
 }

--- a/packages/bcsc-core/ios/BcscCore.m
+++ b/packages/bcsc-core/ios/BcscCore.m
@@ -22,6 +22,7 @@ RCT_EXTERN_METHOD(getAccount:(RCTPromiseResolveBlock)resolve
 
 RCT_EXTERN_METHOD(getRefreshTokenRequestBody:(NSString *)issuer
                   clientID:(NSString *)clientID
+                  refreshToken:(NSString *)refreshToken
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 

--- a/packages/bcsc-core/src/NativeBcscCore.ts
+++ b/packages/bcsc-core/src/NativeBcscCore.ts
@@ -55,7 +55,8 @@ export interface Spec extends TurboModule {
   setAccount(account: Omit<NativeAccount, 'id'>): Promise<void>;
   getRefreshTokenRequestBody(
     issuer: string,
-    clientID: string
+    clientID: string,
+    refreshToken: string
   ): Promise<string | null>;
   signPairingCode(
     code: string,

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -135,18 +135,27 @@ export const getAccount = async (): Promise<NativeAccount | null> => {
 /**
  * Constructs the body for a refresh token request.
  * This involves creating a JWT, signing it with the latest private key,
- * and then formatting it along with the existing refresh token and other
+ * and then formatting it along with the provided refresh token and other
  * necessary OAuth parameters.
  * @param issuer The issuer URL for the OAuth provider.
  * @param clientID The client ID for the OAuth application.
+ * @param refreshToken The refresh token to include in the request.
  * @returns A promise that resolves to a string containing the full
  *          refresh token request body, or null if an error occurs.
  */
 export const getRefreshTokenRequestBody = async (
   issuer: string,
-  clientID: string
+  clientID: string,
+  refreshToken: string
 ): Promise<string | null> => {
-  return BcscCore.getRefreshTokenRequestBody(issuer, clientID);
+  // Validate all parameters are provided
+  if (!issuer || !clientID || !refreshToken) {
+    throw new Error(
+      'All parameters (issuer, clientID, refreshToken) are required'
+    );
+  }
+
+  return BcscCore.getRefreshTokenRequestBody(issuer, clientID, refreshToken);
 };
 
 /**


### PR DESCRIPTION
Update the `getRefreshTokenRequestBody` method to require a refresh token as a parameter, ensuring all necessary parameters are validated before processing. This change improves the method's usability and clarity.