### PR TITLE
chore: include metro cache locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ bifold/
 aries-oca-bundles/
 credo-ts/
 app/vendor/
+
+.metro-cache/

--- a/app/metro.config.js
+++ b/app/metro.config.js
@@ -3,6 +3,8 @@ const fs = require('fs')
 const path = require('path')
 const escape = require('escape-string-regexp')
 const exclusionList = require('metro-config/src/defaults/exclusionList')
+const { FileStore } = require('metro-cache')
+
 require('dotenv').config()
 
 const packageDirs = [
@@ -72,6 +74,11 @@ module.exports = (async () => {
       sourceExts: [...sourceExts, 'svg', 'cjs'],
     },
     watchFolders,
+    cacheStores: [
+      new FileStore({
+        root: path.join(__dirname, '.metro-cache'),
+      }),
+    ],
   }
 
   return mergeConfig(getDefaultConfig(__dirname), metroConfig)


### PR DESCRIPTION
# Summary of Changes

Includes the metro cache in the local project directory. This makes it easier to wipe the cache and prevents strange cache permission issues in tmp directories.

#### Testing Notes
- app/.metro-cache should exists and be populated with cache files after yarn start + yarn ios/android

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes
