### PR TITLE
fix: handle missing email

### DIFF
--- a/app/__tests__/hooks/useSetupSteps.test.tsx
+++ b/app/__tests__/hooks/useSetupSteps.test.tsx
@@ -197,7 +197,91 @@ describe('useSetupSteps Hook', () => {
       expect(hook.result.current.email.completed).toBe(false)
     })
 
-    it('should be completed when email and emailConfirmed are provided', () => {
+    it('should be focused when BCSC card (Photo/NonPhoto) has serial but no email after completing ID and address steps', () => {
+      const store = structuredClone(initialState)
+      store.bcsc.nicknames = ['test']
+      store.bcsc.selectedNickname = 'test'
+      store.bcsc.cardType = BCSCCardType.Combined
+      store.bcsc.serial = '123456789'
+      store.bcsc.email = undefined
+      store.bcsc.deviceCode = 'ABCDEFGH'
+
+      const hook = renderHook(() => useSetupSteps(store))
+
+      expect(hook.result.current.id.completed).toBe(true)
+      expect(hook.result.current.id.focused).toBe(false)
+
+      expect(hook.result.current.address.completed).toBe(true)
+      expect(hook.result.current.address.focused).toBe(false)
+
+      expect(hook.result.current.email.focused).toBe(true)
+      expect(hook.result.current.email.completed).toBe(false)
+
+      expect(hook.result.current.verify.focused).toBe(false)
+      expect(hook.result.current.verify.completed).toBe(false)
+    })
+
+    it('should work with NonPhoto card type when serial available but email is falsey', () => {
+      const store = structuredClone(initialState)
+      store.bcsc.nicknames = ['test']
+      store.bcsc.selectedNickname = 'test'
+      store.bcsc.cardType = BCSCCardType.NonPhoto
+      store.bcsc.serial = '123456789'
+      store.bcsc.email = ''
+      store.bcsc.deviceCode = 'ABCDEFGH'
+      store.bcsc.additionalEvidenceData = [
+        {
+          evidenceType: {
+            has_photo: true,
+          },
+        },
+      ] as any[]
+
+      const hook = renderHook(() => useSetupSteps(store))
+
+      expect(hook.result.current.id.completed).toBe(true)
+      expect(hook.result.current.id.focused).toBe(false)
+
+      expect(hook.result.current.address.completed).toBe(true)
+      expect(hook.result.current.address.focused).toBe(false)
+
+      expect(hook.result.current.email.focused).toBe(true)
+      expect(hook.result.current.email.completed).toBe(false)
+    })
+
+    it('should not be completed when email is provided but emailConfirmed is false', () => {
+      const store = structuredClone(initialState)
+      store.bcsc.nicknames = ['test']
+      store.bcsc.selectedNickname = 'test'
+      store.bcsc.cardType = BCSCCardType.Combined
+      store.bcsc.serial = '123456789'
+      store.bcsc.email = 'steveBrule@email.com'
+      store.bcsc.deviceCode = 'ABCDEFGH'
+      store.bcsc.emailConfirmed = false
+
+      const hook = renderHook(() => useSetupSteps(store))
+
+      expect(hook.result.current.email.focused).toBe(true)
+      expect(hook.result.current.email.completed).toBe(false)
+    })
+
+    it('should not be completed when emailConfirmed is true but email is missing', () => {
+      const store = structuredClone(initialState)
+      store.bcsc.nicknames = ['test']
+      store.bcsc.selectedNickname = 'test'
+      store.bcsc.cardType = BCSCCardType.Combined
+      store.bcsc.serial = '123456789'
+      store.bcsc.email = undefined
+      store.bcsc.deviceCode = 'ABCDEFGH'
+      store.bcsc.emailConfirmed = true
+
+      const hook = renderHook(() => useSetupSteps(store))
+
+      expect(hook.result.current.email.focused).toBe(true)
+      expect(hook.result.current.email.completed).toBe(false)
+    })
+
+    it('should be completed when both email and emailConfirmed are true (email may be set to BCSC_EMAIL_NOT_PROVIDED)', () => {
       const store = structuredClone(initialState)
       store.bcsc.nicknames = ['test']
       store.bcsc.selectedNickname = 'test'

--- a/app/__tests__/hooks/useSetupSteps.test.tsx
+++ b/app/__tests__/hooks/useSetupSteps.test.tsx
@@ -160,7 +160,6 @@ describe('useSetupSteps Hook', () => {
 
       const hook = renderHook(() => useSetupSteps(store))
 
-      // Address step should be focused
       expect(hook.result.current.address.focused).toBe(true)
       expect(hook.result.current.address.completed).toBe(false)
     })
@@ -221,7 +220,7 @@ describe('useSetupSteps Hook', () => {
       expect(hook.result.current.verify.completed).toBe(false)
     })
 
-    it('should work with NonPhoto card type when serial available but email is falsey', () => {
+    it('should be focused with NonPhoto card type when serial available but email is falsey', () => {
       const store = structuredClone(initialState)
       store.bcsc.nicknames = ['test']
       store.bcsc.selectedNickname = 'test'
@@ -360,7 +359,6 @@ describe('useSetupSteps Hook', () => {
 
       const hook = renderHook(() => useSetupSteps(store))
 
-      // Step 1: Nickname step should be focused
       expect(hook.result.current.nickname.completed).toBe(false)
       expect(hook.result.current.nickname.focused).toBe(true)
       expect(hook.result.current.id.completed).toBe(false)
@@ -372,7 +370,6 @@ describe('useSetupSteps Hook', () => {
       expect(hook.result.current.verify.completed).toBe(false)
       expect(hook.result.current.verify.focused).toBe(false)
 
-      // Complete Step 1
       store.bcsc.nicknames = ['test']
       store.bcsc.selectedNickname = 'test'
 
@@ -381,11 +378,9 @@ describe('useSetupSteps Hook', () => {
       expect(hook.result.current.nickname.completed).toBe(true)
       expect(hook.result.current.nickname.focused).toBe(false)
 
-      // Step 2: ID step should be focused
       expect(hook.result.current.id.completed).toBe(false)
       expect(hook.result.current.id.focused).toBe(true)
 
-      // Complete Step 2
       store.bcsc.cardType = BCSCCardType.Combined
       store.bcsc.serial = '123456789'
       store.bcsc.email = 'steveBrule@email.com'
@@ -395,11 +390,9 @@ describe('useSetupSteps Hook', () => {
       expect(hook.result.current.id.completed).toBe(true)
       expect(hook.result.current.id.focused).toBe(false)
 
-      // Step 3: Address step should be focused
       expect(hook.result.current.address.completed).toBe(false)
       expect(hook.result.current.address.focused).toBe(true)
 
-      // Complete Step 3
       store.bcsc.deviceCode = 'ABCDEFGH'
 
       hook.rerender(store)
@@ -407,11 +400,9 @@ describe('useSetupSteps Hook', () => {
       expect(hook.result.current.address.completed).toBe(true)
       expect(hook.result.current.address.focused).toBe(false)
 
-      // Step 4: Email step should be focused
       expect(hook.result.current.email.completed).toBe(false)
       expect(hook.result.current.email.focused).toBe(true)
 
-      // Complete Step 4
       store.bcsc.emailConfirmed = true
 
       hook.rerender(store)
@@ -419,11 +410,9 @@ describe('useSetupSteps Hook', () => {
       expect(hook.result.current.email.completed).toBe(true)
       expect(hook.result.current.email.focused).toBe(false)
 
-      // Step 5: Verify step should be focused
       expect(hook.result.current.verify.completed).toBe(false)
       expect(hook.result.current.verify.focused).toBe(true)
 
-      // Complete Step 5
       store.bcsc.verified = true
       store.bcsc.pendingVerification = false
 

--- a/app/src/bcsc-theme/features/account-transfer/TransferQRScannerScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/TransferQRScannerScreen.tsx
@@ -1,6 +1,7 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { useBCSCApiClientState } from '@/bcsc-theme/hooks/useBCSCApiClient'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
+import { BCSC_EMAIL_NOT_PROVIDED } from '@/constants'
 import { BCDispatchAction, BCState } from '@/store'
 import {
   DismissiblePopupModal,
@@ -65,7 +66,7 @@ const TransferQRScannerScreen: React.FC = () => {
     const expiresAt = new Date(Date.now() + deviceAuth.expires_in * 1000)
     dispatch({
       type: BCDispatchAction.UPDATE_EMAIL,
-      payload: [{ email: deviceAuth.verified_email, emailConfirmed: !!deviceAuth.verified_email }],
+      payload: [{ email: deviceAuth.verified_email || BCSC_EMAIL_NOT_PROVIDED, emailConfirmed: true }],
     })
     dispatch({ type: BCDispatchAction.UPDATE_DEVICE_CODE, payload: [deviceAuth.device_code] })
     dispatch({ type: BCDispatchAction.UPDATE_USER_CODE, payload: [deviceAuth.user_code] })

--- a/app/src/bcsc-theme/features/verify/email/EnterEmailScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EnterEmailScreen.tsx
@@ -1,6 +1,7 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { BCSCCardType } from '@/bcsc-theme/types/cards'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
+import { BCSC_EMAIL_NOT_PROVIDED } from '@/constants'
 import { BCDispatchAction, BCState } from '@/store'
 import {
   Button,
@@ -94,7 +95,7 @@ const EnterEmailScreen = ({ navigation, route }: EnterEmailScreenProps) => {
           onPress: () => {
             dispatch({
               type: BCDispatchAction.UPDATE_EMAIL,
-              payload: [{ email: 'Not provided', emailConfirmed: true }],
+              payload: [{ email: BCSC_EMAIL_NOT_PROVIDED, emailConfirmed: true }],
             })
             navigation.goBack()
           },

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -35,6 +35,7 @@ export const BCThemeNames = {
 } as const
 
 // BCSC Constants
+export const BCSC_EMAIL_NOT_PROVIDED = 'Not provided'
 export const BCSC_APPLE_STORE_URL = 'https://apps.apple.com/us/app/id1234298467'
 export const BCSC_GOOGLE_PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=ca.bc.gov.id.servicescard'
 export const ACCOUNT_SERVICES_URL = 'https://id.gov.bc.ca/account/services'

--- a/app/src/hooks/useSetupSteps.ts
+++ b/app/src/hooks/useSetupSteps.ts
@@ -27,9 +27,7 @@ export const useSetupSteps = (store: BCState) => {
   const nonPhotoBcscNeedsAdditionalCard = isNonPhotoCard && missingPhotoId
 
   // card registration state
-  const bcscRegistered = Boolean(
-    !isNonBCSCCards && !isNoneCard && bcscSerialNumber && emailAddress && !nonPhotoBcscNeedsAdditionalCard
-  )
+  const bcscRegistered = Boolean(!isNonBCSCCards && !isNoneCard && bcscSerialNumber && !nonPhotoBcscNeedsAdditionalCard)
   const nonBcscRegistered =
     isNonBCSCCards && store.bcsc.additionalEvidenceData.length === 2 && !nonBcscNeedsAdditionalCard
 


### PR DESCRIPTION
# Summary of Changes
We were expecting (and requiring) email to be present for all BCSC card types, when in reality it will often be missing. Never caught this because our test account creator makes email mandatory. Added tests to prevent regressions and also added a constant for when users choose not to provide an email. The last thing I fixed was making sure if a users transfers an account that is missing an email that we mark it as not provided and treat it as confirmed, since we never want to risk showing them setup steps after they are verified.

# Testing Instructions

Use the following test account that is missing an email: 
Combo Card
CSN: RC0000080
DOB: January 1st, 2000

Before this PR, the above account will be stuck on step 2, after it should proceed to the email step (4) and then onward after skipping or adding an email

# Acceptance Criteria

You can get through setup steps with a BCSC account that is missing an email

# Screenshots, videos, or gifs

![setup_steps_email](https://github.com/user-attachments/assets/2fd8b73e-db07-4203-9c88-63ed2d34a9a5)
![setup_steps_not_provided](https://github.com/user-attachments/assets/a0931a5b-5db3-42a4-b762-153c53633200)

# Related Issues

#2884

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes
