### PR TITLE
fix: refresh tokens race condition v2

### DIFF
--- a/app/__tests__/bcsc-theme/api/bcsc-client.test.ts
+++ b/app/__tests__/bcsc-theme/api/bcsc-client.test.ts
@@ -1,5 +1,4 @@
 import BCSCApiClient from '@/bcsc-theme/api/client'
-import { AxiosResponse } from 'axios'
 
 describe('BCSC Client', () => {
   it('should suppress logging for status codes if suppressStatusCodeLogs prop is set', async () => {

--- a/app/__tests__/bcsc-theme/api/bcsc-client.test.ts
+++ b/app/__tests__/bcsc-theme/api/bcsc-client.test.ts
@@ -1,5 +1,4 @@
 import BCSCApiClient from '@/bcsc-theme/api/client'
-import { AxiosInstance } from 'axios'
 
 describe('BCSC Client', () => {
   it('should suppress logging for status codes if suppressStatusCodeLogs prop is set', async () => {

--- a/app/__tests__/bcsc-theme/api/bcsc-client.test.ts
+++ b/app/__tests__/bcsc-theme/api/bcsc-client.test.ts
@@ -1,4 +1,5 @@
 import BCSCApiClient from '@/bcsc-theme/api/client'
+import { AxiosResponse } from 'axios'
 
 describe('BCSC Client', () => {
   it('should suppress logging for status codes if suppressStatusCodeLogs prop is set', async () => {
@@ -54,5 +55,47 @@ describe('BCSC Client', () => {
         expect.objectContaining({ name: expect.any(String) })
       )
     }
+  })
+
+  describe('getTokensForRefreshToken', () => {
+    it('should return the promise if already exists', async () => {
+      const mockLogger = { info: jest.fn() }
+      const baseURL = 'https://example.com'
+      const client = new BCSCApiClient(baseURL, mockLogger as any)
+
+      const mockPromise = new Promise((resolve) => {
+        setTimeout(() => resolve('tokens'), 100)
+      })
+      client.tokensPromise = mockPromise as any
+
+      const tokensPromise1 = client.getTokensForRefreshToken('refreshToken1')
+      const tokensPromise2 = client.getTokensForRefreshToken('refreshToken2')
+
+      expect(await tokensPromise1).toBe('tokens')
+      expect(await tokensPromise2).toBe('tokens')
+    })
+
+    it('should fetch new tokens if no existing promise', async () => {
+      const mockLogger = { info: jest.fn() }
+      const baseURL = 'https://example.com'
+      const client = new BCSCApiClient(baseURL, mockLogger as any)
+
+      const mockTokens = {
+        access_token: 'accessToken',
+        refresh_token: 'refreshToken',
+      }
+
+      const privateFetchTokens = jest.spyOn(BCSCApiClient.prototype as any, 'fetchTokens').mockResolvedValue(mockTokens)
+
+      const tokens = client.getTokensForRefreshToken('refreshToken1')
+      expect(client.tokensPromise).toBeInstanceOf(Promise)
+      expect(client.tokens).toBeUndefined()
+
+      await tokens
+
+      expect(privateFetchTokens).toHaveBeenCalledWith('refreshToken1')
+      expect(client.tokens).toBe(mockTokens)
+      expect(client.tokensPromise).toBeNull()
+    })
   })
 })

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -46,7 +46,6 @@ class BCSCApiClient {
   endpoints: BCSCEndpoints
   config: BCSCConfig
   baseURL: string
-  // TODO (MD): Persist tokens securely using PersistentStorage ie: loadTokens(), saveTokens()
   tokens?: TokenResponse // this token will be used to interact and access data from IAS servers
   tokensPromise: Promise<TokenResponse> | null // to prevent multiple simultaneous token fetches
 
@@ -152,16 +151,26 @@ class BCSCApiClient {
     }
   }
 
-  async fetchAccessToken(): Promise<TokenResponse> {
+  async ensureValidTokens(): Promise<TokenResponse> {
     return withAccount(async () => {
+      if (this.tokensPromise) {
+        // Return the existing promise if currently refreshing
+        return this.tokensPromise
+      }
+
       if (!this.tokens) {
         // initialize tokens using `getTokensForRefreshToken`
-        throw new Error('Client tokens not initialized')
+        throw new Error('Client missing tokens')
       }
 
       if (this.isTokenExpired(this.tokens.refresh_token)) {
         // note: refresh tokens should not expire
         throw new Error('Refresh token expired')
+      }
+
+      if (!this.isTokenExpired(this.tokens.access_token)) {
+        // access token is still valid don't refresh
+        return this.tokens
       }
 
       // access token is expired, fetch new tokens using refresh token
@@ -188,44 +197,41 @@ class BCSCApiClient {
       return config
     }
 
-    if (!this.tokens || !this.isTokenExpired(this.tokens.access_token)) {
-      this.tokens = await this.fetchAccessToken()
-    }
+    const tokens = await this.ensureValidTokens()
 
-    if (this.tokens) {
-      config.headers.set('Authorization', `Bearer ${this.tokens.access_token}`)
-    }
+    config.headers.set('Authorization', `Bearer ${tokens.access_token}`)
 
     return config
   }
 
-  async getTokensForRefreshToken(refreshToken: string): Promise<TokenResponse> {
+  private fetchTokens(refreshToken: string): Promise<TokenResponse> {
     return withAccount(async (account) => {
-      // Return the existing promise if already in progress
-      // Prevents the `invalid_access_token` error from IAS due to multiple simultaneous refresh requests
-      if (this.tokensPromise) {
-        return this.tokensPromise
-      }
+      const tokenBody = await getRefreshTokenRequestBody(account.issuer, account.clientID, refreshToken)
 
-      try {
-        const tokenBody = await getRefreshTokenRequestBody(account.issuer, account.clientID, refreshToken)
+      const tokensResponse = await this.post<TokenResponse>(this.endpoints.token, tokenBody, {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        skipBearerAuth: true,
+      })
 
-        const tokensPromise = this.post<TokenResponse>(this.endpoints.token, tokenBody, {
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          skipBearerAuth: true,
-        })
-          // Extract data from response
-          .then((response) => response.data)
-
-        this.tokensPromise = tokensPromise
-        this.tokens = await tokensPromise
-      } finally {
-        // Clear the promise cache regardless of success or failure
-        this.tokensPromise = null
-      }
-
-      return this.tokens
+      return tokensResponse.data
     })
+  }
+
+  async getTokensForRefreshToken(refreshToken: string): Promise<TokenResponse> {
+    if (this.tokensPromise) {
+      // Return the existing promise if currently refreshing
+      return this.tokensPromise
+    }
+
+    try {
+      this.tokensPromise = this.fetchTokens(refreshToken)
+      this.tokens = await this.tokensPromise
+    } finally {
+      // Clear the promise cache regardless of success or failure
+      this.tokensPromise = null
+    }
+
+    return this.tokens
   }
 
   async get<T>(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -169,7 +169,7 @@ class BCSCApiClient {
       }
 
       if (!this.isTokenExpired(this.tokens.access_token)) {
-        // access token is still valid don't refresh
+        // access token is still valid, don't refresh
         return this.tokens
       }
 

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -151,10 +151,10 @@ class BCSCApiClient {
     }
   }
 
-  async ensureValidTokens(): Promise<TokenResponse> {
+  private async ensureValidTokens(): Promise<TokenResponse> {
     return withAccount(async () => {
       if (this.tokensPromise) {
-        // Return the existing promise if currently refreshing
+        // return the existing promise if currently refreshing
         return this.tokensPromise
       }
 
@@ -164,7 +164,7 @@ class BCSCApiClient {
       }
 
       if (this.isTokenExpired(this.tokens.refresh_token)) {
-        // note: refresh tokens should not expire
+        // refresh tokens should not expire
         throw new Error('Refresh token expired')
       }
 

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -160,11 +160,13 @@ class BCSCApiClient {
 
       if (!this.tokens) {
         // initialize tokens using `getTokensForRefreshToken`
+        this.logger.error('BCSCClient: Missing tokens - call getTokensForRefreshToken to initialize tokens')
         throw new Error('Client missing tokens')
       }
 
       if (this.isTokenExpired(this.tokens.refresh_token)) {
         // refresh tokens should not expire
+        this.logger.error('BCSCClient: Refresh token expired - fatal error detected')
         throw new Error('Refresh token expired')
       }
 
@@ -198,7 +200,6 @@ class BCSCApiClient {
     }
 
     const tokens = await this.ensureValidTokens()
-
     config.headers.set('Authorization', `Bearer ${tokens.access_token}`)
 
     return config

--- a/app/src/bcsc-theme/features/settings/ContactUsScreen.tsx
+++ b/app/src/bcsc-theme/features/settings/ContactUsScreen.tsx
@@ -43,16 +43,28 @@ export const ContactUsScreen = (): JSX.Element => {
           {t('Unified.ContactUs.HoursOfServiceTitle')}
         </ThemedText>
         <ThemedText>{t('Unified.ContactUs.HoursOfServiceDescription1')}</ThemedText>
-        <ThemedText style={{ marginBottom: Spacing.md }}>{t('Unified.ContactUs.HoursOfServiceDescription2')}</ThemedText>
+        <ThemedText style={{ marginBottom: Spacing.md }}>
+          {t('Unified.ContactUs.HoursOfServiceDescription2')}
+        </ThemedText>
         <ThemedText>{t('Unified.ContactUs.TollFreeLabel')}</ThemedText>
-        <Link style={{ marginBottom: Spacing.md }} linkText={t('Unified.ContactUs.TollFreeNumber')} onPress={onPressTollFree} />
+        <Link
+          style={{ marginBottom: Spacing.md }}
+          linkText={t('Unified.ContactUs.TollFreeNumber')}
+          onPress={onPressTollFree}
+        />
         <ThemedText>{t('Unified.ContactUs.LowerMainlandLabel')}</ThemedText>
-        <Link style={{ marginBottom: Spacing.xl }} linkText={t('Unified.ContactUs.LowerMainlandNumber')} onPress={onPressLowerMainland} />
+        <Link
+          style={{ marginBottom: Spacing.xl }}
+          linkText={t('Unified.ContactUs.LowerMainlandNumber')}
+          onPress={onPressLowerMainland}
+        />
         <ThemedText variant={'bold'} style={{ marginBottom: Spacing.md }}>
           {t('Unified.ContactUs.OtherContactsTitle')}
         </ThemedText>
         <ThemedText style={{ marginBottom: Spacing.md }}>
-          {t('Unified.ContactUs.VisitThe')} <Link linkText={t('Unified.ContactUs.GovernmentWebsiteText')} onPress={onPressGovernmentWebsite} /> {t('Unified.ContactUs.ToFindWhoToContact')}
+          {t('Unified.ContactUs.VisitThe')}{' '}
+          <Link linkText={t('Unified.ContactUs.GovernmentWebsiteText')} onPress={onPressGovernmentWebsite} />{' '}
+          {t('Unified.ContactUs.ToFindWhoToContact')}
         </ThemedText>
         <BulletPoint pointsText={t('Unified.ContactUs.BulletPoint1')} />
         <BulletPoint pointsText={t('Unified.ContactUs.BulletPoint2')} />


### PR DESCRIPTION
# Summary of Changes

Missed a race condition with the first PR.

This PR fixes the race condition with requests fetching a new access token while other requests simultaneously requesting data from IAS.

Senario:

1. Call 1: We call getTokensForRefreshToken - fetches token and sets internal state
2. Call 2: While Call 1 is resolving but before it has set internal state we make a request to IAS with stale access token.
3. Call 2: Fails with invalid_access_token, even though the class has the correct access token in state (race condition)

The fix:
If any outgoing request to IAS has tokens refreshing or resolving, await tokens promise and use as current tokens.


# Testing Instructions

Refreshing the application, or removing the running app and restarting should eventually trigger the race condtion. 


remove these lines client.ts line 156-159 or swap with this to trigger race condition.
```ts
      if (this.tokensPromise) {
        // return the existing promise if currently refreshing
        return this.tokens as any // this.tokensPromise
      }

```

# Acceptance Criteria

Invalid access token race condition should never display in the logs.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues
https://github.com/orgs/bcgov/projects/108?pane=issue&itemId=135457496&issue=bcgov%7Cbc-wallet-mobile%7C2811
# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes
