### PR TITLE
feat: add did:webvh resolver

### DIFF
--- a/.yarn/patches/@credo-ts-webvh-npm-0.5.17-alpha-20250818210456-132526c9e9.patch
+++ b/.yarn/patches/@credo-ts-webvh-npm-0.5.17-alpha-20250818210456-132526c9e9.patch
@@ -1,0 +1,15 @@
+diff --git a/package.json b/package.json
+index 2bac336949dfc9bf0c4bc67b7800f4abf38a9d08..8abab78122903110b2dc44da72916f20322c1566 100644
+--- a/package.json
++++ b/package.json
+@@ -17,8 +17,8 @@
+     "didwebvh-ts": "^2.5.3",
+     "json-canonicalize": "^1.2.0",
+     "tsyringe": "^4.8.0",
+-    "@credo-ts/anoncreds": "0.5.17-alpha-20250818210456",
+-    "@credo-ts/core": "0.5.17-alpha-20250818210456"
++    "@credo-ts/anoncreds": "0.5.13",
++    "@credo-ts/core": "0.5.13"
+   },
+   "devDependencies": {
+     "rimraf": "^4.4.0",

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -26,6 +26,7 @@ import Toast from 'react-native-toast-message'
 import { container } from 'tsyringe'
 
 import Root from '@/Root'
+import '@/shims/credo-multibase'
 import { BCThemeNames, surveyMonkeyExitUrl, surveyMonkeyUrl } from '@/constants'
 import { localization } from '@/localization'
 import { initialState, reducer } from '@/store'

--- a/app/metro.config.js
+++ b/app/metro.config.js
@@ -12,6 +12,7 @@ const packageDirs = [
   fs.realpathSync(path.join(__dirname, 'node_modules', '@bifold/verifier')),
   fs.realpathSync(path.join(__dirname, 'node_modules', '@bifold/react-native-attestation')),
   fs.realpathSync(path.join(__dirname, 'node_modules', 'react-native-bcsc-core')),
+  fs.realpathSync(path.join(__dirname, 'node_modules', '@credo-ts/webvh')),
 ]
 
 const watchFolders = [...packageDirs]
@@ -33,6 +34,11 @@ for (const packageDir of packageDirs) {
     return acc
   }, extraNodeModules)
 }
+
+// Ensure metro never resolves nested copies of core libs from within @credo-ts/webvh
+const webvhDir = fs.realpathSync(path.join(__dirname, 'node_modules', '@credo-ts/webvh'))
+extraExclusionlist.push(path.join(webvhDir, 'node_modules', '@credo-ts', 'core'))
+extraExclusionlist.push(path.join(webvhDir, 'node_modules', '@credo-ts', 'anoncreds'))
 
 module.exports = (async () => {
   const {

--- a/app/package.json
+++ b/app/package.json
@@ -56,6 +56,7 @@
     "@credo-ts/question-answer": "0.5.13",
     "@credo-ts/react-hooks": "0.6.0",
     "@credo-ts/react-native": "0.5.13",
+    "@credo-ts/webvh": "0.5.17-alpha-20250818210456",
     "@formatjs/intl-datetimeformat": "~4.2.6",
     "@formatjs/intl-displaynames": "~5.2.6",
     "@formatjs/intl-getcanonicallocales": "~1.7.3",

--- a/app/src/shims/credo-multibase.ts
+++ b/app/src/shims/credo-multibase.ts
@@ -1,0 +1,15 @@
+// This is required to make @credo-ts/core@0.5.13 work with @credo-ts/webvh@0.5.17-alpha-20250817083021
+// because @credo-ts/webvh@0.5.17-alpha-20250817083021 uses the internal utils from @credo-ts/core@0.5.13
+// and @credo-ts/core@0.5.13 does not export the internal utils.
+// This is a temporary shim until BC wallet uses @credo-ts/core@0.5.17.
+
+import * as core from '@credo-ts/core'
+import { MultiBaseEncoder } from '@credo-ts/core/build/utils/MultiBaseEncoder'
+import { MultiHashEncoder } from '@credo-ts/core/build/utils/MultiHashEncoder'
+
+if (!(core as any).MultiBaseEncoder) {
+  ;(core as any).MultiBaseEncoder = MultiBaseEncoder
+}
+if (!(core as any).MultiHashEncoder) {
+  ;(core as any).MultiHashEncoder = MultiHashEncoder
+}

--- a/app/src/utils/bc-agent-modules.ts
+++ b/app/src/utils/bc-agent-modules.ts
@@ -8,6 +8,7 @@ import {
   V1CredentialProtocol,
   V1ProofProtocol,
 } from '@credo-ts/anoncreds'
+import type { AnonCredsRegistry } from '@credo-ts/anoncreds'
 import { AskarModule } from '@credo-ts/askar'
 import {
   Agent,
@@ -15,6 +16,7 @@ import {
   AutoAcceptProof,
   ConnectionsModule,
   CredentialsModule,
+  DidResolver,
   DidsModule,
   DifPresentationExchangeProofFormatService,
   MediationRecipientModule,
@@ -23,6 +25,7 @@ import {
   V2CredentialProtocol,
   V2ProofProtocol,
 } from '@credo-ts/core'
+import { WebvhDidResolver, WebVhAnonCredsRegistry } from '@credo-ts/webvh'
 import { DrpcModule } from '@credo-ts/drpc'
 import { IndyVdrAnonCredsRegistry, IndyVdrModule, IndyVdrPoolConfig } from '@credo-ts/indy-vdr'
 import { PushNotificationsApnsModule, PushNotificationsFcmModule } from '@credo-ts/push-notifications'
@@ -77,7 +80,7 @@ export function getBCAgentModules({
     }),
     anoncreds: new AnonCredsModule({
       anoncreds,
-      registries: [new IndyVdrAnonCredsRegistry()],
+      registries: [new IndyVdrAnonCredsRegistry(), new WebVhAnonCredsRegistry() as unknown as AnonCredsRegistry],
     }),
     indyVdr: new IndyVdrModule({
       indyVdr,
@@ -118,17 +121,22 @@ export function getBCAgentModules({
     }),
     pushNotificationsFcm: new PushNotificationsFcmModule(),
     pushNotificationsApns: new PushNotificationsApnsModule(),
-    dids: new DidsModule(),
+    dids: new DidsModule({
+      resolvers: [new WebvhDidResolver() as unknown as DidResolver],
+    }),
     drpc: new DrpcModule(),
   }
 
   if (enableProxy && proxyBaseUrl) {
     modules.anoncreds = new AnonCredsModule({
       anoncreds,
-      registries: [new IndyVdrProxyAnonCredsRegistry({ proxyBaseUrl, cacheOptions: proxyCacheSettings })],
+      registries: [
+        new IndyVdrProxyAnonCredsRegistry({ proxyBaseUrl, cacheOptions: proxyCacheSettings }),
+        new WebVhAnonCredsRegistry() as unknown as AnonCredsRegistry,
+      ],
     })
     modules.dids = new DidsModule({
-      resolvers: [new IndyVdrProxyDidResolver({ proxyBaseUrl })],
+      resolvers: [new IndyVdrProxyDidResolver({ proxyBaseUrl }), new WebvhDidResolver() as unknown as DidResolver],
     })
   }
 

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -6,6 +6,7 @@
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
+      "react-native-bcsc-core": ["../packages/bcsc-core/src/index"],
       "@/*": ["src/*"],
       "@assets/*": ["src/assets/*"],
       "@bcwallet-theme/*": ["src/bcwallet-theme/*"],

--- a/package.json
+++ b/package.json
@@ -51,7 +51,11 @@
     "@credo-ts/anoncreds@npm:^0.5.11": "patch:@credo-ts/anoncreds@npm%3A0.5.13#~/.yarn/patches/@credo-ts-anoncreds-npm-0.5.13-446ac3168e.patch",
     "@credo-ts/core@npm:0.5.13": "patch:@credo-ts/core@npm%3A0.5.13#~/.yarn/patches/@credo-ts-core-npm-0.5.13-725ab940d0.patch",
     "@credo-ts/core@npm:^0.5.11": "patch:@credo-ts/core@npm%3A0.5.13#~/.yarn/patches/@credo-ts-core-npm-0.5.13-725ab940d0.patch",
+    "@credo-ts/core@npm:0.5.17-alpha-20250818210456": "npm:0.5.13",
+    "@credo-ts/anoncreds@npm:0.5.17-alpha-20250818210456": "npm:0.5.13",
+    "@credo-ts/webvh@npm:0.5.17-alpha-20250818210456": "patch:@credo-ts/webvh@npm%3A0.5.17-alpha-20250818210456#~/.yarn/patches/@credo-ts-webvh-npm-0.5.17-alpha-20250818210456-132526c9e9.patch",
     "@credo-ts/indy-vdr": "patch:@credo-ts/indy-vdr@npm%3A0.5.13#~/.yarn/patches/@credo-ts-indy-vdr-npm-0.5.13-007d41ad5c.patch",
+    "@credo-ts/webvh": "patch:@credo-ts/webvh@npm%3A0.5.17-alpha-20250818210456#~/.yarn/patches/@credo-ts-webvh-npm-0.5.17-alpha-20250818210456-132526c9e9.patch",
     "@hyperledger/indy-vdr-shared@npm:0.2.2": "patch:@hyperledger/indy-vdr-shared@npm%3A0.2.2#~/.yarn/patches/@hyperledger-indy-vdr-shared-npm-0.2.2-b989282fc6.patch",
     "@hyperledger/indy-vdr-react-native": "patch:@hyperledger/indy-vdr-react-native@npm%3A0.2.2#~/.yarn/patches/@hyperledger-indy-vdr-react-native-npm-0.2.2-627d424b96.patch",
     "@sphereon/pex": "patch:@sphereon/pex@npm%3A3.3.3#./.yarn/patches/@sphereon-pex-npm-3.3.3-144d9252ec.patch"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4055,6 +4055,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@credo-ts/webvh@npm:0.5.17-alpha-20250818210456":
+  version: 0.5.17-alpha-20250818210456
+  resolution: "@credo-ts/webvh@npm:0.5.17-alpha-20250818210456"
+  dependencies:
+    "@credo-ts/anoncreds": "npm:0.5.17-alpha-20250818210456"
+    "@credo-ts/core": "npm:0.5.17-alpha-20250818210456"
+    class-transformer: "npm:^0.5.1"
+    class-validator: "npm:0.14.1"
+    didwebvh-ts: "npm:^2.5.3"
+    json-canonicalize: "npm:^1.2.0"
+    tsyringe: "npm:^4.8.0"
+  checksum: 10c0/2a4bb1c06f85cc2bb06c60f4c36dcbceb11b869c61cebf29f67a4a92cb47cb52f47ba4496ff251389de4b01e1b5c2e1f7b4584f681e951a0f482a17ab7bfc762
+  languageName: node
+  linkType: hard
+
+"@credo-ts/webvh@patch:@credo-ts/webvh@npm%3A0.5.17-alpha-20250818210456#~/.yarn/patches/@credo-ts-webvh-npm-0.5.17-alpha-20250818210456-132526c9e9.patch":
+  version: 0.5.17-alpha-20250818210456
+  resolution: "@credo-ts/webvh@patch:@credo-ts/webvh@npm%3A0.5.17-alpha-20250818210456#~/.yarn/patches/@credo-ts-webvh-npm-0.5.17-alpha-20250818210456-132526c9e9.patch::version=0.5.17-alpha-20250818210456&hash=55d7ec"
+  dependencies:
+    "@credo-ts/anoncreds": "npm:0.5.17-alpha-20250818210456"
+    "@credo-ts/core": "npm:0.5.17-alpha-20250818210456"
+    class-transformer: "npm:^0.5.1"
+    class-validator: "npm:0.14.1"
+    didwebvh-ts: "npm:^2.5.3"
+    json-canonicalize: "npm:^1.2.0"
+    tsyringe: "npm:^4.8.0"
+  checksum: 10c0/de2d31369cda09adafec5c162e07402fb0178557a8019e99b7feac2acb44e65f0ee94643d82d1b487b9a3cfc9726e723f206b32bf715dd5cc2ab82f017e93237
+  languageName: node
+  linkType: hard
+
 "@cspotcode/source-map-support@npm:^0.8.0":
   version: 0.8.1
   resolution: "@cspotcode/source-map-support@npm:0.8.1"
@@ -5575,6 +5605,13 @@ __metadata:
   version: 1.4.0
   resolution: "@noble/hashes@npm:1.4.0"
   checksum: 10c0/8c3f005ee72e7b8f9cff756dfae1241485187254e3f743873e22073d63906863df5d4f13d441b7530ea614b7a093f0d889309f28b59850f33b66cb26a779a4a5
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "@noble/hashes@npm:1.8.0"
+  checksum: 10c0/06a0b52c81a6fa7f04d67762e08b2c476a00285858150caeaaff4037356dd5e119f45b2a530f638b77a5eeca013168ec1b655db41bae3236cb2e9d511484fc77
   languageName: node
   linkType: hard
 
@@ -11074,6 +11111,7 @@ __metadata:
     "@credo-ts/question-answer": "npm:0.5.13"
     "@credo-ts/react-hooks": "npm:0.6.0"
     "@credo-ts/react-native": "npm:0.5.13"
+    "@credo-ts/webvh": "npm:0.5.17-alpha-20250818210456"
     "@eslint/js": "npm:~8.57.1"
     "@formatjs/intl-datetimeformat": "npm:~4.2.6"
     "@formatjs/intl-displaynames": "npm:~5.2.6"
@@ -14243,6 +14281,18 @@ __metadata:
   version: 4.1.0
   resolution: "did-resolver@npm:4.1.0"
   checksum: 10c0/3ccb21c85958a2e47122e90b7c3bfdf738360a85745eb5dbe556b6bd33d2d7c2bc080d9b12da1a5de3491934a17329dd1cdc99854afb850699d6af3765102dbc
+  languageName: node
+  linkType: hard
+
+"didwebvh-ts@npm:^2.5.3":
+  version: 2.5.3
+  resolution: "didwebvh-ts@npm:2.5.3"
+  dependencies:
+    "@noble/hashes": "npm:^1.8.0"
+    json-canonicalize: "npm:^1.0.6"
+  bin:
+    didwebvh: dist/cli/didwebvh.js
+  checksum: 10c0/9e45f8d201d567625786a34183e6d12fcbfc0b04a3ea42b64a4eee9d3ecc6fe769acf612fcf789572575e176d99ddb0115548fe2c2e7d89d14b9fc18ef62fec6
   languageName: node
   linkType: hard
 
@@ -20568,6 +20618,13 @@ __metadata:
   bin:
     jsesc: bin/jsesc
   checksum: 10c0/ef22148f9e793180b14d8a145ee6f9f60f301abf443288117b4b6c53d0ecd58354898dc506ccbb553a5f7827965cd38bc5fb726575aae93c5e8915e2de8290e1
+  languageName: node
+  linkType: hard
+
+"json-canonicalize@npm:^1.0.6, json-canonicalize@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "json-canonicalize@npm:1.2.0"
+  checksum: 10c0/98b031dbd8d8d5d2cfb826d226e23ea126e6caf8c80edc95814c547343d82bae4657fc2816915022ba2a7cffca64f3b9353096d90d3dbd1279a7767060124690
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds the did:webvh resolver from [this](https://github.com/openwallet-foundation/credo-ts/pull/2238) open PR in credo.

Anything that is not related to the resolver is to appease a very finicky build / test / commit automation process. I'm happy to remove any of that stuff if there are better workarounds or I'm missing things