### PR TITLE
fix(hot-reload): make bcsc api client a singleton

### DIFF
--- a/app/__tests__/bcsc-theme/components/BCSCApiClientProvider.test.tsx
+++ b/app/__tests__/bcsc-theme/components/BCSCApiClientProvider.test.tsx
@@ -1,0 +1,238 @@
+import {
+  _resetBCSCApiClientSingleton,
+  BCSCApiClientContext,
+  BCSCApiClientProvider,
+} from '@/bcsc-theme/contexts/BCSCApiClientContext'
+import { renderHook, waitFor } from '@testing-library/react-native'
+import { useContext } from 'react'
+import * as Bifold from '@bifold/core'
+import BCSCApiClient from '@/bcsc-theme/api/client'
+import { DispatchAction } from '@bifold/core'
+
+jest.mock('@/bcsc-theme/api/client')
+
+jest.mock('@bifold/core')
+
+describe('BCSCApiClientProvider', () => {
+  beforeEach(() => {
+    _resetBCSCApiClientSingleton()
+    jest.resetAllMocks()
+  })
+
+  it('should initialize the client', async () => {
+    const bifoldMock = jest.mocked(Bifold)
+    const bcscApiClientMock = jest.mocked(BCSCApiClient)
+
+    const mockStore: any = {
+      stateLoaded: true,
+      developer: {
+        environment: {
+          iasApiBaseUrl: 'https://example.com',
+        },
+      },
+    }
+    const mockLogger: any = {}
+    const dispatchMock = jest.fn()
+
+    bifoldMock.useServices.mockReturnValue([mockLogger])
+    bifoldMock.useStore.mockReturnValue([mockStore, dispatchMock])
+
+    bcscApiClientMock.prototype.fetchEndpointsAndConfig = jest.fn().mockResolvedValue(true)
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <BCSCApiClientProvider>{children}</BCSCApiClientProvider>
+    )
+
+    const { result } = renderHook(() => useContext(BCSCApiClientContext), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current?.client).toBeDefined()
+      expect(result.current?.client).toBeInstanceOf(BCSCApiClient)
+      expect(result.current?.clientIsReady).toBe(true)
+      expect(result.current?.error).toBeNull()
+      expect(bcscApiClientMock.prototype.fetchEndpointsAndConfig).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('should not initialize if store.stateLoaded is false', async () => {
+    const bifoldMock = jest.mocked(Bifold)
+    const bcscApiClientMock = jest.mocked(BCSCApiClient)
+
+    const mockStore: any = {
+      stateLoaded: false,
+      developer: { environment: { iasApiBaseUrl: 'https://example.com' } },
+    }
+    const dispatchMock = jest.fn()
+    bifoldMock.useServices.mockReturnValue([{}])
+    bifoldMock.useStore.mockReturnValue([mockStore, dispatchMock])
+
+    bcscApiClientMock.prototype.fetchEndpointsAndConfig = jest.fn().mockResolvedValue(true)
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <BCSCApiClientProvider>{children}</BCSCApiClientProvider>
+    )
+
+    const { result } = renderHook(() => useContext(BCSCApiClientContext), { wrapper })
+
+    // No initialization → stays false
+    expect(result.current?.clientIsReady).toBe(false)
+    expect(result.current?.client).toBeNull()
+    expect(result.current?.error).toBeNull()
+    expect(bcscApiClientMock.prototype.fetchEndpointsAndConfig).not.toHaveBeenCalled()
+  })
+
+  it('should not initialize if iasApiBaseUrl is missing', async () => {
+    const bifoldMock = jest.mocked(Bifold)
+    const bcscApiClientMock = jest.mocked(BCSCApiClient)
+
+    const mockStore: any = {
+      stateLoaded: true,
+      developer: { environment: { iasApiBaseUrl: '' } },
+    }
+    const dispatchMock = jest.fn()
+    bifoldMock.useServices.mockReturnValue([{}])
+    bifoldMock.useStore.mockReturnValue([mockStore, dispatchMock])
+
+    bcscApiClientMock.prototype.fetchEndpointsAndConfig = jest.fn().mockResolvedValue(true)
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <BCSCApiClientProvider>{children}</BCSCApiClientProvider>
+    )
+
+    const { result } = renderHook(() => useContext(BCSCApiClientContext), { wrapper })
+
+    expect(result.current?.clientIsReady).toBe(false)
+    expect(result.current?.client).toBeNull()
+    expect(result.current?.error).toBeNull()
+    expect(bcscApiClientMock.prototype.fetchEndpointsAndConfig).not.toHaveBeenCalled()
+  })
+
+  it('should use the singleton instance', async () => {
+    const bifoldMock = jest.mocked(Bifold)
+    const bcscApiClientMock = jest.mocked(BCSCApiClient)
+
+    const mockStore: any = {
+      stateLoaded: true,
+      developer: { environment: { iasApiBaseUrl: 'https://example.com' } },
+    }
+    const dispatchMock = jest.fn()
+    bifoldMock.useServices.mockReturnValue([{}])
+    bifoldMock.useStore.mockReturnValue([mockStore, dispatchMock])
+
+    bcscApiClientMock.prototype.fetchEndpointsAndConfig = jest.fn().mockResolvedValue(true)
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <BCSCApiClientProvider>{children}</BCSCApiClientProvider>
+    )
+
+    const { result, rerender } = renderHook(() => useContext(BCSCApiClientContext), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current?.clientIsReady).toBe(true)
+      expect(result.current?.client).toBeDefined()
+      expect(result.current?.error).toBeNull()
+      expect(bcscApiClientMock.prototype.fetchEndpointsAndConfig).toHaveBeenCalledTimes(1)
+    })
+
+    Object.assign(result.current?.client || {}, { baseURL: 'singleton' })
+
+    rerender({})
+
+    await waitFor(() => {
+      expect(result.current?.clientIsReady).toBe(true)
+      expect(result.current?.client).toBeDefined()
+      expect(result.current?.client?.baseURL).toBe('singleton')
+      expect(result.current?.error).toBeNull()
+      expect(bcscApiClientMock.prototype.fetchEndpointsAndConfig).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('should handle initialization errors', async () => {
+    const bifoldMock = jest.mocked(Bifold)
+    const bcscApiClientMock = jest.mocked(BCSCApiClient)
+
+    const mockStore: any = {
+      stateLoaded: true,
+      developer: { environment: { iasApiBaseUrl: 'https://example.com' } },
+    }
+    const dispatchMock = jest.fn()
+    bifoldMock.useServices.mockReturnValue([{}])
+    bifoldMock.useStore.mockReturnValue([mockStore, dispatchMock])
+
+    bcscApiClientMock.prototype.fetchEndpointsAndConfig = jest
+      .fn()
+      .mockRejectedValue(new Error('Initialization failed'))
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <BCSCApiClientProvider>{children}</BCSCApiClientProvider>
+    )
+
+    const { result } = renderHook(() => useContext(BCSCApiClientContext), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current?.clientIsReady).toBe(false)
+      expect(result.current?.client).toBeNull()
+      expect(result.current?.error).toBeDefined()
+      expect(result.current?.error).toContain('Initialization failed')
+      expect(bcscApiClientMock.prototype.fetchEndpointsAndConfig).toHaveBeenCalledTimes(1)
+      expect(dispatchMock).toHaveBeenCalledWith({
+        type: DispatchAction.BANNER_MESSAGES,
+        payload: [
+          {
+            id: 'IASServerError',
+            title: 'Unable to retrieve server status',
+            type: 'error',
+            variant: 'summary',
+            dismissible: true,
+          },
+        ],
+      })
+    })
+  })
+
+  it('should re-attempt initialization if iasApiBaseUrl changes', async () => {
+    const bifoldMock = jest.mocked(Bifold)
+    const bcscApiClientMock = jest.mocked(BCSCApiClient)
+    const fetchMock = jest.fn()
+
+    let store: any = {
+      stateLoaded: true,
+      developer: { environment: { iasApiBaseUrl: 'https://example.com' } },
+    }
+    const dispatchMock = jest.fn()
+    bifoldMock.useServices.mockReturnValue([{}])
+    bifoldMock.useStore.mockImplementation(() => [store, dispatchMock])
+
+    bcscApiClientMock.mockImplementation(
+      () =>
+        ({
+          fetchEndpointsAndConfig: fetchMock,
+          baseURL: store.developer.environment.iasApiBaseUrl,
+        } as any)
+    )
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <BCSCApiClientProvider>{children}</BCSCApiClientProvider>
+    )
+
+    const { result, rerender } = renderHook(() => useContext(BCSCApiClientContext), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current?.client?.baseURL).toBe('https://example.com')
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    // replace store with new object before rerender
+    store = {
+      stateLoaded: true,
+      developer: { environment: { iasApiBaseUrl: 'https://new.com' } },
+    }
+
+    rerender({})
+
+    await waitFor(() => {
+      expect(result.current?.client?.baseURL).toBe('https://new.com')
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/app/__tests__/bcsc-theme/hooks/useBCSCApiClient.test.ts
+++ b/app/__tests__/bcsc-theme/hooks/useBCSCApiClient.test.ts
@@ -1,0 +1,71 @@
+import { useBCSCApiClient, useBCSCApiClientState } from '@/bcsc-theme/hooks/useBCSCApiClient'
+import { renderHook } from '@testing-library/react-native'
+import React from 'react'
+
+describe('BCSC API Client Hooks', () => {
+  describe('useBCSCApiClient', () => {
+    it('should throw if used outside of BCSCApiClientProvider', () => {
+      try {
+        renderHook(() => useBCSCApiClient())
+      } catch (error: any) {
+        expect(error.message).toContain('within a BCSCApiClientProvider')
+      }
+    })
+
+    it('should throw if BCSCClientProvider reports an error', () => {
+      const mockContext = { error: 'Test error', client: null, clientIsReady: false }
+
+      jest.spyOn(React, 'useContext').mockReturnValue(mockContext)
+
+      try {
+        renderHook(() => useBCSCApiClient())
+      } catch (error: any) {
+        expect(error.message).toBe('BCSC client error: Test error')
+      }
+    })
+
+    it('should throw if client is not ready', () => {
+      const mockContext = { error: null, client: null, clientIsReady: false }
+
+      jest.spyOn(React, 'useContext').mockReturnValue(mockContext)
+
+      try {
+        renderHook(() => useBCSCApiClient())
+      } catch (error: any) {
+        expect(error.message).toContain('client not ready')
+      }
+    })
+
+    it('should throw if client is undefined', () => {
+      const mockContext = { error: null, client: null, clientIsReady: true }
+
+      jest.spyOn(React, 'useContext').mockReturnValue(mockContext)
+
+      try {
+        renderHook(() => useBCSCApiClient())
+      } catch (error: any) {
+        expect(error.message).toContain('client not ready')
+      }
+    })
+
+    it('should return the client if ready and no errors', () => {
+      const mockClient = {}
+      const mockContext = { error: null, client: mockClient, clientIsReady: true }
+
+      jest.spyOn(React, 'useContext').mockReturnValue(mockContext)
+
+      const { result } = renderHook(() => useBCSCApiClient())
+      expect(result.current).toBe(mockClient)
+    })
+  })
+
+  describe('useBCSCApiClientState', () => {
+    it('should throw if used outside of BCSCApiClientProvider', () => {
+      try {
+        renderHook(() => useBCSCApiClientState())
+      } catch (error: any) {
+        expect(error.message).toContain('within a BCSCApiClientProvider')
+      }
+    })
+  })
+})

--- a/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
@@ -13,12 +13,20 @@ export interface BCSCApiClientContextType {
   error: string | null
 }
 
-export const BCSCApiClientContext = createContext<BCSCApiClientContextType>({
-  client: null,
-  clientIsReady: false,
-  error: null,
-})
+export const BCSCApiClientContext = createContext<BCSCApiClientContextType | null>(null)
 
+/**
+ * Provides a singleton BCSCApiClient instance to child components via context.
+ *
+ * The client is initialized based on the current developer environment and automatically
+ * reconfigures if the environment changes. If initialization fails, an error state is exposed.
+ *
+ * Children can access the client, its readiness, and errors via BCSCApiClientContext, or
+ * just the client using useBCSCApiClient/useBCSCApiClientState hooks.
+ *
+ * @param {React.ReactNode} children - The child components that will have access to the BCSCApiClient instance.
+ * @returns {*} {JSX.Element} The BCSCApiClientProvider component wrapping its children.
+ */
 export const BCSCApiClientProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [store, dispatch] = useStore<BCState>()
   const [clientIsReady, setClientIsReady] = useState(false)
@@ -86,4 +94,9 @@ export const BCSCApiClientProvider: React.FC<{ children: React.ReactNode }> = ({
   )
 
   return <BCSCApiClientContext.Provider value={contextValue}>{children}</BCSCApiClientContext.Provider>
+}
+
+// This function is used to reset the singleton instance in tests
+export function _resetBCSCApiClientSingleton() {
+  BCSC_API_CLIENT_SINGLETON = null
 }


### PR DESCRIPTION
# Summary of Changes

This can wait till @bryce-mcmath is back, as he is the most familiar with the reactive client changes.

THis PR resolves a strange issue with hot reloading and the BCSC api client. 

When the application is hot-reloaded the api client is re-initialized, but the tokens are initialized in useInitializeBCSC. So any change to the code would re-initialize the client but not update the tokens making all subsequent requests fail (missing refresh token). 

The internal methods of the BCSC api client are modifying the class properties (tokens), so every time we call a client method that updates the internal properties we would also need to call setState in the BCSCApiClientProvider OR use a singleton client as we did previously.

This PR slightly changes the BCSCApiClientPRovider to be a hybrid between the new reactive client and the previous non-reactive version (singleton).

# Screenshots, videos, or gifs

Before change - client re-initializing and tokens undefined
https://github.com/user-attachments/assets/ea08f919-b4bd-4bc5-a5fb-f298c86f811e


After change - singleton client and tokens defined
https://github.com/user-attachments/assets/d0f938a3-b0ef-45b5-92f3-b098bab4e656



# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes
