### PR TITLE
feat: Add more logging and loud failures for Google play integrity issues 

### DIFF
--- a/app/src/services/attestation.ts
+++ b/app/src/services/attestation.ts
@@ -627,7 +627,7 @@ export class AttestationMonitor implements AttestationMonitorI {
         'Google Attestation Error',
         'There was a problem with the Google Integrity API.',
         (error as Error)?.message || 'No details provided.',
-        AttestationErrorCodes.FailedToGenerateAttestation,
+        AttestationErrorCodes.IntegrityUnavailable,
       )
       throw bifoldError
     }

--- a/app/src/services/attestation.ts
+++ b/app/src/services/attestation.ts
@@ -610,7 +610,6 @@ export class AttestationMonitor implements AttestationMonitorI {
         'The device attestation process cannot be completed without Google Play Integrity services.',
         AttestationErrorCodes.IntegrityUnavailable,
       )
-      DeviceEventEmitter.emit(AttestationEventTypes.FailedHandleOffer, error)
 
       throw error
     } else {

--- a/app/src/services/attestation.ts
+++ b/app/src/services/attestation.ts
@@ -619,13 +619,23 @@ export class AttestationMonitor implements AttestationMonitorI {
 
     this.log?.info('Using Google on-device attestation')
 
-    const tokenString = await googleAttestation(nonce)
+    let tokenString: string
+    try {
+      tokenString = await googleAttestation(nonce)
+    } catch (error) {
+      const bifoldError = new BifoldError(
+        'Google Attestation Error',
+        'There was a problem with the Google Integrity API.',
+        (error as Error)?.message || 'No details provided.',
+        AttestationErrorCodes.FailedToGenerateAttestation,
+      )
+      throw bifoldError
+    }
     const attestationRequest = {
       ...common,
       platform: 'google',
       attestation_object: tokenString,
     } as AttestationRequestParams
-
     this.log?.info('On-device Google attestation complete')
 
     return attestationRequest

--- a/app/src/services/attestation.ts
+++ b/app/src/services/attestation.ts
@@ -83,6 +83,7 @@ const AttestationErrorCodes = {
   FailedToGenerateAttestation: 2032,
   FailedToRequestAttestation: 2033,
   FailedToValidateAttestation: 2034,
+  IntegrityUnavailable: 2035,
 } as const
 
 type Restriction = {
@@ -99,7 +100,7 @@ const findCredDefIDs = (restrictions: [Restriction]): Array<string> => {
 const invitationUrlFromRestrictions = async (
   proof: ProofExchangeRecord,
   agent: BifoldAgent,
-  restrictions: AttestationRestrictionsType
+  restrictions: AttestationRestrictionsType,
 ): Promise<string | undefined> => {
   const format = (await agent.proofs.getFormatData(proof.id)) as unknown as AttestationProofRequestFormat
   const formatToUse = format.request?.anoncreds ? 'anoncreds' : 'indy'
@@ -126,7 +127,7 @@ const invitationUrlFromRestrictions = async (
 export const isProofRequestingAttestation = async (
   proof: ProofExchangeRecord,
   agent: BifoldAgent,
-  restrictions: AttestationRestrictionsType
+  restrictions: AttestationRestrictionsType,
 ): Promise<boolean> => {
   return (await invitationUrlFromRestrictions(proof, agent, restrictions)) !== undefined
 }
@@ -200,7 +201,7 @@ export class AttestationMonitor implements AttestationMonitorI {
         'Attestation Service',
         'There was a problem with the remote attestation service.',
         'The agent cannot be undefined.',
-        AttestationErrorCodes.FailedToFetchNonceForAttestation
+        AttestationErrorCodes.FailedToFetchNonceForAttestation,
       )
     }
 
@@ -215,7 +216,7 @@ export class AttestationMonitor implements AttestationMonitorI {
           'Attestation Service',
           'Unable to connect to the attestation service.',
           'No details provided.',
-          AttestationErrorCodes.FailedToConnectToAttestationAgent
+          AttestationErrorCodes.FailedToConnectToAttestationAgent,
         )
       }
 
@@ -225,7 +226,7 @@ export class AttestationMonitor implements AttestationMonitorI {
           'Attestation Service',
           'Unable to connect to the attestation service.',
           'No details provided.',
-          AttestationErrorCodes.FailedToConnectToAttestationAgent
+          AttestationErrorCodes.FailedToConnectToAttestationAgent,
         )
       }
 
@@ -235,7 +236,7 @@ export class AttestationMonitor implements AttestationMonitorI {
           'Attestation Service',
           'There was a problem with the attestation service.',
           'No details provided.',
-          AttestationErrorCodes.FailedToFetchNonceForAttestation
+          AttestationErrorCodes.FailedToFetchNonceForAttestation,
         )
       }
 
@@ -245,7 +246,7 @@ export class AttestationMonitor implements AttestationMonitorI {
           'Attestation Service',
           'There was a problem with the attestation service.',
           'No details provided.',
-          AttestationErrorCodes.FailedToGenerateAttestation
+          AttestationErrorCodes.FailedToGenerateAttestation,
         )
       }
 
@@ -255,7 +256,7 @@ export class AttestationMonitor implements AttestationMonitorI {
           'Attestation Service',
           'There was a problem with the attestation service.',
           'No details provided.',
-          AttestationErrorCodes.FailedToValidateAttestation
+          AttestationErrorCodes.FailedToValidateAttestation,
         )
       }
     } catch (error) {
@@ -302,7 +303,7 @@ export class AttestationMonitor implements AttestationMonitorI {
         'Attestation Service',
         'There was a problem with the remote attestation service.',
         'The agent cannot be undefined.',
-        AttestationErrorCodes.FailedToFetchNonceForAttestation
+        AttestationErrorCodes.FailedToFetchNonceForAttestation,
       )
     }
 
@@ -358,7 +359,7 @@ export class AttestationMonitor implements AttestationMonitorI {
         'Attestation Service',
         'There was a problem with the remote attestation service.',
         'The agent cannot be undefined.',
-        AttestationErrorCodes.FailedToFetchNonceForAttestation
+        AttestationErrorCodes.FailedToFetchNonceForAttestation,
       )
     }
 
@@ -422,7 +423,7 @@ export class AttestationMonitor implements AttestationMonitorI {
         'Attestation Service',
         'There was a problem with the remote attestation service.',
         'The agent cannot be undefined.',
-        AttestationErrorCodes.FailedToFetchNonceForAttestation
+        AttestationErrorCodes.FailedToFetchNonceForAttestation,
       )
     }
 
@@ -435,7 +436,7 @@ export class AttestationMonitor implements AttestationMonitorI {
         'Attestation Service',
         'Unable to parse the attestation agent invitation',
         'No details provided.',
-        AttestationErrorCodes.BadInvitation
+        AttestationErrorCodes.BadInvitation,
       )
     }
 
@@ -449,7 +450,7 @@ export class AttestationMonitor implements AttestationMonitorI {
         'Attestation Service',
         'Unable to accept attestation agent invitation',
         'No details provided.',
-        AttestationErrorCodes.BadInvitation
+        AttestationErrorCodes.BadInvitation,
       )
     }
 
@@ -464,7 +465,7 @@ export class AttestationMonitor implements AttestationMonitorI {
         'Attestation Service',
         'There was a problem with the remote attestation service.',
         'The agent cannot be undefined.',
-        AttestationErrorCodes.FailedToFetchNonceForAttestation
+        AttestationErrorCodes.FailedToFetchNonceForAttestation,
       )
     }
 
@@ -480,7 +481,7 @@ export class AttestationMonitor implements AttestationMonitorI {
         'Attestation Service',
         'There was a problem with the remote attestation service.',
         'Timeout occurred.',
-        AttestationErrorCodes.FailedToFetchNonceForAttestation
+        AttestationErrorCodes.FailedToFetchNonceForAttestation,
       )
     }
 
@@ -488,14 +489,14 @@ export class AttestationMonitor implements AttestationMonitorI {
 
     if (nonceResponse.error) {
       this.log?.error(
-        `Failed to fetch nonce for attestation, code = ${nonceResponse.error.code}, reason = ${nonceResponse.error.message}`
+        `Failed to fetch nonce for attestation, code = ${nonceResponse.error.code}, reason = ${nonceResponse.error.message}`,
       )
 
       throw new BifoldError(
         'Attestation Service',
         'There was a problem with the remote attestation service.',
         nonceResponse.error.message ?? 'No details provided.',
-        AttestationErrorCodes.FailedToFetchNonceForAttestation
+        AttestationErrorCodes.FailedToFetchNonceForAttestation,
       )
     }
 
@@ -506,14 +507,14 @@ export class AttestationMonitor implements AttestationMonitorI {
 
   private async requestAttestation(
     connection: ConnectionRecord,
-    attestationObj: AttestationRequestParams
+    attestationObj: AttestationRequestParams,
   ): Promise<AttestationResult> {
     if (!this.agent) {
       throw new BifoldError(
         'Attestation Service',
         'There was a problem with the remote attestation service.',
         'No details provided.',
-        AttestationErrorCodes.FailedToFetchNonceForAttestation
+        AttestationErrorCodes.FailedToFetchNonceForAttestation,
       )
     }
 
@@ -529,7 +530,7 @@ export class AttestationMonitor implements AttestationMonitorI {
         'Attestation Service',
         'There was a problem with the remote attestation service.',
         'Timeout occurred.',
-        AttestationErrorCodes.FailedToRequestAttestation
+        AttestationErrorCodes.FailedToRequestAttestation,
       )
     }
 
@@ -537,14 +538,14 @@ export class AttestationMonitor implements AttestationMonitorI {
 
     if (attestationResponse.error) {
       this.log?.error(
-        `Failed to request attestation, code = ${attestationResponse.error.code}, reason = ${attestationResponse.error.message}`
+        `Failed to request attestation, code = ${attestationResponse.error.code}, reason = ${attestationResponse.error.message}`,
       )
 
       throw new BifoldError(
         'Attestation Service',
         'There was a problem with the remote attestation service.',
         attestationResponse.error.message ?? 'No details provided.',
-        AttestationErrorCodes.FailedToRequestAttestation
+        AttestationErrorCodes.FailedToRequestAttestation,
       )
     }
 
@@ -601,7 +602,19 @@ export class AttestationMonitor implements AttestationMonitorI {
 
     const available = await isPlayIntegrityAvailable()
     if (!available) {
-      return null
+      this.log?.error('Google Play Integrity is unavailable')
+
+      const error = new BifoldError(
+        'Google Play Integrity Unavailable',
+        'Google Play Integrity is required for device attestation but is not available on this device.',
+        'The device attestation process cannot be completed without Google Play Integrity services.',
+        AttestationErrorCodes.IntegrityUnavailable,
+      )
+      DeviceEventEmitter.emit(AttestationEventTypes.FailedHandleOffer, error)
+
+      throw error
+    } else {
+      this.log?.info('Google Play Integrity is available')
     }
 
     this.log?.info('Using Google on-device attestation')


### PR DESCRIPTION
Added error logging and error modals to Google Play integrity errors.

![showndetails](https://github.com/user-attachments/assets/6b957071-0221-4c7f-9571-ebea1ee6cf2d)

Error modal shown when isPlayIntegrityAvailable() returns false

![other](https://github.com/user-attachments/assets/74522d96-6ffb-4141-aedd-414521faa79f)
error shown when googleAttestation() fails

Related to https://github.com/bcgov/bc-wallet-mobile/issues/2251
