### PR TITLE
feat: code scanning screen and components for alt person flow

### DIFF
--- a/app/src/bcsc-theme/components/CodeScanningCamera.tsx
+++ b/app/src/bcsc-theme/components/CodeScanningCamera.tsx
@@ -1,0 +1,224 @@
+import { useTheme } from '@bifold/core'
+import React, { useEffect, useRef, useState } from 'react'
+import { StyleSheet, View, ViewStyle, useWindowDimensions, ColorValue } from 'react-native'
+import {
+  Camera,
+  useCameraPermission,
+  useCameraDevice,
+  useCodeScanner,
+  CodeType,
+  Code,
+  CodeScannerFrame,
+} from 'react-native-vision-camera'
+import QRScannerTorch from '@bifold/core/src/components/misc/QRScannerTorch'
+
+const overlayTint: ColorValue = 'rgba(0, 0, 0, 0.4)'
+
+export interface CodeScanningCameraProps {
+  codeTypes: CodeType[]
+
+  /**
+   * Callback function called when a code is successfully scanned
+   * @param codes Array of scanned codes
+   * @param frame The camera frame information
+   */
+  onCodeScanned: (codes: Code[], frame: CodeScannerFrame) => void
+
+  /**
+   * Custom style for the camera container
+   */
+  style?: ViewStyle
+
+  /**
+   * Should camera permission be requested
+   * @default true
+   */
+  autoRequestPermission?: boolean
+
+  /**
+   * Which camera to use
+   * @default 'back'
+   */
+  cameraType?: 'front' | 'back'
+}
+
+const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
+  codeTypes,
+  onCodeScanned,
+  style,
+  autoRequestPermission = true,
+  cameraType = 'back',
+}) => {
+  const { ColorPallet } = useTheme()
+  const camera = useRef<Camera>(null)
+  const [torchEnabled, setTorchEnabled] = useState(false)
+  const { width } = useWindowDimensions()
+
+  const { hasPermission, requestPermission } = useCameraPermission()
+  const device = useCameraDevice(cameraType)
+  useEffect(() => {
+    if (!hasPermission) {
+      requestPermission()
+    }
+  }, [hasPermission, requestPermission])
+
+  const scanSize = Math.min(width - 80, 250)
+
+  const getScanAreaDimensions = () => {
+    // if we want to use a different sized
+    // scan area for different code types,
+    // this can be adjusted to return different width/height
+    // depending on codetypes passed
+
+    // the current value roughly matches the shape
+    // of either code on a dl/ combined card
+    const scanWidth = scanSize * 1.3
+    const scanHeight = scanWidth / 5
+
+    return {
+      width: scanWidth,
+      height: scanHeight,
+    }
+  }
+
+  const scanAreaDimensions = getScanAreaDimensions()
+
+  const codeScanner = useCodeScanner({
+    codeTypes,
+    onCodeScanned: (codes, frame) => {
+      if (codes.length > 0) {
+        onCodeScanned(codes, frame)
+      }
+    },
+  })
+
+  useEffect(() => {
+    if (autoRequestPermission && !hasPermission) {
+      requestPermission()
+    }
+  }, [hasPermission, requestPermission, autoRequestPermission])
+
+  const toggleTorch = () => {
+    setTorchEnabled((prev) => !prev)
+  }
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: ColorPallet.brand.primaryBackground,
+      position: 'relative',
+    },
+    camera: {
+      flex: 1,
+    },
+    overlayContainer: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    overlayTop: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: '50%',
+      marginBottom: scanAreaDimensions.height / 2,
+      backgroundColor: overlayTint,
+    },
+    overlayBottom: {
+      position: 'absolute',
+      top: '50%',
+      marginTop: scanAreaDimensions.height / 2,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      backgroundColor: overlayTint,
+    },
+    overlayLeft: {
+      position: 'absolute',
+      top: '50%',
+      marginTop: -scanAreaDimensions.height / 2,
+      left: 0,
+      right: '50%',
+      marginRight: scanAreaDimensions.width / 2,
+      height: scanAreaDimensions.height,
+      backgroundColor: overlayTint,
+    },
+    overlayRight: {
+      position: 'absolute',
+      top: '50%',
+      marginTop: -scanAreaDimensions.height / 2,
+      right: 0,
+      left: '50%',
+      marginLeft: scanAreaDimensions.width / 2,
+      height: scanAreaDimensions.height,
+      backgroundColor: overlayTint,
+    },
+    overlayOpening: {
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      width: scanAreaDimensions.width,
+      height: scanAreaDimensions.height,
+      marginTop: -scanAreaDimensions.height / 2,
+      marginLeft: -scanAreaDimensions.width / 2,
+      borderColor: 'rgba(255, 255, 255, 0.8)',
+      borderWidth: 2,
+    },
+    torchContainer: {
+      position: 'absolute',
+      bottom: 0,
+      right: 24,
+      zIndex: 10,
+    },
+  })
+
+  if (!device || !hasPermission) {
+    // return view with error message
+    return (
+      <View style={[styles.container, style]}>
+        <View style={styles.overlayContainer}>
+          <View style={styles.overlayTop} />
+          <View style={styles.overlayBottom} />
+          <View style={styles.overlayLeft} />
+          <View style={styles.overlayRight} />
+          <View style={styles.overlayOpening} />
+        </View>
+        <View style={styles.torchContainer}>
+          <QRScannerTorch active={torchEnabled} onPress={toggleTorch} />
+        </View>
+      </View>
+    )
+  }
+
+  return (
+    <View style={[styles.container, style]}>
+      <Camera
+        ref={camera}
+        style={styles.camera}
+        device={device}
+        isActive={true && hasPermission}
+        codeScanner={codeScanner}
+        torch={torchEnabled ? 'on' : 'off'}
+      />
+      {/* scan area cutout */}
+      <View style={styles.overlayContainer}>
+        <View style={styles.overlayTop} />
+        <View style={styles.overlayBottom} />
+        <View style={styles.overlayLeft} />
+        <View style={styles.overlayRight} />
+        <View style={styles.overlayOpening} />
+      </View>
+      {/* reuse qrscannertorch from bifold */}
+      <View style={styles.torchContainer}>
+        <QRScannerTorch active={torchEnabled} onPress={toggleTorch} />
+      </View>
+    </View>
+  )
+}
+
+export default CodeScanningCamera

--- a/app/src/bcsc-theme/components/CodeScanningCamera.tsx
+++ b/app/src/bcsc-theme/components/CodeScanningCamera.tsx
@@ -178,7 +178,7 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
   })
 
   if (!device || !hasPermission) {
-    // return view with error message
+    // return placeholder view
     return (
       <View style={[styles.container, style]}>
         <View style={styles.overlayContainer}>
@@ -201,7 +201,7 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
         ref={camera}
         style={styles.camera}
         device={device}
-        isActive={true && hasPermission}
+        isActive={hasPermission}
         codeScanner={codeScanner}
         torch={torchEnabled ? 'on' : 'off'}
       />

--- a/app/src/bcsc-theme/features/verify/ScanSerialScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/ScanSerialScreen.tsx
@@ -1,0 +1,102 @@
+import { Button, ButtonType, testIdWithKey, ThemedText, useStore, useTheme } from '@bifold/core'
+import React, { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, View } from 'react-native'
+
+import { BCDispatchAction, BCState } from '@/store'
+import { StackNavigationProp } from '@react-navigation/stack'
+import { BCSCScreens, BCSCVerifyIdentityStackParams } from '@/bcsc-theme/types/navigators'
+
+import CodeScanningCamera from '../../components/CodeScanningCamera'
+
+const maxSerialNumberLength = 15
+
+type ScanSerialScreenProps = {
+  navigation: StackNavigationProp<BCSCVerifyIdentityStackParams, BCSCScreens.ManualSerial>
+}
+
+const ScanSerialScreen: React.FC<ScanSerialScreenProps> = ({ navigation }: ScanSerialScreenProps) => {
+  const { t } = useTranslation()
+  const { ColorPallet, Spacing } = useTheme()
+  const [store, dispatch] = useStore<BCState>()
+  const [serial, setSerial] = useState(store.bcsc.serial ?? '')
+
+  const styles = StyleSheet.create({
+    screenContainer: {
+      flex: 1,
+      backgroundColor: ColorPallet.brand.primaryBackground,
+      padding: Spacing.md,
+    },
+    cameraContainer: {
+      flex: 1,
+      marginBottom: Spacing.md,
+    },
+    contentContainer: {
+      flex: 1,
+      flexDirection: 'column',
+      justifyContent: 'space-between',
+    },
+
+    // below used as helpful label for view, no properties needed atp
+    controlsContainer: {},
+
+    buttonContainer: {
+      width: '100%',
+    },
+  })
+
+  const validateSerial = useCallback(() => {
+    // TODO: update this validation logic
+    // once we know the serial number format
+    if (serial.length < 1) {
+      return false
+    }
+    if (serial.length > maxSerialNumberLength) {
+      return false
+    }
+    return true
+  }, [serial])
+
+  const onCodeScanned = (val: any) => {
+    // the scanner might pick up multiple codes
+    // we will take the first valid one
+
+    interface ScannedCode {
+      value: string
+      [key: string]: unknown
+    }
+    for (const code of val as ScannedCode[]) {
+      setSerial(code.value)
+
+      if (validateSerial()) {
+        dispatch({ type: BCDispatchAction.UPDATE_SERIAL, payload: [code.value] })
+        navigation.navigate(BCSCScreens.EnterBirthdate)
+        return
+      }
+    }
+  }
+
+  return (
+    <View style={styles.screenContainer}>
+      <View style={styles.cameraContainer}>
+        <CodeScanningCamera codeTypes={['code-128']} onCodeScanned={onCodeScanned} cameraType={'back'} />
+      </View>
+      <View style={styles.contentContainer}>
+        <View>
+          <ThemedText style={{ marginBottom: Spacing.sm }}>{t('Unified.Instructions.Paragraph')}</ThemedText>
+        </View>
+        <View style={styles.buttonContainer}>
+          <Button
+            title={t('Unified.Instructions.EnterManually')}
+            buttonType={ButtonType.Secondary}
+            onPress={() => navigation.navigate(BCSCScreens.ManualSerial)}
+            accessibilityLabel={t('Unified.Instructions.EnterManually')}
+            testID={testIdWithKey('EnterManually')}
+          />
+        </View>
+      </View>
+    </View>
+  )
+}
+
+export default ScanSerialScreen

--- a/app/src/bcsc-theme/features/verify/SerialInstructionsScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/SerialInstructionsScreen.tsx
@@ -46,11 +46,7 @@ const SerialInstructionsScreen: React.FC<SerialInstructionsScreenProps> = ({
   return (
     <SafeAreaView style={styles.pageContainer} edges={['bottom', 'left', 'right']}>
       <ScrollView contentContainerStyle={styles.scrollView}>
-        <Image
-          source={{ uri: SERIAL_HIGHLIGHT_IMAGE }}
-          style={styles.image}
-          resizeMode={'contain'}
-        />
+        <Image source={{ uri: SERIAL_HIGHLIGHT_IMAGE }} style={styles.image} resizeMode={'contain'} />
         <ThemedText variant={'headingThree'} style={{ marginBottom: Spacing.md }}>
           {t('Unified.Instructions.Heading')}
         </ThemedText>
@@ -61,6 +57,7 @@ const SerialInstructionsScreen: React.FC<SerialInstructionsScreenProps> = ({
           title={t('Unified.Instructions.ScanBarcode')}
           accessibilityLabel={t('Unified.Instructions.ScanBarcode')}
           testID={testIdWithKey('ScanBarcode')}
+          onPress={() => navigation.navigate(BCSCScreens.ScanSerial)}
           buttonType={ButtonType.Primary}
         />
         <View style={{ marginTop: Spacing.md }}>

--- a/app/src/bcsc-theme/features/verify/VerifyIdentityStack.tsx
+++ b/app/src/bcsc-theme/features/verify/VerifyIdentityStack.tsx
@@ -7,6 +7,7 @@ import HelpHeaderButton from '@/bcsc-theme/components/HelpHeaderButton'
 import IdentitySelectionScreen from './IdentitySelectionScreen'
 import SerialInstructionsScreen from './SerialInstructionsScreen'
 import ManualSerialScreen from './ManualSerialScreen'
+import ScanSerialScreen from './ScanSerialScreen'
 import EnterBirthdateScreen from './EnterBirthdateScreen'
 import VerificationMethodSelectionScreen from './VerificationMethodSelectionScreen'
 import VerifyInPersonScreen from './VerifyInPersonScreen'
@@ -24,13 +25,12 @@ const VerifyIdentityStack = () => {
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
 
   useEffect(() => {
-    registration.register()
-      .catch((error) => {
-        logger.error(`Error during registration: ${error}`)
-        // Handle error appropriately, e.g., show an alert or log it
-      })
-      // TODO: registration shouldn't actually be called here, this is just temporary until we move the flow where it should be
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    registration.register().catch((error) => {
+      logger.error(`Error during registration: ${error}`)
+      // Handle error appropriately, e.g., show an alert or log it
+    })
+    // TODO: registration shouldn't actually be called here, this is just temporary until we move the flow where it should be
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return (
@@ -55,6 +55,7 @@ const VerifyIdentityStack = () => {
       <Stack.Screen name={BCSCScreens.IdentitySelection} component={IdentitySelectionScreen} />
       <Stack.Screen name={BCSCScreens.SerialInstructions} component={SerialInstructionsScreen} />
       <Stack.Screen name={BCSCScreens.ManualSerial} component={ManualSerialScreen} />
+      <Stack.Screen name={BCSCScreens.ScanSerial} component={ScanSerialScreen} />
       <Stack.Screen name={BCSCScreens.EnterBirthdate} component={EnterBirthdateScreen} />
       <Stack.Screen name={BCSCScreens.MismatchedSerial} component={MismatchedSerialScreen} />
       <Stack.Screen

--- a/app/src/bcsc-theme/types/navigators.ts
+++ b/app/src/bcsc-theme/types/navigators.ts
@@ -13,6 +13,7 @@ export enum BCSCScreens {
   IdentitySelection = 'BCSCIdentitySelection',
   SerialInstructions = 'BCSCSerialInstructions',
   ManualSerial = 'BCSCManualSerial',
+  ScanSerial = 'BCSCScanSerial',
   EnterBirthdate = 'BCSCEnterBirthdate',
   MismatchedSerial = 'BCSCMismatchedSerial',
   VerificationMethodSelection = 'BCSCVerificationMethodSelection',
@@ -40,6 +41,7 @@ export type BCSCVerifyIdentityStackParams = {
   [BCSCScreens.IdentitySelection]: undefined
   [BCSCScreens.SerialInstructions]: undefined
   [BCSCScreens.ManualSerial]: undefined
+  [BCSCScreens.ScanSerial]: undefined
   [BCSCScreens.EnterBirthdate]: undefined
   [BCSCScreens.MismatchedSerial]: undefined
   [BCSCScreens.VerificationMethodSelection]: undefined


### PR DESCRIPTION
This pr adds the screen for scanning a barcode from a combined bcsc/dl as per https://github.com/bcgov/bc-wallet-mobile/issues/2533. It also adds a CodeScanningCamera component that can be reused when we need to scan other types of codes. More work needs to be done to sanitize inputs from scanned codes. Work for this needs to be defined in https://github.com/bcgov/bc-wallet-mobile/issues/2544.

![untitled480](https://github.com/user-attachments/assets/b23dfbc8-871a-4028-b98b-8709244cee57)

