### PR TITLE
fix: learn more links during onboarding now go to a webview

### DIFF
--- a/app/src/bcsc-theme/features/onboarding/OnboardingPrivacyPolicyScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/OnboardingPrivacyPolicyScreen.tsx
@@ -1,5 +1,7 @@
 import { BCSCOnboardingStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
+import { SECURE_APP_LEARN_MORE_URL } from '@/constants'
 import { StackNavigationProp } from '@react-navigation/stack'
+import { useTranslation } from 'react-i18next'
 import { PrivacyPolicyContent } from './components/PrivacyPolicyContent'
 
 interface OnboardingPrivacyPolicyScreenProps {
@@ -14,9 +16,18 @@ interface OnboardingPrivacyPolicyScreenProps {
 export const OnboardingPrivacyPolicyScreen: React.FC<OnboardingPrivacyPolicyScreenProps> = ({
   navigation,
 }: OnboardingPrivacyPolicyScreenProps): JSX.Element => {
+  const { t } = useTranslation()
+
   const onPress = () => {
     navigation.navigate(BCSCScreens.OnboardingTermsOfUse)
   }
 
-  return <PrivacyPolicyContent onPress={onPress} />
+  const handleLearnMore = () => {
+    navigation.navigate(BCSCScreens.OnboardingWebView, {
+      title: t('Unified.Onboarding.LearnMore'),
+      url: SECURE_APP_LEARN_MORE_URL,
+    })
+  }
+
+  return <PrivacyPolicyContent onPress={onPress} onLearnMore={handleLearnMore} />
 }

--- a/app/src/bcsc-theme/features/onboarding/SecureAppScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/SecureAppScreen.tsx
@@ -1,5 +1,6 @@
 import { CardButton } from '@/bcsc-theme/components/CardButton'
 import { BCSCOnboardingStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
+import { SECURE_APP_LEARN_MORE_URL } from '@/constants'
 import { BCDispatchAction } from '@/store'
 import { ThemedText, useStore, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -30,6 +31,13 @@ export const SecureAppScreen = ({ navigation }: SecureAppScreenProps): JSX.Eleme
       gap: Spacing.lg,
     },
   })
+
+  const handleLearnMore = () => {
+    navigation.navigate(BCSCScreens.OnboardingWebView, {
+      title: t('Unified.Onboarding.LearnMore'),
+      url: SECURE_APP_LEARN_MORE_URL,
+    })
+  }
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
@@ -66,7 +74,7 @@ export const SecureAppScreen = ({ navigation }: SecureAppScreenProps): JSX.Eleme
           }}
         />
 
-        <CardButton title={t('BCSC.Onboarding.LearnMore')} endIcon="open-in-new" onPress={() => {}} />
+        <CardButton title={t('Unified.Onboarding.LearnMore')} endIcon="open-in-new" onPress={handleLearnMore} />
       </ScrollView>
     </SafeAreaView>
   )

--- a/app/src/bcsc-theme/features/onboarding/components/PrivacyPolicyContent.tsx
+++ b/app/src/bcsc-theme/features/onboarding/components/PrivacyPolicyContent.tsx
@@ -1,12 +1,12 @@
 import { CardButton } from '@/bcsc-theme/components/CardButton'
-import { SECURE_APP_LEARN_MORE_URL } from '@/constants'
 import { Button, ButtonType, testIdWithKey, ThemedText, TOKENS, useServices, useTheme } from '@bifold/core'
 import { useTranslation } from 'react-i18next'
-import { Linking, ScrollView, StyleSheet, View } from 'react-native'
+import { ScrollView, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 interface PrivacyPolicyContentProps {
   onPress?: () => void
+  onLearnMore?: () => void
 }
 
 /**
@@ -19,6 +19,7 @@ interface PrivacyPolicyContentProps {
  */
 export const PrivacyPolicyContent: React.FC<PrivacyPolicyContentProps> = ({
   onPress,
+  onLearnMore,
 }: PrivacyPolicyContentProps): JSX.Element => {
   const { t } = useTranslation()
   const theme = useTheme()
@@ -46,7 +47,9 @@ export const PrivacyPolicyContent: React.FC<PrivacyPolicyContentProps> = ({
 
   const handlePressLearnMore = async () => {
     try {
-      await Linking.openURL(SECURE_APP_LEARN_MORE_URL)
+      if (onLearnMore) {
+        onLearnMore()
+      }
     } catch (error) {
       logger.error('Error opening Secure App Help URL', error instanceof Error ? error : new Error(String(error)))
     }

--- a/app/src/bcsc-theme/features/onboarding/components/PrivacyPolicyContent.tsx
+++ b/app/src/bcsc-theme/features/onboarding/components/PrivacyPolicyContent.tsx
@@ -1,12 +1,12 @@
 import { CardButton } from '@/bcsc-theme/components/CardButton'
-import { Button, ButtonType, testIdWithKey, ThemedText, TOKENS, useServices, useTheme } from '@bifold/core'
+import { Button, ButtonType, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 interface PrivacyPolicyContentProps {
   onPress?: () => void
-  onLearnMore?: () => void
+  onLearnMore: () => void
 }
 
 /**
@@ -14,7 +14,7 @@ interface PrivacyPolicyContentProps {
  *
  * onPress: optional function to be called when the Continue button is pressed,
  * if not provided, the Continue button will not be displayed.
- * onLearnMore: optional function to be called when the Learn More button is pressed.
+ * onLearnMore: function to be called when the Learn More button is pressed.
  *
  * @returns {*} {JSX.Element} The PrivacyPolicyContent component.
  */
@@ -24,7 +24,6 @@ export const PrivacyPolicyContent: React.FC<PrivacyPolicyContentProps> = ({
 }: PrivacyPolicyContentProps): JSX.Element => {
   const { t } = useTranslation()
   const theme = useTheme()
-  const [logger] = useServices([TOKENS.UTIL_LOGGER])
 
   const styles = StyleSheet.create({
     container: {
@@ -46,16 +45,6 @@ export const PrivacyPolicyContent: React.FC<PrivacyPolicyContentProps> = ({
     },
   })
 
-  const handlePressLearnMore = async () => {
-    try {
-      if (onLearnMore) {
-        onLearnMore()
-      }
-    } catch (error) {
-      logger.error('Error opening Secure App Help URL', error instanceof Error ? error : new Error(String(error)))
-    }
-  }
-
   return (
     <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
       <ScrollView contentContainerStyle={styles.scrollContainer}>
@@ -71,7 +60,7 @@ export const PrivacyPolicyContent: React.FC<PrivacyPolicyContentProps> = ({
           <ThemedText style={styles.contentText}>{t('BCSC.Onboarding.PrivacyPolicyContentC')}</ThemedText>
         </View>
 
-        <CardButton title={t('BCSC.Onboarding.LearnMore')} onPress={handlePressLearnMore} endIcon="open-in-new" />
+        <CardButton title={t('BCSC.Onboarding.LearnMore')} onPress={onLearnMore} endIcon="open-in-new" />
       </ScrollView>
 
       {onPress ? (

--- a/app/src/bcsc-theme/features/onboarding/components/PrivacyPolicyContent.tsx
+++ b/app/src/bcsc-theme/features/onboarding/components/PrivacyPolicyContent.tsx
@@ -14,6 +14,7 @@ interface PrivacyPolicyContentProps {
  *
  * onPress: optional function to be called when the Continue button is pressed,
  * if not provided, the Continue button will not be displayed.
+ * onLearnMore: optional function to be called when the Learn More button is pressed.
  *
  * @returns {*} {JSX.Element} The PrivacyPolicyContent component.
  */

--- a/app/src/bcsc-theme/features/settings/SettingsPrivacyPolicyScreen.tsx
+++ b/app/src/bcsc-theme/features/settings/SettingsPrivacyPolicyScreen.tsx
@@ -1,11 +1,29 @@
+import { BCSCMainStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
+import { SECURE_APP_LEARN_MORE_URL } from '@/constants'
+import { StackNavigationProp } from '@react-navigation/stack'
+import { useTranslation } from 'react-i18next'
 import { PrivacyPolicyContent } from '../onboarding/components/PrivacyPolicyContent'
 
+interface SettingsPrivacyPolicyScreenProps {
+  navigation: StackNavigationProp<BCSCMainStackParams, BCSCScreens.MainPrivacyPolicy>
+}
 /**
  * Privacy Policy screen component that informs users about the app's privacy practices,
  * to be shown in the Settings section of the app with no continue button.
  *
  * @returns {*} {JSX.Element} The SettingsPrivacyPolicyScreen component.
  */
-export const SettingsPrivacyPolicyScreen: React.FC = (): JSX.Element => {
-  return <PrivacyPolicyContent />
+export const SettingsPrivacyPolicyScreen: React.FC<SettingsPrivacyPolicyScreenProps> = ({
+  navigation,
+}: SettingsPrivacyPolicyScreenProps): JSX.Element => {
+  const { t } = useTranslation()
+
+  const handleLearnMore = () => {
+    navigation.navigate(BCSCScreens.MainWebView, {
+      title: t('BCSC.Screens.PrivacyInformation'),
+      url: SECURE_APP_LEARN_MORE_URL,
+    })
+  }
+
+  return <PrivacyPolicyContent onLearnMore={handleLearnMore} />
 }


### PR DESCRIPTION
# Summary of Changes

PR to add a web view component to the learn more links in the privacy and choose how to secure this app onboarding screens.

# Testing Instructions

During onboarding in the privacy screen and choose how to secure this app screen clicking the learn more button now takes you to a web view with the relevant content.

# Acceptance Criteria


# Screenshots, videos, or gifs

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes
