### PR TITLE
feat(pickup): Manually batch pickup queued messages

### DIFF
--- a/app/src/hooks/useBCAgentSetup.ts
+++ b/app/src/hooks/useBCAgentSetup.ts
@@ -19,6 +19,7 @@ import { CachesDirectoryPath } from 'react-native-fs'
 import { activate } from '@/utils/PushNotificationsHelper'
 import { getBCAgentModules } from '@/utils/bc-agent-modules'
 import { BCState, BCLocalStorageKeys } from '@/store'
+import { batchPickup } from '@/utils/mediator'
 
 const loadCachedLedgers = async (): Promise<IndyVdrPoolConfig[] | undefined> => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -57,6 +58,8 @@ const useBCAgentSetup = () => {
           key: walletSecret.key,
         })
         await agent.initialize()
+
+        batchPickup(agent)
       } catch (error) {
         logger.warn(`Agent restart failed with error ${error}`)
         // if the existing agents wallet cannot be opened or initialize() fails it was
@@ -201,6 +204,8 @@ const useBCAgentSetup = () => {
 
       logger.info('Initializing agent...')
       await newAgent.initialize()
+
+      batchPickup(newAgent)
 
       logger.info('Warming up cache...')
       await warmUpCache(newAgent, cachedLedgers)

--- a/app/src/utils/mediator.ts
+++ b/app/src/utils/mediator.ts
@@ -1,0 +1,13 @@
+import { Agent, MediatorPickupStrategy } from '@credo-ts/core'
+
+export const batchPickup = async (agent: Agent): Promise<void> => {
+  try {
+    for (let i = 0; i < 10; i++) {
+      agent.config.logger.debug(`Batch pickup attempt ${i + 1}`)
+      agent.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.Implicit)
+      await new Promise((resolve) => setTimeout(resolve, 50)) // wait for .05 seconds before next pickup
+    }
+  } catch (error) {
+    agent.config.logger.error(`Error during batch pickup: ${error}`)
+  }
+}


### PR DESCRIPTION
I know the real goal is to get everything migrated to the credo mediator with pickupv2 support but this is going to take some time. To do it without the user noticing you need to update all the serviceEndpoints for the didDocs for all connections through the mediator.

This just fixes the single message pickup problem by repeatedly doing the pickupv1 ten times in the background on startup or restarts.

The only difference to the user is they will load with a small delay (.05secs) between the UI elements displaying.

Tested with the dev acapy mediator.