### PR TITLE
fix(ui tweaks): terms of use loading indicator and swipeable intro carousel

### DIFF
--- a/app/src/bcsc-theme/features/onboarding/IntroCarousel.tsx
+++ b/app/src/bcsc-theme/features/onboarding/IntroCarousel.tsx
@@ -4,6 +4,7 @@ import { StackNavigationProp } from '@react-navigation/stack'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native'
+import { Directions, FlingGestureHandler, State } from 'react-native-gesture-handler'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 // TODO (MD): Waiting on final content, replace mock content with real carousel text
@@ -105,41 +106,59 @@ export const IntroCarouselScreen = (props: IntroCarouselScreenProps): JSX.Elemen
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.scrollContainer}>
-        <ScrollView>{carouselPages[carouselIndex]}</ScrollView>
+      <FlingGestureHandler
+        direction={Directions.LEFT}
+        onHandlerStateChange={(event) => {
+          if (event.nativeEvent.state === State.ACTIVE) {
+            handleNext()
+          }
+        }}
+      >
+        <FlingGestureHandler
+          direction={Directions.RIGHT}
+          onHandlerStateChange={(event) => {
+            if (event.nativeEvent.state === State.ACTIVE) {
+              handleBack()
+            }
+          }}
+        >
+          <View style={styles.scrollContainer}>
+            <ScrollView>{carouselPages[carouselIndex]}</ScrollView>
 
-        <View style={styles.carouselContainer}>
-          <TouchableOpacity
-            style={[styles.carouselActionButtonContainer, carouselIndex === 0 && { opacity: 0.5 }]}
-            onPress={handleBack}
-            testID={testIdWithKey('CarouselBack')}
-            accessibilityRole="button"
-            accessibilityLabel={t('Unified.Onboarding.CarouselBack')}
-            disabled={carouselIndex === 0}
-          >
-            <ThemedText style={styles.carouselActionButtonText}>{t('Unified.Onboarding.CarouselBack')}</ThemedText>
-          </TouchableOpacity>
+            <View style={styles.carouselContainer}>
+              <TouchableOpacity
+                style={[styles.carouselActionButtonContainer, carouselIndex === 0 && { opacity: 0.5 }]}
+                onPress={handleBack}
+                testID={testIdWithKey('CarouselBack')}
+                accessibilityRole="button"
+                accessibilityLabel={t('Unified.Onboarding.CarouselBack')}
+                disabled={carouselIndex === 0}
+              >
+                <ThemedText style={styles.carouselActionButtonText}>{t('Unified.Onboarding.CarouselBack')}</ThemedText>
+              </TouchableOpacity>
 
-          <View style={styles.carouselCirclesContainer}>
-            {carouselPages.map((element, index) => (
-              <View
-                key={`carousel-circle-${element.key}`}
-                style={[styles.carouselCircle, carouselIndex === index && styles.carouselCircleHighlighted]}
-              />
-            ))}
+              <View style={styles.carouselCirclesContainer}>
+                {carouselPages.map((element, index) => (
+                  <View
+                    key={`carousel-circle-${element.key}`}
+                    style={[styles.carouselCircle, carouselIndex === index && styles.carouselCircleHighlighted]}
+                  />
+                ))}
+              </View>
+
+              <TouchableOpacity
+                style={styles.carouselActionButtonContainer}
+                onPress={handleNext}
+                testID={testIdWithKey('CarouselNext')}
+                accessibilityRole="button"
+                accessibilityLabel={t('Unified.Onboarding.CarouselNext')}
+              >
+                <ThemedText style={styles.carouselActionButtonText}>{t('Unified.Onboarding.CarouselNext')}</ThemedText>
+              </TouchableOpacity>
+            </View>
           </View>
-
-          <TouchableOpacity
-            style={styles.carouselActionButtonContainer}
-            onPress={handleNext}
-            testID={testIdWithKey('CarouselNext')}
-            accessibilityRole="button"
-            accessibilityLabel={t('Unified.Onboarding.CarouselNext')}
-          >
-            <ThemedText style={styles.carouselActionButtonText}>{t('Unified.Onboarding.CarouselNext')}</ThemedText>
-          </TouchableOpacity>
-        </View>
-      </View>
+        </FlingGestureHandler>
+      </FlingGestureHandler>
     </SafeAreaView>
   )
 }

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
@@ -1,7 +1,9 @@
 import { BCSCOnboardingStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { TERMS_OF_USE_URL } from '@/constants'
+import { useDebounce } from '@/hooks/useDebounce'
 import { Button, ButtonType, testIdWithKey, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
+import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -26,8 +28,7 @@ export const TermsOfUseScreen = (props: TermsOfUseScreenProps): JSX.Element => {
     },
     webViewContainer: {
       flex: 1,
-      padding: theme.Spacing.md,
-      gap: theme.Spacing.lg,
+      margin: theme.Spacing.sm,
     },
     buttonContainer: {
       paddingTop: theme.Spacing.md,
@@ -44,15 +45,18 @@ export const TermsOfUseScreen = (props: TermsOfUseScreenProps): JSX.Element => {
     <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
       <WebView
         style={styles.webViewContainer}
+        // source={{ uri: 'https://httpstat.us/200?sleep=5000' }}
         source={{ uri: TERMS_OF_USE_URL }}
-        renderLoading={() => <ActivityIndicator size={'large'} style={styles.activityIndicator} />}
         bounces={false}
         domStorageEnabled={true}
         javaScriptEnabled={true}
+        startInLoadingState={true}
         // Remove header, footer, and navigation elements for a cleaner view
         injectedJavaScriptBeforeContentLoaded={`
           document.addEventListener('DOMContentLoaded', function() {
             document.querySelectorAll('footer, header, nav[aria-label="breadcrumb"]').forEach(el => el.remove());
+            document.body.style.backgroundColor = '${theme.ColorPalette.brand.primaryBackground}';
+            document.body.style.color = '${theme.ColorPalette.brand.secondary}';
           });
         `}
       />

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
@@ -1,11 +1,9 @@
 import { BCSCOnboardingStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { TERMS_OF_USE_URL } from '@/constants'
-import { useDebounce } from '@/hooks/useDebounce'
 import { Button, ButtonType, testIdWithKey, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
-import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ActivityIndicator, StyleSheet, View } from 'react-native'
+import { StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import WebView from 'react-native-webview'
 
@@ -45,7 +43,6 @@ export const TermsOfUseScreen = (props: TermsOfUseScreenProps): JSX.Element => {
     <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
       <WebView
         style={styles.webViewContainer}
-        // source={{ uri: 'https://httpstat.us/200?sleep=5000' }}
         source={{ uri: TERMS_OF_USE_URL }}
         bounces={false}
         domStorageEnabled={true}

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
@@ -2,8 +2,9 @@ import { BCSCOnboardingStackParams, BCSCScreens } from '@/bcsc-theme/types/navig
 import { TERMS_OF_USE_URL } from '@/constants'
 import { Button, ButtonType, testIdWithKey, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, View } from 'react-native'
+import { ActivityIndicator, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import WebView from 'react-native-webview'
 
@@ -19,12 +20,16 @@ interface TermsOfUseScreenProps {
 export const TermsOfUseScreen = (props: TermsOfUseScreenProps): JSX.Element => {
   const { t } = useTranslation()
   const theme = useTheme()
+  const [showWebView, setShowWebView] = useState(false)
 
   const styles = StyleSheet.create({
     container: {
       flex: 1,
     },
-    webViewContainer: {
+    webViewContainerLoading: {
+      display: 'none',
+    },
+    webViewContainerLoaded: {
       flex: 1,
       margin: theme.Spacing.sm,
     },
@@ -42,12 +47,19 @@ export const TermsOfUseScreen = (props: TermsOfUseScreenProps): JSX.Element => {
   return (
     <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
       <WebView
-        style={styles.webViewContainer}
+        style={showWebView ? styles.webViewContainerLoaded : styles.webViewContainerLoading}
         source={{ uri: TERMS_OF_USE_URL }}
         bounces={false}
         domStorageEnabled={true}
         javaScriptEnabled={true}
+        // Show loading indicator while the WebView is loading
         startInLoadingState={true}
+        renderLoading={() => (
+          <SafeAreaView style={{ flex: 1, backgroundColor: theme.ColorPalette.brand.primaryBackground }}>
+            <ActivityIndicator size={'large'} style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }} />
+          </SafeAreaView>
+        )}
+        onLoad={() => setShowWebView(true)}
         // Remove header, footer, and navigation elements for a cleaner view
         injectedJavaScriptBeforeContentLoaded={`
           document.addEventListener('DOMContentLoaded', function() {
@@ -67,6 +79,7 @@ export const TermsOfUseScreen = (props: TermsOfUseScreenProps): JSX.Element => {
           }}
           testID={testIdWithKey('AcceptAndContinue')}
           accessibilityLabel={t('Unified.Onboarding.AcceptAndContinueButton')}
+          disabled={!showWebView}
         />
       </View>
     </SafeAreaView>

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
@@ -79,6 +79,7 @@ export const TermsOfUseScreen = (props: TermsOfUseScreenProps): JSX.Element => {
           }}
           testID={testIdWithKey('AcceptAndContinue')}
           accessibilityLabel={t('Unified.Onboarding.AcceptAndContinueButton')}
+          // Content must be visible and loaded before user can accept terms
           disabled={!showWebView}
         />
       </View>


### PR DESCRIPTION
# Summary of Changes

This PR makes three suggested changes to the onboarding screens.

1. Intro carousel is now swipeable
2. Terms of Use screen now displays loading indicator
3. Terms of Use screen now renders content with correct background and text colour

# Testing Instructions

1. Load onboarding
2. Swipe through intro carousel pages (first onboarding screen)
3. Verify terms of use is rendering with correct background (won't look like a webview).

# Acceptance Criteria

Visual and gesture changes look and feel correct.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [ ] Related issues are included under the Related Issues section above
- [ ] If applicable, screenshots, gifs, or video are included for UI changes
