### PR TITLE
feat: remove account (frontend)

### DIFF
--- a/app/src/bcsc-theme/features/account/Account.tsx
+++ b/app/src/bcsc-theme/features/account/Account.tsx
@@ -127,6 +127,10 @@ const Account: React.FC = () => {
               title="All account details"
               description={'View your account activity, manage your email address, and more.'}
             />
+            <SectionButton
+              onPress={() => navigation.navigate(BCSCScreens.RemoveAccountConfirmation)}
+              title="Remove account"
+            />
           </View>
         </View>
       )}

--- a/app/src/bcsc-theme/features/account/Account.tsx
+++ b/app/src/bcsc-theme/features/account/Account.tsx
@@ -13,6 +13,7 @@ import React, { useCallback, useEffect, useState } from 'react'
 import { ActivityIndicator, Linking, StyleSheet, View } from 'react-native'
 import AccountField from './components/AccountField'
 import AccountPhoto from './components/AccountPhoto'
+import { useTranslation } from 'react-i18next'
 
 type AccountNavigationProp = StackNavigationProp<BCSCRootStackParams>
 
@@ -25,6 +26,7 @@ const Account: React.FC = () => {
   const [userInfo, setUserInfo] = useState<UserInfoResponseData | null>(null)
   const [pictureUri, setPictureUri] = useState<string>()
   const url = useQuickLoginUrl('account/')
+  const { t } = useTranslation()
 
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
 
@@ -129,7 +131,7 @@ const Account: React.FC = () => {
             />
             <SectionButton
               onPress={() => navigation.navigate(BCSCScreens.RemoveAccountConfirmation)}
-              title="Remove account"
+              title={t('Unified.Account.RemoveAccount')}
             />
           </View>
         </View>

--- a/app/src/bcsc-theme/features/account/RemoveAccountConfirmationScreen.tsx
+++ b/app/src/bcsc-theme/features/account/RemoveAccountConfirmationScreen.tsx
@@ -2,25 +2,25 @@ import client from '@/bcsc-theme/api/client'
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { BCSCRootStackParams, BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
 import { BrandColors } from '@/bcwallet-theme/theme'
-import { BCState } from '@/store'
-import { ThemedText, TOKENS, useServices, useStore, useTheme, Button, ButtonType } from '@bifold/core'
+import { BCDispatchAction, BCState } from '@/store'
+import { ThemedText, useStore, useTheme, Button, ButtonType } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import { set } from 'mockdate'
 import React, { useCallback, useEffect, useState } from 'react'
 import { StyleSheet, View } from 'react-native'
+import { getAccount } from 'react-native-bcsc-core'
 
 
 type AccountNavigationProp = StackNavigationProp<BCSCRootStackParams>
 
 const RemoveAccountConfirmationScreen: React.FC = () => {
   const { Spacing } = useTheme()
-  const { user } = useApi()
+  // const { user } = useApi()
   const navigation = useNavigation<AccountNavigationProp>()
-  const [loading, setLoading] = useState(true)
-
-  const [logger] = useServices([TOKENS.UTIL_LOGGER])
-
+  // const { useTokenApi } = useApi()
+  // const { checkDeviceCodeStatus } = useTokenApi()
+  const [store, dispatch] = useStore<BCState>()
+  
 
   const styles = StyleSheet.create({
     container: {
@@ -38,7 +38,8 @@ const RemoveAccountConfirmationScreen: React.FC = () => {
   })
 
   const handleRemoveAccount = () => {
-    console.log('Not implemented')
+    dispatch({ type: BCDispatchAction.CLEAR_BCSC })
+
   }
 
   return (

--- a/app/src/bcsc-theme/features/account/RemoveAccountConfirmationScreen.tsx
+++ b/app/src/bcsc-theme/features/account/RemoveAccountConfirmationScreen.tsx
@@ -4,7 +4,7 @@ import { ThemedText, useStore, useTheme, Button, ButtonType, useServices, TOKENS
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { StyleSheet, View, Platform } from 'react-native'
 import * as BcscCore from '@/../../packages/bcsc-core/src/index'
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { useTranslation } from 'react-i18next'
@@ -35,14 +35,17 @@ const RemoveAccountConfirmationScreen: React.FC = () => {
 
   const handleRemoveAccount = async () => {
     try {
-      dispatch({ type: BCDispatchAction.CLEAR_BCSC })
-      await BcscCore.removeAccount()
-
-      // refresh accounts file with new account
-      await registration.register()
-
-      // log out
-      dispatch({ type: DispatchAction.DID_AUTHENTICATE, payload: [false] })
+      // Todo(TL): needs implementation on ios https://github.com/bcgov/bc-wallet-mobile/issues/2636
+      if (Platform.OS === 'android') {
+        await BcscCore.removeAccount()
+        dispatch({ type: BCDispatchAction.CLEAR_BCSC })
+        // refresh accounts file with new account
+        await registration.register()
+        // log out
+        dispatch({ type: DispatchAction.DID_AUTHENTICATE, payload: [false] })
+      } else {
+        logger.info('removeAccount not implemented on IOS')
+      }
     } catch (error: unknown) {
       logger.error(error)
     }

--- a/app/src/bcsc-theme/features/account/RemoveAccountConfirmationScreen.tsx
+++ b/app/src/bcsc-theme/features/account/RemoveAccountConfirmationScreen.tsx
@@ -1,0 +1,62 @@
+import client from '@/bcsc-theme/api/client'
+import useApi from '@/bcsc-theme/api/hooks/useApi'
+import { BCSCRootStackParams, BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
+import { BrandColors } from '@/bcwallet-theme/theme'
+import { BCState } from '@/store'
+import { ThemedText, TOKENS, useServices, useStore, useTheme, Button, ButtonType } from '@bifold/core'
+import { useNavigation } from '@react-navigation/native'
+import { StackNavigationProp } from '@react-navigation/stack'
+import { set } from 'mockdate'
+import React, { useCallback, useEffect, useState } from 'react'
+import { StyleSheet, View } from 'react-native'
+
+
+type AccountNavigationProp = StackNavigationProp<BCSCRootStackParams>
+
+const RemoveAccountConfirmationScreen: React.FC = () => {
+  const { Spacing } = useTheme()
+  const { user } = useApi()
+  const navigation = useNavigation<AccountNavigationProp>()
+  const [loading, setLoading] = useState(true)
+
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
+
+
+  const styles = StyleSheet.create({
+    container: {
+      padding: Spacing.md,
+    //   backgroundColor: BrandColors.primaryBackground,
+      flex: 1,
+    },
+    buttonsContainer: {
+      gap: Spacing.md,
+      marginTop: Spacing.lg,
+    },
+    textContainer: {
+        marginBottom: Spacing.md,
+    }
+  })
+
+  const handleRemoveAccount = () => {
+    console.log('Not implemented')
+  }
+
+  return (
+    <View style={styles.container}>
+        <View style={styles.textContainer}>
+            <ThemedText variant={'headingThree'}>{'Remove account From this app?'}</ThemedText>
+            <ThemedText>{'To use this app again, you\'ll need to provide your ID and verify your identity'}</ThemedText>
+        </View>
+        <View style={styles.buttonsContainer}>
+          <Button
+            buttonType={ButtonType.Critical}
+            title={'Remove Account'} onPress={handleRemoveAccount} />
+          <Button
+            buttonType={ButtonType.Secondary}
+            title={'Cancel'} onPress={() => navigation.goBack()} />
+        </View>
+      </View>
+  )
+}
+
+export default RemoveAccountConfirmationScreen

--- a/app/src/bcsc-theme/features/account/RemoveAccountConfirmationScreen.tsx
+++ b/app/src/bcsc-theme/features/account/RemoveAccountConfirmationScreen.tsx
@@ -22,7 +22,6 @@ const RemoveAccountConfirmationScreen: React.FC = () => {
   const styles = StyleSheet.create({
     container: {
       padding: Spacing.md,
-      //   backgroundColor: BrandColors.primaryBackground,
       flex: 1,
     },
     buttonsContainer: {

--- a/app/src/bcsc-theme/features/account/RemoveAccountConfirmationScreen.tsx
+++ b/app/src/bcsc-theme/features/account/RemoveAccountConfirmationScreen.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 import { StyleSheet, View } from 'react-native'
 import * as BcscCore from '@/../../packages/bcsc-core/src/index'
 import useApi from '@/bcsc-theme/api/hooks/useApi'
+import { useTranslation } from 'react-i18next'
 
 type AccountNavigationProp = StackNavigationProp<BCSCRootStackParams>
 
@@ -16,6 +17,7 @@ const RemoveAccountConfirmationScreen: React.FC = () => {
   const [, dispatch] = useStore<BCState>()
   const { registration } = useApi()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const { t } = useTranslation()
 
   const styles = StyleSheet.create({
     container: {
@@ -50,12 +52,22 @@ const RemoveAccountConfirmationScreen: React.FC = () => {
   return (
     <View style={styles.container}>
       <View style={styles.textContainer}>
-        <ThemedText variant={'headingThree'}>{'Remove account From this app?'}</ThemedText>
-        <ThemedText>{"To use this app again, you'll need to provide your ID and verify your identity"}</ThemedText>
+        <ThemedText variant={'headingThree'}>{t('Unified.Account.RemoveAccountTitle')}</ThemedText>
+        <ThemedText>{t('Unified.Account.RemoveAccountParagraph')}</ThemedText>
       </View>
       <View style={styles.buttonsContainer}>
-        <Button buttonType={ButtonType.Critical} title={'Remove Account'} onPress={handleRemoveAccount} />
-        <Button buttonType={ButtonType.Secondary} title={'Cancel'} onPress={() => navigation.goBack()} />
+        <Button
+          accessibilityLabel={t('Unified.Account.RemoveAccount')}
+          buttonType={ButtonType.Critical}
+          title={t('Unified.Account.RemoveAccount')}
+          onPress={handleRemoveAccount}
+        />
+        <Button
+          accessibilityLabel={t('Global.Cancel')}
+          buttonType={ButtonType.Secondary}
+          title={t('Global.Cancel')}
+          onPress={() => navigation.goBack()}
+        />
       </View>
     </View>
   )

--- a/app/src/bcsc-theme/features/account/RemoveAccountConfirmationScreen.tsx
+++ b/app/src/bcsc-theme/features/account/RemoveAccountConfirmationScreen.tsx
@@ -1,6 +1,6 @@
 import { BCSCRootStackParams } from '@/bcsc-theme/types/navigators'
 import { BCDispatchAction, BCState } from '@/store'
-import { ThemedText, useStore, useTheme, Button, ButtonType, useServices, TOKENS } from '@bifold/core'
+import { ThemedText, useStore, useTheme, Button, ButtonType, useServices, TOKENS, DispatchAction } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React from 'react'
@@ -42,7 +42,7 @@ const RemoveAccountConfirmationScreen: React.FC = () => {
       await registration.register()
 
       // log out
-      dispatch({ type: 'authentication/didAuthenticate', payload: [false] })
+      dispatch({ type: DispatchAction.DID_AUTHENTICATE, payload: [false] })
     } catch (error: unknown) {
       logger.error(error)
     }

--- a/app/src/bcsc-theme/features/account/RemoveAccountConfirmationScreen.tsx
+++ b/app/src/bcsc-theme/features/account/RemoveAccountConfirmationScreen.tsx
@@ -1,31 +1,26 @@
-import client from '@/bcsc-theme/api/client'
-import useApi from '@/bcsc-theme/api/hooks/useApi'
-import { BCSCRootStackParams, BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
-import { BrandColors } from '@/bcwallet-theme/theme'
+import { BCSCRootStackParams } from '@/bcsc-theme/types/navigators'
 import { BCDispatchAction, BCState } from '@/store'
-import { ThemedText, useStore, useTheme, Button, ButtonType } from '@bifold/core'
+import { ThemedText, useStore, useTheme, Button, ButtonType, useServices, TOKENS } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React, { useCallback, useEffect, useState } from 'react'
+import React from 'react'
 import { StyleSheet, View } from 'react-native'
-import { getAccount } from 'react-native-bcsc-core'
-
+import * as BcscCore from '@/../../packages/bcsc-core/src/index'
+import useApi from '@/bcsc-theme/api/hooks/useApi'
 
 type AccountNavigationProp = StackNavigationProp<BCSCRootStackParams>
 
 const RemoveAccountConfirmationScreen: React.FC = () => {
   const { Spacing } = useTheme()
-  // const { user } = useApi()
   const navigation = useNavigation<AccountNavigationProp>()
-  // const { useTokenApi } = useApi()
-  // const { checkDeviceCodeStatus } = useTokenApi()
-  const [store, dispatch] = useStore<BCState>()
-  
+  const [, dispatch] = useStore<BCState>()
+  const { registration } = useApi()
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
 
   const styles = StyleSheet.create({
     container: {
       padding: Spacing.md,
-    //   backgroundColor: BrandColors.primaryBackground,
+      //   backgroundColor: BrandColors.primaryBackground,
       flex: 1,
     },
     buttonsContainer: {
@@ -33,30 +28,36 @@ const RemoveAccountConfirmationScreen: React.FC = () => {
       marginTop: Spacing.lg,
     },
     textContainer: {
-        marginBottom: Spacing.md,
-    }
+      marginBottom: Spacing.md,
+    },
   })
 
-  const handleRemoveAccount = () => {
-    dispatch({ type: BCDispatchAction.CLEAR_BCSC })
+  const handleRemoveAccount = async () => {
+    try {
+      dispatch({ type: BCDispatchAction.CLEAR_BCSC })
+      await BcscCore.removeAccount()
 
+      // refresh accounts file with new account
+      await registration.register()
+
+      // log out
+      dispatch({ type: 'authentication/didAuthenticate', payload: [false] })
+    } catch (error: unknown) {
+      logger.error(error)
+    }
   }
 
   return (
     <View style={styles.container}>
-        <View style={styles.textContainer}>
-            <ThemedText variant={'headingThree'}>{'Remove account From this app?'}</ThemedText>
-            <ThemedText>{'To use this app again, you\'ll need to provide your ID and verify your identity'}</ThemedText>
-        </View>
-        <View style={styles.buttonsContainer}>
-          <Button
-            buttonType={ButtonType.Critical}
-            title={'Remove Account'} onPress={handleRemoveAccount} />
-          <Button
-            buttonType={ButtonType.Secondary}
-            title={'Cancel'} onPress={() => navigation.goBack()} />
-        </View>
+      <View style={styles.textContainer}>
+        <ThemedText variant={'headingThree'}>{'Remove account From this app?'}</ThemedText>
+        <ThemedText>{"To use this app again, you'll need to provide your ID and verify your identity"}</ThemedText>
       </View>
+      <View style={styles.buttonsContainer}>
+        <Button buttonType={ButtonType.Critical} title={'Remove Account'} onPress={handleRemoveAccount} />
+        <Button buttonType={ButtonType.Secondary} title={'Cancel'} onPress={() => navigation.goBack()} />
+      </View>
+    </View>
   )
 }
 

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 import { View } from 'react-native'
 import ManualPairingCode from '../features/pairing/ManualPairing'
 import PairingConfirmation from '../features/pairing/PairingConfirmation'
+import RemoveAccountConfirmationScreen from '../features/account/RemoveAccountConfirmationScreen'
 import WebViewScreen from '../features/webview/WebViewScreen'
 import { BCSCRootStackParams, BCSCScreens, BCSCStacks } from '../types/navigators'
 import BCSCTabStack from './TabStack'
@@ -55,6 +56,14 @@ const MainStack: React.FC = () => {
           options={() => ({
             headerShown: true,
             headerLeft: () => null,
+          })}
+        />
+        <Stack.Screen
+          name={BCSCScreens.RemoveAccountConfirmation}
+          component={RemoveAccountConfirmationScreen}
+          options={() => ({
+            headerShown: true,
+            headerBackTitleVisible: false,
           })}
         />
       </Stack.Navigator>

--- a/app/src/bcsc-theme/types/navigators.ts
+++ b/app/src/bcsc-theme/types/navigators.ts
@@ -4,7 +4,6 @@ import { BCSCCardType } from './cards'
 
 export enum BCSCStacks {
   TabStack = 'BCSCTabStack',
-  AccountStack = 'BCSCAccountStack',
 }
 
 export enum BCSCScreens {
@@ -54,13 +53,9 @@ export type BCSCTabStackParams = {
 
 export type BCSCRootStackParams = {
   [BCSCStacks.TabStack]: NavigatorScreenParams<BCSCTabStackParams>
-  [BCSCStacks.AccountStack]: NavigatorScreenParams<BCSCAccountStackParams>
   [BCSCScreens.WebView]: { url: string; title: string }
   [BCSCScreens.ManualPairingCode]: undefined
   [BCSCScreens.PairingConfirmation]: { serviceName: string; serviceId: string }
-}
-
-export type BCSCAccountStackParams = {
   [BCSCScreens.RemoveAccountConfirmation]: undefined
 }
 

--- a/app/src/bcsc-theme/types/navigators.ts
+++ b/app/src/bcsc-theme/types/navigators.ts
@@ -4,6 +4,7 @@ import { BCSCCardType } from './cards'
 
 export enum BCSCStacks {
   TabStack = 'BCSCTabStack',
+  AccountStack = 'BCSCAccountStack',
 }
 
 export enum BCSCScreens {
@@ -41,6 +42,7 @@ export enum BCSCScreens {
   EvidenceTypeList = 'EvidenceTypeList',
   EvidenceCapture = 'BCSCEvidenceCapture',
   EvidenceIDCollection = 'BCSCEvidenceIDCollection',
+  RemoveAccountConfirmation = 'RemoveAccountConfirmationScreen',
 }
 
 export type BCSCTabStackParams = {
@@ -52,9 +54,14 @@ export type BCSCTabStackParams = {
 
 export type BCSCRootStackParams = {
   [BCSCStacks.TabStack]: NavigatorScreenParams<BCSCTabStackParams>
+  [BCSCStacks.AccountStack]: NavigatorScreenParams<BCSCAccountStackParams>
   [BCSCScreens.WebView]: { url: string; title: string }
   [BCSCScreens.ManualPairingCode]: undefined
   [BCSCScreens.PairingConfirmation]: { serviceName: string; serviceId: string }
+}
+
+export type BCSCAccountStackParams = {
+  [BCSCScreens.RemoveAccountConfirmation]: undefined
 }
 
 export type BCSCVerifyIdentityStackParams = {

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -286,6 +286,11 @@ const translation = {
       "Heading": "Choose photo ID",
       "Description": "Use an ID that has the same name as on your BC Services Card.",
       "FirstID": "Choose your first ID",
+    },
+    "Account": {
+      "RemoveAccount": "Remove account",
+      "RemoveAccountTitle": "Remove account from this app?",
+      "RemoveAccountParagraph": "To use this app again, you'll need to provide your ID and verify your identity."
     }
   },
   "RemoteLogging": {

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -283,6 +283,11 @@ const translation = {
       "Heading": "Choose photo ID (FR)",
       "Description": "Use an ID that has the same name as on your BC Services Card. (FR)",
       "FirstID": "Choose your first ID (FR)",
+    },
+    "Account": {
+      "RemoveAccount": "Remove account (FR)",
+      "RemoveAccountTitle": "Remove account from this app? (FR)",
+      "RemoveAccountParagraph": "To use this app again, you'll need to provide your ID and verify your identity. (FR)"
     }
   },
   "RemoteLogging": {

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -283,6 +283,11 @@ const translation = {
       "Heading": "Choose photo ID (PT-BR)",
       "Description": "Use an ID that has the same name as on your BC Services Card. (PT-BR)",
       "FirstID": "Choose your first ID (PT-BR)",
+    },
+    "Account": {
+      "RemoveAccount": "Remove account (PT-BR)",
+      "RemoveAccountTitle": "Remove account from this app? (PT-BR)",
+      "RemoveAccountParagraph": "To use this app again, you'll need to provide your ID and verify your identity. (PT-BR)"
     }
   },
   "RemoteLogging": {

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -982,23 +982,29 @@ class BcscCoreModule(reactContext: ReactApplicationContext) :
    */
   @ReactMethod
   override fun removeAccount(promise: Promise) {
+    Log.d(NAME, "removeAccount - Starting account removal process")
+    val account: WritableMap?
     try {
-      Log.d(NAME, "removeAccount - Starting account removal process")
-      
-      val account = getAccountSync()
-      val accountId = account?.getString("id")
-      
-      if (accountId != null) {
+      account = getAccountSync()
+    } catch (e: Exception) {
+      Log.e(NAME, "removeAccount - Error retrieving account: ${e.message}", e)
+      promise.reject("E_GET_ACCOUNT_ERROR", "Failed to retrieve account: ${e.message}", e)
+      return
+    }
+    val accountId = account?.getString("id")
+    if (accountId != null) {
+      try {
         Log.d(NAME, "removeAccount - Removing data for account ID: $accountId")
         removeAccountFromFile(accountId)
         Log.d(NAME, "removeAccount - Successfully removed account data")
-      } else {
-        Log.d(NAME, "removeAccount - No account found to remove")
+        promise.resolve(null)
+      } catch (e: Exception) {
+        Log.e(NAME, "removeAccount - Error removing account: ${e.message}", e)
+        promise.reject("E_REMOVE_ACCOUNT_ERROR", "Failed to remove account: ${e.message}", e)
       }
+    } else {
+      Log.d(NAME, "removeAccount - No account found to remove")
       promise.resolve(null)
-    } catch (e: Exception) {
-      Log.e(NAME, "removeAccount - Error removing account: ${e.message}", e)
-      promise.reject("E_REMOVE_ACCOUNT_ERROR", "Failed to remove account: ${e.message}", e)
     }
   }
   

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -439,7 +439,7 @@ class BcscCoreModule(reactContext: ReactApplicationContext) :
         // Always overwrite the accounts file with the new single account
         try {
           accountsFile.parentFile?.mkdirs() // Ensure directory exists
-          FileWriter(accountsFile as File).use { writer ->
+          FileWriter(accountsFile).use { writer ->
             writer.write(accountsArray.toString())
             writer.flush()
           }

--- a/packages/bcsc-core/android/src/oldarch/BcscCoreSpec.kt
+++ b/packages/bcsc-core/android/src/oldarch/BcscCoreSpec.kt
@@ -20,4 +20,5 @@ abstract class BcscCoreSpec internal constructor(context: ReactApplicationContex
   abstract fun createEvidenceRequestJWT(deviceCode: String, clientID: String, promise: Promise)
   abstract fun hashBase64(base64: String, promise: Promise)
   abstract fun decodePayload(jweString: String, promise: Promise)
+  abstract fun removeAccount(promise: Promise)
 }

--- a/packages/bcsc-core/src/NativeBcscCore.ts
+++ b/packages/bcsc-core/src/NativeBcscCore.ts
@@ -95,6 +95,7 @@ export interface Spec extends TurboModule {
     deviceToken?: string
   ): Promise<string>;
   hashBase64(base64: string): Promise<string>;
+  removeAccount(): Promise<void>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('BcscCore');

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -292,3 +292,11 @@ export const getRegistrationToken = async (): Promise<TokenInfo | null> => {
   // For now, return null
   return null;
 };
+
+/**
+ * Removes the current account from the accounts file
+ * @returns A promise that resolves when the account has been successfully removed.
+ */
+export const removeAccount = async (): Promise<void> => {
+  return BcscCore.removeAccount();
+};


### PR DESCRIPTION
# Summary of Changes

Added screens and functionality to remove an account from the bcsc side of the app. Removing an account resets the verification process. This pr does not include the api side of the remove account flow.

# Video

[untitled.webm](https://github.com/user-attachments/assets/d495c3c0-bc36-4489-af9e-8a4b6f065a30)


# Related Issues

https://github.com/bcgov/bc-wallet-mobile/issues/2560

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes
