### PR TITLE
feat: use non bcsc id to verify identity

### DIFF
--- a/app/src/bcsc-theme/features/verify/IdentitySelectionScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/IdentitySelectionScreen.tsx
@@ -86,8 +86,9 @@ const IdentitySelectionScreen: React.FC<IdentitySelectionScreenProps> = ({
   }, [])
 
   const onPressOtherID = useCallback(() => {
-    // TODO: Implement
-  }, [])
+    dispatch({ type: BCDispatchAction.UPDATE_CARD_TYPE, payload: [BCSCCardType.Other] })
+    navigation.navigate(BCSCScreens.EvidenceTypeList)
+  }, [dispatch, navigation])
 
   const cardButtons = useMemo(() => {
     return (

--- a/app/src/bcsc-theme/features/verify/SetupStepsScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/SetupStepsScreen.tsx
@@ -166,6 +166,7 @@ const SetupStepsScreen: React.FC<SetupStepsScreenProps> = ({ navigation }) => {
       <TouchableOpacity
         onPress={() => {
           if (!registered) {
+            dispatch({ type: BCDispatchAction.UPDATE_CARD_TYPE, payload: [BCSCCardType.None] })
             navigation.navigate(BCSCScreens.IdentitySelection)
           }
 


### PR DESCRIPTION
# Summary of Changes

Allows users to register for BCSC without a BC Services card. Verification flow requires two non BCSC identification cards, alongside additional metadata that is required for IAS API calls.

The flow for this is slightly different, as a lot of the metadata is not auto-populated anymore. The user will need to manually enter their address, email and submit an additional ID.

Lots of the changes where related to the SetupStepsScreen and organizing the state logic there. Mostly making it compatible with non-bcsc card verifications.

### New components:

1. SetupStep - Unified the styling of the Steps in SetupStepsScreen into one component.
2. ResidentialAddressScreen - For entering the users address information
3. InputWithValidation - Stateless component which renders an input, label, error etc.
4. DualIdentificationRequiredScreen - Information screen when registering non BCSC identification cards.


# Screenshots, videos, or gifs

...

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [ ] Related issues are included under the Related Issues section above
- [ ] If applicable, screenshots, gifs, or video are included for UI changes
