### PR TITLE
feat: new setup screen and fixes for setup selection

### DIFF
--- a/app/__tests__/bcsc-theme/components/RadioButton.test.tsx
+++ b/app/__tests__/bcsc-theme/components/RadioButton.test.tsx
@@ -1,0 +1,191 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
+import React from 'react'
+
+import { BasicAppContext } from '../../../__mocks__/helpers/app'
+import { RadioButton } from '../../../src/bcsc-theme/components/RadioButton'
+
+describe('RadioButton Component', () => {
+  const defaultProps = {
+    label: 'Test Option',
+    value: 'test-value',
+    selected: false,
+    onPress: jest.fn(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    test('renders correctly when unselected', () => {
+      const tree = render(
+        <BasicAppContext>
+          <RadioButton {...defaultProps} />
+        </BasicAppContext>
+      )
+
+      waitFor(() => {
+        expect(tree).toMatchSnapshot()
+      })
+    })
+
+    test('renders correctly when selected', () => {
+      const tree = render(
+        <BasicAppContext>
+          <RadioButton {...defaultProps} selected={true} />
+        </BasicAppContext>
+      )
+
+      waitFor(() => {
+        expect(tree).toMatchSnapshot()
+      })
+    })
+
+    test('renders correctly when disabled', () => {
+      const tree = render(
+        <BasicAppContext>
+          <RadioButton {...defaultProps} disabled={true} />
+        </BasicAppContext>
+      )
+
+      waitFor(() => {
+        expect(tree).toMatchSnapshot()
+      })
+    })
+
+    test('renders correctly when selected and disabled', () => {
+      const tree = render(
+        <BasicAppContext>
+          <RadioButton {...defaultProps} selected={true} disabled={true} />
+        </BasicAppContext>
+      )
+
+      waitFor(() => {
+        expect(tree).toMatchSnapshot()
+      })
+    })
+
+    test('displays the correct label text', () => {
+      const { getByText } = render(
+        <BasicAppContext>
+          <RadioButton {...defaultProps} label="Custom Label" />
+        </BasicAppContext>
+      )
+
+      expect(getByText('Custom Label')).toBeTruthy()
+    })
+  })
+
+  describe('Interaction', () => {
+    test('calls onPress with correct value when pressed', () => {
+      const mockOnPress = jest.fn()
+      const { getByRole } = render(
+        <BasicAppContext>
+          <RadioButton {...defaultProps} onPress={mockOnPress} />
+        </BasicAppContext>
+      )
+
+      const radioButton = getByRole('radio')
+      fireEvent.press(radioButton)
+
+      expect(mockOnPress).toHaveBeenCalledWith('test-value')
+      expect(mockOnPress).toHaveBeenCalledTimes(1)
+    })
+
+    test('does not call onPress when disabled', () => {
+      const mockOnPress = jest.fn()
+      const { getByRole } = render(
+        <BasicAppContext>
+          <RadioButton {...defaultProps} onPress={mockOnPress} disabled={true} />
+        </BasicAppContext>
+      )
+
+      const radioButton = getByRole('radio')
+      fireEvent.press(radioButton)
+
+      expect(mockOnPress).not.toHaveBeenCalled()
+    })
+
+    test('calls onPress multiple times for multiple presses', () => {
+      const mockOnPress = jest.fn()
+      const { getByRole } = render(
+        <BasicAppContext>
+          <RadioButton {...defaultProps} onPress={mockOnPress} />
+        </BasicAppContext>
+      )
+
+      const radioButton = getByRole('radio')
+      fireEvent.press(radioButton)
+      fireEvent.press(radioButton)
+      fireEvent.press(radioButton)
+
+      expect(mockOnPress).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('Accessibility', () => {
+    test('has correct accessibility role', () => {
+      const { getByRole } = render(
+        <BasicAppContext>
+          <RadioButton {...defaultProps} />
+        </BasicAppContext>
+      )
+
+      expect(getByRole('radio')).toBeTruthy()
+    })
+
+    test('has correct accessibility state when unselected', () => {
+      const { getByRole } = render(
+        <BasicAppContext>
+          <RadioButton {...defaultProps} selected={false} />
+        </BasicAppContext>
+      )
+
+      const radioButton = getByRole('radio')
+      expect(radioButton.props.accessibilityState.selected).toBe(false)
+    })
+
+    test('has correct accessibility state when selected', () => {
+      const { getByRole } = render(
+        <BasicAppContext>
+          <RadioButton {...defaultProps} selected={true} />
+        </BasicAppContext>
+      )
+
+      const radioButton = getByRole('radio')
+      expect(radioButton.props.accessibilityState.selected).toBe(true)
+    })
+
+    test('has correct accessibility state when disabled', () => {
+      const { getByRole } = render(
+        <BasicAppContext>
+          <RadioButton {...defaultProps} disabled={true} />
+        </BasicAppContext>
+      )
+
+      const radioButton = getByRole('radio')
+      expect(radioButton.props.accessibilityState.disabled).toBe(true)
+    })
+
+    test('has correct accessibility label', () => {
+      const { getByRole } = render(
+        <BasicAppContext>
+          <RadioButton {...defaultProps} label="Accessibility Label" />
+        </BasicAppContext>
+      )
+
+      const radioButton = getByRole('radio')
+      expect(radioButton.props.accessibilityLabel).toBe('Accessibility Label')
+    })
+
+    test('has correct testID when provided', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <RadioButton {...defaultProps} testID="custom-test-id" />
+        </BasicAppContext>
+      )
+
+      expect(getByTestId('custom-test-id')).toBeTruthy()
+    })
+  })
+})

--- a/app/__tests__/bcsc-theme/components/RadioButton.test.tsx
+++ b/app/__tests__/bcsc-theme/components/RadioButton.test.tsx
@@ -7,9 +7,10 @@ import { RadioButton } from '../../../src/bcsc-theme/components/RadioButton'
 describe('RadioButton Component', () => {
   const defaultProps = {
     label: 'Test Option',
-    value: 'test-value',
-    selected: false,
-    onPress: jest.fn(),
+    value: false,
+    selectedValue: undefined,
+    onValueChange: jest.fn(),
+    testID: 'default-test-id',
   }
 
   beforeEach(() => {
@@ -32,7 +33,7 @@ describe('RadioButton Component', () => {
     test('renders correctly when selected', () => {
       const tree = render(
         <BasicAppContext>
-          <RadioButton {...defaultProps} selected={true} />
+          <RadioButton {...defaultProps} value={true} selectedValue={true} />
         </BasicAppContext>
       )
 
@@ -56,7 +57,7 @@ describe('RadioButton Component', () => {
     test('renders correctly when selected and disabled', () => {
       const tree = render(
         <BasicAppContext>
-          <RadioButton {...defaultProps} selected={true} disabled={true} />
+          <RadioButton {...defaultProps} selectedValue={false} disabled={true} />
         </BasicAppContext>
       )
 
@@ -77,40 +78,40 @@ describe('RadioButton Component', () => {
   })
 
   describe('Interaction', () => {
-    test('calls onPress with correct value when pressed', () => {
-      const mockOnPress = jest.fn()
+    test('calls onValueChange with correct value when pressed', () => {
+      const mockonValueChange = jest.fn()
       const { getByRole } = render(
         <BasicAppContext>
-          <RadioButton {...defaultProps} onPress={mockOnPress} />
+          <RadioButton {...defaultProps} onValueChange={mockonValueChange} />
         </BasicAppContext>
       )
 
       const radioButton = getByRole('radio')
       fireEvent.press(radioButton)
 
-      expect(mockOnPress).toHaveBeenCalledWith('test-value')
-      expect(mockOnPress).toHaveBeenCalledTimes(1)
+      expect(mockonValueChange).toHaveBeenCalledWith(false)
+      expect(mockonValueChange).toHaveBeenCalledTimes(1)
     })
 
-    test('does not call onPress when disabled', () => {
-      const mockOnPress = jest.fn()
+    test('does not call onValueChange when disabled', () => {
+      const mockonValueChange = jest.fn()
       const { getByRole } = render(
         <BasicAppContext>
-          <RadioButton {...defaultProps} onPress={mockOnPress} disabled={true} />
+          <RadioButton {...defaultProps} onValueChange={mockonValueChange} disabled={true} />
         </BasicAppContext>
       )
 
       const radioButton = getByRole('radio')
       fireEvent.press(radioButton)
 
-      expect(mockOnPress).not.toHaveBeenCalled()
+      expect(mockonValueChange).not.toHaveBeenCalled()
     })
 
-    test('calls onPress multiple times for multiple presses', () => {
-      const mockOnPress = jest.fn()
+    test('calls onValueChange multiple times for multiple presses', () => {
+      const mockonValueChange = jest.fn()
       const { getByRole } = render(
         <BasicAppContext>
-          <RadioButton {...defaultProps} onPress={mockOnPress} />
+          <RadioButton {...defaultProps} onValueChange={mockonValueChange} />
         </BasicAppContext>
       )
 
@@ -119,7 +120,7 @@ describe('RadioButton Component', () => {
       fireEvent.press(radioButton)
       fireEvent.press(radioButton)
 
-      expect(mockOnPress).toHaveBeenCalledTimes(3)
+      expect(mockonValueChange).toHaveBeenCalledTimes(3)
     })
   })
 
@@ -137,7 +138,7 @@ describe('RadioButton Component', () => {
     test('has correct accessibility state when unselected', () => {
       const { getByRole } = render(
         <BasicAppContext>
-          <RadioButton {...defaultProps} selected={false} />
+          <RadioButton {...defaultProps} />
         </BasicAppContext>
       )
 
@@ -148,7 +149,7 @@ describe('RadioButton Component', () => {
     test('has correct accessibility state when selected', () => {
       const { getByRole } = render(
         <BasicAppContext>
-          <RadioButton {...defaultProps} selected={true} />
+          <RadioButton {...defaultProps} selectedValue={false} />
         </BasicAppContext>
       )
 

--- a/app/__tests__/bcsc-theme/components/RadioGroup.test.tsx
+++ b/app/__tests__/bcsc-theme/components/RadioGroup.test.tsx
@@ -14,6 +14,7 @@ describe('RadioGroup Component', () => {
   const defaultProps = {
     options: defaultOptions,
     onValueChange: jest.fn(),
+    testID: 'test-radio-group',
   }
 
   beforeEach(() => {
@@ -33,34 +34,10 @@ describe('RadioGroup Component', () => {
       })
     })
 
-    test('renders correctly with title', () => {
-      const tree = render(
-        <BasicAppContext>
-          <RadioGroup {...defaultProps} title="Choose an option" />
-        </BasicAppContext>
-      )
-
-      waitFor(() => {
-        expect(tree).toMatchSnapshot()
-      })
-    })
-
     test('renders correctly with selected value', () => {
       const tree = render(
         <BasicAppContext>
           <RadioGroup {...defaultProps} selectedValue="option2" />
-        </BasicAppContext>
-      )
-
-      waitFor(() => {
-        expect(tree).toMatchSnapshot()
-      })
-    })
-
-    test('renders correctly when disabled', () => {
-      const tree = render(
-        <BasicAppContext>
-          <RadioGroup {...defaultProps} disabled={true} />
         </BasicAppContext>
       )
 
@@ -98,27 +75,6 @@ describe('RadioGroup Component', () => {
       expect(getByText('Option 2')).toBeTruthy()
       expect(getByText('Option 3')).toBeTruthy()
     })
-
-    test('displays title when provided', () => {
-      const { getByText } = render(
-        <BasicAppContext>
-          <RadioGroup {...defaultProps} title="Select your choice" />
-        </BasicAppContext>
-      )
-
-      expect(getByText('Select your choice')).toBeTruthy()
-    })
-
-    test('does not display title when not provided', () => {
-      const { queryByText } = render(
-        <BasicAppContext>
-          <RadioGroup {...defaultProps} />
-        </BasicAppContext>
-      )
-
-      // Should not find any title text
-      expect(queryByText('Select your choice')).toBeFalsy()
-    })
   })
 
   describe('Interaction', () => {
@@ -151,19 +107,6 @@ describe('RadioGroup Component', () => {
       expect(mockOnValueChange).toHaveBeenCalledWith('option3')
 
       expect(mockOnValueChange).toHaveBeenCalledTimes(2)
-    })
-
-    test('does not call onValueChange when group is disabled', () => {
-      const mockOnValueChange = jest.fn()
-      const { getByText } = render(
-        <BasicAppContext>
-          <RadioGroup {...defaultProps} onValueChange={mockOnValueChange} disabled={true} />
-        </BasicAppContext>
-      )
-
-      fireEvent.press(getByText('Option 1'))
-
-      expect(mockOnValueChange).not.toHaveBeenCalled()
     })
 
     test('does not call onValueChange for individually disabled options', () => {
@@ -199,14 +142,14 @@ describe('RadioGroup Component', () => {
     test('shows correct selection state for each option', () => {
       const { getByTestId } = render(
         <BasicAppContext>
-          <RadioGroup {...defaultProps} selectedValue="option2" testID="radio-group" />
+          <RadioGroup {...defaultProps} selectedValue="option2" />
         </BasicAppContext>
       )
 
       // Check that the correct option shows as selected via accessibility state
-      const option1 = getByTestId('radio-group-option-option1')
-      const option2 = getByTestId('radio-group-option-option2')
-      const option3 = getByTestId('radio-group-option-option3')
+      const option1 = getByTestId('test-radio-group-option-Option1')
+      const option2 = getByTestId('test-radio-group-option-Option2')
+      const option3 = getByTestId('test-radio-group-option-Option3')
 
       expect(option1.props.accessibilityState.selected).toBe(false)
       expect(option2.props.accessibilityState.selected).toBe(true)
@@ -217,24 +160,21 @@ describe('RadioGroup Component', () => {
       const mockOnValueChange = jest.fn()
       let selectedValue = 'option1'
 
+      const onValueChange = (value: string) => {
+        selectedValue = value
+        mockOnValueChange(value)
+      }
+
       const TestComponent = () => (
         <BasicAppContext>
-          <RadioGroup
-            {...defaultProps}
-            selectedValue={selectedValue}
-            onValueChange={(value) => {
-              selectedValue = value
-              mockOnValueChange(value)
-            }}
-            testID="radio-group"
-          />
+          <RadioGroup {...defaultProps} selectedValue={selectedValue} onValueChange={onValueChange} />
         </BasicAppContext>
       )
 
       const { getByText, getByTestId, rerender } = render(<TestComponent />)
 
       // Initially option1 should be selected
-      expect(getByTestId('radio-group-option-option1').props.accessibilityState.selected).toBe(true)
+      expect(getByTestId('test-radio-group-option-Option1').props.accessibilityState.selected).toBe(true)
 
       // Select option2
       fireEvent.press(getByText('Option 2'))
@@ -243,8 +183,8 @@ describe('RadioGroup Component', () => {
       selectedValue = 'option2'
       rerender(<TestComponent />)
 
-      expect(getByTestId('radio-group-option-option2').props.accessibilityState.selected).toBe(true)
-      expect(getByTestId('radio-group-option-option1').props.accessibilityState.selected).toBe(false)
+      expect(getByTestId('test-radio-group-option-Option2').props.accessibilityState.selected).toBe(true)
+      expect(getByTestId('test-radio-group-option-Option1').props.accessibilityState.selected).toBe(false)
     })
   })
 
@@ -266,21 +206,9 @@ describe('RadioGroup Component', () => {
         </BasicAppContext>
       )
 
-      expect(getByTestId('test-group-option-option1')).toBeTruthy()
-      expect(getByTestId('test-group-option-option2')).toBeTruthy()
-      expect(getByTestId('test-group-option-option3')).toBeTruthy()
-    })
-
-    test('uses default testID for options when no testID provided', () => {
-      const { getByTestId } = render(
-        <BasicAppContext>
-          <RadioGroup {...defaultProps} />
-        </BasicAppContext>
-      )
-
-      expect(getByTestId('radioGroup-option-option1')).toBeTruthy()
-      expect(getByTestId('radioGroup-option-option2')).toBeTruthy()
-      expect(getByTestId('radioGroup-option-option3')).toBeTruthy()
+      expect(getByTestId('test-group-option-Option1')).toBeTruthy()
+      expect(getByTestId('test-group-option-Option2')).toBeTruthy()
+      expect(getByTestId('test-group-option-Option3')).toBeTruthy()
     })
   })
 
@@ -314,14 +242,14 @@ describe('RadioGroup Component', () => {
     test('handles selectedValue that does not match any option', () => {
       const { getByTestId } = render(
         <BasicAppContext>
-          <RadioGroup {...defaultProps} selectedValue="nonexistent" testID="radio-group" />
+          <RadioGroup {...defaultProps} selectedValue="nonexistent" />
         </BasicAppContext>
       )
 
       // All options should be unselected
-      expect(getByTestId('radio-group-option-option1').props.accessibilityState.selected).toBe(false)
-      expect(getByTestId('radio-group-option-option2').props.accessibilityState.selected).toBe(false)
-      expect(getByTestId('radio-group-option-option3').props.accessibilityState.selected).toBe(false)
+      expect(getByTestId('test-radio-group-option-Option1').props.accessibilityState.selected).toBe(false)
+      expect(getByTestId('test-radio-group-option-Option2').props.accessibilityState.selected).toBe(false)
+      expect(getByTestId('test-radio-group-option-Option3').props.accessibilityState.selected).toBe(false)
     })
   })
 })

--- a/app/__tests__/bcsc-theme/components/RadioGroup.test.tsx
+++ b/app/__tests__/bcsc-theme/components/RadioGroup.test.tsx
@@ -1,0 +1,327 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
+import React from 'react'
+
+import { BasicAppContext } from '../../../__mocks__/helpers/app'
+import { RadioGroup } from '../../../src/bcsc-theme/components/RadioGroup'
+
+describe('RadioGroup Component', () => {
+  const defaultOptions = [
+    { label: 'Option 1', value: 'option1' },
+    { label: 'Option 2', value: 'option2' },
+    { label: 'Option 3', value: 'option3' },
+  ]
+
+  const defaultProps = {
+    options: defaultOptions,
+    onValueChange: jest.fn(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    test('renders correctly with default props', () => {
+      const tree = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} />
+        </BasicAppContext>
+      )
+
+      waitFor(() => {
+        expect(tree).toMatchSnapshot()
+      })
+    })
+
+    test('renders correctly with title', () => {
+      const tree = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} title="Choose an option" />
+        </BasicAppContext>
+      )
+
+      waitFor(() => {
+        expect(tree).toMatchSnapshot()
+      })
+    })
+
+    test('renders correctly with selected value', () => {
+      const tree = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} selectedValue="option2" />
+        </BasicAppContext>
+      )
+
+      waitFor(() => {
+        expect(tree).toMatchSnapshot()
+      })
+    })
+
+    test('renders correctly when disabled', () => {
+      const tree = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} disabled={true} />
+        </BasicAppContext>
+      )
+
+      waitFor(() => {
+        expect(tree).toMatchSnapshot()
+      })
+    })
+
+    test('renders correctly with mixed disabled options', () => {
+      const optionsWithDisabled = [
+        { label: 'Option 1', value: 'option1' },
+        { label: 'Option 2 (Disabled)', value: 'option2', disabled: true },
+        { label: 'Option 3', value: 'option3' },
+      ]
+
+      const tree = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} options={optionsWithDisabled} />
+        </BasicAppContext>
+      )
+
+      waitFor(() => {
+        expect(tree).toMatchSnapshot()
+      })
+    })
+
+    test('displays all option labels', () => {
+      const { getByText } = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} />
+        </BasicAppContext>
+      )
+
+      expect(getByText('Option 1')).toBeTruthy()
+      expect(getByText('Option 2')).toBeTruthy()
+      expect(getByText('Option 3')).toBeTruthy()
+    })
+
+    test('displays title when provided', () => {
+      const { getByText } = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} title="Select your choice" />
+        </BasicAppContext>
+      )
+
+      expect(getByText('Select your choice')).toBeTruthy()
+    })
+
+    test('does not display title when not provided', () => {
+      const { queryByText } = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} />
+        </BasicAppContext>
+      )
+
+      // Should not find any title text
+      expect(queryByText('Select your choice')).toBeFalsy()
+    })
+  })
+
+  describe('Interaction', () => {
+    test('calls onValueChange when an option is selected', () => {
+      const mockOnValueChange = jest.fn()
+      const { getByText } = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} onValueChange={mockOnValueChange} />
+        </BasicAppContext>
+      )
+
+      fireEvent.press(getByText('Option 2'))
+
+      expect(mockOnValueChange).toHaveBeenCalledWith('option2')
+      expect(mockOnValueChange).toHaveBeenCalledTimes(1)
+    })
+
+    test('calls onValueChange with correct value for each option', () => {
+      const mockOnValueChange = jest.fn()
+      const { getByText } = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} onValueChange={mockOnValueChange} />
+        </BasicAppContext>
+      )
+
+      fireEvent.press(getByText('Option 1'))
+      expect(mockOnValueChange).toHaveBeenCalledWith('option1')
+
+      fireEvent.press(getByText('Option 3'))
+      expect(mockOnValueChange).toHaveBeenCalledWith('option3')
+
+      expect(mockOnValueChange).toHaveBeenCalledTimes(2)
+    })
+
+    test('does not call onValueChange when group is disabled', () => {
+      const mockOnValueChange = jest.fn()
+      const { getByText } = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} onValueChange={mockOnValueChange} disabled={true} />
+        </BasicAppContext>
+      )
+
+      fireEvent.press(getByText('Option 1'))
+
+      expect(mockOnValueChange).not.toHaveBeenCalled()
+    })
+
+    test('does not call onValueChange for individually disabled options', () => {
+      const mockOnValueChange = jest.fn()
+      const optionsWithDisabled = [
+        { label: 'Option 1', value: 'option1' },
+        { label: 'Option 2', value: 'option2', disabled: true },
+        { label: 'Option 3', value: 'option3' },
+      ]
+
+      const { getByText } = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} options={optionsWithDisabled} onValueChange={mockOnValueChange} />
+        </BasicAppContext>
+      )
+
+      // Press enabled option - should work
+      fireEvent.press(getByText('Option 1'))
+      expect(mockOnValueChange).toHaveBeenCalledWith('option1')
+
+      // Press disabled option - should not work
+      fireEvent.press(getByText('Option 2'))
+      expect(mockOnValueChange).toHaveBeenCalledTimes(1) // Still just the first call
+
+      // Press another enabled option - should work
+      fireEvent.press(getByText('Option 3'))
+      expect(mockOnValueChange).toHaveBeenCalledWith('option3')
+      expect(mockOnValueChange).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('Accessibility Selection State', () => {
+    test('shows correct selection state for each option', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} selectedValue="option2" testID="radio-group" />
+        </BasicAppContext>
+      )
+
+      // Check that the correct option shows as selected via accessibility state
+      const option1 = getByTestId('radio-group-option-option1')
+      const option2 = getByTestId('radio-group-option-option2')
+      const option3 = getByTestId('radio-group-option-option3')
+
+      expect(option1.props.accessibilityState.selected).toBe(false)
+      expect(option2.props.accessibilityState.selected).toBe(true)
+      expect(option3.props.accessibilityState.selected).toBe(false)
+    })
+
+    test('updates selection state when value changes', () => {
+      const mockOnValueChange = jest.fn()
+      let selectedValue = 'option1'
+
+      const TestComponent = () => (
+        <BasicAppContext>
+          <RadioGroup
+            {...defaultProps}
+            selectedValue={selectedValue}
+            onValueChange={(value) => {
+              selectedValue = value
+              mockOnValueChange(value)
+            }}
+            testID="radio-group"
+          />
+        </BasicAppContext>
+      )
+
+      const { getByText, getByTestId, rerender } = render(<TestComponent />)
+
+      // Initially option1 should be selected
+      expect(getByTestId('radio-group-option-option1').props.accessibilityState.selected).toBe(true)
+
+      // Select option2
+      fireEvent.press(getByText('Option 2'))
+
+      // Re-render with new selected value
+      selectedValue = 'option2'
+      rerender(<TestComponent />)
+
+      expect(getByTestId('radio-group-option-option2').props.accessibilityState.selected).toBe(true)
+      expect(getByTestId('radio-group-option-option1').props.accessibilityState.selected).toBe(false)
+    })
+  })
+
+  describe('Accessibility', () => {
+    test('has correct testID when provided', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} testID="custom-radio-group" />
+        </BasicAppContext>
+      )
+
+      expect(getByTestId('custom-radio-group')).toBeTruthy()
+    })
+
+    test('generates correct testIDs for individual options', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} testID="test-group" />
+        </BasicAppContext>
+      )
+
+      expect(getByTestId('test-group-option-option1')).toBeTruthy()
+      expect(getByTestId('test-group-option-option2')).toBeTruthy()
+      expect(getByTestId('test-group-option-option3')).toBeTruthy()
+    })
+
+    test('uses default testID for options when no testID provided', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} />
+        </BasicAppContext>
+      )
+
+      expect(getByTestId('radioGroup-option-option1')).toBeTruthy()
+      expect(getByTestId('radioGroup-option-option2')).toBeTruthy()
+      expect(getByTestId('radioGroup-option-option3')).toBeTruthy()
+    })
+  })
+
+  describe('Edge Cases', () => {
+    test('handles empty options array', () => {
+      const tree = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} options={[]} />
+        </BasicAppContext>
+      )
+
+      waitFor(() => {
+        expect(tree).toMatchSnapshot()
+      })
+    })
+
+    test('handles single option', () => {
+      const singleOption = [{ label: 'Only Option', value: 'only' }]
+
+      const tree = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} options={singleOption} />
+        </BasicAppContext>
+      )
+
+      waitFor(() => {
+        expect(tree).toMatchSnapshot()
+      })
+    })
+
+    test('handles selectedValue that does not match any option', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <RadioGroup {...defaultProps} selectedValue="nonexistent" testID="radio-group" />
+        </BasicAppContext>
+      )
+
+      // All options should be unselected
+      expect(getByTestId('radio-group-option-option1').props.accessibilityState.selected).toBe(false)
+      expect(getByTestId('radio-group-option-option2').props.accessibilityState.selected).toBe(false)
+      expect(getByTestId('radio-group-option-option3').props.accessibilityState.selected).toBe(false)
+    })
+  })
+})

--- a/app/__tests__/bcsc-theme/components/__snapshots__/RadioButton.test.tsx.snap
+++ b/app/__tests__/bcsc-theme/components/__snapshots__/RadioButton.test.tsx.snap
@@ -24,7 +24,9 @@ exports[`RadioButton Component Rendering renders correctly when disabled 1`] = `
   accessible={true}
   collapsable={false}
   focusable={true}
+  onBlur={[Function]}
   onClick={[Function]}
+  onFocus={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -36,7 +38,6 @@ exports[`RadioButton Component Rendering renders correctly when disabled 1`] = `
       "alignItems": "center",
       "backgroundColor": "#FFFFFF",
       "flexDirection": "row",
-      "opacity": 1,
       "paddingHorizontal": 24,
       "paddingVertical": 16,
     }
@@ -97,7 +98,9 @@ exports[`RadioButton Component Rendering renders correctly when selected 1`] = `
   accessible={true}
   collapsable={false}
   focusable={true}
+  onBlur={[Function]}
   onClick={[Function]}
+  onFocus={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -109,7 +112,6 @@ exports[`RadioButton Component Rendering renders correctly when selected 1`] = `
       "alignItems": "center",
       "backgroundColor": "#FFFFFF",
       "flexDirection": "row",
-      "opacity": 1,
       "paddingHorizontal": 24,
       "paddingVertical": 16,
     }
@@ -181,7 +183,9 @@ exports[`RadioButton Component Rendering renders correctly when selected and dis
   accessible={true}
   collapsable={false}
   focusable={true}
+  onBlur={[Function]}
   onClick={[Function]}
+  onFocus={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -193,7 +197,6 @@ exports[`RadioButton Component Rendering renders correctly when selected and dis
       "alignItems": "center",
       "backgroundColor": "#FFFFFF",
       "flexDirection": "row",
-      "opacity": 1,
       "paddingHorizontal": 24,
       "paddingVertical": 16,
     }
@@ -265,7 +268,9 @@ exports[`RadioButton Component Rendering renders correctly when unselected 1`] =
   accessible={true}
   collapsable={false}
   focusable={true}
+  onBlur={[Function]}
   onClick={[Function]}
+  onFocus={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -277,7 +282,6 @@ exports[`RadioButton Component Rendering renders correctly when unselected 1`] =
       "alignItems": "center",
       "backgroundColor": "#FFFFFF",
       "flexDirection": "row",
-      "opacity": 1,
       "paddingHorizontal": 24,
       "paddingVertical": 16,
     }

--- a/app/__tests__/bcsc-theme/components/__snapshots__/RadioButton.test.tsx.snap
+++ b/app/__tests__/bcsc-theme/components/__snapshots__/RadioButton.test.tsx.snap
@@ -41,6 +41,7 @@ exports[`RadioButton Component Rendering renders correctly when disabled 1`] = `
       "paddingVertical": 16,
     }
   }
+  testID="default-test-id"
 >
   <Text
     style={
@@ -113,6 +114,7 @@ exports[`RadioButton Component Rendering renders correctly when selected 1`] = `
       "paddingVertical": 16,
     }
   }
+  testID="default-test-id"
 >
   <Text
     style={
@@ -196,6 +198,7 @@ exports[`RadioButton Component Rendering renders correctly when selected and dis
       "paddingVertical": 16,
     }
   }
+  testID="default-test-id"
 >
   <Text
     style={
@@ -279,6 +282,7 @@ exports[`RadioButton Component Rendering renders correctly when unselected 1`] =
       "paddingVertical": 16,
     }
   }
+  testID="default-test-id"
 >
   <Text
     style={

--- a/app/__tests__/bcsc-theme/components/__snapshots__/RadioButton.test.tsx.snap
+++ b/app/__tests__/bcsc-theme/components/__snapshots__/RadioButton.test.tsx.snap
@@ -1,0 +1,311 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RadioButton Component Rendering renders correctly when disabled 1`] = `
+<View
+  accessibilityLabel="Test Option"
+  accessibilityRole="radio"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": true,
+      "expanded": undefined,
+      "selected": false,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "#FFFFFF",
+      "flexDirection": "row",
+      "opacity": 1,
+      "paddingHorizontal": 24,
+      "paddingVertical": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "#606060",
+        "flex": 1,
+        "fontFamily": "BCSans-Regular",
+        "fontSize": 18,
+        "fontWeight": "normal",
+      }
+    }
+  >
+    Test Option
+  </Text>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "backgroundColor": "transparent",
+        "borderColor": "#606060",
+        "borderRadius": 12,
+        "borderWidth": 3,
+        "height": 24,
+        "justifyContent": "center",
+        "width": 24,
+      }
+    }
+  />
+</View>
+`;
+
+exports[`RadioButton Component Rendering renders correctly when selected 1`] = `
+<View
+  accessibilityLabel="Test Option"
+  accessibilityRole="radio"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": false,
+      "expanded": undefined,
+      "selected": true,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "#FFFFFF",
+      "flexDirection": "row",
+      "opacity": 1,
+      "paddingHorizontal": 24,
+      "paddingVertical": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "#FFFFFF",
+        "flex": 1,
+        "fontFamily": "BCSans-Regular",
+        "fontSize": 18,
+        "fontWeight": "normal",
+      }
+    }
+  >
+    Test Option
+  </Text>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "backgroundColor": "transparent",
+        "borderColor": "#003366",
+        "borderRadius": 12,
+        "borderWidth": 3,
+        "height": 24,
+        "justifyContent": "center",
+        "width": 24,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "backgroundColor": "#003366",
+          "borderRadius": 6,
+          "height": 12,
+          "width": 12,
+        }
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`RadioButton Component Rendering renders correctly when selected and disabled 1`] = `
+<View
+  accessibilityLabel="Test Option"
+  accessibilityRole="radio"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": true,
+      "expanded": undefined,
+      "selected": true,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "#FFFFFF",
+      "flexDirection": "row",
+      "opacity": 1,
+      "paddingHorizontal": 24,
+      "paddingVertical": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "#606060",
+        "flex": 1,
+        "fontFamily": "BCSans-Regular",
+        "fontSize": 18,
+        "fontWeight": "normal",
+      }
+    }
+  >
+    Test Option
+  </Text>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "backgroundColor": "transparent",
+        "borderColor": "#606060",
+        "borderRadius": 12,
+        "borderWidth": 3,
+        "height": 24,
+        "justifyContent": "center",
+        "width": 24,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "backgroundColor": "#606060",
+          "borderRadius": 6,
+          "height": 12,
+          "width": 12,
+        }
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`RadioButton Component Rendering renders correctly when unselected 1`] = `
+<View
+  accessibilityLabel="Test Option"
+  accessibilityRole="radio"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": false,
+      "expanded": undefined,
+      "selected": false,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "#FFFFFF",
+      "flexDirection": "row",
+      "opacity": 1,
+      "paddingHorizontal": 24,
+      "paddingVertical": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "#FFFFFF",
+        "flex": 1,
+        "fontFamily": "BCSans-Regular",
+        "fontSize": 18,
+        "fontWeight": "normal",
+      }
+    }
+  >
+    Test Option
+  </Text>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "backgroundColor": "transparent",
+        "borderColor": "#003366",
+        "borderRadius": 12,
+        "borderWidth": 3,
+        "height": 24,
+        "justifyContent": "center",
+        "width": 24,
+      }
+    }
+  />
+</View>
+`;

--- a/app/__tests__/bcsc-theme/components/__snapshots__/RadioGroup.test.tsx.snap
+++ b/app/__tests__/bcsc-theme/components/__snapshots__/RadioGroup.test.tsx.snap
@@ -1,0 +1,1337 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RadioGroup Component Edge Cases handles empty options array 1`] = `
+<View
+  style={{}}
+>
+  <View
+    style={
+      {
+        "paddingBottom": 4,
+      }
+    }
+  />
+</View>
+`;
+
+exports[`RadioGroup Component Edge Cases handles single option 1`] = `
+<View
+  style={{}}
+>
+  <View
+    style={
+      {
+        "paddingBottom": 4,
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Only Option"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "opacity": 1,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+        }
+      }
+      testID="radioGroup-option-only"
+    >
+      <Text
+        style={
+          {
+            "color": "#FFFFFF",
+            "flex": 1,
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        Only Option
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#003366",
+            "borderRadius": 12,
+            "borderWidth": 3,
+            "height": 24,
+            "justifyContent": "center",
+            "width": 24,
+          }
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`RadioGroup Component Rendering renders correctly when disabled 1`] = `
+<View
+  style={{}}
+>
+  <View
+    style={
+      {
+        "paddingBottom": 4,
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Option 1"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": true,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "opacity": 1,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+        }
+      }
+      testID="radioGroup-option-option1"
+    >
+      <Text
+        style={
+          {
+            "color": "#606060",
+            "flex": 1,
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        Option 1
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#606060",
+            "borderRadius": 12,
+            "borderWidth": 3,
+            "height": 24,
+            "justifyContent": "center",
+            "width": 24,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "height": 8,
+        }
+      }
+    />
+    <View
+      accessibilityLabel="Option 2"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": true,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "opacity": 1,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+        }
+      }
+      testID="radioGroup-option-option2"
+    >
+      <Text
+        style={
+          {
+            "color": "#606060",
+            "flex": 1,
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        Option 2
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#606060",
+            "borderRadius": 12,
+            "borderWidth": 3,
+            "height": 24,
+            "justifyContent": "center",
+            "width": 24,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "height": 8,
+        }
+      }
+    />
+    <View
+      accessibilityLabel="Option 3"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": true,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "opacity": 1,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+        }
+      }
+      testID="radioGroup-option-option3"
+    >
+      <Text
+        style={
+          {
+            "color": "#606060",
+            "flex": 1,
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        Option 3
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#606060",
+            "borderRadius": 12,
+            "borderWidth": 3,
+            "height": 24,
+            "justifyContent": "center",
+            "width": 24,
+          }
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`RadioGroup Component Rendering renders correctly with default props 1`] = `
+<View
+  style={{}}
+>
+  <View
+    style={
+      {
+        "paddingBottom": 4,
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Option 1"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "opacity": 1,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+        }
+      }
+      testID="radioGroup-option-option1"
+    >
+      <Text
+        style={
+          {
+            "color": "#FFFFFF",
+            "flex": 1,
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        Option 1
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#003366",
+            "borderRadius": 12,
+            "borderWidth": 3,
+            "height": 24,
+            "justifyContent": "center",
+            "width": 24,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "height": 8,
+        }
+      }
+    />
+    <View
+      accessibilityLabel="Option 2"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "opacity": 1,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+        }
+      }
+      testID="radioGroup-option-option2"
+    >
+      <Text
+        style={
+          {
+            "color": "#FFFFFF",
+            "flex": 1,
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        Option 2
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#003366",
+            "borderRadius": 12,
+            "borderWidth": 3,
+            "height": 24,
+            "justifyContent": "center",
+            "width": 24,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "height": 8,
+        }
+      }
+    />
+    <View
+      accessibilityLabel="Option 3"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "opacity": 1,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+        }
+      }
+      testID="radioGroup-option-option3"
+    >
+      <Text
+        style={
+          {
+            "color": "#FFFFFF",
+            "flex": 1,
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        Option 3
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#003366",
+            "borderRadius": 12,
+            "borderWidth": 3,
+            "height": 24,
+            "justifyContent": "center",
+            "width": 24,
+          }
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`RadioGroup Component Rendering renders correctly with mixed disabled options 1`] = `
+<View
+  style={{}}
+>
+  <View
+    style={
+      {
+        "paddingBottom": 4,
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Option 1"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "opacity": 1,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+        }
+      }
+      testID="radioGroup-option-option1"
+    >
+      <Text
+        style={
+          {
+            "color": "#FFFFFF",
+            "flex": 1,
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        Option 1
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#003366",
+            "borderRadius": 12,
+            "borderWidth": 3,
+            "height": 24,
+            "justifyContent": "center",
+            "width": 24,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "height": 8,
+        }
+      }
+    />
+    <View
+      accessibilityLabel="Option 2 (Disabled)"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": true,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "opacity": 1,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+        }
+      }
+      testID="radioGroup-option-option2"
+    >
+      <Text
+        style={
+          {
+            "color": "#606060",
+            "flex": 1,
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        Option 2 (Disabled)
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#606060",
+            "borderRadius": 12,
+            "borderWidth": 3,
+            "height": 24,
+            "justifyContent": "center",
+            "width": 24,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "height": 8,
+        }
+      }
+    />
+    <View
+      accessibilityLabel="Option 3"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "opacity": 1,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+        }
+      }
+      testID="radioGroup-option-option3"
+    >
+      <Text
+        style={
+          {
+            "color": "#FFFFFF",
+            "flex": 1,
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        Option 3
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#003366",
+            "borderRadius": 12,
+            "borderWidth": 3,
+            "height": 24,
+            "justifyContent": "center",
+            "width": 24,
+          }
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`RadioGroup Component Rendering renders correctly with selected value 1`] = `
+<View
+  style={{}}
+>
+  <View
+    style={
+      {
+        "paddingBottom": 4,
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Option 1"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "opacity": 1,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+        }
+      }
+      testID="radioGroup-option-option1"
+    >
+      <Text
+        style={
+          {
+            "color": "#FFFFFF",
+            "flex": 1,
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        Option 1
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#003366",
+            "borderRadius": 12,
+            "borderWidth": 3,
+            "height": 24,
+            "justifyContent": "center",
+            "width": 24,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "height": 8,
+        }
+      }
+    />
+    <View
+      accessibilityLabel="Option 2"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": true,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "opacity": 1,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+        }
+      }
+      testID="radioGroup-option-option2"
+    >
+      <Text
+        style={
+          {
+            "color": "#FFFFFF",
+            "flex": 1,
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        Option 2
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#003366",
+            "borderRadius": 12,
+            "borderWidth": 3,
+            "height": 24,
+            "justifyContent": "center",
+            "width": 24,
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "backgroundColor": "#003366",
+              "borderRadius": 6,
+              "height": 12,
+              "width": 12,
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      style={
+        {
+          "height": 8,
+        }
+      }
+    />
+    <View
+      accessibilityLabel="Option 3"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "opacity": 1,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+        }
+      }
+      testID="radioGroup-option-option3"
+    >
+      <Text
+        style={
+          {
+            "color": "#FFFFFF",
+            "flex": 1,
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        Option 3
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#003366",
+            "borderRadius": 12,
+            "borderWidth": 3,
+            "height": 24,
+            "justifyContent": "center",
+            "width": 24,
+          }
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`RadioGroup Component Rendering renders correctly with title 1`] = `
+<View
+  style={{}}
+>
+  <View
+    style={
+      {
+        "paddingBottom": 4,
+        "paddingHorizontal": 16,
+        "paddingTop": 16,
+      }
+    }
+  >
+    <Text
+      maxFontSizeMultiplier={2}
+      style={
+        [
+          {
+            "color": "#313132",
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          },
+          {
+            "color": "#000000",
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 14,
+            "fontWeight": "600",
+          },
+        ]
+      }
+    >
+      Choose an option
+    </Text>
+  </View>
+  <View
+    style={
+      {
+        "paddingBottom": 4,
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Option 1"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "opacity": 1,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+        }
+      }
+      testID="radioGroup-option-option1"
+    >
+      <Text
+        style={
+          {
+            "color": "#FFFFFF",
+            "flex": 1,
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        Option 1
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#003366",
+            "borderRadius": 12,
+            "borderWidth": 3,
+            "height": 24,
+            "justifyContent": "center",
+            "width": 24,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "height": 8,
+        }
+      }
+    />
+    <View
+      accessibilityLabel="Option 2"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "opacity": 1,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+        }
+      }
+      testID="radioGroup-option-option2"
+    >
+      <Text
+        style={
+          {
+            "color": "#FFFFFF",
+            "flex": 1,
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        Option 2
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#003366",
+            "borderRadius": 12,
+            "borderWidth": 3,
+            "height": 24,
+            "justifyContent": "center",
+            "width": 24,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "height": 8,
+        }
+      }
+    />
+    <View
+      accessibilityLabel="Option 3"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "opacity": 1,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+        }
+      }
+      testID="radioGroup-option-option3"
+    >
+      <Text
+        style={
+          {
+            "color": "#FFFFFF",
+            "flex": 1,
+            "fontFamily": "BCSans-Regular",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        Option 3
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#003366",
+            "borderRadius": 12,
+            "borderWidth": 3,
+            "height": 24,
+            "justifyContent": "center",
+            "width": 24,
+          }
+        }
+      />
+    </View>
+  </View>
+</View>
+`;

--- a/app/__tests__/bcsc-theme/components/__snapshots__/RadioGroup.test.tsx.snap
+++ b/app/__tests__/bcsc-theme/components/__snapshots__/RadioGroup.test.tsx.snap
@@ -50,7 +50,9 @@ exports[`RadioGroup Component Edge Cases handles single option 1`] = `
       accessible={true}
       collapsable={false}
       focusable={true}
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -62,7 +64,6 @@ exports[`RadioGroup Component Edge Cases handles single option 1`] = `
           "alignItems": "center",
           "backgroundColor": "#FFFFFF",
           "flexDirection": "row",
-          "opacity": 1,
           "paddingHorizontal": 24,
           "paddingVertical": 16,
         }
@@ -136,7 +137,9 @@ exports[`RadioGroup Component Rendering renders correctly with default props 1`]
       accessible={true}
       collapsable={false}
       focusable={true}
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -148,7 +151,6 @@ exports[`RadioGroup Component Rendering renders correctly with default props 1`]
           "alignItems": "center",
           "backgroundColor": "#FFFFFF",
           "flexDirection": "row",
-          "opacity": 1,
           "paddingHorizontal": 24,
           "paddingVertical": 16,
         }
@@ -213,7 +215,9 @@ exports[`RadioGroup Component Rendering renders correctly with default props 1`]
       accessible={true}
       collapsable={false}
       focusable={true}
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -225,7 +229,6 @@ exports[`RadioGroup Component Rendering renders correctly with default props 1`]
           "alignItems": "center",
           "backgroundColor": "#FFFFFF",
           "flexDirection": "row",
-          "opacity": 1,
           "paddingHorizontal": 24,
           "paddingVertical": 16,
         }
@@ -290,7 +293,9 @@ exports[`RadioGroup Component Rendering renders correctly with default props 1`]
       accessible={true}
       collapsable={false}
       focusable={true}
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -302,7 +307,6 @@ exports[`RadioGroup Component Rendering renders correctly with default props 1`]
           "alignItems": "center",
           "backgroundColor": "#FFFFFF",
           "flexDirection": "row",
-          "opacity": 1,
           "paddingHorizontal": 24,
           "paddingVertical": 16,
         }
@@ -376,7 +380,9 @@ exports[`RadioGroup Component Rendering renders correctly with mixed disabled op
       accessible={true}
       collapsable={false}
       focusable={true}
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -388,7 +394,6 @@ exports[`RadioGroup Component Rendering renders correctly with mixed disabled op
           "alignItems": "center",
           "backgroundColor": "#FFFFFF",
           "flexDirection": "row",
-          "opacity": 1,
           "paddingHorizontal": 24,
           "paddingVertical": 16,
         }
@@ -453,7 +458,9 @@ exports[`RadioGroup Component Rendering renders correctly with mixed disabled op
       accessible={true}
       collapsable={false}
       focusable={true}
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -465,7 +472,6 @@ exports[`RadioGroup Component Rendering renders correctly with mixed disabled op
           "alignItems": "center",
           "backgroundColor": "#FFFFFF",
           "flexDirection": "row",
-          "opacity": 1,
           "paddingHorizontal": 24,
           "paddingVertical": 16,
         }
@@ -530,7 +536,9 @@ exports[`RadioGroup Component Rendering renders correctly with mixed disabled op
       accessible={true}
       collapsable={false}
       focusable={true}
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -542,7 +550,6 @@ exports[`RadioGroup Component Rendering renders correctly with mixed disabled op
           "alignItems": "center",
           "backgroundColor": "#FFFFFF",
           "flexDirection": "row",
-          "opacity": 1,
           "paddingHorizontal": 24,
           "paddingVertical": 16,
         }
@@ -616,7 +623,9 @@ exports[`RadioGroup Component Rendering renders correctly with selected value 1`
       accessible={true}
       collapsable={false}
       focusable={true}
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -628,7 +637,6 @@ exports[`RadioGroup Component Rendering renders correctly with selected value 1`
           "alignItems": "center",
           "backgroundColor": "#FFFFFF",
           "flexDirection": "row",
-          "opacity": 1,
           "paddingHorizontal": 24,
           "paddingVertical": 16,
         }
@@ -693,7 +701,9 @@ exports[`RadioGroup Component Rendering renders correctly with selected value 1`
       accessible={true}
       collapsable={false}
       focusable={true}
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -705,7 +715,6 @@ exports[`RadioGroup Component Rendering renders correctly with selected value 1`
           "alignItems": "center",
           "backgroundColor": "#FFFFFF",
           "flexDirection": "row",
-          "opacity": 1,
           "paddingHorizontal": 24,
           "paddingVertical": 16,
         }
@@ -781,7 +790,9 @@ exports[`RadioGroup Component Rendering renders correctly with selected value 1`
       accessible={true}
       collapsable={false}
       focusable={true}
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -793,7 +804,6 @@ exports[`RadioGroup Component Rendering renders correctly with selected value 1`
           "alignItems": "center",
           "backgroundColor": "#FFFFFF",
           "flexDirection": "row",
-          "opacity": 1,
           "paddingHorizontal": 24,
           "paddingVertical": 16,
         }

--- a/app/__tests__/bcsc-theme/components/__snapshots__/RadioGroup.test.tsx.snap
+++ b/app/__tests__/bcsc-theme/components/__snapshots__/RadioGroup.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`RadioGroup Component Edge Cases handles empty options array 1`] = `
 <View
   style={{}}
+  testID="test-radio-group"
 >
   <View
     style={
@@ -17,6 +18,7 @@ exports[`RadioGroup Component Edge Cases handles empty options array 1`] = `
 exports[`RadioGroup Component Edge Cases handles single option 1`] = `
 <View
   style={{}}
+  testID="test-radio-group"
 >
   <View
     style={
@@ -65,7 +67,7 @@ exports[`RadioGroup Component Edge Cases handles single option 1`] = `
           "paddingVertical": 16,
         }
       }
-      testID="radioGroup-option-only"
+      testID="test-radio-group-option-OnlyOption"
     >
       <Text
         style={
@@ -99,248 +101,10 @@ exports[`RadioGroup Component Edge Cases handles single option 1`] = `
 </View>
 `;
 
-exports[`RadioGroup Component Rendering renders correctly when disabled 1`] = `
-<View
-  style={{}}
->
-  <View
-    style={
-      {
-        "paddingBottom": 4,
-      }
-    }
-  >
-    <View
-      accessibilityLabel="Option 1"
-      accessibilityRole="radio"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": false,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "backgroundColor": "#FFFFFF",
-          "flexDirection": "row",
-          "opacity": 1,
-          "paddingHorizontal": 24,
-          "paddingVertical": 16,
-        }
-      }
-      testID="radioGroup-option-option1"
-    >
-      <Text
-        style={
-          {
-            "color": "#606060",
-            "flex": 1,
-            "fontFamily": "BCSans-Regular",
-            "fontSize": 18,
-            "fontWeight": "normal",
-          }
-        }
-      >
-        Option 1
-      </Text>
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "transparent",
-            "borderColor": "#606060",
-            "borderRadius": 12,
-            "borderWidth": 3,
-            "height": 24,
-            "justifyContent": "center",
-            "width": 24,
-          }
-        }
-      />
-    </View>
-    <View
-      style={
-        {
-          "height": 8,
-        }
-      }
-    />
-    <View
-      accessibilityLabel="Option 2"
-      accessibilityRole="radio"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": false,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "backgroundColor": "#FFFFFF",
-          "flexDirection": "row",
-          "opacity": 1,
-          "paddingHorizontal": 24,
-          "paddingVertical": 16,
-        }
-      }
-      testID="radioGroup-option-option2"
-    >
-      <Text
-        style={
-          {
-            "color": "#606060",
-            "flex": 1,
-            "fontFamily": "BCSans-Regular",
-            "fontSize": 18,
-            "fontWeight": "normal",
-          }
-        }
-      >
-        Option 2
-      </Text>
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "transparent",
-            "borderColor": "#606060",
-            "borderRadius": 12,
-            "borderWidth": 3,
-            "height": 24,
-            "justifyContent": "center",
-            "width": 24,
-          }
-        }
-      />
-    </View>
-    <View
-      style={
-        {
-          "height": 8,
-        }
-      }
-    />
-    <View
-      accessibilityLabel="Option 3"
-      accessibilityRole="radio"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": false,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "backgroundColor": "#FFFFFF",
-          "flexDirection": "row",
-          "opacity": 1,
-          "paddingHorizontal": 24,
-          "paddingVertical": 16,
-        }
-      }
-      testID="radioGroup-option-option3"
-    >
-      <Text
-        style={
-          {
-            "color": "#606060",
-            "flex": 1,
-            "fontFamily": "BCSans-Regular",
-            "fontSize": 18,
-            "fontWeight": "normal",
-          }
-        }
-      >
-        Option 3
-      </Text>
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "transparent",
-            "borderColor": "#606060",
-            "borderRadius": 12,
-            "borderWidth": 3,
-            "height": 24,
-            "justifyContent": "center",
-            "width": 24,
-          }
-        }
-      />
-    </View>
-  </View>
-</View>
-`;
-
 exports[`RadioGroup Component Rendering renders correctly with default props 1`] = `
 <View
   style={{}}
+  testID="test-radio-group"
 >
   <View
     style={
@@ -389,7 +153,7 @@ exports[`RadioGroup Component Rendering renders correctly with default props 1`]
           "paddingVertical": 16,
         }
       }
-      testID="radioGroup-option-option1"
+      testID="test-radio-group-option-Option1"
     >
       <Text
         style={
@@ -466,7 +230,7 @@ exports[`RadioGroup Component Rendering renders correctly with default props 1`]
           "paddingVertical": 16,
         }
       }
-      testID="radioGroup-option-option2"
+      testID="test-radio-group-option-Option2"
     >
       <Text
         style={
@@ -543,7 +307,7 @@ exports[`RadioGroup Component Rendering renders correctly with default props 1`]
           "paddingVertical": 16,
         }
       }
-      testID="radioGroup-option-option3"
+      testID="test-radio-group-option-Option3"
     >
       <Text
         style={
@@ -580,6 +344,7 @@ exports[`RadioGroup Component Rendering renders correctly with default props 1`]
 exports[`RadioGroup Component Rendering renders correctly with mixed disabled options 1`] = `
 <View
   style={{}}
+  testID="test-radio-group"
 >
   <View
     style={
@@ -628,7 +393,7 @@ exports[`RadioGroup Component Rendering renders correctly with mixed disabled op
           "paddingVertical": 16,
         }
       }
-      testID="radioGroup-option-option1"
+      testID="test-radio-group-option-Option1"
     >
       <Text
         style={
@@ -705,7 +470,7 @@ exports[`RadioGroup Component Rendering renders correctly with mixed disabled op
           "paddingVertical": 16,
         }
       }
-      testID="radioGroup-option-option2"
+      testID="test-radio-group-option-Option2(Disabled)"
     >
       <Text
         style={
@@ -782,7 +547,7 @@ exports[`RadioGroup Component Rendering renders correctly with mixed disabled op
           "paddingVertical": 16,
         }
       }
-      testID="radioGroup-option-option3"
+      testID="test-radio-group-option-Option3"
     >
       <Text
         style={
@@ -819,6 +584,7 @@ exports[`RadioGroup Component Rendering renders correctly with mixed disabled op
 exports[`RadioGroup Component Rendering renders correctly with selected value 1`] = `
 <View
   style={{}}
+  testID="test-radio-group"
 >
   <View
     style={
@@ -867,7 +633,7 @@ exports[`RadioGroup Component Rendering renders correctly with selected value 1`
           "paddingVertical": 16,
         }
       }
-      testID="radioGroup-option-option1"
+      testID="test-radio-group-option-Option1"
     >
       <Text
         style={
@@ -944,7 +710,7 @@ exports[`RadioGroup Component Rendering renders correctly with selected value 1`
           "paddingVertical": 16,
         }
       }
-      testID="radioGroup-option-option2"
+      testID="test-radio-group-option-Option2"
     >
       <Text
         style={
@@ -1032,277 +798,7 @@ exports[`RadioGroup Component Rendering renders correctly with selected value 1`
           "paddingVertical": 16,
         }
       }
-      testID="radioGroup-option-option3"
-    >
-      <Text
-        style={
-          {
-            "color": "#FFFFFF",
-            "flex": 1,
-            "fontFamily": "BCSans-Regular",
-            "fontSize": 18,
-            "fontWeight": "normal",
-          }
-        }
-      >
-        Option 3
-      </Text>
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "transparent",
-            "borderColor": "#003366",
-            "borderRadius": 12,
-            "borderWidth": 3,
-            "height": 24,
-            "justifyContent": "center",
-            "width": 24,
-          }
-        }
-      />
-    </View>
-  </View>
-</View>
-`;
-
-exports[`RadioGroup Component Rendering renders correctly with title 1`] = `
-<View
-  style={{}}
->
-  <View
-    style={
-      {
-        "paddingBottom": 4,
-        "paddingHorizontal": 16,
-        "paddingTop": 16,
-      }
-    }
-  >
-    <Text
-      maxFontSizeMultiplier={2}
-      style={
-        [
-          {
-            "color": "#313132",
-            "fontFamily": "BCSans-Regular",
-            "fontSize": 18,
-            "fontWeight": "normal",
-          },
-          {
-            "color": "#000000",
-            "fontFamily": "BCSans-Regular",
-            "fontSize": 14,
-            "fontWeight": "600",
-          },
-        ]
-      }
-    >
-      Choose an option
-    </Text>
-  </View>
-  <View
-    style={
-      {
-        "paddingBottom": 4,
-      }
-    }
-  >
-    <View
-      accessibilityLabel="Option 1"
-      accessibilityRole="radio"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": false,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "backgroundColor": "#FFFFFF",
-          "flexDirection": "row",
-          "opacity": 1,
-          "paddingHorizontal": 24,
-          "paddingVertical": 16,
-        }
-      }
-      testID="radioGroup-option-option1"
-    >
-      <Text
-        style={
-          {
-            "color": "#FFFFFF",
-            "flex": 1,
-            "fontFamily": "BCSans-Regular",
-            "fontSize": 18,
-            "fontWeight": "normal",
-          }
-        }
-      >
-        Option 1
-      </Text>
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "transparent",
-            "borderColor": "#003366",
-            "borderRadius": 12,
-            "borderWidth": 3,
-            "height": 24,
-            "justifyContent": "center",
-            "width": 24,
-          }
-        }
-      />
-    </View>
-    <View
-      style={
-        {
-          "height": 8,
-        }
-      }
-    />
-    <View
-      accessibilityLabel="Option 2"
-      accessibilityRole="radio"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": false,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "backgroundColor": "#FFFFFF",
-          "flexDirection": "row",
-          "opacity": 1,
-          "paddingHorizontal": 24,
-          "paddingVertical": 16,
-        }
-      }
-      testID="radioGroup-option-option2"
-    >
-      <Text
-        style={
-          {
-            "color": "#FFFFFF",
-            "flex": 1,
-            "fontFamily": "BCSans-Regular",
-            "fontSize": 18,
-            "fontWeight": "normal",
-          }
-        }
-      >
-        Option 2
-      </Text>
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "transparent",
-            "borderColor": "#003366",
-            "borderRadius": 12,
-            "borderWidth": 3,
-            "height": 24,
-            "justifyContent": "center",
-            "width": 24,
-          }
-        }
-      />
-    </View>
-    <View
-      style={
-        {
-          "height": 8,
-        }
-      }
-    />
-    <View
-      accessibilityLabel="Option 3"
-      accessibilityRole="radio"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": false,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "backgroundColor": "#FFFFFF",
-          "flexDirection": "row",
-          "opacity": 1,
-          "paddingHorizontal": 24,
-          "paddingVertical": 16,
-        }
-      }
-      testID="radioGroup-option-option3"
+      testID="test-radio-group-option-Option3"
     >
       <Text
         style={

--- a/app/src/bcsc-theme/components/RadioButton.tsx
+++ b/app/src/bcsc-theme/components/RadioButton.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@bifold/core'
 import React, { useCallback } from 'react'
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
 
 interface RadioButtonProps<T> {
   label: string
@@ -60,7 +60,7 @@ export const RadioButton = <T,>({
   }, [disabled, onValueChange, value])
 
   return (
-    <TouchableOpacity
+    <Pressable
       style={styles.container}
       onPress={handlePress}
       disabled={disabled}
@@ -72,6 +72,6 @@ export const RadioButton = <T,>({
     >
       <Text style={styles.label}>{label}</Text>
       <View style={styles.radioCircle}>{selected && <View style={styles.innerCircle} />}</View>
-    </TouchableOpacity>
+    </Pressable>
   )
 }

--- a/app/src/bcsc-theme/components/RadioButton.tsx
+++ b/app/src/bcsc-theme/components/RadioButton.tsx
@@ -1,25 +1,26 @@
 import { useTheme } from '@bifold/core'
-import React from 'react'
+import React, { useCallback } from 'react'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
-export interface RadioButtonProps {
+interface RadioButtonProps<T> {
   label: string
-  value: string
-  selected: boolean
-  onPress: (value: string) => void
+  value: T
+  selectedValue?: T
+  onValueChange: (value: T) => void
   disabled?: boolean
-  testID?: string
+  testID: string
 }
 
-export const RadioButton: React.FC<RadioButtonProps> = ({
+export const RadioButton = <T,>({
   label,
   value,
-  selected,
-  onPress,
+  selectedValue,
+  onValueChange,
   disabled = false,
   testID,
-}) => {
+}: RadioButtonProps<T>) => {
   const { ColorPalette, TextTheme, Spacing } = useTheme()
+  const selected = selectedValue === value
 
   const styles = StyleSheet.create({
     container: {
@@ -52,11 +53,11 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
     },
   })
 
-  const handlePress = () => {
+  const handlePress = useCallback(() => {
     if (!disabled) {
-      onPress(value)
+      onValueChange(value)
     }
-  }
+  }, [disabled, onValueChange, value])
 
   return (
     <TouchableOpacity

--- a/app/src/bcsc-theme/components/RadioButton.tsx
+++ b/app/src/bcsc-theme/components/RadioButton.tsx
@@ -1,0 +1,76 @@
+import { useTheme } from '@bifold/core'
+import React from 'react'
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+
+export interface RadioButtonProps {
+  label: string
+  value: string
+  selected: boolean
+  onPress: (value: string) => void
+  disabled?: boolean
+  testID?: string
+}
+
+export const RadioButton: React.FC<RadioButtonProps> = ({
+  label,
+  value,
+  selected,
+  onPress,
+  disabled = false,
+  testID,
+}) => {
+  const { ColorPalette, TextTheme, Spacing } = useTheme()
+
+  const styles = StyleSheet.create({
+    container: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: Spacing.md,
+      paddingHorizontal: Spacing.lg,
+      backgroundColor: ColorPalette.brand.secondaryBackground,
+    },
+    radioCircle: {
+      width: Spacing.lg,
+      height: Spacing.lg,
+      borderRadius: Spacing.lg / 2,
+      borderWidth: 3,
+      borderColor: disabled ? ColorPalette.grayscale.mediumGrey : ColorPalette.brand.primary,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: 'transparent',
+    },
+    innerCircle: {
+      width: Spacing.lg / 2,
+      height: Spacing.lg / 2,
+      borderRadius: Spacing.lg / 4,
+      backgroundColor: disabled ? ColorPalette.grayscale.mediumGrey : ColorPalette.brand.primary,
+    },
+    label: {
+      ...TextTheme.normal,
+      color: disabled ? ColorPalette.grayscale.mediumGrey : ColorPalette.grayscale.white,
+      flex: 1,
+    },
+  })
+
+  const handlePress = () => {
+    if (!disabled) {
+      onPress(value)
+    }
+  }
+
+  return (
+    <TouchableOpacity
+      style={styles.container}
+      onPress={handlePress}
+      disabled={disabled}
+      accessible
+      accessibilityRole="radio"
+      accessibilityState={{ selected, disabled }}
+      accessibilityLabel={label}
+      testID={testID}
+    >
+      <Text style={styles.label}>{label}</Text>
+      <View style={styles.radioCircle}>{selected && <View style={styles.innerCircle} />}</View>
+    </TouchableOpacity>
+  )
+}

--- a/app/src/bcsc-theme/components/RadioGroup.tsx
+++ b/app/src/bcsc-theme/components/RadioGroup.tsx
@@ -1,0 +1,76 @@
+import { ThemedText, useTheme } from '@bifold/core'
+import React from 'react'
+import { StyleSheet, View, ViewStyle } from 'react-native'
+import { RadioButton } from './RadioButton'
+
+export interface RadioOption {
+  label: string
+  value: string
+  disabled?: boolean
+}
+
+export interface RadioGroupProps {
+  options: RadioOption[]
+  selectedValue?: string
+  onValueChange: (value: string) => void
+  title?: string
+  disabled?: boolean
+  testID?: string
+  style?: ViewStyle
+}
+
+export const RadioGroup: React.FC<RadioGroupProps> = ({
+  options,
+  selectedValue,
+  onValueChange,
+  title,
+  disabled = false,
+  testID,
+  style = {},
+}) => {
+  const { ColorPalette, TextTheme, Spacing } = useTheme()
+
+  const styles = StyleSheet.create({
+    titleContainer: {
+      paddingHorizontal: Spacing.md,
+      paddingTop: Spacing.md,
+      paddingBottom: Spacing.xs,
+    },
+    title: {
+      ...TextTheme.labelSubtitle,
+      color: disabled ? ColorPalette.grayscale.mediumGrey : ColorPalette.grayscale.black,
+      fontWeight: '600',
+    },
+    optionsContainer: {
+      paddingBottom: Spacing.xs,
+    },
+    separator: {
+      height: Spacing.sm,
+    },
+  })
+
+  return (
+    <View testID={testID} style={style}>
+      {title && (
+        <View style={styles.titleContainer}>
+          <ThemedText style={styles.title}>{title}</ThemedText>
+        </View>
+      )}
+      <View style={styles.optionsContainer}>
+        {options.map((option, index) => (
+          <React.Fragment key={option.value}>
+            {index > 0 && <View style={styles.separator} />}
+            <RadioButton
+              label={option.label}
+              value={option.value}
+              selected={selectedValue === option.value}
+              onPress={onValueChange}
+              disabled={disabled || option.disabled}
+              testID={`${testID || 'radioGroup'}-option-${option.value}`}
+            />
+          </React.Fragment>
+        ))}
+      </View>
+    </View>
+  )
+}

--- a/app/src/bcsc-theme/components/RadioGroup.tsx
+++ b/app/src/bcsc-theme/components/RadioGroup.tsx
@@ -1,46 +1,26 @@
-import { ThemedText, useTheme } from '@bifold/core'
+import { testIdForAccessabilityLabel, useTheme } from '@bifold/core'
 import React from 'react'
 import { StyleSheet, View, ViewStyle } from 'react-native'
 import { RadioButton } from './RadioButton'
 
-export interface RadioOption {
+interface RadioOption<T> {
   label: string
-  value: string
+  value: T
   disabled?: boolean
 }
 
-export interface RadioGroupProps {
-  options: RadioOption[]
-  selectedValue?: string
-  onValueChange: (value: string) => void
-  title?: string
-  disabled?: boolean
-  testID?: string
+interface RadioGroupProps<T> {
+  options: RadioOption<T>[]
+  selectedValue?: T
+  onValueChange: (value: T) => void
+  testID: string
   style?: ViewStyle
 }
 
-export const RadioGroup: React.FC<RadioGroupProps> = ({
-  options,
-  selectedValue,
-  onValueChange,
-  title,
-  disabled = false,
-  testID,
-  style = {},
-}) => {
-  const { ColorPalette, TextTheme, Spacing } = useTheme()
+export const RadioGroup = <T,>({ options, selectedValue, onValueChange, testID, style = {} }: RadioGroupProps<T>) => {
+  const { Spacing } = useTheme()
 
   const styles = StyleSheet.create({
-    titleContainer: {
-      paddingHorizontal: Spacing.md,
-      paddingTop: Spacing.md,
-      paddingBottom: Spacing.xs,
-    },
-    title: {
-      ...TextTheme.labelSubtitle,
-      color: disabled ? ColorPalette.grayscale.mediumGrey : ColorPalette.grayscale.black,
-      fontWeight: '600',
-    },
     optionsContainer: {
       paddingBottom: Spacing.xs,
     },
@@ -51,22 +31,17 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
 
   return (
     <View testID={testID} style={style}>
-      {title && (
-        <View style={styles.titleContainer}>
-          <ThemedText style={styles.title}>{title}</ThemedText>
-        </View>
-      )}
       <View style={styles.optionsContainer}>
         {options.map((option, index) => (
-          <React.Fragment key={option.value}>
+          <React.Fragment key={option.label}>
             {index > 0 && <View style={styles.separator} />}
-            <RadioButton
+            <RadioButton<T>
               label={option.label}
               value={option.value}
-              selected={selectedValue === option.value}
-              onPress={onValueChange}
-              disabled={disabled || option.disabled}
-              testID={`${testID || 'radioGroup'}-option-${option.value}`}
+              selectedValue={selectedValue}
+              onValueChange={onValueChange}
+              disabled={option.disabled}
+              testID={`${testID}-option-${testIdForAccessabilityLabel(option.label)}`}
             />
           </React.Fragment>
         ))}

--- a/app/src/bcsc-theme/features/account-transfer/AccountSetupSelectionScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/AccountSetupSelectionScreen.tsx
@@ -1,14 +1,17 @@
 import GenericCardImage from '@/bcsc-theme/components/GenericCardImage'
 import { BCSCScreens, BCSCVerifyIdentityStackParams } from '@/bcsc-theme/types/navigators'
-import { Button, ButtonType, ThemedText, useTheme } from '@bifold/core'
+import { BCState } from '@/store'
+import { Button, ButtonType, ThemedText, useStore, useTheme } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 const AccountSetupSelectionScreen: React.FC = () => {
+  const [store] = useStore<BCState>()
   const { t } = useTranslation()
   const navigation = useNavigation<StackNavigationProp<BCSCVerifyIdentityStackParams>>()
   const { Spacing } = useTheme()
@@ -17,36 +20,49 @@ const AccountSetupSelectionScreen: React.FC = () => {
     container: {
       flex: 1,
       alignItems: 'center',
-      paddingHorizontal: Spacing.md,
+      padding: Spacing.md,
+      justifyContent: 'space-between',
+    },
+    contentContainer: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    controlsContainer: {
+      marginTop: 'auto',
+      width: '100%',
+      gap: Spacing.sm,
     },
   })
 
   return (
-    <View style={styles.container}>
-      <GenericCardImage />
-      <ThemedText variant="headerTitle" style={{ color: 'white', marginBottom: Spacing.xxl }}>
-        {t('Unified.AccountSetup.Title')}
-      </ThemedText>
+    <SafeAreaView edges={['bottom', 'left', 'right']} style={styles.container}>
+      <View style={styles.contentContainer}>
+        <GenericCardImage />
+        <ThemedText variant={'headerTitle'}>{t('Unified.AccountSetup.Title')}</ThemedText>
+      </View>
 
-      <View style={{ marginBottom: Spacing.md, width: '100%' }}>
+      <View style={styles.controlsContainer}>
         <Button
           buttonType={ButtonType.Primary}
-          title={t('Unified.AccountSetup.CreateAccount')}
+          title={t('Unified.AccountSetup.AddAccount')}
           onPress={() => {
-            navigation.navigate(BCSCScreens.SetupSteps)
+            if (store.bcsc.completedNewSetup) {
+              navigation.navigate(BCSCScreens.SetupSteps)
+            } else {
+              navigation.navigate(BCSCScreens.NewSetup)
+            }
           }}
         />
-      </View>
-      <View style={{ width: '100%' }}>
         <Button
-          buttonType={ButtonType.Tertiary}
+          buttonType={ButtonType.Secondary}
           title={t('Unified.AccountSetup.TransferAccount')}
           onPress={() => {
             navigation.navigate(BCSCScreens.TransferAccountInformation)
           }}
         />
       </View>
-    </View>
+    </SafeAreaView>
   )
 }
 

--- a/app/src/bcsc-theme/features/verify/NewSetupScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/NewSetupScreen.tsx
@@ -1,0 +1,194 @@
+import { RadioGroup } from '@/bcsc-theme/components/RadioGroup'
+import { BCSCScreens, BCSCVerifyIdentityStackParams } from '@/bcsc-theme/types/navigators'
+import { BCDispatchAction, BCState } from '@/store'
+import {
+  Button,
+  ButtonType,
+  InfoBoxType,
+  InfoTextBox,
+  testIdWithKey,
+  ThemedText,
+  useStore,
+  useTheme,
+} from '@bifold/core'
+import { StackNavigationProp } from '@react-navigation/stack'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ScrollView, StyleSheet, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
+
+const iconSize = 40
+
+type NewSetupScreenProps = {
+  navigation: StackNavigationProp<BCSCVerifyIdentityStackParams, BCSCScreens.NewSetup>
+}
+
+const NewSetupScreen = ({ navigation }: NewSetupScreenProps) => {
+  const { ColorPalette, Spacing } = useTheme()
+  const [, dispatch] = useStore<BCState>()
+  const { t } = useTranslation()
+  const [myOwnId, setMyOwnId] = useState<boolean>()
+  const [otherPersonPresent, setOtherPersonPresent] = useState<boolean>()
+
+  const styles = StyleSheet.create({
+    pageContainer: {
+      flex: 1,
+      justifyContent: 'space-between',
+      backgroundColor: ColorPalette.brand.primaryBackground,
+      padding: Spacing.md,
+    },
+    contentContainer: {
+      flexGrow: 1,
+    },
+    controlsContainer: {
+      marginTop: 'auto',
+      gap: Spacing.sm,
+    },
+    bulletContainer: {
+      flexDirection: 'row',
+      marginBottom: Spacing.md,
+      marginLeft: Spacing.sm,
+      flexShrink: 1,
+    },
+    bullet: {
+      marginRight: Spacing.xs,
+    },
+    bulletText: {
+      flexShrink: 1,
+      flexWrap: 'wrap',
+    },
+    helpSection: {
+      flexDirection: 'row',
+      padding: Spacing.md,
+      gap: Spacing.md,
+      flex: 1,
+    },
+    helpSectionTextContainer: {
+      paddingTop: Spacing.sm,
+      flex: 1,
+    },
+    helpSectionTitle: {
+      marginBottom: Spacing.sm,
+    },
+  })
+
+  return (
+    <SafeAreaView edges={['bottom', 'left', 'right']} style={styles.pageContainer}>
+      <ScrollView contentContainerStyle={styles.contentContainer} showsVerticalScrollIndicator={false}>
+        <ThemedText variant={'headingThree'} style={{ marginBottom: Spacing.md }}>
+          {t('Unified.NewSetup.Title')}
+        </ThemedText>
+        <ThemedText variant={'bold'} style={{ marginBottom: Spacing.md }}>
+          {t('Unified.NewSetup.YouWillNeedTo')}
+        </ThemedText>
+        <View style={styles.bulletContainer}>
+          <ThemedText style={styles.bullet}>{'\u2022'}</ThemedText>
+          <ThemedText>{t('Unified.NewSetup.AddPhotoID')}</ThemedText>
+        </View>
+        <View style={[styles.bulletContainer, { marginBottom: Spacing.lg }]}>
+          <ThemedText style={styles.bullet}>{'\u2022'}</ThemedText>
+          <ThemedText>{t('Unified.NewSetup.RecordVideoOrVisit')}</ThemedText>
+        </View>
+        <ThemedText variant={'bold'}>{t('Unified.NewSetup.WhoseIDQuestion')}</ThemedText>
+        <RadioGroup
+          style={{ marginVertical: Spacing.md }}
+          options={[
+            { label: t('Unified.NewSetup.MyOwnID'), value: 'true' },
+            { label: t('Unified.NewSetup.SomeoneElsesID'), value: 'false' },
+          ]}
+          selectedValue={myOwnId?.toString()}
+          onValueChange={(value) => {
+            if (value === 'true') {
+              setOtherPersonPresent(undefined)
+            }
+
+            setMyOwnId(value === 'true')
+          }}
+          testID={testIdWithKey('MyOwnIdRadioGroup')}
+        />
+        {myOwnId === false ? (
+          <>
+            <ThemedText variant={'bold'}>{t('Unified.NewSetup.IsOtherPersonWithYou')}</ThemedText>
+            <RadioGroup
+              style={{ marginVertical: Spacing.md }}
+              options={[
+                { label: t('Unified.NewSetup.Yes'), value: 'true' },
+                { label: t('Unified.NewSetup.No'), value: 'false' },
+              ]}
+              selectedValue={otherPersonPresent?.toString()}
+              onValueChange={(value) => setOtherPersonPresent(value === 'true')}
+              testID={testIdWithKey('OtherPersonPresentRadioGroup')}
+            />
+          </>
+        ) : null}
+        {otherPersonPresent === false ? (
+          <InfoTextBox type={InfoBoxType.Error} style={{ marginBottom: Spacing.lg }}>
+            {t('Unified.NewSetup.CannotFinishWithoutOtherPerson')}
+          </InfoTextBox>
+        ) : null}
+        {otherPersonPresent !== undefined ? (
+          <>
+            <ThemedText variant={'bold'}>{t('Unified.NewSetup.OKToGiveHelp')}</ThemedText>
+            <View style={styles.helpSection}>
+              <Icon name={'check'} size={iconSize} color={ColorPalette.brand.primary} />
+              <View style={styles.helpSectionTextContainer}>
+                <ThemedText variant={'bold'} style={styles.helpSectionTitle}>
+                  {t('Unified.NewSetup.YouCan')}
+                </ThemedText>
+                <View style={styles.bulletContainer}>
+                  <ThemedText style={styles.bullet}>{'\u2022'}</ThemedText>
+                  <ThemedText style={styles.bulletText}>{t('Unified.NewSetup.YouCanReadInstructions')}</ThemedText>
+                </View>
+                <View style={styles.bulletContainer}>
+                  <ThemedText style={styles.bullet}>{'\u2022'}</ThemedText>
+                  <ThemedText style={styles.bulletText}>{t('Unified.NewSetup.YouCanNavigateApp')}</ThemedText>
+                </View>
+                <View style={styles.bulletContainer}>
+                  <ThemedText style={styles.bullet}>{'\u2022'}</ThemedText>
+                  <ThemedText style={styles.bulletText}>{t('Unified.NewSetup.YouCanTypeOrScan')}</ThemedText>
+                </View>
+              </View>
+            </View>
+            <View style={styles.helpSection}>
+              <Icon name={'cancel'} size={iconSize} color={ColorPalette.brand.primary} />
+              <View style={styles.helpSectionTextContainer}>
+                <ThemedText variant={'bold'} style={styles.helpSectionTitle}>
+                  {t('Unified.NewSetup.YouCannot')}
+                </ThemedText>
+                <View style={styles.bulletContainer}>
+                  <ThemedText style={styles.bullet}>{'\u2022'}</ThemedText>
+                  <ThemedText style={styles.bulletText}>{t('Unified.NewSetup.YouCannotBeInVideo')}</ThemedText>
+                </View>
+              </View>
+            </View>
+          </>
+        ) : null}
+        <View style={styles.controlsContainer}>
+          <Button
+            buttonType={ButtonType.Primary}
+            title={t('Global.Continue')}
+            onPress={() => {
+              dispatch({ type: BCDispatchAction.UPDATE_COMPLETED_NEW_SETUP, payload: [true] })
+              navigation.navigate(BCSCScreens.SetupSteps)
+            }}
+            testID={testIdWithKey('Continue')}
+            accessibilityLabel={t('Global.Continue')}
+            disabled={myOwnId === undefined || (myOwnId === false && otherPersonPresent === undefined)}
+          />
+          <Button
+            buttonType={ButtonType.Secondary}
+            title={t('Global.Cancel')}
+            onPress={() => {
+              navigation.goBack()
+            }}
+            testID={testIdWithKey('Cancel')}
+            accessibilityLabel={t('Global.Cancel')}
+          />
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  )
+}
+
+export default NewSetupScreen

--- a/app/src/bcsc-theme/features/verify/NewSetupScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/NewSetupScreen.tsx
@@ -12,7 +12,7 @@ import {
   useTheme,
 } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -30,6 +30,10 @@ const NewSetupScreen = ({ navigation }: NewSetupScreenProps) => {
   const { t } = useTranslation()
   const [myOwnId, setMyOwnId] = useState<boolean>()
   const [otherPersonPresent, setOtherPersonPresent] = useState<boolean>()
+  const canContinue = useMemo(
+    () => myOwnId !== undefined && (myOwnId === true || otherPersonPresent !== undefined),
+    [myOwnId, otherPersonPresent]
+  )
 
   const styles = StyleSheet.create({
     pageContainer: {
@@ -91,33 +95,33 @@ const NewSetupScreen = ({ navigation }: NewSetupScreenProps) => {
           <ThemedText>{t('Unified.NewSetup.RecordVideoOrVisit')}</ThemedText>
         </View>
         <ThemedText variant={'bold'}>{t('Unified.NewSetup.WhoseIDQuestion')}</ThemedText>
-        <RadioGroup
+        <RadioGroup<boolean>
           style={{ marginVertical: Spacing.md }}
           options={[
-            { label: t('Unified.NewSetup.MyOwnID'), value: 'true' },
-            { label: t('Unified.NewSetup.SomeoneElsesID'), value: 'false' },
+            { label: t('Unified.NewSetup.MyOwnID'), value: true },
+            { label: t('Unified.NewSetup.SomeoneElsesID'), value: false },
           ]}
-          selectedValue={myOwnId?.toString()}
+          selectedValue={myOwnId}
           onValueChange={(value) => {
-            if (value === 'true') {
+            if (value) {
               setOtherPersonPresent(undefined)
             }
 
-            setMyOwnId(value === 'true')
+            setMyOwnId(value)
           }}
           testID={testIdWithKey('MyOwnIdRadioGroup')}
         />
         {myOwnId === false ? (
           <>
             <ThemedText variant={'bold'}>{t('Unified.NewSetup.IsOtherPersonWithYou')}</ThemedText>
-            <RadioGroup
+            <RadioGroup<boolean>
               style={{ marginVertical: Spacing.md }}
               options={[
-                { label: t('Unified.NewSetup.Yes'), value: 'true' },
-                { label: t('Unified.NewSetup.No'), value: 'false' },
+                { label: t('Unified.NewSetup.Yes'), value: true },
+                { label: t('Unified.NewSetup.No'), value: false },
               ]}
-              selectedValue={otherPersonPresent?.toString()}
-              onValueChange={(value) => setOtherPersonPresent(value === 'true')}
+              selectedValue={otherPersonPresent}
+              onValueChange={(value) => setOtherPersonPresent(value)}
               testID={testIdWithKey('OtherPersonPresentRadioGroup')}
             />
           </>
@@ -127,7 +131,7 @@ const NewSetupScreen = ({ navigation }: NewSetupScreenProps) => {
             {t('Unified.NewSetup.CannotFinishWithoutOtherPerson')}
           </InfoTextBox>
         ) : null}
-        {otherPersonPresent !== undefined ? (
+        {typeof otherPersonPresent === 'boolean' ? (
           <>
             <ThemedText variant={'bold'}>{t('Unified.NewSetup.OKToGiveHelp')}</ThemedText>
             <View style={styles.helpSection}>
@@ -174,7 +178,7 @@ const NewSetupScreen = ({ navigation }: NewSetupScreenProps) => {
             }}
             testID={testIdWithKey('Continue')}
             accessibilityLabel={t('Global.Continue')}
-            disabled={myOwnId === undefined || (myOwnId === false && otherPersonPresent === undefined)}
+            disabled={!canContinue}
           />
           <Button
             buttonType={ButtonType.Secondary}

--- a/app/src/bcsc-theme/features/verify/VerifyIdentityStack.tsx
+++ b/app/src/bcsc-theme/features/verify/VerifyIdentityStack.tsx
@@ -4,6 +4,7 @@ import { BCSCScreens, BCSCVerifyIdentityStackParams } from '@/bcsc-theme/types/n
 import { HelpCentreUrl } from '@/constants'
 import { testIdWithKey, useDefaultStackOptions, useTheme } from '@bifold/core'
 import { createStackNavigator } from '@react-navigation/stack'
+import { useTranslation } from 'react-i18next'
 import AccountSetupSelectionScreen from '../account-transfer/AccountSetupSelectionScreen'
 import TransferInformationScreen from '../account-transfer/TransferInformationScreen'
 import TransferInstructionsScreen from '../account-transfer/TransferInstructionsScreen'
@@ -49,6 +50,7 @@ import VideoTooLongScreen from './send-video/VideoTooLongScreen'
 const VerifyIdentityStack = () => {
   const Stack = createStackNavigator<BCSCVerifyIdentityStackParams>()
   const theme = useTheme()
+  const { t } = useTranslation()
   const defaultStackOptions = useDefaultStackOptions(theme)
 
   return (
@@ -58,7 +60,7 @@ const VerifyIdentityStack = () => {
         component={AccountSetupSelectionScreen}
         options={{
           headerLeft: () => null,
-          title: 'BC Services Card',
+          title: t('Unified.Screens.SetupTypes'),
         }}
       />
       <Stack.Screen name={BCSCScreens.NewSetup} component={NewSetupScreen} />
@@ -66,7 +68,7 @@ const VerifyIdentityStack = () => {
         name={BCSCScreens.SetupSteps}
         component={SetupStepsScreen}
         options={{
-          title: 'Setup Steps',
+          title: t('Unified.Screens.SetupSteps'),
           headerRight: createHelpHeaderButton({ helpCentreUrl: HelpCentreUrl.HOW_TO_SETUP }),
           headerLeft: () => null,
         }}
@@ -105,7 +107,7 @@ const VerifyIdentityStack = () => {
         name={BCSCScreens.VerificationMethodSelection}
         component={VerificationMethodSelectionScreen}
         options={{
-          title: 'Choose How to Verify',
+          title: t('Unified.Screens.VerificationMethodSelection'),
           headerRight: createHelpHeaderButton({ helpCentreUrl: HelpCentreUrl.VERIFICATION_METHODS }),
         }}
       />
@@ -119,7 +121,7 @@ const VerifyIdentityStack = () => {
       <Stack.Screen
         name={BCSCScreens.InformationRequired}
         component={InformationRequiredScreen}
-        options={{ title: 'Information Required' }}
+        options={{ title: t('Unified.Screens.InformationRequired') }}
       />
       <Stack.Screen name={BCSCScreens.PhotoInstructions} component={PhotoInstructionsScreen} />
       <Stack.Screen name={BCSCScreens.TakePhoto} component={TakePhotoScreen} options={{ headerShown: false }} />

--- a/app/src/bcsc-theme/features/verify/VerifyIdentityStack.tsx
+++ b/app/src/bcsc-theme/features/verify/VerifyIdentityStack.tsx
@@ -14,6 +14,7 @@ import EnterBirthdateScreen from './EnterBirthdateScreen'
 import IdentitySelectionScreen from './IdentitySelectionScreen'
 import ManualSerialScreen from './ManualSerialScreen'
 import MismatchedSerialScreen from './MismatchedSerialScreen'
+import NewSetupScreen from './NewSetupScreen'
 import PhotoInstructionsScreen from './PhotoInstructionsScreen'
 import PhotoReviewScreen from './PhotoReviewScreen'
 import { ResidentialAddressScreen } from './ResidentialAddressScreen'
@@ -57,8 +58,10 @@ const VerifyIdentityStack = () => {
         component={AccountSetupSelectionScreen}
         options={{
           headerLeft: () => null,
+          title: 'BC Services Card',
         }}
       />
+      <Stack.Screen name={BCSCScreens.NewSetup} component={NewSetupScreen} />
       <Stack.Screen
         name={BCSCScreens.SetupSteps}
         component={SetupStepsScreen}
@@ -68,34 +71,10 @@ const VerifyIdentityStack = () => {
           headerLeft: () => null,
         }}
       />
-      <Stack.Screen
-        name={BCSCScreens.TransferAccountInformation}
-        component={TransferInformationScreen}
-        options={() => ({
-          headerShown: true,
-        })}
-      />
-      <Stack.Screen
-        name={BCSCScreens.TransferAccountSuccess}
-        component={TransferSuccessScreen}
-        options={() => ({
-          headerShown: true,
-        })}
-      />
-      <Stack.Screen
-        name={BCSCScreens.TransferAccountInstructions}
-        component={TransferInstructionsScreen}
-        options={() => ({
-          headerShown: true,
-        })}
-      />
-      <Stack.Screen
-        name={BCSCScreens.TransferAccountQRScan}
-        component={TransferQRScannerScreen}
-        options={() => ({
-          headerShown: true,
-        })}
-      />
+      <Stack.Screen name={BCSCScreens.TransferAccountInformation} component={TransferInformationScreen} />
+      <Stack.Screen name={BCSCScreens.TransferAccountSuccess} component={TransferSuccessScreen} />
+      <Stack.Screen name={BCSCScreens.TransferAccountInstructions} component={TransferInstructionsScreen} />
+      <Stack.Screen name={BCSCScreens.TransferAccountQRScan} component={TransferQRScannerScreen} />
       <Stack.Screen name={BCSCScreens.IdentitySelection} component={IdentitySelectionScreen} />
       <Stack.Screen
         name={BCSCScreens.SerialInstructions}

--- a/app/src/bcsc-theme/theme.ts
+++ b/app/src/bcsc-theme/theme.ts
@@ -1,7 +1,7 @@
-import { DeepPartial, IColorPalette, INotificationColors, ITheme, ThemeBuilder } from '@bifold/core'
+import { BCThemeNames } from '@/constants'
 import Logo from '@assets/img/logo-with-text-dark.svg'
 import { BCWalletTheme, GrayscaleColors, NotificationColors } from '@bcwallet-theme/theme'
-import { BCThemeNames } from '@/constants'
+import { DeepPartial, IColorPalette, INotificationColors, ITheme, ThemeBuilder } from '@bifold/core'
 
 export const BCSCNotificationColors: INotificationColors = {
   ...NotificationColors,
@@ -9,6 +9,10 @@ export const BCSCNotificationColors: INotificationColors = {
   infoBorder: GrayscaleColors.lightGrey,
   infoIcon: '#FCBA19',
   infoText: GrayscaleColors.lightGrey,
+  error: '#CE3E39',
+  errorText: GrayscaleColors.white,
+  errorBorder: '#CE3E39',
+  errorIcon: GrayscaleColors.white,
 }
 
 export const BCSCColorPalette: IColorPalette = {
@@ -241,8 +245,12 @@ export const BCSCTheme = new ThemeBuilder(BCWalletTheme)
           fontWeight: 'bold',
           textAlign: 'center',
         },
+        secondary: {
+          backgroundColor: '#1E5189',
+          borderWidth: 0,
+        },
         secondaryText: {
-          color: theme.ColorPalette.brand.primary,
+          color: theme.ColorPalette.grayscale.white,
           textAlign: 'center',
         },
         secondaryTextDisabled: {

--- a/app/src/bcsc-theme/types/navigators.ts
+++ b/app/src/bcsc-theme/types/navigators.ts
@@ -13,6 +13,7 @@ export enum BCSCScreens {
   Account = 'BCSCAccount',
   WebView = 'BCSCWebView',
   Settings = 'BCSCSettings',
+  NewSetup = 'BCSCNewSetup',
   SetupSteps = 'BCSCSetupSteps',
   SetupTypes = 'BCSCSetupTypes',
   IdentitySelection = 'BCSCIdentitySelection',
@@ -81,6 +82,7 @@ export type BCSCRootStackParams = {
 }
 
 export type BCSCVerifyIdentityStackParams = {
+  [BCSCScreens.NewSetup]: undefined
   [BCSCScreens.SetupSteps]: undefined
   [BCSCScreens.SetupTypes]: undefined
   [BCSCScreens.TransferAccountInstructions]: undefined

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -316,8 +316,28 @@ const translation = {
     },
     "AccountSetup": {
       "Title": "BC Services Card Account",
-      "CreateAccount": "Create new Account",
-      "TransferAccount": "Transfer Account From Another Device"
+      "AddAccount": "Add account",
+      "TransferAccount": "Transfer from another device"
+    },
+    "NewSetup": {
+      "Title": "New setup",
+      "YouWillNeedTo": "You will need to:",
+      "AddPhotoID": "Add a photo ID",
+      "RecordVideoOrVisit": "Record a short video, have a video call, or visit a Service BC office",
+      "WhoseIDQuestion": "Whose ID are you adding?",
+      "MyOwnID": "My own ID",
+      "SomeoneElsesID": "Someone else's ID",
+      "IsOtherPersonWithYou": "Is this other person with you?",
+      "Yes": "Yes",
+      "No": "No",
+      "CannotFinishWithoutOtherPerson": "You will not be able to finish setting up this app without the other person being present.",
+      "OKToGiveHelp": "It's OK to give someone a bit of help to setup their account.",
+      "YouCan": "You can",
+      "YouCanReadInstructions": "Read instructions",
+      "YouCanNavigateApp": "Navigate the app",
+      "YouCanTypeOrScan": "Type, scan, or take pictures",
+      "YouCannot": "You cannot",
+      "YouCannotBeInVideo": "Be in video recordings or calls. Only the other person can be."
     },
     "TransferQRInformation": {
       "Title": "Open the BC Services Card app on your other mobile device",

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -256,6 +256,12 @@ const translation = {
     "NoSavedServices": "No saved services",
   },
   "Unified": {
+    "Screens": {
+      "SetupTypes": "BC Services Card",
+      "SetupSteps": "Setup Steps",
+      "VerificationMethodSelection": "Choose How to Verify",
+      "InformationRequired": "Information Required",
+    },
     "Steps": {
       "ScanOrTakePhotos": "Scan or take photos of your ID.",
       "Step1": "Step 1",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -254,6 +254,12 @@ const translation = {
     "NoSavedServices": "No saved services (FR)",
   },
   "Unified": {
+    "Screens": {
+      "SetupTypes": "BC Services Card (FR)",
+      "SetupSteps": "Setup Steps (FR)",
+      "VerificationMethodSelection": "Choose How to Verify (FR)",
+      "InformationRequired": "Information Required (FR)",
+    },
     "Steps": {
       "ScanOrTakePhotos": "Scan or take photos of your ID. (FR)",
       "Step1": "Step 1 (FR)",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -314,8 +314,28 @@ const translation = {
     },
     "AccountSetup": {
       "Title": "BC Services Card Account (FR)",
-      "CreateAccount": "Create new Account (FR)",
-      "TransferAccount": "Transfer Account From Another Device (FR)",
+      "AddAccount": "Add account (FR)",
+      "TransferAccount": "Transfer from another device (FR)"
+    },
+    "NewSetup": {
+      "Title": "Nouvelle configuration (FR)",
+      "YouWillNeedTo": "Vous devrez: (FR)",
+      "AddPhotoID": "Ajouter une pièce d'identité avec photo (FR)",
+      "RecordVideoOrVisit": "Enregistrer une courte vidéo, avoir un appel vidéo, ou visiter un bureau Service BC (FR)",
+      "WhoseIDQuestion": "De qui ajoutez-vous la pièce d'identité? (FR)",
+      "MyOwnID": "Ma propre pièce d'identité (FR)",
+      "SomeoneElsesID": "La pièce d'identité de quelqu'un d'autre (FR)",
+      "IsOtherPersonWithYou": "Cette autre personne est-elle avec vous? (FR)",
+      "Yes": "Oui (FR)",
+      "No": "Non (FR)",
+      "CannotFinishWithoutOtherPerson": "Vous ne pourrez pas terminer la configuration de cette application sans que l'autre personne soit présente. (FR)",
+      "OKToGiveHelp": "Il est acceptable d'aider quelqu'un à configurer son compte. (FR)",
+      "YouCan": "Vous pouvez (FR)",
+      "YouCanReadInstructions": "Lire les instructions (FR)",
+      "YouCanNavigateApp": "Naviguer dans l'application (FR)",
+      "YouCanTypeOrScan": "Taper, scanner, ou prendre des photos (FR)",
+      "YouCannot": "Vous ne pouvez pas (FR)",
+      "YouCannotBeInVideo": "Être dans les enregistrements vidéo ou les appels. Seule l'autre personne peut l'être. (FR)"
     },
     "TransferQRInformation": {
       "Title": "Open the BC Services Card app on your other mobile device (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -314,8 +314,28 @@ const translation = {
     },
     "AccountSetup": {
       "Title": "BC Services Card Account (PT-BR)",
-      "CreateAccount": "Create new Account (PT-BR)",
-      "TransferAccount": "Transfer Account From Another Device (PT-BR)"
+      "AddAccount": "Add account (PT-BR)",
+      "TransferAccount": "Transfer from another device (PT-BR)"
+    },
+    "NewSetup": {
+      "Title": "Nova configuração (PT-BR)",
+      "YouWillNeedTo": "Você precisará: (PT-BR)",
+      "AddPhotoID": "Adicionar um documento de identidade com foto (PT-BR)",
+      "RecordVideoOrVisit": "Gravar um vídeo curto, fazer uma chamada de vídeo, ou visitar um escritório Service BC (PT-BR)",
+      "WhoseIDQuestion": "De quem você está adicionando o documento? (PT-BR)",
+      "MyOwnID": "Meu próprio documento (PT-BR)",
+      "SomeoneElsesID": "Documento de outra pessoa (PT-BR)",
+      "IsOtherPersonWithYou": "Esta outra pessoa está com você? (PT-BR)",
+      "Yes": "Sim (PT-BR)",
+      "No": "Não (PT-BR)",
+      "CannotFinishWithoutOtherPerson": "Você não conseguirá terminar a configuração deste aplicativo sem que a outra pessoa esteja presente. (PT-BR)",
+      "OKToGiveHelp": "É OK ajudar alguém a configurar sua conta. (PT-BR)",
+      "YouCan": "Você pode (PT-BR)",
+      "YouCanReadInstructions": "Ler instruções (PT-BR)",
+      "YouCanNavigateApp": "Navegar no aplicativo (PT-BR)",
+      "YouCanTypeOrScan": "Digitar, escanear, ou tirar fotos (PT-BR)",
+      "YouCannot": "Você não pode (PT-BR)",
+      "YouCannotBeInVideo": "Estar em gravações de vídeo ou chamadas. Apenas a outra pessoa pode estar. (PT-BR)"
     },
     "TransferQRInformation": {
       "Title": "Open the BC Services Card app on your other mobile device (PT-BR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -254,6 +254,12 @@ const translation = {
     "NoSavedServices": "No saved services (PT-BR)",
   },
   "Unified": {
+    "Screens": {
+      "SetupTypes": "BC Services Card (PT-BR)",
+      "SetupSteps": "Setup Steps (PT-BR)",
+      "VerificationMethodSelection": "Choose How to Verify (PT-BR)",
+      "InformationRequired": "Information Required (PT-BR)",
+    },
     "Steps": {
       "ScanOrTakePhotos": "Scan or take photos of your ID. (PT-BR)",
       "Step1": "Step 1 (PT-BR)",

--- a/app/src/store.tsx
+++ b/app/src/store.tsx
@@ -8,6 +8,7 @@ import {
 } from '@bifold/core'
 
 import { BCSCCardType } from '@bcsc-theme/types/cards'
+import Config from 'react-native-config'
 import {
   EvidenceType,
   VerificationPhotoUploadPayload,
@@ -16,7 +17,6 @@ import {
 } from './bcsc-theme/api/hooks/useEvidenceApi'
 import { ProvinceCode } from './bcsc-theme/utils/address-utils'
 import { PhotoMetadata } from './bcsc-theme/utils/file-info'
-import Config from 'react-native-config'
 
 export interface IASEnvironment {
   name: string
@@ -63,6 +63,7 @@ export interface NonBCSCUserMetadata {
 }
 
 export interface BCSCState {
+  completedNewSetup: boolean
   verified: boolean
   // used during verification, use IAS ID token cardType for everything else
   cardType: BCSCCardType
@@ -123,6 +124,7 @@ enum RemoteDebuggingDispatchAction {
 }
 
 enum BCSCDispatchAction {
+  UPDATE_COMPLETED_NEW_SETUP = 'bcsc/updateCompletedNewSetup',
   UPDATE_VERIFIED = 'bcsc/updateVerified',
   UPDATE_CARD_TYPE = 'bcsc/updateCardType',
   UPDATE_SERIAL = 'bcsc/updateSerial',
@@ -214,6 +216,7 @@ const dismissPersonCredentialOfferState: DismissPersonCredentialOffer = {
 }
 
 const bcscState: BCSCState = {
+  completedNewSetup: false,
   verified: false,
   cardType: BCSCCardType.None,
   serial: '',
@@ -317,6 +320,13 @@ const bcReducer = (state: BCState, action: ReducerAction<BCDispatchAction>): BCS
         newState.dismissPersonCredentialOffer
       )
 
+      return newState
+    }
+    case BCSCDispatchAction.UPDATE_COMPLETED_NEW_SETUP: {
+      const completedNewSetup = (action?.payload || []).pop() ?? true
+      const bcsc = { ...state.bcsc, completedNewSetup }
+      const newState = { ...state, bcsc }
+      PersistentStorage.storeValueForKey<BCSCState>(BCLocalStorageKeys.BCSC, bcsc)
       return newState
     }
     case BCSCDispatchAction.UPDATE_VERIFIED: {


### PR DESCRIPTION
# Summary of Changes

- Created new setup screen
- Created new RadioGroup component for use in new setup screen
- Updated account setup selection screen
- Updated theme

# Testing Instructions

Fresh install, switch to BCSC mode, press add account, play with radio buttons, press continue

# Acceptance Criteria

See ticket

# Screenshots, videos, or gifs

### New screen
![new_setup](https://github.com/user-attachments/assets/09fa9416-967a-4728-981f-6ba9aab86b97)

### Before and after of existing screen

<img width="425" height="920" alt="transfer_before" src="https://github.com/user-attachments/assets/8873ebbc-7ec7-40ac-b58e-ba09b961eb76" />
<img width="425" height="920" alt="transfer_after" src="https://github.com/user-attachments/assets/014f43e4-9400-4c56-851d-cc429146ea71" />

# Related Issues

#2744

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes
