### PR TITLE
fix: regressed settings updates

### DIFF
--- a/app/src/bcsc-theme/features/settings/SettingsContent.tsx
+++ b/app/src/bcsc-theme/features/settings/SettingsContent.tsx
@@ -51,22 +51,20 @@ export const SettingsContent: React.FC<SettingsContentProps> = ({
       padding: Spacing.md,
     },
     sectionHeader: {
-      padding: Spacing.md,
-      fontWeight: 'bold',
-      fontSize: 16,
+      paddingVertical: Spacing.md,
     },
     sectionContainer: {
       gap: Spacing.xs / 2,
+      borderRadius: Spacing.sm,
+      overflow: 'hidden',
     },
     cardContainer: {
       padding: Spacing.md,
       backgroundColor: ColorPalette.brand.secondaryBackground,
     },
     versionContainer: {
-      padding: Spacing.md,
+      paddingTop: Spacing.md,
       gap: Spacing.xs,
-      justifyContent: 'center',
-      alignItems: 'center',
     },
   })
 
@@ -110,14 +108,16 @@ export const SettingsContent: React.FC<SettingsContentProps> = ({
       <View style={styles.container}>
         {store.bcsc.verified ? (
           <>
-            <SettingsActionCard
-              title={t('BCSCSettings.SignOut')}
-              startAdornment={<Icon name="logout" size={24} color={ColorPalette.brand.secondary} />}
-              onPress={() => {
-                auth.lockOutUser(LockoutReason.Logout)
-                dispatch({ type: BCDispatchAction.SELECT_ACCOUNT, payload: [undefined] })
-              }}
-            />
+            <View style={styles.sectionContainer}>
+              <SettingsActionCard
+                title={t('BCSCSettings.SignOut')}
+                startAdornment={<Icon name="logout" size={24} color={ColorPalette.brand.secondary} />}
+                onPress={() => {
+                  auth.lockOutUser(LockoutReason.Logout)
+                  dispatch({ type: BCDispatchAction.SELECT_ACCOUNT, payload: [undefined] })
+                }}
+              />
+            </View>
 
             <ThemedText variant={'bold'} style={styles.sectionHeader}>
               {t('BCSCSettings.HeaderA')}

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
@@ -226,7 +226,7 @@ const EvidenceIDCollectionScreen = ({ navigation, route }: EvidenceIDCollectionS
   return (
     <View style={{ flex: 1, padding: Spacing.md }}>
       <KeyboardView keyboardAvoiding={false}>
-        <ThemedText variant={'headingOne'}>{cardType.evidence_type_label}</ThemedText>
+        <ThemedText variant={'headingThree'}>{cardType.evidence_type_label}</ThemedText>
         <ThemedText style={{ paddingVertical: 16 }}>
           Enter the information <Text style={{ fontWeight: 'bold' }}>{'exactly as shown'}</Text> on the ID.
         </ThemedText>


### PR DESCRIPTION
# Summary of Changes

A recent PR undid some UI tweaks to the settings screen, this PR just adds them back and makes a heading a more appropriate size as per UX team request.

# Testing Instructions

Check out the settings screen, the section should have rounded corners, all the headings and the version info should be left-aligned with the typical screen padding (Spacing.md)

# Acceptance Criteria

Settings screen looks like wireframes

# Screenshots, videos, or gifs

<img width="283" height="613" alt="settings_top_before" src="https://github.com/user-attachments/assets/4c82cac1-74d7-44a0-9a5b-50f8ed469750" />
<img width="283" height="613" alt="settings_top_after" src="https://github.com/user-attachments/assets/38b0fe25-0c52-4c0f-8e7e-7e9736d3a8c4" />

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes
