### PR TITLE
feat: device invalidation and forced de-registration workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -361,7 +361,7 @@ jobs:
         uses: ./.github/workflows/actions/setup-node
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "zulu"
           java-version: 17

--- a/app/__tests__/services/system-checks/DeviceInvalidatedSystemCheck.test.ts
+++ b/app/__tests__/services/system-checks/DeviceInvalidatedSystemCheck.test.ts
@@ -1,0 +1,215 @@
+import { BCSCModals } from '@/bcsc-theme/types/navigators'
+import { NETWORK_ERROR_CODE, NETWORK_ERROR_MESSAGE } from '@/bcsc-theme/utils/error-utils'
+import { BCSCEvent, BCSCReason, IdToken } from '@/bcsc-theme/utils/id-token'
+import { DeviceInvalidatedSystemCheck } from '@/services/system-checks/DeviceInvalidatedSystemCheck'
+import { SystemCheckNavigation, SystemCheckUtils } from '@/services/system-checks/system-checks'
+import { AxiosError } from 'axios'
+
+describe('DeviceInvalidatedSystemCheck', () => {
+  let mockNavigation: SystemCheckNavigation
+  let mockUtils: SystemCheckUtils
+
+  const createMockIdToken = (overrides?: Partial<IdToken>): IdToken => ({
+    sub: 'test-sub',
+    aud: 'test-aud',
+    iss: 'test-iss',
+    exp: 1234567890,
+    iat: '1234567890',
+    jti: 'test-jti',
+    family_name: 'Test',
+    given_name: 'User',
+    bcsc_card_type: 'Combined' as any,
+    bcsc_event: BCSCEvent.Authorization,
+    bcsc_reason: BCSCReason.ApprovedByAgent,
+    bcsc_status_date: 1234567890,
+    acr: 0,
+    bcsc_devices_count: 1,
+    bcsc_max_devices: 5,
+    hasActivePersonCredential: true,
+    bcsc_account_type: 'BC Services Card with photo' as any,
+    ...overrides,
+  })
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    mockNavigation = {
+      getState: jest.fn().mockReturnValue({
+        routes: [{ name: 'Home' }],
+        index: 0,
+      }),
+      navigate: jest.fn(),
+      canGoBack: jest.fn().mockReturnValue(false),
+      goBack: jest.fn(),
+    } as any
+
+    mockUtils = {
+      dispatch: jest.fn(),
+      translation: jest.fn(),
+      logger: {
+        error: jest.fn(),
+        warn: jest.fn(),
+      } as any,
+    }
+  })
+
+  describe('runCheck', () => {
+    it('should return false when device is invalidated (Cancel event with CanceledByAgent reason)', async () => {
+      const mockIdToken = createMockIdToken({
+        bcsc_event: BCSCEvent.Cancel,
+        bcsc_reason: BCSCReason.CanceledByAgent,
+      })
+      const getIdToken = jest.fn().mockResolvedValue(mockIdToken)
+
+      const check = new DeviceInvalidatedSystemCheck(getIdToken, mockNavigation, mockUtils)
+
+      const result = await check.runCheck()
+
+      expect(result).toBe(false)
+      expect(getIdToken).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return true when device is not invalidated (different event)', async () => {
+      const mockIdToken = createMockIdToken({
+        bcsc_event: BCSCEvent.Authorization,
+        bcsc_reason: BCSCReason.ApprovedByAgent,
+      })
+      const getIdToken = jest.fn().mockResolvedValue(mockIdToken)
+
+      const check = new DeviceInvalidatedSystemCheck(getIdToken, mockNavigation, mockUtils)
+
+      const result = await check.runCheck()
+
+      expect(result).toBe(true)
+      expect(getIdToken).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return true when device is not invalidated (Cancel event with different reason)', async () => {
+      const mockIdToken = createMockIdToken({
+        bcsc_event: BCSCEvent.Cancel,
+        bcsc_reason: BCSCReason.CanceledByUser,
+      })
+      const getIdToken = jest.fn().mockResolvedValue(mockIdToken)
+
+      const check = new DeviceInvalidatedSystemCheck(getIdToken, mockNavigation, mockUtils)
+
+      const result = await check.runCheck()
+
+      expect(result).toBe(true)
+      expect(getIdToken).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return true when network error occurs', async () => {
+      const networkError = new AxiosError(NETWORK_ERROR_MESSAGE)
+      networkError.code = NETWORK_ERROR_CODE
+      ;(networkError as any).isNetworkError = true
+      const getIdToken = jest.fn().mockRejectedValue(networkError)
+
+      const check = new DeviceInvalidatedSystemCheck(getIdToken, mockNavigation, mockUtils)
+
+      const result = await check.runCheck()
+
+      expect(result).toBe(true)
+      expect(getIdToken).toHaveBeenCalledTimes(1)
+      expect(mockUtils.logger.error).toHaveBeenCalledWith(
+        'DeviceInvalidatedSystemCheck: Id token request failed',
+        networkError
+      )
+    })
+
+    it('should return false when non-network error occurs', async () => {
+      const nonNetworkError = new Error('Some other error')
+      const getIdToken = jest.fn().mockRejectedValue(nonNetworkError)
+
+      const check = new DeviceInvalidatedSystemCheck(getIdToken, mockNavigation, mockUtils)
+
+      const result = await check.runCheck()
+
+      expect(result).toBe(false)
+      expect(getIdToken).toHaveBeenCalledTimes(1)
+      expect(mockUtils.logger.error).toHaveBeenCalledWith(
+        'DeviceInvalidatedSystemCheck: Id token request failed',
+        nonNetworkError
+      )
+    })
+  })
+
+  describe('onFail', () => {
+    it('should navigate to DeviceInvalidated modal when not already visible', () => {
+      mockNavigation.getState = jest.fn().mockReturnValue({
+        routes: [{ name: 'Home' }],
+        index: 0,
+      })
+      const getIdToken = jest.fn()
+
+      const check = new DeviceInvalidatedSystemCheck(getIdToken, mockNavigation, mockUtils)
+
+      check.onFail()
+
+      expect(mockUtils.logger.warn).toHaveBeenCalledWith('DeviceInvalidatedSystemCheck: Device invalidated')
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCModals.DeviceInvalidated)
+    })
+
+    it('should not navigate when modal is already visible', () => {
+      mockNavigation.getState = jest.fn().mockReturnValue({
+        routes: [{ name: BCSCModals.DeviceInvalidated }],
+        index: 0,
+      })
+      const getIdToken = jest.fn()
+
+      const check = new DeviceInvalidatedSystemCheck(getIdToken, mockNavigation, mockUtils)
+
+      check.onFail()
+
+      expect(mockUtils.logger.warn).toHaveBeenCalledWith('DeviceInvalidatedSystemCheck: Device invalidated')
+      expect(mockNavigation.navigate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('onSuccess', () => {
+    it('should go back when modal is visible and canGoBack returns true', () => {
+      mockNavigation.getState = jest.fn().mockReturnValue({
+        routes: [{ name: BCSCModals.DeviceInvalidated }],
+        index: 0,
+      })
+      mockNavigation.canGoBack = jest.fn().mockReturnValue(true)
+      const getIdToken = jest.fn()
+
+      const check = new DeviceInvalidatedSystemCheck(getIdToken, mockNavigation, mockUtils)
+
+      check.onSuccess()
+
+      expect(mockNavigation.goBack).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not go back when modal is not visible', () => {
+      mockNavigation.getState = jest.fn().mockReturnValue({
+        routes: [{ name: 'Home' }],
+        index: 0,
+      })
+      mockNavigation.canGoBack = jest.fn().mockReturnValue(true)
+      const getIdToken = jest.fn()
+
+      const check = new DeviceInvalidatedSystemCheck(getIdToken, mockNavigation, mockUtils)
+
+      check.onSuccess()
+
+      expect(mockNavigation.goBack).not.toHaveBeenCalled()
+    })
+
+    it('should not go back when canGoBack returns false', () => {
+      mockNavigation.getState = jest.fn().mockReturnValue({
+        routes: [{ name: BCSCModals.DeviceInvalidated }],
+        index: 0,
+      })
+      mockNavigation.canGoBack = jest.fn().mockReturnValue(false)
+      const getIdToken = jest.fn()
+
+      const check = new DeviceInvalidatedSystemCheck(getIdToken, mockNavigation, mockUtils)
+
+      check.onSuccess()
+
+      expect(mockNavigation.goBack).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/app/src/bcsc-theme/features/modal/DeviceInvalidated.tsx
+++ b/app/src/bcsc-theme/features/modal/DeviceInvalidated.tsx
@@ -1,0 +1,90 @@
+import { useFactoryReset } from '@/bcsc-theme/api/hooks/useFactoryReset'
+import { Button, ButtonType, ThemedText, TOKENS, useServices, useTheme } from '@bifold/core'
+import { useFocusEffect, useNavigation } from '@react-navigation/native'
+import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ScrollView, StyleSheet, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import Icon from 'react-native-vector-icons/MaterialIcons'
+
+/**
+ * Component displayed when the device has been invalidated.
+ *
+ * @returns {*} {JSX.Element} The DeviceInvalidated component.
+ */
+export const DeviceInvalidated = (): JSX.Element => {
+  const { t } = useTranslation()
+  const { Spacing, ColorPalette } = useTheme()
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const navigation = useNavigation()
+  const factoryReset = useFactoryReset()
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: ColorPalette.brand.modalPrimaryBackground,
+    },
+    scollContainer: {
+      alignItems: 'center',
+    },
+    icon: {
+      paddingVertical: Spacing.lg,
+    },
+    buttonContainer: {
+      padding: Spacing.md,
+    },
+    textContent: {
+      lineHeight: 30,
+    },
+    textContainer: {
+      padding: Spacing.md,
+      gap: Spacing.lg,
+    },
+  })
+
+  /**
+   * Prevents the user from navigating back to the previous screen.
+   */
+  useFocusEffect(
+    useCallback(() => {
+      const beforeRemove = navigation.addListener('beforeRemove', (event) => {
+        event.preventDefault()
+      })
+      return () => {
+        beforeRemove()
+      }
+    }, [navigation])
+  )
+
+  /**
+   * Handles the factory reset operation.
+   */
+  const handleFactoryReset = useCallback(async () => {
+    const result = await factoryReset()
+
+    if (!result.success) {
+      logger.error('Factory reset failed', result.error)
+    }
+  }, [factoryReset, logger])
+
+  return (
+    <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
+      <ScrollView contentContainerStyle={styles.scollContainer}>
+        <Icon name="phonelink-erase" size={200} color={ColorPalette.brand.icon} style={styles.icon} />
+        <View style={styles.textContainer}>
+          <ThemedText variant="headingThree">{t('BCSC.Modals.DeviceInvalidated.Header')}</ThemedText>
+          <ThemedText style={styles.textContent}>{t('BCSC.Modals.DeviceInvalidated.ContentA')}</ThemedText>
+          <ThemedText style={styles.textContent}>{t('BCSC.Modals.DeviceInvalidated.ContentB')}</ThemedText>
+        </View>
+      </ScrollView>
+
+      <View style={styles.buttonContainer}>
+        <Button
+          title={t('BCSC.Modals.DeviceInvalidated.OKButton')}
+          buttonType={ButtonType.Primary}
+          onPress={handleFactoryReset}
+        />
+      </View>
+    </SafeAreaView>
+  )
+}

--- a/app/src/bcsc-theme/features/modal/DeviceInvalidated.tsx
+++ b/app/src/bcsc-theme/features/modal/DeviceInvalidated.tsx
@@ -1,11 +1,7 @@
 import { useFactoryReset } from '@/bcsc-theme/api/hooks/useFactoryReset'
-import { Button, ButtonType, ThemedText, TOKENS, useServices, useTheme } from '@bifold/core'
-import { useFocusEffect, useNavigation } from '@react-navigation/native'
+import { TOKENS, useServices } from '@bifold/core'
 import { useCallback } from 'react'
-import { useTranslation } from 'react-i18next'
-import { ScrollView, StyleSheet, View } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
-import Icon from 'react-native-vector-icons/MaterialIcons'
+import { SystemModal } from './components/SystemModal'
 
 /**
  * Component displayed when the device has been invalidated.
@@ -13,48 +9,8 @@ import Icon from 'react-native-vector-icons/MaterialIcons'
  * @returns {*} {JSX.Element} The DeviceInvalidated component.
  */
 export const DeviceInvalidated = (): JSX.Element => {
-  const { t } = useTranslation()
-  const { Spacing, ColorPalette } = useTheme()
-  const [logger] = useServices([TOKENS.UTIL_LOGGER])
-  const navigation = useNavigation()
   const factoryReset = useFactoryReset()
-
-  const styles = StyleSheet.create({
-    container: {
-      flex: 1,
-      backgroundColor: ColorPalette.brand.modalPrimaryBackground,
-    },
-    scollContainer: {
-      alignItems: 'center',
-    },
-    icon: {
-      paddingVertical: Spacing.lg,
-    },
-    buttonContainer: {
-      padding: Spacing.md,
-    },
-    textContent: {
-      lineHeight: 30,
-    },
-    textContainer: {
-      padding: Spacing.md,
-      gap: Spacing.lg,
-    },
-  })
-
-  /**
-   * Prevents the user from navigating back to the previous screen.
-   */
-  useFocusEffect(
-    useCallback(() => {
-      const beforeRemove = navigation.addListener('beforeRemove', (event) => {
-        event.preventDefault()
-      })
-      return () => {
-        beforeRemove()
-      }
-    }, [navigation])
-  )
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
 
   /**
    * Handles the factory reset operation.
@@ -68,23 +24,12 @@ export const DeviceInvalidated = (): JSX.Element => {
   }, [factoryReset, logger])
 
   return (
-    <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
-      <ScrollView contentContainerStyle={styles.scollContainer}>
-        <Icon name="phonelink-erase" size={200} color={ColorPalette.brand.icon} style={styles.icon} />
-        <View style={styles.textContainer}>
-          <ThemedText variant="headingThree">{t('BCSC.Modals.DeviceInvalidated.Header')}</ThemedText>
-          <ThemedText style={styles.textContent}>{t('BCSC.Modals.DeviceInvalidated.ContentA')}</ThemedText>
-          <ThemedText style={styles.textContent}>{t('BCSC.Modals.DeviceInvalidated.ContentB')}</ThemedText>
-        </View>
-      </ScrollView>
-
-      <View style={styles.buttonContainer}>
-        <Button
-          title={t('BCSC.Modals.DeviceInvalidated.OKButton')}
-          buttonType={ButtonType.Primary}
-          onPress={handleFactoryReset}
-        />
-      </View>
-    </SafeAreaView>
+    <SystemModal
+      iconName="phonelink-erase"
+      headerKey="BCSC.Modals.DeviceInvalidated.Header"
+      contentKeys={['BCSC.Modals.DeviceInvalidated.ContentA', 'BCSC.Modals.DeviceInvalidated.ContentB']}
+      buttonTitleKey="BCSC.Modals.DeviceInvalidated.OKButton"
+      onButtonPress={handleFactoryReset}
+    />
   )
 }

--- a/app/src/bcsc-theme/features/modal/DeviceInvalidated.tsx
+++ b/app/src/bcsc-theme/features/modal/DeviceInvalidated.tsx
@@ -1,6 +1,7 @@
 import { useFactoryReset } from '@/bcsc-theme/api/hooks/useFactoryReset'
 import { TOKENS, useServices } from '@bifold/core'
 import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 import { SystemModal } from './components/SystemModal'
 
 /**
@@ -9,9 +10,9 @@ import { SystemModal } from './components/SystemModal'
  * @returns {*} {JSX.Element} The DeviceInvalidated component.
  */
 export const DeviceInvalidated = (): JSX.Element => {
+  const { t } = useTranslation()
   const factoryReset = useFactoryReset()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
-
   /**
    * Handles the factory reset operation.
    */
@@ -26,9 +27,9 @@ export const DeviceInvalidated = (): JSX.Element => {
   return (
     <SystemModal
       iconName="phonelink-erase"
-      headerKey="BCSC.Modals.DeviceInvalidated.Header"
-      contentKeys={['BCSC.Modals.DeviceInvalidated.ContentA', 'BCSC.Modals.DeviceInvalidated.ContentB']}
-      buttonTitleKey="BCSC.Modals.DeviceInvalidated.OKButton"
+      headerText={t('BCSC.Modals.DeviceInvalidated.Header')}
+      contentText={[t('BCSC.Modals.DeviceInvalidated.ContentA'), t('BCSC.Modals.DeviceInvalidated.ContentB')]}
+      buttonText={t('BCSC.Modals.DeviceInvalidated.OKButton')}
       onButtonPress={handleFactoryReset}
     />
   )

--- a/app/src/bcsc-theme/features/modal/InternetDisconnected.tsx
+++ b/app/src/bcsc-theme/features/modal/InternetDisconnected.tsx
@@ -1,7 +1,7 @@
 import { InternetStatusSystemCheck } from '@/services/system-checks/InternetStatusSystemCheck'
 import { Button, ButtonType, ThemedText, TOKENS, useServices, useTheme } from '@bifold/core'
 import { useNetInfo } from '@react-native-community/netinfo'
-import { useNavigation } from '@react-navigation/native'
+import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, View } from 'react-native'
@@ -42,6 +42,20 @@ export const InternetDisconnected = (): JSX.Element => {
       gap: Spacing.lg,
     },
   })
+
+  /**
+   * Prevents the user from navigating back to the previous screen.
+   */
+  useFocusEffect(
+    useCallback(() => {
+      const beforeRemove = navigation.addListener('beforeRemove', (event) => {
+        event.preventDefault()
+      })
+      return () => {
+        beforeRemove()
+      }
+    }, [navigation])
+  )
 
   /**
    * Handler for the retry button press to re-check internet connectivity.

--- a/app/src/bcsc-theme/features/modal/InternetDisconnected.tsx
+++ b/app/src/bcsc-theme/features/modal/InternetDisconnected.tsx
@@ -3,6 +3,7 @@ import { TOKENS, useServices } from '@bifold/core'
 import { useNetInfo } from '@react-native-community/netinfo'
 import { useNavigation } from '@react-navigation/native'
 import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 import { SystemModal } from './components/SystemModal'
 
 /**
@@ -11,6 +12,7 @@ import { SystemModal } from './components/SystemModal'
  * @returns {*} {JSX.Element} The InternetDisconnected component.
  */
 export const InternetDisconnected = (): JSX.Element => {
+  const { t } = useTranslation()
   const navigation = useNavigation()
   const netInfo = useNetInfo()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
@@ -34,9 +36,9 @@ export const InternetDisconnected = (): JSX.Element => {
   return (
     <SystemModal
       iconName="wifi-off"
-      headerKey="BCSC.Modals.InternetDisconnected.Header"
-      contentKeys={['BCSC.Modals.InternetDisconnected.ContentA', 'BCSC.Modals.InternetDisconnected.ContentB']}
-      buttonTitleKey="BCSC.Modals.InternetDisconnected.RetryButton"
+      headerText={t('BCSC.Modals.InternetDisconnected.Header')}
+      contentText={[t('BCSC.Modals.InternetDisconnected.ContentA'), t('BCSC.Modals.InternetDisconnected.ContentB')]}
+      buttonText={t('BCSC.Modals.InternetDisconnected.RetryButton')}
       onButtonPress={handleRetry}
     />
   )

--- a/app/src/bcsc-theme/features/modal/InternetDisconnected.tsx
+++ b/app/src/bcsc-theme/features/modal/InternetDisconnected.tsx
@@ -1,12 +1,9 @@
 import { InternetStatusSystemCheck } from '@/services/system-checks/InternetStatusSystemCheck'
-import { Button, ButtonType, ThemedText, TOKENS, useServices, useTheme } from '@bifold/core'
+import { TOKENS, useServices } from '@bifold/core'
 import { useNetInfo } from '@react-native-community/netinfo'
-import { useFocusEffect, useNavigation } from '@react-navigation/native'
+import { useNavigation } from '@react-navigation/native'
 import { useCallback } from 'react'
-import { useTranslation } from 'react-i18next'
-import { ScrollView, StyleSheet, View } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
-import Icon from 'react-native-vector-icons/MaterialIcons'
+import { SystemModal } from './components/SystemModal'
 
 /**
  * Component displayed when the device is disconnected from the internet.
@@ -14,48 +11,9 @@ import Icon from 'react-native-vector-icons/MaterialIcons'
  * @returns {*} {JSX.Element} The InternetDisconnected component.
  */
 export const InternetDisconnected = (): JSX.Element => {
-  const { t } = useTranslation()
-  const { Spacing, ColorPalette } = useTheme()
   const navigation = useNavigation()
   const netInfo = useNetInfo()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
-
-  const styles = StyleSheet.create({
-    container: {
-      flex: 1,
-      backgroundColor: ColorPalette.brand.modalPrimaryBackground,
-    },
-    scollContainer: {
-      alignItems: 'center',
-    },
-    icon: {
-      paddingVertical: Spacing.lg,
-    },
-    buttonContainer: {
-      padding: Spacing.md,
-    },
-    textContent: {
-      lineHeight: 30,
-    },
-    textContainer: {
-      padding: Spacing.md,
-      gap: Spacing.lg,
-    },
-  })
-
-  /**
-   * Prevents the user from navigating back to the previous screen.
-   */
-  useFocusEffect(
-    useCallback(() => {
-      const beforeRemove = navigation.addListener('beforeRemove', (event) => {
-        event.preventDefault()
-      })
-      return () => {
-        beforeRemove()
-      }
-    }, [navigation])
-  )
 
   /**
    * Handler for the retry button press to re-check internet connectivity.
@@ -74,23 +32,12 @@ export const InternetDisconnected = (): JSX.Element => {
   }, [logger, navigation, netInfo])
 
   return (
-    <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
-      <ScrollView contentContainerStyle={styles.scollContainer}>
-        <Icon name="wifi-off" size={200} color={ColorPalette.brand.icon} style={styles.icon} />
-        <View style={styles.textContainer}>
-          <ThemedText variant="headingThree">{t('BCSC.Modals.InternetDisconnected.Header')}</ThemedText>
-          <ThemedText style={styles.textContent}>{t('BCSC.Modals.InternetDisconnected.ContentA')}</ThemedText>
-          <ThemedText style={styles.textContent}>{t('BCSC.Modals.InternetDisconnected.ContentB')}</ThemedText>
-        </View>
-      </ScrollView>
-
-      <View style={styles.buttonContainer}>
-        <Button
-          title={t('BCSC.Modals.InternetDisconnected.RetryButton')}
-          buttonType={ButtonType.Primary}
-          onPress={handleRetry}
-        />
-      </View>
-    </SafeAreaView>
+    <SystemModal
+      iconName="wifi-off"
+      headerKey="BCSC.Modals.InternetDisconnected.Header"
+      contentKeys={['BCSC.Modals.InternetDisconnected.ContentA', 'BCSC.Modals.InternetDisconnected.ContentB']}
+      buttonTitleKey="BCSC.Modals.InternetDisconnected.RetryButton"
+      onButtonPress={handleRetry}
+    />
   )
 }

--- a/app/src/bcsc-theme/features/modal/MandatoryUpdate.tsx
+++ b/app/src/bcsc-theme/features/modal/MandatoryUpdate.tsx
@@ -1,11 +1,7 @@
 import { getBCSCAppStoreUrl } from '@/utils/links'
-import { Button, ButtonType, ThemedText, TOKENS, useServices, useTheme } from '@bifold/core'
-import { useFocusEffect, useNavigation } from '@react-navigation/native'
-import { useCallback } from 'react'
-import { useTranslation } from 'react-i18next'
-import { Linking, Platform, ScrollView, StyleSheet, View } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
-import Icon from 'react-native-vector-icons/MaterialIcons'
+import { TOKENS, useServices } from '@bifold/core'
+import { Linking, Platform } from 'react-native'
+import { SystemModal } from './components/SystemModal'
 
 /**
  * Component displayed when a mandatory app update is required.
@@ -13,49 +9,9 @@ import Icon from 'react-native-vector-icons/MaterialIcons'
  * @returns {*} {JSX.Element} The MandatoryUpdate component.
  */
 export const MandatoryUpdate = (): JSX.Element => {
-  const { t } = useTranslation()
-  const { Spacing, ColorPalette } = useTheme()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
-  const navigation = useNavigation()
 
   const platformStore = Platform.OS === 'ios' ? 'App Store' : 'Google Play'
-
-  const styles = StyleSheet.create({
-    container: {
-      flex: 1,
-      backgroundColor: ColorPalette.brand.modalPrimaryBackground,
-    },
-    scollContainer: {
-      alignItems: 'center',
-    },
-    icon: {
-      paddingVertical: Spacing.lg,
-    },
-    buttonContainer: {
-      padding: Spacing.md,
-    },
-    textContent: {
-      lineHeight: 30,
-    },
-    textContainer: {
-      padding: Spacing.md,
-      gap: Spacing.lg,
-    },
-  })
-
-  /**
-   * Prevents the user from navigating back to the previous screen.
-   */
-  useFocusEffect(
-    useCallback(() => {
-      const beforeRemove = navigation.addListener('beforeRemove', (event) => {
-        event.preventDefault()
-      })
-      return () => {
-        beforeRemove()
-      }
-    }, [navigation])
-  )
 
   const handleGoToStore = () => {
     try {
@@ -66,25 +22,13 @@ export const MandatoryUpdate = (): JSX.Element => {
   }
 
   return (
-    <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
-      <ScrollView contentContainerStyle={styles.scollContainer}>
-        <Icon name="system-update" size={200} color={ColorPalette.brand.icon} style={styles.icon} />
-        <View style={styles.textContainer}>
-          <ThemedText variant="headingThree">{t('BCSC.Modals.MandatoryUpdate.Header')}</ThemedText>
-          <ThemedText style={styles.textContent}>{t('BCSC.Modals.MandatoryUpdate.ContentA')}</ThemedText>
-          <ThemedText style={styles.textContent}>
-            {t('BCSC.Modals.MandatoryUpdate.ContentB', { platformStore })}
-          </ThemedText>
-        </View>
-      </ScrollView>
-
-      <View style={styles.buttonContainer}>
-        <Button
-          title={t('BCSC.Modals.MandatoryUpdate.UpdateButton', { platformStore })}
-          buttonType={ButtonType.Primary}
-          onPress={handleGoToStore}
-        />
-      </View>
-    </SafeAreaView>
+    <SystemModal
+      iconName="system-update"
+      headerKey="BCSC.Modals.MandatoryUpdate.Header"
+      contentKeys={['BCSC.Modals.MandatoryUpdate.ContentA', 'BCSC.Modals.MandatoryUpdate.ContentB']}
+      buttonTitleKey="BCSC.Modals.MandatoryUpdate.UpdateButton"
+      onButtonPress={handleGoToStore}
+      translationParams={{ platformStore }}
+    />
   )
 }

--- a/app/src/bcsc-theme/features/modal/MandatoryUpdate.tsx
+++ b/app/src/bcsc-theme/features/modal/MandatoryUpdate.tsx
@@ -1,5 +1,7 @@
 import { getBCSCAppStoreUrl } from '@/utils/links'
 import { Button, ButtonType, ThemedText, TOKENS, useServices, useTheme } from '@bifold/core'
+import { useFocusEffect, useNavigation } from '@react-navigation/native'
+import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Linking, Platform, ScrollView, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -14,6 +16,7 @@ export const MandatoryUpdate = (): JSX.Element => {
   const { t } = useTranslation()
   const { Spacing, ColorPalette } = useTheme()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const navigation = useNavigation()
 
   const platformStore = Platform.OS === 'ios' ? 'App Store' : 'Google Play'
 
@@ -39,6 +42,20 @@ export const MandatoryUpdate = (): JSX.Element => {
       gap: Spacing.lg,
     },
   })
+
+  /**
+   * Prevents the user from navigating back to the previous screen.
+   */
+  useFocusEffect(
+    useCallback(() => {
+      const beforeRemove = navigation.addListener('beforeRemove', (event) => {
+        event.preventDefault()
+      })
+      return () => {
+        beforeRemove()
+      }
+    }, [navigation])
+  )
 
   const handleGoToStore = () => {
     try {

--- a/app/src/bcsc-theme/features/modal/MandatoryUpdate.tsx
+++ b/app/src/bcsc-theme/features/modal/MandatoryUpdate.tsx
@@ -1,5 +1,6 @@
 import { getBCSCAppStoreUrl } from '@/utils/links'
 import { TOKENS, useServices } from '@bifold/core'
+import { useTranslation } from 'react-i18next'
 import { Linking, Platform } from 'react-native'
 import { SystemModal } from './components/SystemModal'
 
@@ -9,6 +10,7 @@ import { SystemModal } from './components/SystemModal'
  * @returns {*} {JSX.Element} The MandatoryUpdate component.
  */
 export const MandatoryUpdate = (): JSX.Element => {
+  const { t } = useTranslation()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
 
   const platformStore = Platform.OS === 'ios' ? 'App Store' : 'Google Play'
@@ -24,11 +26,13 @@ export const MandatoryUpdate = (): JSX.Element => {
   return (
     <SystemModal
       iconName="system-update"
-      headerKey="BCSC.Modals.MandatoryUpdate.Header"
-      contentKeys={['BCSC.Modals.MandatoryUpdate.ContentA', 'BCSC.Modals.MandatoryUpdate.ContentB']}
-      buttonTitleKey="BCSC.Modals.MandatoryUpdate.UpdateButton"
+      headerText={t('BCSC.Modals.MandatoryUpdate.Header')}
+      contentText={[
+        t('BCSC.Modals.MandatoryUpdate.ContentA'),
+        t('BCSC.Modals.MandatoryUpdate.ContentB', { platformStore }),
+      ]}
+      buttonText={t('BCSC.Modals.MandatoryUpdate.UpdateButton', { platformStore })}
       onButtonPress={handleGoToStore}
-      translationParams={{ platformStore }}
     />
   )
 }

--- a/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
+++ b/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
@@ -1,7 +1,6 @@
 import { Button, ButtonType, ThemedText, useTheme } from '@bifold/core'
 import { useFocusEffect, useNavigation } from '@react-navigation/native'
-import { useCallback, useRef } from 'react'
-import { useTranslation } from 'react-i18next'
+import { useCallback } from 'react'
 import { ScrollView, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialIcons'
@@ -16,17 +15,17 @@ export interface SystemModalProps {
    */
   iconSize?: number
   /**
-   * Translation key for the header text
+   * Header text
    */
-  headerKey: string
+  headerText: string
   /**
-   * Array of translation keys for content paragraphs
+   * Content text
    */
-  contentKeys: string[]
+  contentText: string[]
   /**
-   * Translation key for the button title
+   * Button text
    */
-  buttonTitleKey: string
+  buttonText: string
   /**
    * Callback function when the button is pressed
    */
@@ -46,16 +45,13 @@ export interface SystemModalProps {
 export const SystemModal = ({
   iconName,
   iconSize = 200,
-  headerKey,
-  contentKeys,
-  buttonTitleKey,
+  headerText,
+  contentText,
+  buttonText,
   onButtonPress,
-  translationParams,
 }: SystemModalProps): JSX.Element => {
-  const { t } = useTranslation()
   const { Spacing, ColorPalette } = useTheme()
   const navigation = useNavigation()
-  const allowNavigationRef = useRef(false)
 
   const styles = StyleSheet.create({
     container: {
@@ -88,11 +84,10 @@ export const SystemModal = ({
   useFocusEffect(
     useCallback(() => {
       const beforeRemove = navigation.addListener('beforeRemove', (event) => {
-        if (allowNavigationRef.current) {
-          allowNavigationRef.current = false
-          return
+        if (!event.data.action.source) {
+          // gesture navigation has no action source so we prevent it
+          event.preventDefault()
         }
-        event.preventDefault()
       })
       return () => {
         beforeRemove()
@@ -100,34 +95,22 @@ export const SystemModal = ({
     }, [navigation])
   )
 
-  /**
-   * Wraps the onButtonPress handler to allow programmatic navigation.
-   */
-  const handleButtonPress = useCallback(async () => {
-    allowNavigationRef.current = true
-    await onButtonPress()
-  }, [onButtonPress])
-
   return (
     <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
       <ScrollView contentContainerStyle={styles.scollContainer}>
         <Icon name={iconName} size={iconSize} color={ColorPalette.brand.icon} style={styles.icon} />
         <View style={styles.textContainer}>
-          <ThemedText variant="headingThree">{t(headerKey, translationParams)}</ThemedText>
-          {contentKeys.map((key) => (
-            <ThemedText key={key} style={styles.textContent}>
-              {t(key, translationParams)}
+          <ThemedText variant="headingThree">{headerText}</ThemedText>
+          {contentText.map((text) => (
+            <ThemedText key={text} style={styles.textContent}>
+              {text}
             </ThemedText>
           ))}
         </View>
       </ScrollView>
 
       <View style={styles.buttonContainer}>
-        <Button
-          title={t(buttonTitleKey, translationParams)}
-          buttonType={ButtonType.Primary}
-          onPress={handleButtonPress}
-        />
+        <Button title={buttonText} buttonType={ButtonType.Primary} onPress={onButtonPress} />
       </View>
     </SafeAreaView>
   )

--- a/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
+++ b/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
@@ -30,10 +30,6 @@ export interface SystemModalProps {
    * Callback function when the button is pressed
    */
   onButtonPress: () => void | Promise<void>
-  /**
-   * Optional parameters for translation interpolation
-   */
-  translationParams?: Record<string, string | number>
 }
 
 /**

--- a/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
+++ b/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
@@ -1,0 +1,134 @@
+import { Button, ButtonType, ThemedText, useTheme } from '@bifold/core'
+import { useFocusEffect, useNavigation } from '@react-navigation/native'
+import { useCallback, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ScrollView, StyleSheet, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import Icon from 'react-native-vector-icons/MaterialIcons'
+
+export interface SystemModalProps {
+  /**
+   * Name of the MaterialIcons icon to display
+   */
+  iconName: string
+  /**
+   * Size of the icon (default: 200)
+   */
+  iconSize?: number
+  /**
+   * Translation key for the header text
+   */
+  headerKey: string
+  /**
+   * Array of translation keys for content paragraphs
+   */
+  contentKeys: string[]
+  /**
+   * Translation key for the button title
+   */
+  buttonTitleKey: string
+  /**
+   * Callback function when the button is pressed
+   */
+  onButtonPress: () => void | Promise<void>
+  /**
+   * Optional parameters for translation interpolation
+   */
+  translationParams?: Record<string, string | number>
+}
+
+/**
+ * A reusable modal component for system-related messages (device invalidated, internet disconnected, mandatory update, etc.)
+ *
+ * @param {SystemModalProps} props - The component props
+ * @returns {JSX.Element} The SystemModal component
+ */
+export const SystemModal = ({
+  iconName,
+  iconSize = 200,
+  headerKey,
+  contentKeys,
+  buttonTitleKey,
+  onButtonPress,
+  translationParams,
+}: SystemModalProps): JSX.Element => {
+  const { t } = useTranslation()
+  const { Spacing, ColorPalette } = useTheme()
+  const navigation = useNavigation()
+  const allowNavigationRef = useRef(false)
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: ColorPalette.brand.modalPrimaryBackground,
+    },
+    scollContainer: {
+      alignItems: 'center',
+    },
+    icon: {
+      paddingVertical: Spacing.lg,
+    },
+    buttonContainer: {
+      padding: Spacing.md,
+    },
+    textContent: {
+      lineHeight: 30,
+    },
+    textContainer: {
+      padding: Spacing.md,
+      gap: Spacing.lg,
+    },
+  })
+
+  /**
+   * Prevents the user from navigating back to the previous screen on Android,
+   * but allows programmatic navigation (e.g., when button is pressed).
+   * Note: gestureEnabled: false works for iOS, but Android requires this listener.
+   */
+  useFocusEffect(
+    useCallback(() => {
+      const beforeRemove = navigation.addListener('beforeRemove', (event) => {
+        if (allowNavigationRef.current) {
+          allowNavigationRef.current = false
+          return
+        }
+        event.preventDefault()
+      })
+      return () => {
+        beforeRemove()
+      }
+    }, [navigation])
+  )
+
+  /**
+   * Wraps the onButtonPress handler to allow programmatic navigation.
+   */
+  const handleButtonPress = useCallback(async () => {
+    allowNavigationRef.current = true
+    await onButtonPress()
+  }, [onButtonPress])
+
+  return (
+    <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
+      <ScrollView contentContainerStyle={styles.scollContainer}>
+        <Icon name={iconName} size={iconSize} color={ColorPalette.brand.icon} style={styles.icon} />
+        <View style={styles.textContainer}>
+          <ThemedText variant="headingThree">{t(headerKey, translationParams)}</ThemedText>
+          {contentKeys.map((key, index) => (
+            <ThemedText key={index} style={styles.textContent}>
+              {t(key, translationParams)}
+            </ThemedText>
+          ))}
+        </View>
+      </ScrollView>
+
+      <View style={styles.buttonContainer}>
+        <Button
+          title={t(buttonTitleKey, translationParams)}
+          buttonType={ButtonType.Primary}
+          onPress={handleButtonPress}
+        />
+      </View>
+    </SafeAreaView>
+  )
+}

--- a/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
+++ b/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
@@ -114,8 +114,8 @@ export const SystemModal = ({
         <Icon name={iconName} size={iconSize} color={ColorPalette.brand.icon} style={styles.icon} />
         <View style={styles.textContainer}>
           <ThemedText variant="headingThree">{t(headerKey, translationParams)}</ThemedText>
-          {contentKeys.map((key, index) => (
-            <ThemedText key={index} style={styles.textContent}>
+          {contentKeys.map((key) => (
+            <ThemedText key={key} style={styles.textContent}>
               {t(key, translationParams)}
             </ThemedText>
           ))}

--- a/app/src/bcsc-theme/features/services/hooks/useFilterServiceClients.ts
+++ b/app/src/bcsc-theme/features/services/hooks/useFilterServiceClients.ts
@@ -86,7 +86,7 @@ export const useFilterServiceClients = (filter: ServiceClientsFilter): FilterSer
   if (!serviceClients && isReady) {
     Alert.alert(t('Error.Title2033'), t('Error.Message2033'), [
       {
-        text: t('Global.OK'),
+        text: t('Error.OK'),
         onPress: () => {
           navigation.goBack()
         },

--- a/app/src/bcsc-theme/features/verify/email/EmailConfirmationScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EmailConfirmationScreen.tsx
@@ -138,7 +138,7 @@ const EmailConfirmationScreen = ({ navigation, route }: EmailConfirmationScreenP
 
     Linking.openURL(url).catch(() => {
       Alert.alert(t('BCSC.EmailConfirmation.UnableToOpenEmail'), t('BCSC.EmailConfirmation.UnableToOpenEmailMessage'), [
-        { text: t('Global.OK') },
+        { text: t('BCSC.EmailConfirmation.OKButton') },
       ])
     })
   }

--- a/app/src/bcsc-theme/hooks/useSystemChecks.tsx
+++ b/app/src/bcsc-theme/hooks/useSystemChecks.tsx
@@ -1,6 +1,7 @@
 import { useEventListener } from '@/hooks/useEventListener'
 import { AccountExpirySystemCheck } from '@/services/system-checks/AccountExpirySystemCheck'
 import { DeviceCountSystemCheck } from '@/services/system-checks/DeviceCountSystemCheck'
+import { DeviceInvalidatedSystemCheck } from '@/services/system-checks/DeviceInvalidatedSystemCheck'
 import { InternetStatusSystemCheck } from '@/services/system-checks/InternetStatusSystemCheck'
 import { ServerStatusSystemCheck } from '@/services/system-checks/ServerStatusSystemCheck'
 import { runSystemChecks, SystemCheckNavigation, SystemCheckStrategy } from '@/services/system-checks/system-checks'
@@ -91,6 +92,7 @@ export const useSystemChecks = (scope: SystemCheckScope) => {
           const accountExpiry = await userApi.getAccountExpirationDate()
 
           await runSystemChecks([
+            new DeviceInvalidatedSystemCheck(getIdToken, navigation, utils),
             new DeviceCountSystemCheck(getIdToken, utils),
             new AccountExpirySystemCheck(accountExpiry, utils),
           ])

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -186,6 +186,7 @@ const MainStack: React.FC = () => {
           component={InternetDisconnected}
           options={{
             ...getDefaultModalOptions(t('BCSC.Title')),
+            gestureEnabled: false,
           }}
         />
 
@@ -194,6 +195,7 @@ const MainStack: React.FC = () => {
           component={MandatoryUpdate}
           options={{
             ...getDefaultModalOptions(t('BCSC.Title')),
+            gestureEnabled: false,
           }}
         />
 
@@ -202,6 +204,7 @@ const MainStack: React.FC = () => {
           component={DeviceInvalidated}
           options={{
             ...getDefaultModalOptions(t('BCSC.Title')),
+            gestureEnabled: false,
           }}
         />
       </Stack.Navigator>

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -14,6 +14,7 @@ import TransferQRInformationScreen from '../features/account-transfer/TransferQR
 import TransferSuccessScreen from '../features/account-transfer/TransferSuccessScreen'
 import EditNicknameScreen from '../features/account/EditNicknameScreen'
 import RemoveAccountConfirmationScreen from '../features/account/RemoveAccountConfirmationScreen'
+import { DeviceInvalidated } from '../features/modal/DeviceInvalidated'
 import { InternetDisconnected } from '../features/modal/InternetDisconnected'
 import { MandatoryUpdate } from '../features/modal/MandatoryUpdate'
 import ManualPairingCode from '../features/pairing/ManualPairing'
@@ -185,7 +186,6 @@ const MainStack: React.FC = () => {
           component={InternetDisconnected}
           options={{
             ...getDefaultModalOptions(t('BCSC.Title')),
-            gestureEnabled: false, // Disable swipe to dismiss
           }}
         />
 
@@ -194,7 +194,14 @@ const MainStack: React.FC = () => {
           component={MandatoryUpdate}
           options={{
             ...getDefaultModalOptions(t('BCSC.Title')),
-            gestureEnabled: false, // Disable swipe to dismiss
+          }}
+        />
+
+        <Stack.Screen
+          name={BCSCModals.DeviceInvalidated}
+          component={DeviceInvalidated}
+          options={{
+            ...getDefaultModalOptions(t('BCSC.Title')),
           }}
         />
       </Stack.Navigator>

--- a/app/src/bcsc-theme/navigators/OnboardingStack.tsx
+++ b/app/src/bcsc-theme/navigators/OnboardingStack.tsx
@@ -80,6 +80,7 @@ const OnboardingStack = (): JSX.Element => {
         component={InternetDisconnected}
         options={{
           ...getDefaultModalOptions(t('BCSC.Title')),
+          gestureEnabled: false,
         }}
       />
 
@@ -88,6 +89,7 @@ const OnboardingStack = (): JSX.Element => {
         component={MandatoryUpdate}
         options={{
           ...getDefaultModalOptions(t('BCSC.Title')),
+          gestureEnabled: false,
         }}
       />
     </Stack.Navigator>

--- a/app/src/bcsc-theme/navigators/OnboardingStack.tsx
+++ b/app/src/bcsc-theme/navigators/OnboardingStack.tsx
@@ -80,7 +80,6 @@ const OnboardingStack = (): JSX.Element => {
         component={InternetDisconnected}
         options={{
           ...getDefaultModalOptions(t('BCSC.Title')),
-          gestureEnabled: false, // Disable swipe to dismiss
         }}
       />
 
@@ -89,7 +88,6 @@ const OnboardingStack = (): JSX.Element => {
         component={MandatoryUpdate}
         options={{
           ...getDefaultModalOptions(t('BCSC.Title')),
-          gestureEnabled: false, // Disable swipe to dismiss
         }}
       />
     </Stack.Navigator>

--- a/app/src/bcsc-theme/navigators/VerifyStack.tsx
+++ b/app/src/bcsc-theme/navigators/VerifyStack.tsx
@@ -289,7 +289,6 @@ const VerifyStack = () => {
         component={InternetDisconnected}
         options={{
           ...getDefaultModalOptions(t('BCSC.Title')),
-          gestureEnabled: false, // Disable swipe to dismiss
         }}
       />
 
@@ -298,7 +297,6 @@ const VerifyStack = () => {
         component={MandatoryUpdate}
         options={{
           ...getDefaultModalOptions(t('BCSC.Title')),
-          gestureEnabled: false, // Disable swipe to dismiss
         }}
       />
     </Stack.Navigator>

--- a/app/src/bcsc-theme/navigators/VerifyStack.tsx
+++ b/app/src/bcsc-theme/navigators/VerifyStack.tsx
@@ -289,6 +289,7 @@ const VerifyStack = () => {
         component={InternetDisconnected}
         options={{
           ...getDefaultModalOptions(t('BCSC.Title')),
+          gestureEnabled: false,
         }}
       />
 
@@ -297,6 +298,7 @@ const VerifyStack = () => {
         component={MandatoryUpdate}
         options={{
           ...getDefaultModalOptions(t('BCSC.Title')),
+          gestureEnabled: false,
         }}
       />
     </Stack.Navigator>

--- a/app/src/bcsc-theme/types/navigators.ts
+++ b/app/src/bcsc-theme/types/navigators.ts
@@ -1,13 +1,7 @@
 import { NavigatorScreenParams } from '@react-navigation/native'
-import { StackNavigationProp } from '@react-navigation/stack'
 import { EvidenceType } from '../api/hooks/useEvidenceApi'
 import { ClientMetadata } from '../api/hooks/useMetadataApi'
 import { BCSCCardType } from './cards'
-
-export type ModalNavigation = StackNavigationProp<
-  BCSCMainStackParams | BCSCVerifyStackParams | BCSCOnboardingStackParams,
-  BCSCModals.InternetDisconnected | BCSCModals.MandatoryUpdate
->
 
 export enum BCSCStacks {
   Startup = 'BCSCStartupStack',
@@ -20,6 +14,7 @@ export enum BCSCStacks {
 export enum BCSCModals {
   InternetDisconnected = 'BCSCNoInternet',
   MandatoryUpdate = 'BCSCMandatoryUpdate',
+  DeviceInvalidated = 'BCSCDeviceInvalidated',
 }
 
 export enum BCSCScreens {
@@ -196,4 +191,5 @@ export type BCSCMainStackParams = {
 
   [BCSCModals.InternetDisconnected]: undefined
   [BCSCModals.MandatoryUpdate]: undefined
+  [BCSCModals.DeviceInvalidated]: undefined
 }

--- a/app/src/bcsc-theme/utils/id-token.ts
+++ b/app/src/bcsc-theme/utils/id-token.ts
@@ -9,6 +9,39 @@ export enum BCSCAccountType {
 }
 
 /**
+ * BCSC event types
+ * Added from https://citz-cdt.atlassian.net/wiki/spaces/BMS/pages/301574688/5.1+System+Interfaces#ID-Token
+ * @export
+ * @enum {number}
+ */
+export enum BCSCEvent {
+  Authorization = 'Authorization',
+  Renewal = 'Renewal',
+  Replace = 'Replace',
+  Cancel = 'Cancel',
+  Expire = 'Expire',
+}
+
+/**
+ * BCSC reason types
+ *
+ * @export
+ * @enum {number}
+ */
+export enum BCSCReason {
+  ApprovedByAgent = 'Approved by Agent',
+  Renew = 'Renewed by Card Renew',
+  Replace = 'Replaced by Card Replace',
+  Cancel = 'Canceled by Card Cancel',
+  ExpiredBySystem = 'Expired by System',
+  CanceledByAgent = 'Canceled by Agent',
+  CanceledByUser = 'Canceled by User',
+  CanceledByAdditionalCardNew = 'Canceled by Additional Card New for R2.6',
+  CanceledByCardTypeChangeNew = 'Canceled by Card Type Change New for R2.6',
+  CanceledDueToInactivity = 'Canceled due to Inactivity',
+}
+
+/**
  * IAS BCSC ID token
  *
  * @see https://citz-cdt.atlassian.net/wiki/spaces/BMS/pages/301574688/5.1+System+Interfaces#ID-Token
@@ -25,8 +58,8 @@ export interface IdToken {
   middle_name?: string
   // note: this value is undefined for non-bcsc cards, transform to 'Other' in that case
   bcsc_card_type: BCSCCardType.Combined | BCSCCardType.Photo | BCSCCardType.NonPhoto | BCSCCardType.Other
-  bcsc_event: string
-  bcsc_reason: string
+  bcsc_event: BCSCEvent
+  bcsc_reason: BCSCReason
   bcsc_status_date: number // epoch
   acr: number // Defined since R2.6.x
   bcsc_devices_count: number // Defined since R2.10.2

--- a/app/src/bcsc-theme/utils/id-token.ts
+++ b/app/src/bcsc-theme/utils/id-token.ts
@@ -36,8 +36,8 @@ export enum BCSCReason {
   ExpiredBySystem = 'Expired by System',
   CanceledByAgent = 'Canceled by Agent',
   CanceledByUser = 'Canceled by User',
-  CanceledByAdditionalCardNew = 'Canceled by Additional Card New for R2.6',
-  CanceledByCardTypeChangeNew = 'Canceled by Card Type Change New for R2.6',
+  CanceledByAdditionalCard = 'Canceled by Additional Card',
+  CanceledByCardTypeChange = 'Canceled by Card Type Change',
   CanceledDueToInactivity = 'Canceled due to Inactivity',
 }
 

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -191,8 +191,8 @@ const translation = {
         "UpdateButton": "Go to {{platformStore}}",
       },
       "DeviceInvalidated": {
-        "Header": "Device removed",
-        "ContentA": "This device was removed after you registered another one. You can only be signed in on three devices at a time.",
+        "Header": "Device invalidated",
+        "ContentA": "This device has been invalidated. You must re-authorize the device to continue.",
         "ContentB": "Tap OK to clear local data and restart setup on this device.",
         "OKButton": "OK",
       }

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -18,6 +18,7 @@ const translation = {
     "Message2032": "There was a problem while opening the app-to-app URL.",
     "Title2033": "Failed to load services",
     "Message2033": "There was a problem while loading the services. Please try again later.",
+    "OK": "OK",
     "NoMessage": "No Message",
   },
   "Credentials": {
@@ -188,7 +189,13 @@ const translation = {
         "ContentA": "You must update this app to continue.",
         "ContentB": "Please update to the latest version from the {{platformStore}}.",
         "UpdateButton": "Go to {{platformStore}}",
-      }    
+      },
+      "DeviceInvalidated": {
+        "Header": "Device removed",
+        "ContentA": "This device was removed after you registered another one. You can only be signed in on three devices at a time.",
+        "ContentB": "Tap OK to clear local data and restart setup on this device.",
+        "OKButton": "OK",
+      }
     },
     "Home": {
       "WhereToUseTitle": "Where to use",
@@ -439,6 +446,7 @@ const translation = {
       "EnterTheSixDigitCode": "Enter the six digit code sent to your email",
       "ResendCode": "Resend code",
       "GoToEmail": "Go to my email",
+      "OKButton": "OK",
     },
     "VerifyIdentity": {
       "DeviceCodeError": "Device code or user code is missing in the store.",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -18,6 +18,7 @@ const translation = {
     "Message2032": "There was a problem while opening the app-to-app URL. (FR)",
     "Title2033": "Failed to load services (FR)",
     "Message2033": "There was a problem while loading the services. Please try again later. (FR)",
+    "OK": "OK (FR)",
     "NoMessage": "Aucun message",
   },
   "Credentials": {
@@ -188,7 +189,13 @@ const translation = {
         "ContentA": "You must update this app to continue. (FR)",
         "ContentB": "Please update to the latest version from the {{platformStore}}. (FR)",
         "UpdateButton": "Go to {{platformStore}} (FR)",
-      }    
+      } ,
+      "DeviceInvalidated": {
+        "Header": "Device removed (FR)",
+        "ContentA": "This device was removed after you registered another one. You can only be signed in on three devices at a time. (FR)",
+        "ContentB": "Tap OK to clear local data and restart setup on this device. (FR)",
+        "OKButton": "OK (FR)",
+      }  
     },
     "Home": {
       "WhereToUseTitle": "Where to use (FR)",
@@ -439,6 +446,7 @@ const translation = {
       "EnterTheSixDigitCode": "Enter the six digit code sent to your email (FR)",
       "ResendCode": "Resend code (FR)",
       "GoToEmail": "Go to my email (FR)",
+      "OKButton": "OK (FR)",
     },
     "VerifyIdentity": {
       "DeviceCodeError": "Device code or user code is missing in the store. (FR)",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -191,8 +191,8 @@ const translation = {
         "UpdateButton": "Go to {{platformStore}} (FR)",
       } ,
       "DeviceInvalidated": {
-        "Header": "Device removed (FR)",
-        "ContentA": "This device was removed after you registered another one. You can only be signed in on three devices at a time. (FR)",
+        "Header": "Device invalidated (FR)",
+        "ContentA": "This device has been invalidated. You must re-authorize the device to continue. (FR)",
         "ContentB": "Tap OK to clear local data and restart setup on this device. (FR)",
         "OKButton": "OK (FR)",
       }  

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -19,6 +19,7 @@ const translation = {
     "Title2033": "Failed to load services (PT-BR)",
     "Message2033": "There was a problem while loading the services. Please try again later. (PT-BR)",
     "NoMessage": "No Message (PT-BR)",
+    "OK": "OK (PT-BR)",
   },
   "Credentials": {
     "AddCredential": "Add Credential (PT-BR)",
@@ -188,7 +189,13 @@ const translation = {
         "ContentA": "You must update this app to continue. (PT-BR)",
         "ContentB": "Please update to the latest version from the {{platformStore}}. (PT-BR)",
         "UpdateButton": "Go to {{platformStore}} (PT-BR)",
-      }    
+      },
+      "DeviceInvalidated": {
+        "Header": "Device removed (PT-BR)",
+        "ContentA": "This device was removed after you registered another one. You can only be signed in on three devices at a time. (PT-BR)",
+        "ContentB": "Tap OK to clear local data and restart setup on this device. (PT-BR)",
+        "OKButton": "OK (PT-BR)",
+      }  
     },
     "Home": {
       "WhereToUseTitle": "Where to use (PT-BR)",
@@ -439,6 +446,7 @@ const translation = {
       "EnterTheSixDigitCode": "Enter the six digit code sent to your email (PT-BR)",
       "ResendCode": "Resend code (PT-BR)",
       "GoToEmail": "Go to my email (PT-BR)",
+      "OKButton": "OK (PT-BR)",
     },
     "VerifyIdentity": {
       "DeviceCodeError": "Device code or user code is missing in the store. (PT-BR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -191,8 +191,8 @@ const translation = {
         "UpdateButton": "Go to {{platformStore}} (PT-BR)",
       },
       "DeviceInvalidated": {
-        "Header": "Device removed (PT-BR)",
-        "ContentA": "This device was removed after you registered another one. You can only be signed in on three devices at a time. (PT-BR)",
+        "Header": "Device invalidated (PT-BR)",
+        "ContentA": "This device has been invalidated. You must re-authorize the device to continue. (PT-BR)",
         "ContentB": "Tap OK to clear local data and restart setup on this device. (PT-BR)",
         "OKButton": "OK (PT-BR)",
       }  

--- a/app/src/services/system-checks/DeviceInvalidatedSystemCheck.ts
+++ b/app/src/services/system-checks/DeviceInvalidatedSystemCheck.ts
@@ -1,4 +1,5 @@
 import { BCSCModals } from '@/bcsc-theme/types/navigators'
+import { isNetworkError } from '@/bcsc-theme/utils/error-utils'
 import { BCSCEvent, BCSCReason, IdToken } from '@/bcsc-theme/utils/id-token'
 import { SystemCheckNavigation, SystemCheckStrategy, SystemCheckUtils } from './system-checks'
 
@@ -48,7 +49,7 @@ export class DeviceInvalidatedSystemCheck implements SystemCheckStrategy {
       return true
     } catch (error) {
       this.utils.logger.error('DeviceInvalidatedSystemCheck: Id token request failed', error as Error)
-      return false
+      return isNetworkError(error)
     }
   }
 

--- a/app/src/services/system-checks/DeviceInvalidatedSystemCheck.ts
+++ b/app/src/services/system-checks/DeviceInvalidatedSystemCheck.ts
@@ -1,0 +1,88 @@
+import { BCSCModals } from '@/bcsc-theme/types/navigators'
+import { BCSCEvent, BCSCReason, IdToken } from '@/bcsc-theme/utils/id-token'
+import { SystemCheckNavigation, SystemCheckStrategy, SystemCheckUtils } from './system-checks'
+
+/**
+ * Checks if the device has been invalidated.
+ *
+ * Note: Determines the invalidation reason based on the values in the ID token.
+ *   On failure, it navigates to the DeviceInvalidated modal.
+ *   On success, it navigates back if currently on the DeviceInvalidated modal.
+ *
+ * @export
+ * @class DeviceInvalidatedSystemCheck
+ * @implements {SystemCheckStrategy}
+ */
+export class DeviceInvalidatedSystemCheck implements SystemCheckStrategy {
+  private readonly getIdToken: () => Promise<IdToken>
+  private readonly navigation: SystemCheckNavigation
+  private readonly utils: SystemCheckUtils
+
+  constructor(getIdToken: () => Promise<IdToken>, navigation: SystemCheckNavigation, utils: SystemCheckUtils) {
+    this.getIdToken = getIdToken
+    this.navigation = navigation
+    this.utils = utils
+  }
+
+  private get isModalVisible() {
+    const state = this.navigation.getState()
+    const currentRouteName = state?.routes[state.index].name
+    return currentRouteName === BCSCModals.DeviceInvalidated
+  }
+
+  /**
+   * Runs the device invalidated check to verify if the device has been invalidated.
+   *
+   * @return {*}  {Promise<boolean>}
+   * @memberof DeviceInvalidatedSystemCheck
+   */
+  async runCheck(): Promise<boolean> {
+    try {
+      const idToken = await this.getIdToken()
+
+      if (idToken.bcsc_event === BCSCEvent.Cancel && idToken.bcsc_reason === BCSCReason.CanceledByAgent) {
+        // Device has been invalidated by the agent, user must re-authorize the device
+        return false
+      }
+
+      return true
+    } catch (error) {
+      this.utils.logger.error('DeviceInvalidatedSystemCheck: Id token request failed', error as Error)
+      return false
+    }
+  }
+
+  /**
+   * Handles the failure of the device invalidated check
+   * by navigating to the DeviceInvalidated modal.
+   *
+   * @returns {*} {void}
+   * @memberof DeviceInvalidatedSystemCheck
+   */
+  onFail() {
+    this.utils.logger.warn('DeviceInvalidatedSystemCheck: Device invalidated')
+
+    // Only navigate if the modal is not already visible
+    if (this.isModalVisible) {
+      return
+    }
+
+    this.navigation.navigate(BCSCModals.DeviceInvalidated)
+  }
+
+  /**
+   * Handles the success of the device invalidated check
+   * by navigating back if currently on the DeviceInvalidated modal.
+   *
+   * @returns {*} {void}
+   * @memberof DeviceInvalidatedSystemCheck
+   */
+  onSuccess() {
+    // Only navigate back if the modal is visible
+    if (!this.isModalVisible || !this.navigation.canGoBack()) {
+      return
+    }
+
+    this.navigation.goBack()
+  }
+}


### PR DESCRIPTION
# Summary of Changes

This PR implements device invalidation detection and handling, allowing the app to detect when a device has been invalidated by an agent and guide users through the re-authorization process. The implementation includes:

1. **Device Invalidation System Check**: A new system check that monitors the ID token for device invalidation events (`bcsc_event: 'Cancel'` and `bcsc_reason: 'Canceled by Agent'`). When detected, it automatically navigates to a dedicated modal screen.

2. **Device Invalidated Modal**: A new modal component that displays when a device has been invalidated, informing users they must re-authorize the device and providing a factory reset option to clear local data and restart setup.

3. **ID Token Enhancements**: Extended the ID token utilities with `BCSCEvent` and `BCSCReason` enums to support device invalidation detection and other BCSC events.

4. **Modal Navigation Improvements (Android Fix)**: Enhanced modal components (`InternetDisconnected` and `MandatoryUpdate`) to properly prevent back navigation on Android devices using React Navigation's `useFocusEffect` hook with `beforeRemove` listener. The previous `gestureEnabled: false` approach only works on iOS to prevent swipe gestures, but does not prevent Android's hardware/software back button navigation or swipe gestures. This change ensures consistent behavior across both platforms by preventing all forms of back navigation (swipe gestures and back button on Android, swipe gestures on iOS).

5. **Localization**: Added translations for the Device Invalidated modal in English, French, and Portuguese.

6. **Infrastructure Updates**: Updated GitHub Actions workflow to use `actions/setup-java@v5` for improved Java setup in CI/CD pipelines.

7. **Bug Fixes**: Removed unavailable global OK translation references and improved modal wording.

# Testing Instructions

## Device Invalidation Flow

1. **Setup Test Environment**:
   - Ensure you have a test BCSC account
   - Have access to 4 devices (or emulators/simulators) with the app installed
   - Note: Agent access is only needed for alternative testing methods

2. **Trigger Device Invalidation** (Easiest Method - Device Limit):
   - Register 3 devices with the same BCSC account
   - Register a 4th device with the same account
   - The 3rd device (oldest registered device) will be automatically invalidated by the system
   - Open the app on the 3rd device to trigger the invalidation check
   
3. **Verify System Check Detection**:
   - Open the app or navigate to any screen
   - The system check should detect the invalidation and automatically navigate to the Device Invalidated modal
   - Verify the modal cannot be dismissed by back navigation or gestures

4. **Test Factory Reset**:
   - Tap the "OK" button on the Device Invalidated modal
   - Verify that factory reset is triggered and local data is cleared
   - Verify the app restarts the setup flow

# Acceptance Criteria

- [x] Device invalidation is detected when `bcsc_event: 'Cancel'` and `bcsc_reason: 'Canceled by Agent'` are present in the ID token
- [x] Device Invalidated modal is displayed automatically when invalidation is detected
- [x] Device Invalidated modal cannot be dismissed via back navigation or gestures
- [x] Factory reset functionality works correctly when user taps OK button
- [x] Modal navigation prevention works for InternetDisconnected, MandatoryUpdate, and DeviceInvalidated modals on both iOS and Android (prevents swipe gestures and back button on Android, swipe gestures on iOS)
- [x] All translations are present and correct in English, French, and Portuguese
- [x] GitHub Actions workflow uses setup-java@v5

# Screenshots, videos, or gifs

N/A - UI changes follow existing modal design patterns and can be verified through testing.

# Related Issues

N/A

# Pull Request Checklist

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes