### PR TITLE
fix: invalid access token fix

### DIFF
--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -207,18 +207,17 @@ class BCSCApiClient {
         return this.tokensPromise
       }
 
-      const tokenBody = await getRefreshTokenRequestBody(account.issuer, account.clientID, refreshToken)
-
-      const tokensPromise = this.post<TokenResponse>(this.endpoints.token, tokenBody, {
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        skipBearerAuth: true,
-      })
-        // Extract data from response
-        .then((response) => response.data)
-
-      this.tokensPromise = tokensPromise
-
       try {
+        const tokenBody = await getRefreshTokenRequestBody(account.issuer, account.clientID, refreshToken)
+
+        const tokensPromise = this.post<TokenResponse>(this.endpoints.token, tokenBody, {
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          skipBearerAuth: true,
+        })
+          // Extract data from response
+          .then((response) => response.data)
+
+        this.tokensPromise = tokensPromise
         this.tokens = await tokensPromise
       } finally {
         // Clear the promise cache regardless of success or failure


### PR DESCRIPTION
# Summary of Changes

This PR fixes a race condition with the IAS tokens request, which throws an "Invalid access token: ..." error.

How?
The fix caches the tokens promise for subsequent requests. If multiple requests come in at the same time, both will resolve to the **same** promise.

# Testing Instructions

1. In client.ts comment out these lines (206-208):
```ts
      if (this.tokensPromise) {
        return this.tokensPromise
      }
```
2. Reload the application
3. Check logs for "Invalid access token: ..." error.
4. Repeat steps 2-3 util you see the error.
5. Uncomment and check again (should not see error)

# Acceptance Criteria

Invalid access token does not appear in the logs.

# Screenshots, videos, or gifs
<img width="967" height="682" alt="Screenshot 2025-10-24 at 9 46 28 AM" src="https://github.com/user-attachments/assets/7562dee9-3952-4ebf-8e6d-604fcb64083f" />

# Related Issues



# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes
