### PR TITLE
refactor: JWT creation to eliminate code duplication

### DIFF
--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -260,19 +260,19 @@ class BcscCoreModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  override fun getDeviceCodeRequestBody(deviceCode: String, clientId: String, confirmationCode: String, promise: Promise) {
+  override fun getDeviceCodeRequestBody(deviceCode: String, clientId: String, issuer: String, confirmationCode: String, promise: Promise) {
     // Validate all parameters are provided
-    if (deviceCode.isEmpty() || clientId.isEmpty() || confirmationCode.isEmpty()) {
-      promise.reject("E_INVALID_PARAMETERS", "All parameters (deviceCode, clientId, confirmationCode) are required and cannot be empty.")
+    if (deviceCode.isEmpty() || clientId.isEmpty() || issuer.isEmpty() || confirmationCode.isEmpty()) {
+      promise.reject("E_INVALID_PARAMETERS", "All parameters (deviceCode, clientId, issuer, confirmationCode) are required and cannot be empty.")
       return
     }
     
     // Mock implementation - returns a device code request body
     // In a real implementation, this would:
-    // 1. Create and sign a JWT assertion using the provided clientId
+    // 1. Create and sign a JWT assertion using the provided clientId and issuer
     // 2. Format the OAuth device code request body with the provided deviceCode and confirmationCode
     // 3. Return the constructed request body
-    Log.d(NAME, "getDeviceCodeRequestBody called with deviceCode: [REDACTED], clientId: $clientId, confirmationCode: [REDACTED]")
+    Log.d(NAME, "getDeviceCodeRequestBody called with deviceCode: [REDACTED], clientId: $clientId, issuer: $issuer, confirmationCode: [REDACTED]")
     
     val mockRequestBody = "grant_type=urn:ietf:params:oauth:grant-type:device_code&device_code=$deviceCode&client_id=$clientId&code=$confirmationCode"
     promise.resolve(mockRequestBody)

--- a/packages/bcsc-core/android/src/oldarch/BcscCoreSpec.kt
+++ b/packages/bcsc-core/android/src/oldarch/BcscCoreSpec.kt
@@ -15,5 +15,5 @@ abstract class BcscCoreSpec internal constructor(context: ReactApplicationContex
   abstract fun getRefreshTokenRequestBody(issuer: String, clientID: String, refreshToken: String, promise: Promise)
   abstract fun signPairingCode(code: String, issuer: String, clientID: String, fcmDeviceToken: String, deviceToken: String?, promise: Promise)
   abstract fun getDynamicClientRegistrationBody(fcmDeviceToken: String, deviceToken: String?, promise: Promise)
-  abstract fun getDeviceCodeRequestBody(deviceCode: String, clientId: String, confirmationCode: String, promise: Promise)
+  abstract fun getDeviceCodeRequestBody(deviceCode: String, clientId: String, issuer: String, confirmationCode: String, promise: Promise)
 }

--- a/packages/bcsc-core/ios/BcscCore.m
+++ b/packages/bcsc-core/ios/BcscCore.m
@@ -41,6 +41,7 @@ RCT_EXTERN_METHOD(getDynamicClientRegistrationBody:(NSString *)fcmDeviceToken
 
 RCT_EXTERN_METHOD(getDeviceCodeRequestBody:(NSString *)deviceCode
                   clientID:(NSString *)clientID
+                  issuer:(NSString *)issuer
                   confirmationCode:(NSString *)confirmationCode
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -46,12 +46,13 @@ class BcscCore: NSObject {
   /**
    * Creates a signed JWT client assertion for OAuth requests
    * @param audience The audience for the JWT (typically issuer or clientID)
-   * @param clientID The client ID for iss and sub claims
+   * @param issuer The issuer for the JWT iss claim
+   * @param subject The subject for the JWT sub claim
    * @param additionalClaims Optional additional claims to include in the JWT
    * @param reject The reject callback for error handling
    * @returns The signed JWT string, or nil if an error occurred
    */
-  private func createClientAssertionJWT(audience: String, clientID: String, additionalClaims: [String: Any] = [:], reject: @escaping RCTPromiseRejectBlock) -> String? {
+  private func createClientAssertionJWT(audience: String, issuer: String, subject: String, additionalClaims: [String: Any] = [:], reject: @escaping RCTPromiseRejectBlock) -> String? {
     let clientAssertionJwtExpirationSeconds = 3600 // 1 hour
     
     // Make JWT Claim Set
@@ -67,8 +68,8 @@ class BcscCore: NSObject {
     // Add standard claims
     builder
         .claim(name: "aud", value: audience)
-        .claim(name: "iss", value: clientID)
-        .claim(name: "sub", value: clientID)
+        .claim(name: "iss", value: issuer)
+        .claim(name: "sub", value: subject)
         .claim(name: "iat", value: seconds)
         .claim(name: "jti", value: uuid)
         .claim(name: "exp", value: expireSeconds)
@@ -380,7 +381,7 @@ class BcscCore: NSObject {
     let grantType = "refresh_token"
 
     // Create the client assertion JWT using the helper function
-    guard let serializedJWT = createClientAssertionJWT(audience: issuer, clientID: clientID, reject: reject) else {
+    guard let serializedJWT = createClientAssertionJWT(audience: issuer, issuer: clientID, subject: clientID, reject: reject) else {
         return // Error already handled by createClientAssertionJWT
     }
 
@@ -570,7 +571,7 @@ class BcscCore: NSObject {
     
     // Create the client assertion JWT using the helper function with additional code claim
     let additionalClaims = ["code": confirmationCode]
-    guard let serializedJWT = createClientAssertionJWT(audience: clientID, clientID: clientID, additionalClaims: additionalClaims, reject: reject) else {
+    guard let serializedJWT = createClientAssertionJWT(audience: clientID, issuer: clientID, subject: clientID, additionalClaims: additionalClaims, reject: reject) else {
         return // Error already handled by createClientAssertionJWT
     }
 

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -559,19 +559,19 @@ class BcscCore: NSObject {
   }
 
   @objc
-  func getDeviceCodeRequestBody(_ deviceCode: String, clientID: String, confirmationCode: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+  func getDeviceCodeRequestBody(_ deviceCode: String, clientID: String, issuer: String, confirmationCode: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
     let grantType = "urn:ietf:params:oauth:grant-type:device_code"
     let assertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
     // Validate all parameters are provided
-    guard !deviceCode.isEmpty, !clientID.isEmpty, !confirmationCode.isEmpty else {
-      reject("E_INVALID_PARAMETERS", "All parameters (deviceCode, clientID, confirmationCode) are required and cannot be empty.", nil)
+    guard !deviceCode.isEmpty, !clientID.isEmpty, !issuer.isEmpty, !confirmationCode.isEmpty else {
+      reject("E_INVALID_PARAMETERS", "All parameters (deviceCode, clientID, issuer, confirmationCode) are required and cannot be empty.", nil)
       return
     }
     
     // Create the client assertion JWT using the helper function with additional code claim
     let additionalClaims = ["code": confirmationCode]
-    guard let serializedJWT = createClientAssertionJWT(audience: clientID, issuer: clientID, subject: clientID, additionalClaims: additionalClaims, reject: reject) else {
+    guard let serializedJWT = createClientAssertionJWT(audience: issuer, issuer: clientID, subject: clientID, additionalClaims: additionalClaims, reject: reject) else {
         return // Error already handled by createClientAssertionJWT
     }
 

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -42,7 +42,51 @@ class BcscCore: NSObject {
   }
   
   // MARK: - Private Helper Methods
-  
+
+  /**
+   * Creates a signed JWT client assertion for OAuth requests
+   * @param audience The audience for the JWT (typically issuer or clientID)
+   * @param clientID The client ID for iss and sub claims
+   * @param additionalClaims Optional additional claims to include in the JWT
+   * @param reject The reject callback for error handling
+   * @returns The signed JWT string, or nil if an error occurred
+   */
+  private func createClientAssertionJWT(audience: String, clientID: String, additionalClaims: [String: Any] = [:], reject: @escaping RCTPromiseRejectBlock) -> String? {
+    let clientAssertionJwtExpirationSeconds = 3600 // 1 hour
+    
+    // Make JWT Claim Set
+    guard let uuid = UIDevice.current.identifierForVendor?.uuidString else {
+        reject("E_UUID_NOT_FOUND", "UUID not found for the device.", nil)    
+        return nil
+    }
+
+    let builder = JWTClaimsSet.builder()
+    let seconds = Int(Date().timeIntervalSince1970)
+    let expireSeconds = Int(Date().addingTimeInterval(TimeInterval(clientAssertionJwtExpirationSeconds)).timeIntervalSince1970)
+    
+    // Add standard claims
+    builder
+        .claim(name: "aud", value: audience)
+        .claim(name: "iss", value: clientID)
+        .claim(name: "sub", value: clientID)
+        .claim(name: "iat", value: seconds)
+        .claim(name: "jti", value: uuid)
+        .claim(name: "exp", value: expireSeconds)
+    
+    // Add any additional claims
+    for (key, value) in additionalClaims {
+        builder.claim(name: key, value: value)
+    }
+
+    let payload = builder.build()
+
+    guard let serializedJWT = signJWT(payload: payload, reject: reject) else {
+        return nil // Error already handled by signJWT
+    }
+    
+    return serializedJWT
+  }
+
   private func signJWT(payload: JWTClaimsSet, reject: @escaping RCTPromiseRejectBlock) -> String? {
     let keyPairManager = KeyPairManager()
     let keys = keyPairManager.findAllPrivateKeys()
@@ -334,30 +378,10 @@ class BcscCore: NSObject {
     
     let assertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
     let grantType = "refresh_token"
-    let clientAssertionJwtExpirationSeconds = 3600 // 1 hour
 
-    // Make JWT Claim Set
-    guard let uuid = UIDevice.current.identifierForVendor?.uuidString else {
-        reject("E_UUID_NOT_FOUND", "UUID not found for the device.", nil)    
-        return
-    }
-
-    let builder = JWTClaimsSet.builder()
-    let seconds = Int(Date().timeIntervalSince1970)
-    let expireSeconds = Int(Date().addingTimeInterval(TimeInterval(clientAssertionJwtExpirationSeconds)).timeIntervalSince1970)
-    
-    builder
-        .claim(name: "aud", value: issuer)
-        .claim(name: "iss", value: clientID) // was from registration
-        .claim(name: "sub", value: clientID) // was from registration
-        .claim(name: "iat", value: seconds)
-        .claim(name: "jti", value: uuid)
-        .claim(name: "exp", value: expireSeconds)
-
-    let payload = builder.build()
-
-    guard let serializedJWT = signJWT(payload: payload, reject: reject) else {
-        return // Error already handled by signJWT
+    // Create the client assertion JWT using the helper function
+    guard let serializedJWT = createClientAssertionJWT(audience: issuer, clientID: clientID, reject: reject) else {
+        return // Error already handled by createClientAssertionJWT
     }
 
     // Construct the body for the refresh token request using the provided refreshToken
@@ -537,7 +561,6 @@ class BcscCore: NSObject {
   func getDeviceCodeRequestBody(_ deviceCode: String, clientID: String, confirmationCode: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
     let grantType = "urn:ietf:params:oauth:grant-type:device_code"
     let assertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
-    let clientAssertionJwtExpirationSeconds = 3600 // 1 hour
 
     // Validate all parameters are provided
     guard !deviceCode.isEmpty, !clientID.isEmpty, !confirmationCode.isEmpty else {
@@ -545,29 +568,10 @@ class BcscCore: NSObject {
       return
     }
     
-    // Make JWT Claim Set
-    guard let uuid = UIDevice.current.identifierForVendor?.uuidString else {
-        reject("E_UUID_NOT_FOUND", "UUID not found for the device.", nil)    
-        return
-    }
-
-    let builder = JWTClaimsSet.builder()
-    let seconds = Int(Date().timeIntervalSince1970)
-    let expireSeconds = Int(Date().addingTimeInterval(TimeInterval(clientAssertionJwtExpirationSeconds)).timeIntervalSince1970)
-    
-    builder
-        .claim(name: "aud", value: clientID) // Using clientID as audience
-        .claim(name: "iss", value: clientID) // was from registration
-        .claim(name: "sub", value: clientID) // was from registration
-        .claim(name: "iat", value: seconds)
-        .claim(name: "jti", value: uuid)
-        .claim(name: "exp", value: expireSeconds)
-        .claim(name: "code", value: confirmationCode) // Add the confirmationCode claim
-
-    let payload = builder.build()
-
-    guard let serializedJWT = signJWT(payload: payload, reject: reject) else {
-        return // Error already handled by signJWT
+    // Create the client assertion JWT using the helper function with additional code claim
+    let additionalClaims = ["code": confirmationCode]
+    guard let serializedJWT = createClientAssertionJWT(audience: clientID, clientID: clientID, additionalClaims: additionalClaims, reject: reject) else {
+        return // Error already handled by createClientAssertionJWT
     }
 
     // Construct the body for the device code request using the provided information

--- a/packages/bcsc-core/src/NativeBcscCore.ts
+++ b/packages/bcsc-core/src/NativeBcscCore.ts
@@ -72,6 +72,7 @@ export interface Spec extends TurboModule {
   getDeviceCodeRequestBody(
     deviceCode: string,
     clientId: string,
+    issuer: string,
     confirmationCode: string
   ): Promise<string | null>;
 }

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -206,6 +206,7 @@ export const getDynamicClientRegistrationBody = async (
  * and constructing the full OAuth device code request body.
  * @param deviceCode The device code received from the authorization server.
  * @param clientId The client ID for the OAuth application.
+ * @param issuer The issuer URL for the OAuth provider.
  * @param confirmationCode The confirmation code to include in the request.
  * @returns A promise that resolves to a string containing the full
  *          device code request body, or null if an error occurs.
@@ -213,18 +214,20 @@ export const getDynamicClientRegistrationBody = async (
 export const getDeviceCodeRequestBody = async (
   deviceCode: string,
   clientId: string,
+  issuer: string,
   confirmationCode: string
 ): Promise<string | null> => {
   // Validate all parameters are provided
-  if (!deviceCode || !clientId || !confirmationCode) {
+  if (!deviceCode || !clientId || !issuer || !confirmationCode) {
     throw new Error(
-      'All parameters (deviceCode, clientId, confirmationCode) are required'
+      'All parameters (deviceCode, clientId, issuer, confirmationCode) are required'
     );
   }
 
   return BcscCore.getDeviceCodeRequestBody(
     deviceCode,
     clientId,
+    issuer,
     confirmationCode
   );
 };


### PR DESCRIPTION
Consolidate the logic for creating JWT client assertions into a single helper method, reducing code duplication and improving maintainability. This change enhances clarity and streamlines the process of generating JWTs across different methods. Added "issuer" param to device code body.