### PR TITLE
fix: better push token mgmt

### DIFF
--- a/app/__tests__/bcsc-theme/utils/push-notification-tokens.test.ts
+++ b/app/__tests__/bcsc-theme/utils/push-notification-tokens.test.ts
@@ -1,0 +1,233 @@
+import { Platform } from 'react-native'
+import messaging from '@react-native-firebase/messaging'
+import { getNotificationTokens, NotificationTokens } from '@/bcsc-theme/utils/push-notification-tokens'
+
+// Mock the messaging module
+const mockGetToken = jest.fn()
+const mockGetAPNSToken = jest.fn()
+
+jest.mock('@react-native-firebase/messaging', () => {
+  return jest.fn(() => ({
+    getToken: mockGetToken,
+    getAPNSToken: mockGetAPNSToken,
+  }))
+})
+
+// Mock Platform
+jest.mock('react-native', () => ({
+  Platform: {
+    OS: 'ios', // Default to iOS, will override in specific tests
+  },
+}))
+
+// Create a mock logger
+const mockLogger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+}
+
+describe('getNotificationTokens', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // Reset Platform.OS to iOS for most tests
+    ;(Platform as any).OS = 'ios'
+  })
+
+  describe('Success Cases', () => {
+    it('should return tokens successfully on iOS with both FCM and APNS tokens', async () => {
+      const mockFCMToken = 'mock_fcm_token_123'
+      const mockAPNSToken = 'mock_apns_token_456'
+
+      mockGetToken.mockResolvedValue(mockFCMToken)
+      mockGetAPNSToken.mockResolvedValue(mockAPNSToken)
+
+      const result = await getNotificationTokens(mockLogger)
+
+      expect(result).toEqual({
+        fcmDeviceToken: mockFCMToken,
+        apnsToken: mockAPNSToken,
+        success: true,
+      })
+      expect(mockLogger.info).toHaveBeenCalledWith('Retrieved all required notification tokens for registration.')
+    })
+
+    it('should return tokens successfully on Android with only FCM token', async () => {
+      ;(Platform as any).OS = 'android'
+      const mockFCMToken = 'mock_fcm_token_android'
+
+      mockGetToken.mockResolvedValue(mockFCMToken)
+      // APNS should not be called on Android
+      mockGetAPNSToken.mockResolvedValue(null)
+
+      const result = await getNotificationTokens(mockLogger)
+
+      expect(result).toEqual({
+        fcmDeviceToken: mockFCMToken,
+        apnsToken: null,
+        success: true,
+      })
+      expect(mockGetAPNSToken).not.toHaveBeenCalled()
+      expect(mockLogger.info).toHaveBeenCalledWith('Retrieved all required notification tokens for registration.')
+    })
+  })
+
+  describe('Failure Cases', () => {
+    it('should throw error when FCM token is null', async () => {
+      ;(Platform as any).OS = 'ios'
+      mockGetToken.mockResolvedValue(null)
+      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+
+      await expect(getNotificationTokens(mockLogger)).rejects.toThrow(
+        'Failed to retrieve required tokens. Errors: FCM token fetch failed (returned null/undefined)'
+      )
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Failed to retrieve required tokens. Errors: FCM token fetch failed (returned null/undefined)'
+      )
+    })
+
+    it('should throw error when FCM token is undefined', async () => {
+      ;(Platform as any).OS = 'ios'
+      mockGetToken.mockResolvedValue(undefined)
+      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+
+      await expect(getNotificationTokens(mockLogger)).rejects.toThrow(
+        'Failed to retrieve required tokens. Errors: FCM token fetch failed (returned null/undefined)'
+      )
+    })
+
+    it('should throw error when FCM token fetch throws exception', async () => {
+      ;(Platform as any).OS = 'ios'
+      const mockError = new Error('FCM service unavailable')
+      mockGetToken.mockRejectedValue(mockError)
+      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+
+      await expect(getNotificationTokens(mockLogger)).rejects.toThrow(
+        'Failed to retrieve required tokens. Errors: FCM token fetch failed: FCM service unavailable'
+      )
+    })
+
+    it('should throw error on iOS when APNS token is null', async () => {
+      ;(Platform as any).OS = 'ios'
+      mockGetToken.mockResolvedValue('mock_fcm_token')
+      mockGetAPNSToken.mockResolvedValue(null)
+
+      await expect(getNotificationTokens(mockLogger)).rejects.toThrow(
+        'Failed to retrieve required tokens. Errors: APNS token fetch failed (returned null/undefined on iOS)'
+      )
+    })
+
+    it('should throw error on iOS when APNS token fetch throws exception', async () => {
+      ;(Platform as any).OS = 'ios'
+      const mockError = new Error('APNS service unavailable')
+      mockGetToken.mockResolvedValue('mock_fcm_token')
+      mockGetAPNSToken.mockRejectedValue(mockError)
+
+      await expect(getNotificationTokens(mockLogger)).rejects.toThrow(
+        'Failed to retrieve required tokens. Errors: APNS token fetch failed: APNS service unavailable'
+      )
+    })
+
+    it('should throw error with multiple failures', async () => {
+      ;(Platform as any).OS = 'ios'
+      mockGetToken.mockResolvedValue(null)
+      mockGetAPNSToken.mockRejectedValue(new Error('APNS error'))
+
+      await expect(getNotificationTokens(mockLogger)).rejects.toThrow(
+        'Failed to retrieve required tokens. Errors: FCM token fetch failed (returned null/undefined); APNS token fetch failed: APNS error'
+      )
+    })
+
+    it('should handle non-Error exceptions properly', async () => {
+      ;(Platform as any).OS = 'ios'
+      mockGetToken.mockRejectedValue('String error message')
+      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+
+      await expect(getNotificationTokens(mockLogger)).rejects.toThrow(
+        'Failed to retrieve required tokens. Errors: FCM token fetch failed: String error message'
+      )
+    })
+  })
+
+  describe('Logger Integration', () => {
+    it('should work without logger (optional parameter)', async () => {
+      mockGetToken.mockResolvedValue('mock_fcm_token')
+      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+
+      const result = await getNotificationTokens()
+
+      expect(result.success).toBe(true)
+      expect(result.fcmDeviceToken).toBe('mock_fcm_token')
+      expect(result.apnsToken).toBe('mock_apns_token')
+    })
+
+    it('should handle logger gracefully when it fails', async () => {
+      // Test that the function works when logger is null/undefined
+      mockGetToken.mockResolvedValue('mock_fcm_token')
+      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+
+      // Should work with null logger
+      const resultWithNull = await getNotificationTokens(null as any)
+      expect(resultWithNull.success).toBe(true)
+
+      // Should work with undefined logger
+      const resultWithUndefined = await getNotificationTokens(undefined)
+      expect(resultWithUndefined.success).toBe(true)
+    })
+  })
+
+  describe('Platform-Specific Behavior', () => {
+    it('should not call getAPNSToken on Android', async () => {
+      ;(Platform as any).OS = 'android'
+      mockGetToken.mockResolvedValue('mock_fcm_token')
+
+      await getNotificationTokens(mockLogger)
+
+      expect(mockGetAPNSToken).not.toHaveBeenCalled()
+    })
+
+    it('should call getAPNSToken on iOS', async () => {
+      ;(Platform as any).OS = 'ios'
+      mockGetToken.mockResolvedValue('mock_fcm_token')
+      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+
+      await getNotificationTokens(mockLogger)
+
+      expect(mockGetAPNSToken).toHaveBeenCalled()
+    })
+
+    it('should handle unknown platform as non-iOS', async () => {
+      ;(Platform as any).OS = 'web'
+      mockGetToken.mockResolvedValue('mock_fcm_token')
+
+      const result = await getNotificationTokens(mockLogger)
+
+      expect(result.success).toBe(true)
+      expect(result.apnsToken).toBe(null)
+      expect(mockGetAPNSToken).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle empty string FCM token as invalid', async () => {
+      ;(Platform as any).OS = 'ios'
+      mockGetToken.mockResolvedValue('')
+      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+
+      await expect(getNotificationTokens(mockLogger)).rejects.toThrow(
+        'FCM token fetch failed (returned null/undefined)'
+      )
+    })
+
+    it('should handle empty string APNS token as invalid on iOS', async () => {
+      ;(Platform as any).OS = 'ios'
+      mockGetToken.mockResolvedValue('mock_fcm_token')
+      mockGetAPNSToken.mockResolvedValue('')
+
+      await expect(getNotificationTokens(mockLogger)).rejects.toThrow(
+        'APNS token fetch failed (returned null/undefined on iOS)'
+      )
+    })
+  })
+})

--- a/app/__tests__/bcsc-theme/utils/push-notification-tokens.test.ts
+++ b/app/__tests__/bcsc-theme/utils/push-notification-tokens.test.ts
@@ -1,6 +1,5 @@
 import { Platform } from 'react-native'
-import messaging from '@react-native-firebase/messaging'
-import { getNotificationTokens, NotificationTokens } from '@/bcsc-theme/utils/push-notification-tokens'
+import { getNotificationTokens } from '@/bcsc-theme/utils/push-notification-tokens'
 
 // Mock the messaging module
 const mockGetToken = jest.fn()
@@ -20,13 +19,23 @@ jest.mock('react-native', () => ({
   },
 }))
 
-// Create a mock logger
+// Create a mock logger that satisfies the BifoldLogger interface
 const mockLogger = {
+  // Methods used by the function under test
   info: jest.fn(),
   error: jest.fn(),
   warn: jest.fn(),
   debug: jest.fn(),
-}
+
+  // Additional methods from BifoldLogger interface (not used but required for typing)
+  logLevel: 0,
+  isEnabled: jest.fn().mockReturnValue(true),
+  test: jest.fn(),
+  trace: jest.fn(),
+  fatal: jest.fn(),
+  report: jest.fn(),
+  log: jest.fn(),
+} as any // Use 'as any' to bypass private property type checking
 
 // Helper to set platform OS in a type-safe way
 const setPlatformOS = (os: 'ios' | 'android' | 'web') => {

--- a/app/src/bcsc-theme/utils/push-notification-tokens.ts
+++ b/app/src/bcsc-theme/utils/push-notification-tokens.ts
@@ -1,26 +1,58 @@
 import { Platform } from 'react-native'
 import messaging from '@react-native-firebase/messaging'
-import { RemoteLogger } from '@bifold/remote-logs'
+import { BifoldLogger } from '@bifold/core'
 
-export const getNotificationTokens = async (logger?: RemoteLogger) => {
-  const fcmDeviceToken = await messaging().getToken()
-  if (!fcmDeviceToken) {
-    logger?.error('Failed to retrieve FCM device token for registration')
-    throw new Error('FCM device token is required for registration')
+// Define a structured return type for clarity
+export interface NotificationTokens {
+  fcmDeviceToken: string
+  apnsToken: string | null // Null if iOS fails or if on Android
+  success: boolean
+  error?: string // Only present if the overall process failed
+}
+
+export const getNotificationTokens = async (logger?: BifoldLogger): Promise<NotificationTokens> => {
+  let fcmToken: string | null = null
+  let apnsToken: string | null = null
+  const errors: string[] = []
+
+  // Fetch FCM Token
+  try {
+    fcmToken = await messaging().getToken()
+    if (!fcmToken) {
+      errors.push('FCM token fetch failed (returned null/undefined)')
+    }
+  } catch (e) {
+    errors.push(`FCM token fetch failed: ${e instanceof Error ? e.message : String(e)}`)
   }
 
-  // On iOS, we also need the APNs token for registration
-  let apnsToken: string | undefined
+  // Fetch APNs Token (iOS only)
   if (Platform.OS === 'ios') {
-    apnsToken = (await messaging().getAPNSToken()) ?? undefined
-
-    if (!apnsToken) {
-      logger?.error('Failed to retrieve APNS token for registration')
-      throw new Error('APNS token is required for registration on iOS')
+    try {
+      // The getAPNSToken() call should resolve to a string or null/undefined
+      apnsToken = (await messaging().getAPNSToken()) ?? null
+      if (!apnsToken) {
+        errors.push('APNS token fetch failed (returned null/undefined on iOS)')
+      }
+    } catch (e) {
+      errors.push(`APNS token fetch failed: ${e instanceof Error ? e.message : String(e)}`)
     }
   }
 
-  logger?.error('Retrieved notification tokens for registration')
+  // 3. Evaluate Results and Log
+  if (fcmToken && (Platform.OS !== 'ios' || apnsToken)) {
+    // SUCCESS: We have the required token(s)
+    logger?.info('Retrieved all required notification tokens for registration.')
+    return {
+      fcmDeviceToken: fcmToken,
+      apnsToken: apnsToken,
+      success: true,
+    }
+  } else {
+    // FAILURE: Log all gathered errors
+    const errorMessage = `Failed to retrieve required tokens. Errors: ${errors.join('; ')}`
+    logger?.error(errorMessage)
 
-  return { fcmDeviceToken, apnsToken }
+    // Fail Fast: Throw an error specific to the token registration requirements
+    throw new Error(errorMessage)
+  }
 }

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -171,7 +171,7 @@ export const signPairingCode = async (
   issuer: string,
   clientID: string,
   fcmDeviceToken: string,
-  deviceToken?: string
+  deviceToken: string | null
 ): Promise<string | null> => {
   return BcscCore.signPairingCode(code, issuer, clientID, fcmDeviceToken, deviceToken);
 };
@@ -187,7 +187,7 @@ export const signPairingCode = async (
  */
 export const getDynamicClientRegistrationBody = async (
   fcmDeviceToken: string,
-  deviceToken?: string
+  deviceToken: string | null
 ): Promise<string | null> => {
   return BcscCore.getDynamicClientRegistrationBody(fcmDeviceToken, deviceToken);
 };
@@ -258,7 +258,7 @@ export const createQuickLoginJWT = async (
   clientRefId: string,
   key: JWK,
   fcmDeviceToken: string,
-  deviceToken?: string
+  deviceToken: string | null
 ): Promise<string> => {
   return BcscCore.createQuickLoginJWT(accessToken, clientId, issuer, clientRefId, key, fcmDeviceToken, deviceToken);
 };


### PR DESCRIPTION
# Summary of Changes

Improve token fetching so if that process fails we understand what token it failed on. Keeps a default `faux` token in place to deal with the immediate problem of not getting a token on iOS. This change will also show us what token failed to be fetched on iOS.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes
