### PR TITLE
fix: transfer device now waits for scan to finish before scanning again

### DIFF
--- a/app/src/bcsc-theme/features/account-transfer/TransferQRScannerScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/TransferQRScannerScreen.tsx
@@ -107,7 +107,6 @@ const TransferQRScannerScreen: React.FC = () => {
         setScanError(
           new QrCodeScanError(t('Scan.InvalidQrCode'), value, 'No account found, restart the app and try again.')
         )
-        setIsLoading(false)
         return
       }
       try {
@@ -140,7 +139,6 @@ const TransferQRScannerScreen: React.FC = () => {
                 'No attestation response, check your connection and try again.'
               )
             )
-            setIsLoading(false)
             return
           }
 
@@ -159,11 +157,11 @@ const TransferQRScannerScreen: React.FC = () => {
           dispatch({ type: BCDispatchAction.UPDATE_REFRESH_TOKEN, payload: [deviceToken.refresh_token] })
 
           navigator.navigate(BCSCScreens.VerificationSuccess)
-          setIsLoading(false)
+        } else {
+          setScanError(new QrCodeScanError(t('Scan.InvalidQrCode'), value, 'No device code found.'))
         }
       } catch (error) {
         setScanError(new QrCodeScanError(t('Scan.InvalidQrCode'), value, (error as Error)?.message))
-        setIsLoading(false)
       } finally {
         setIsLoading(false)
       }

--- a/app/src/bcsc-theme/features/account-transfer/TransferQRScannerScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/TransferQRScannerScreen.tsx
@@ -95,6 +95,11 @@ const TransferQRScannerScreen: React.FC = () => {
 
   const handleScan = useCallback(
     async (value: string) => {
+      // exit early if processing a scan already
+      if (isLoading) {
+        return
+      }
+
       setIsLoading(true)
       setScanError(null)
       const account = await getAccount()
@@ -160,7 +165,7 @@ const TransferQRScannerScreen: React.FC = () => {
         setIsLoading(false)
       }
     },
-    [store.bcsc.deviceCode, deviceAttestation, client, dispatch, navigator, t, token]
+    [store.bcsc.deviceCode, deviceAttestation, client, dispatch, navigator, t, token, isLoading]
   )
 
   if (isLoading) {


### PR DESCRIPTION
# Summary of Changes

When transferring accounts between devices using a qr code, the scanner will wait for a scan to finish before trying to scan again.

# Testing Instructions

Go to the transfer qr scanner screen from app setup and try invalid qr codes or an incorrect build number or bundle id so the transfer will error. 

# Acceptance Criteria

The camera should not repeatedly scan the qr code and should wait until the current scan is done or wait until the error modal is dismissed.

# Screenshots, videos, or gifs

Before:

[old.webm](https://github.com/user-attachments/assets/ebf814ea-17c0-4730-8c9d-a4fa20b87f87)

After:

[new.webm](https://github.com/user-attachments/assets/f7fa3f2f-296d-46bd-9c62-3442f124df69)

# Related Issues

https://github.com/bcgov/bc-wallet-mobile/issues/2797

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes

