### PR TITLE
chore: update android sdk to 35

### DIFF
--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         buildToolsVersion = "33.0.2"
         minSdkVersion = 24
-        compileSdkVersion = 34
-        targetSdkVersion = 34
+        compileSdkVersion = 35
+        targetSdkVersion = 35
         ndkVersion = "25.1.8937393"
         kotlinVersion = "1.7.22"
         androidXBrowser = "1.5.0"


### PR DESCRIPTION
Upgrade the compile and target SDK versions to 35 in the build configuration.

Fixes #2536
