### PR TITLE
feat: learnmore webview

### DIFF
--- a/app/src/bcsc-theme/features/onboarding/OnboardingPrivacyPolicyScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/OnboardingPrivacyPolicyScreen.tsx
@@ -1,4 +1,5 @@
 import { BCSCOnboardingStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
+import { createSecuringAppWebViewJavascriptInjection } from '@/bcsc-theme/utils/webview-utils'
 import { SECURE_APP_LEARN_MORE_URL } from '@/constants'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useTranslation } from 'react-i18next'
@@ -24,7 +25,8 @@ export const OnboardingPrivacyPolicyScreen: React.FC<OnboardingPrivacyPolicyScre
 
   const handleLearnMore = () => {
     navigation.navigate(BCSCScreens.OnboardingWebView, {
-      title: t('BCSC.Onboarding.LearnMore'),
+      title: t('BCSC.Onboarding.PrivacyPolicyHeaderSecuringApp'),
+      injectedJavascript: createSecuringAppWebViewJavascriptInjection(),
       url: SECURE_APP_LEARN_MORE_URL,
     })
   }

--- a/app/src/bcsc-theme/features/onboarding/OnboardingPrivacyPolicyScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/OnboardingPrivacyPolicyScreen.tsx
@@ -24,7 +24,7 @@ export const OnboardingPrivacyPolicyScreen: React.FC<OnboardingPrivacyPolicyScre
 
   const handleLearnMore = () => {
     navigation.navigate(BCSCScreens.OnboardingWebView, {
-      title: t('Unified.Onboarding.LearnMore'),
+      title: t('BCSC.Onboarding.LearnMore'),
       url: SECURE_APP_LEARN_MORE_URL,
     })
   }

--- a/app/src/bcsc-theme/features/onboarding/SecureAppScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/SecureAppScreen.tsx
@@ -34,7 +34,7 @@ export const SecureAppScreen = ({ navigation }: SecureAppScreenProps): JSX.Eleme
 
   const handleLearnMore = () => {
     navigation.navigate(BCSCScreens.OnboardingWebView, {
-      title: t('Unified.Onboarding.LearnMore'),
+      title: t('BCSC.Onboarding.LearnMore'),
       url: SECURE_APP_LEARN_MORE_URL,
     })
   }
@@ -74,7 +74,7 @@ export const SecureAppScreen = ({ navigation }: SecureAppScreenProps): JSX.Eleme
           }}
         />
 
-        <CardButton title={t('Unified.Onboarding.LearnMore')} endIcon="open-in-new" onPress={handleLearnMore} />
+        <CardButton title={t('BCSC.Onboarding.LearnMore')} endIcon="open-in-new" onPress={handleLearnMore} />
       </ScrollView>
     </SafeAreaView>
   )

--- a/app/src/bcsc-theme/features/onboarding/SecureAppScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/SecureAppScreen.tsx
@@ -1,5 +1,6 @@
 import { CardButton } from '@/bcsc-theme/components/CardButton'
 import { BCSCOnboardingStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
+import { createSecuringAppWebViewJavascriptInjection } from '@/bcsc-theme/utils/webview-utils'
 import { SECURE_APP_LEARN_MORE_URL } from '@/constants'
 import { BCDispatchAction } from '@/store'
 import { ThemedText, useStore, useTheme } from '@bifold/core'
@@ -34,7 +35,8 @@ export const SecureAppScreen = ({ navigation }: SecureAppScreenProps): JSX.Eleme
 
   const handleLearnMore = () => {
     navigation.navigate(BCSCScreens.OnboardingWebView, {
-      title: t('BCSC.Onboarding.LearnMore'),
+      title: t('BCSC.Onboarding.PrivacyPolicyHeaderSecuringApp'),
+      injectedJavascript: createSecuringAppWebViewJavascriptInjection(),
       url: SECURE_APP_LEARN_MORE_URL,
     })
   }

--- a/app/src/bcsc-theme/features/settings/MainSettingsScreen.tsx
+++ b/app/src/bcsc-theme/features/settings/MainSettingsScreen.tsx
@@ -23,7 +23,7 @@ export const MainSettingsScreen: React.FC<MainSettingsScreenProps> = ({ navigati
   const onHelp = () => {
     navigation.navigate(BCSCScreens.MainWebView, {
       url: HELP_URL,
-      title: t('Unified.Screens.HelpCentre'),
+      title: t('BCSC.Screens.HelpCentre'),
     })
   }
 

--- a/app/src/bcsc-theme/features/settings/VerifySettingsScreen.tsx
+++ b/app/src/bcsc-theme/features/settings/VerifySettingsScreen.tsx
@@ -23,7 +23,7 @@ export const VerifySettingsScreen: React.FC<VerifySettingsScreenProps> = ({ navi
   const onHelp = () => {
     navigation.navigate(BCSCScreens.VerifyWebView, {
       url: HELP_URL,
-      title: t('Unified.Screens.HelpCentre'),
+      title: t('BCSC.Screens.HelpCentre'),
     })
   }
 

--- a/app/src/bcsc-theme/utils/webview-utils.ts
+++ b/app/src/bcsc-theme/utils/webview-utils.ts
@@ -9,7 +9,7 @@ import { IColorPalette } from '@bifold/core'
  * @param {IColorPalette} colorPalette - The color palette object containing brand colors
  * @returns {*} {string} JavaScript string to be injected into the WebView
  */
-export const createTermsOfUseWebViewJavascriptInjection = (colorPalette: IColorPalette): string => {
+const createTermsOfUseWebViewJavascriptInjection = (colorPalette: IColorPalette): string => {
   return `
     document.addEventListener('DOMContentLoaded', function() {
       const style = document.createElement('style');
@@ -29,3 +29,20 @@ export const createTermsOfUseWebViewJavascriptInjection = (colorPalette: IColorP
     });
   `
 }
+
+/**
+ * The "Securing this App" webview javascript injection to modify the HTML content.
+ *
+ * This is to remove the navigation sections from the page.
+ *
+ * @returns {*} {string} JavaScript string to be injected into the WebView
+ */
+const createSecuringAppWebViewJavascriptInjection = (): string => {
+  return `
+    document.addEventListener('DOMContentLoaded', function() {
+      document.querySelectorAll('footer, header, nav[aria-label="breadcrumb"]').forEach(el => el.remove());
+    });
+  `
+}
+
+export { createSecuringAppWebViewJavascriptInjection, createTermsOfUseWebViewJavascriptInjection }

--- a/app/src/bcsc-theme/utils/webview-utils.ts
+++ b/app/src/bcsc-theme/utils/webview-utils.ts
@@ -9,7 +9,7 @@ import { IColorPalette } from '@bifold/core'
  * @param {IColorPalette} colorPalette - The color palette object containing brand colors
  * @returns {*} {string} JavaScript string to be injected into the WebView
  */
-const createTermsOfUseWebViewJavascriptInjection = (colorPalette: IColorPalette): string => {
+export const createTermsOfUseWebViewJavascriptInjection = (colorPalette: IColorPalette): string => {
   return `
     document.addEventListener('DOMContentLoaded', function() {
       const style = document.createElement('style');
@@ -37,12 +37,10 @@ const createTermsOfUseWebViewJavascriptInjection = (colorPalette: IColorPalette)
  *
  * @returns {*} {string} JavaScript string to be injected into the WebView
  */
-const createSecuringAppWebViewJavascriptInjection = (): string => {
+export const createSecuringAppWebViewJavascriptInjection = (): string => {
   return `
     document.addEventListener('DOMContentLoaded', function() {
       document.querySelectorAll('footer, header, nav[aria-label="breadcrumb"]').forEach(el => el.remove());
     });
   `
 }
-
-export { createSecuringAppWebViewJavascriptInjection, createTermsOfUseWebViewJavascriptInjection }


### PR DESCRIPTION
# Summary of Changes

PR to fix a few inconsistencies that came up during QA of this previous PR. 

- Removed the header and footer from the webView for 'Securing this app' learn more links.
- Updated localization strings to reflect the new pattern.

# Testing Instructions

during onboarding the learn more links now go to a web view that does not have a header or footer.
title is now 'Securing the App' instead of 'Learn More'

# Acceptance Criteria

Clicking on the link opens a webview
Content from the following URL should appear in the content area.
ONLY the page content should appear. No peripheral navigation, headers, footers, etc. should be visible.

# Screenshots, videos, or gifs

<img width="300" alt="Screenshot 2025-11-18 at 8 25 45 AM" src="https://github.com/user-attachments/assets/95c56701-116c-4775-9dac-73ac72b60893" />
<img width="300" alt="Screenshot 2025-11-18 at 8 27 16 AM" src="https://github.com/user-attachments/assets/32c00870-e940-45d2-a581-49eeb2156b43" />

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes
