### PR TITLE
feat: fully typed theme elements as pre-req for issue #2184

### DIFF
--- a/app/src/bcsc-theme/theme.ts
+++ b/app/src/bcsc-theme/theme.ts
@@ -1,4 +1,13 @@
-import { ColorPallet, IColorPallet, IInputs, INotificationColors, ITabTheme, ITextTheme, ITheme } from '@bifold/core'
+import {
+  ColorPallet,
+  IAssets,
+  IColorPallet,
+  IInputs,
+  INotificationColors,
+  ITabTheme,
+  ITextTheme,
+  ITheme,
+} from '@bifold/core'
 import { StyleSheet } from 'react-native'
 
 import Logo from '@assets/img/logo-with-text-dark.svg'
@@ -62,7 +71,7 @@ export const BCSCColorPallet: IColorPallet = {
   semantic: {
     ...BCWalletTheme.ColorPallet.semantic,
     success: '#89CE00',
-  }
+  },
 }
 
 export const BCSCTextTheme: ITextTheme = {
@@ -153,7 +162,7 @@ export const BCSCTextTheme: ITextTheme = {
   },
 }
 
-export const BCSCNavigationTheme = {
+export const BCSCNavigationTheme: ITheme['NavigationTheme'] = {
   dark: true,
   colors: {
     primary: BCSCColorPallet.brand.primaryBackground,
@@ -165,7 +174,7 @@ export const BCSCNavigationTheme = {
   },
 }
 
-export const BCSCOnboardingTheme = {
+export const BCSCOnboardingTheme: ITheme['OnboardingTheme'] = {
   container: {
     backgroundColor: BCSCColorPallet.brand.primaryBackground,
   },
@@ -200,7 +209,7 @@ export const BCSCOnboardingTheme = {
   },
 }
 
-export const BCSCDialogTheme = {
+export const BCSCDialogTheme: ITheme['DialogTheme'] = {
   modalView: {
     backgroundColor: BCSCColorPallet.brand.secondaryBackground,
   },
@@ -218,11 +227,11 @@ export const BCSCDialogTheme = {
   },
 }
 
-export const BCSCLoadingTheme = {
+export const BCSCLoadingTheme: ITheme['LoadingTheme'] = {
   backgroundColor: BCSCColorPallet.brand.primary,
 }
 
-export const BCSCPINInputTheme = {
+export const BCSCPINInputTheme: ITheme['PINInputTheme'] = {
   ...PINInputTheme,
   cell: {
     backgroundColor: BCSCColorPallet.grayscale.white,
@@ -276,7 +285,7 @@ export const BCSCInputs: IInputs = StyleSheet.create({
   },
 })
 
-export const BCSCButtons = StyleSheet.create({
+export const BCSCButtons: ITheme['Buttons'] = StyleSheet.create({
   ...Buttons,
   critical: {
     padding: 16,
@@ -392,7 +401,7 @@ export const BCSCButtons = StyleSheet.create({
   },
 })
 
-export const BCSCListItems = StyleSheet.create({
+export const BCSCListItems: ITheme['ListItems'] = StyleSheet.create({
   ...ListItems,
   credentialBackground: {
     backgroundColor: BCSCColorPallet.brand.secondaryBackground,
@@ -542,7 +551,7 @@ export const BCSCTabTheme: ITabTheme = {
   tabBarSecondaryBackgroundColor: '#252423',
 }
 
-export const BCSCHomeTheme = StyleSheet.create({
+export const BCSCHomeTheme: ITheme['HomeTheme'] = StyleSheet.create({
   ...HomeTheme,
   welcomeHeader: {
     ...BCSCTextTheme.headingOne,
@@ -563,7 +572,7 @@ export const BCSCHomeTheme = StyleSheet.create({
   },
 })
 
-export const BCSCSettingsTheme = {
+export const BCSCSettingsTheme: ITheme['SettingsTheme'] = {
   ...SettingsTheme,
   groupHeader: {
     ...BCSCTextTheme.normal,
@@ -577,7 +586,7 @@ export const BCSCSettingsTheme = {
   },
 }
 
-export const BCSCChatTheme = {
+export const BCSCChatTheme: ITheme['ChatTheme'] = {
   ...ChatTheme,
   leftBubble: {
     ...ChatTheme.leftBubble,
@@ -657,7 +666,7 @@ export const BCSCChatTheme = {
   },
 }
 
-export const BCSCAssets = {
+export const BCSCAssets: IAssets = {
   ...Assets,
   svg: {
     ...Assets.svg,

--- a/app/src/bcwallet-theme/theme.ts
+++ b/app/src/bcwallet-theme/theme.ts
@@ -269,7 +269,7 @@ export const Inputs: IInputs = StyleSheet.create({
   },
 })
 
-export const Buttons = StyleSheet.create({
+export const Buttons: ITheme['Buttons'] = StyleSheet.create({
   critical: {
     padding: 16,
     borderRadius: 4,
@@ -351,7 +351,7 @@ export const Buttons = StyleSheet.create({
   },
 })
 
-export const ListItems = StyleSheet.create({
+export const ListItems: ITheme['ListItems'] = StyleSheet.create({
   credentialBackground: {
     backgroundColor: ColorPallet.brand.secondaryBackground,
   },
@@ -503,7 +503,7 @@ export const TabTheme: ITabTheme = {
   tabBarSecondaryBackgroundColor: ColorPallet.brand.secondaryBackground,
 }
 
-export const NavigationTheme = {
+export const NavigationTheme: ITheme['NavigationTheme'] = {
   dark: true,
   colors: {
     primary: ColorPallet.brand.primary,
@@ -515,7 +515,7 @@ export const NavigationTheme = {
   },
 }
 
-export const HomeTheme = StyleSheet.create({
+export const HomeTheme: ITheme['HomeTheme'] = StyleSheet.create({
   welcomeHeader: {
     ...TextTheme.headingOne,
   },
@@ -548,7 +548,7 @@ export const SettingsTheme = {
   },
 }
 
-export const ChatTheme = {
+export const ChatTheme: ITheme['ChatTheme'] = {
   containerStyle: {
     marginBottom: 16,
     marginLeft: 16,
@@ -645,7 +645,7 @@ export const ChatTheme = {
   },
 }
 
-export const OnboardingTheme = {
+export const OnboardingTheme: ITheme['OnboardingTheme'] = {
   container: {
     backgroundColor: ColorPallet.brand.primaryBackground,
   },
@@ -680,7 +680,7 @@ export const OnboardingTheme = {
   },
 }
 
-export const DialogTheme = {
+export const DialogTheme: ITheme['DialogTheme'] = {
   modalView: {
     backgroundColor: ColorPallet.brand.secondaryBackground,
   },
@@ -698,17 +698,17 @@ export const DialogTheme = {
   },
 }
 
-export const LoadingTheme = {
+export const LoadingTheme: ITheme['LoadingTheme'] = {
   backgroundColor: ColorPallet.brand.primary,
 }
 
-export const PINEnterTheme = {
+export const PINEnterTheme: ITheme['PINEnterTheme'] = {
   image: {
     alignSelf: 'center',
     marginBottom: 20,
   },
 }
-export const PINInputTheme = {
+export const PINInputTheme: ITheme['PINInputTheme'] = {
   cell: {
     backgroundColor: ColorPallet.grayscale.lightGrey,
     borderColor: ColorPallet.grayscale.lightGrey,


### PR DESCRIPTION
### Description
This PR adds explicit types for the theme elements in the BCSC app and BC-Wallet app.

### Why is this needed?
The [PR 1539](https://github.com/openwallet-foundation/bifold-wallet/pull/1593) in Bifold stictens the typing on the individual theme elements. Without explicit types the typescript compiler will complain when attempting to coerce the types.

BCSC/BC-Wallet: 
```ts 
fontWeight: string = 'normal'
```
Bifold: 
```ts
fontWeight: 'bold' | 'normal' = 'normal'
```