### PR TITLE
feat: custom/configurable mediator

### DIFF
--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -1031,7 +1031,7 @@ PODS:
   - React-Mapbuffer (0.73.6):
     - glog
     - React-debug
-  - react-native-attestation (2.1.10):
+  - react-native-attestation (2.2.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1237,6 +1237,8 @@ PODS:
     - React-Core
   - RNCAsyncStorage (1.24.0):
     - React-Core
+  - RNCClipboard (1.16.2):
+    - React-Core
   - RNCMaskedView (0.3.2):
     - glog
     - RCT-Folly (= 2022.05.16.00)
@@ -1358,6 +1360,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - RNArgon2 (from `../node_modules/react-native-argon2`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
+  - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
   - "RNCMaskedView (from `../node_modules/@react-native-masked-view/masked-view`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
@@ -1527,6 +1530,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-argon2"
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
+  RNCClipboard:
+    :path: "../node_modules/@react-native-clipboard/clipboard"
   RNCMaskedView:
     :path: "../node_modules/@react-native-masked-view/masked-view"
   RNDeviceInfo:
@@ -1606,7 +1611,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 85583ef014ce53d731a98c66a0e24496f7a83066
   React-logger: 55764cd993880c6f887505854581c9faf68feff2
   React-Mapbuffer: 15dfcfeb4428d8799cce75e7fe85b18b706029e0
-  react-native-attestation: 1c1f52e238c18702ccdaafe4397bd2497f30161f
+  react-native-attestation: fb2abadabb661d641289eeba42b3095a74be4ff5
   react-native-config: ea73937aecb26d8eb4642ecdb2b2e83d0be59656
   react-native-date-picker: 585252087d4820b4cd8f2cf80068f6e8f5b72413
   react-native-encrypted-storage: 569d114e329b1c2c2d9f8c84bcdbe4478dda2258
@@ -1640,6 +1645,7 @@ SPEC CHECKSUMS:
   ReactCommon: 2e5492a3e3a8e72d635c266405e49d12627e5bf0
   RNArgon2: 708e188b7a4d4ec8baf62463927c47abef453a94
   RNCAsyncStorage: b6410dead2732b5c72a7fdb1ecb5651bbcf4674b
+  RNCClipboard: e1d17c9d093d8129ef50b39b63a17a0e8ccd0ade
   RNCMaskedView: 3f3c27b339db863b1fd5f39cc9660484ecfd46ee
   RNDeviceInfo: d3e91ffb33ee97a7982108476edb68cb3672efa6
   RNFBApp: 827b4dfadf8c039738c1c928474e45b3ec306ba0

--- a/app/package.json
+++ b/app/package.json
@@ -41,11 +41,11 @@
     "gradle:write-locks": "cd android && ./gradlew app:dependencies --write-locks"
   },
   "dependencies": {
-    "@bifold/core": "2.1.10",
-    "@bifold/oca": "2.1.10",
-    "@bifold/react-native-attestation": "2.1.10",
-    "@bifold/remote-logs": "2.1.10",
-    "@bifold/verifier": "2.1.10",
+    "@bifold/core": "2.2.0",
+    "@bifold/oca": "2.2.0",
+    "@bifold/react-native-attestation": "2.2.0",
+    "@bifold/remote-logs": "2.2.0",
+    "@bifold/verifier": "2.2.0",
     "@credo-ts/anoncreds": "0.5.13",
     "@credo-ts/askar": "0.5.13",
     "@credo-ts/core": "0.5.13",

--- a/app/src/utils/mediator.ts
+++ b/app/src/utils/mediator.ts
@@ -2,7 +2,7 @@ import { Agent, MediatorPickupStrategy } from '@credo-ts/core'
 
 export const batchPickup = async (agent: Agent): Promise<void> => {
   try {
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 2; i++) {
       agent.config.logger.debug(`Batch pickup attempt ${i + 1}`)
       agent.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.Implicit)
       await new Promise((resolve) => setTimeout(resolve, 50)) // wait for .05 seconds before next pickup

--- a/yarn.lock
+++ b/yarn.lock
@@ -2994,9 +2994,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bifold/core@npm:2.1.10":
-  version: 2.1.10
-  resolution: "@bifold/core@npm:2.1.10"
+"@bifold/core@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@bifold/core@npm:2.2.0"
   peerDependencies:
     "@credo-ts/anoncreds": 0.5.13
     "@credo-ts/askar": 0.5.13
@@ -3071,38 +3071,38 @@ __metadata:
     uuid: ^9.0.0
   bin:
     bifold: bin/bifold
-  checksum: 10c0/bbdb6dfcbd616b6bf7265c12474c1553cbf7fc84b224286878631717bbddf60501e27af573d3d610120d19d9ec6dd9705aac6cc0e56d30e28b660e193da86610
+  checksum: 10c0/c0e957f3bfc2ed86921ea2d76fa6f360321428f1dcd34b2b86c21f8c0200796fff783552b24bfd99e2498e2f4b8b47801e1c194be4aada1cc875739cac700893
   languageName: node
   linkType: hard
 
-"@bifold/oca@npm:2.1.10":
-  version: 2.1.10
-  resolution: "@bifold/oca@npm:2.1.10"
+"@bifold/oca@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@bifold/oca@npm:2.2.0"
   dependencies:
     "@credo-ts/anoncreds": "npm:0.5.13"
     "@credo-ts/core": "npm:0.5.13"
     axios: "npm:^1.4.0"
     lodash.startcase: "npm:^4.4.0"
     react-native-fs: "npm:^2.16.6"
-  checksum: 10c0/87aa08049b540187461621e5463cc0ddb67e912ef4862865ce25b149ab211012991b0cbda781c5ec7f51c0ae39c11cb83cf746e9e07f862798ec04fd2b47afcd
+  checksum: 10c0/ec03f1eb759b71638366b445a5fe2358fa64f86158f42714bf5fb7a248c11db5e66319aa6ff67285e867442e7595fa37fd50271764af2efa9a6166344cfa52c7
   languageName: node
   linkType: hard
 
-"@bifold/react-native-attestation@npm:2.1.10":
-  version: 2.1.10
-  resolution: "@bifold/react-native-attestation@npm:2.1.10"
+"@bifold/react-native-attestation@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@bifold/react-native-attestation@npm:2.2.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/8dd0b6cefb6155d004b8244e3d5da6e0588b3a6d69d7d1330aab07ee0ccb27adb80d73447e5b8ba8e486c8b1b1c1ff37ec5369b74d958101bf667994006387c4
+  checksum: 10c0/650120cc50399506b46ccb6f2d037c8f33ae13898c2e212a5024a7325327cea054cfe04530dc492e46c407f169336156715e9810c5d267d02daf6657012ff3f5
   languageName: node
   linkType: hard
 
-"@bifold/remote-logs@npm:2.1.10":
-  version: 2.1.10
-  resolution: "@bifold/remote-logs@npm:2.1.10"
+"@bifold/remote-logs@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@bifold/remote-logs@npm:2.2.0"
   dependencies:
-    "@bifold/core": "npm:2.1.10"
+    "@bifold/core": "npm:2.2.0"
     "@credo-ts/core": "npm:0.5.13"
     axios: "npm:^1.4.0"
     buffer: "npm:^6.0.3"
@@ -3116,20 +3116,20 @@ __metadata:
     react: ^18.2.0
     react-native: ^0.73.6
     react-native-logs: ~5.1.0
-  checksum: 10c0/704fb617c26058e03459581bf857a10322ba21a358acfd33bd1724591b6e24a85fea726b0077c79ffe91314fb420b1adffdc8112d46eb35b7196d0c9056df486
+  checksum: 10c0/4ce76d27d1341ff9b5c9269d3982b6ff3a235681e7b995e2eaa19316644f3af678386701cfa6abbc78f067b8d4c3f815013d3617d1af534373c1202e5c612bf0
   languageName: node
   linkType: hard
 
-"@bifold/verifier@npm:2.1.10":
-  version: 2.1.10
-  resolution: "@bifold/verifier@npm:2.1.10"
+"@bifold/verifier@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@bifold/verifier@npm:2.2.0"
   peerDependencies:
     "@credo-ts/anoncreds": 0.5.13
     "@credo-ts/core": 0.5.13
     "@credo-ts/react-hooks": 0.6.0
     "@hyperledger/anoncreds-shared": 0.2.4
     react: ^18.2.0
-  checksum: 10c0/979541618811be6c7352cceeb40015945914686121ab220e1721dfaea8bb4f904cbbfb66285c36528a62a7b4d075f208aa00e9b2497d471333c88d4b283652ac
+  checksum: 10c0/89bb778e59a2dfb57c4c7256809611478644863062df3d7f699ddf612bf0e52292be76c0a544e8081f06d974bc9de82991234d615f1f9a9f3106eb67bc7137ee
   languageName: node
   linkType: hard
 
@@ -11044,11 +11044,11 @@ __metadata:
     "@babel/core": "npm:7.22.1"
     "@babel/preset-env": "npm:7.22.20"
     "@babel/runtime": "npm:7.23.1"
-    "@bifold/core": "npm:2.1.10"
-    "@bifold/oca": "npm:2.1.10"
-    "@bifold/react-native-attestation": "npm:2.1.10"
-    "@bifold/remote-logs": "npm:2.1.10"
-    "@bifold/verifier": "npm:2.1.10"
+    "@bifold/core": "npm:2.2.0"
+    "@bifold/oca": "npm:2.2.0"
+    "@bifold/react-native-attestation": "npm:2.2.0"
+    "@bifold/remote-logs": "npm:2.2.0"
+    "@bifold/verifier": "npm:2.2.0"
     "@commitlint/cli": "npm:11.0.0"
     "@credo-ts/anoncreds": "npm:0.5.13"
     "@credo-ts/askar": "npm:0.5.13"


### PR DESCRIPTION
This PR adds a developer mode option to configure the mediator. By scanning its QR code you can add a mediator service to the list and switch to it. This current implementation is setup to work with the v2 credo mediator. (This is dependent on Bi-fold feat: custom/configurable mediator #1555 to be merged first)