### PR TITLE
refactor: use more well known endpoints

### DIFF
--- a/app/__tests__/bcsc-theme/api/useConfigApi.test.ts
+++ b/app/__tests__/bcsc-theme/api/useConfigApi.test.ts
@@ -4,6 +4,9 @@ import { Platform } from 'react-native'
 
 const mockApiClient = {
   baseURL: 'https://mock-api-base-url.com',
+  endpoints: {
+    cardTap: 'https://mock-api-base-url.com/cardtap',
+  },
   get: jest.fn().mockImplementation(() => Promise.resolve({ data: {} })),
 }
 
@@ -24,10 +27,13 @@ describe('useConfigApi', () => {
       // Call the method we're testing
       const response = await config.getServerStatus()
 
-      // Verify correct endpoint called with the mocked baseURL
-      expect(mockApiClient.get).toHaveBeenCalledWith(`${mockApiClient.baseURL}/cardtap/v3/status/android/mobile_card`, {
-        skipBearerAuth: true,
-      })
+      // Verify correct endpoint called with the mocked endpoints
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        `${mockApiClient.endpoints.cardTap}/v3/status/android/mobile_card`,
+        {
+          skipBearerAuth: true,
+        }
+      )
       expect(response).toEqual({ status: 'ok' })
     })
 
@@ -36,7 +42,7 @@ describe('useConfigApi', () => {
       ;(mockApiClient.get as jest.Mock).mockResolvedValueOnce({ data: { status: 'ok' } })
       const response = await config.getServerStatus()
 
-      expect(mockApiClient.get).toHaveBeenCalledWith(`${mockApiClient.baseURL}/cardtap/v3/status/ios/mobile_card`, {
+      expect(mockApiClient.get).toHaveBeenCalledWith(`${mockApiClient.endpoints.cardTap}/v3/status/ios/mobile_card`, {
         skipBearerAuth: true,
       })
       expect(response).toEqual({ status: 'ok' })
@@ -55,7 +61,7 @@ describe('useConfigApi', () => {
       ;(mockApiClient.get as jest.Mock).mockResolvedValueOnce({ data: { terms: 'Sample terms' } })
       const response = await config.getTermsOfUse()
 
-      expect(mockApiClient.get).toHaveBeenCalledWith(`${mockApiClient.baseURL}/cardtap/v3/terms`)
+      expect(mockApiClient.get).toHaveBeenCalledWith(`${mockApiClient.endpoints.cardTap}/v3/terms`)
       expect(response).toEqual({ terms: 'Sample terms' })
     })
 

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -38,6 +38,10 @@ interface BCSCEndpoints {
   credential: string
   evidence: string
   video: string
+  cardTap: string
+  barcodes: string
+  accountDevices: string
+  account: string
 }
 
 class BCSCApiClient {
@@ -95,6 +99,10 @@ class BCSCApiClient {
       credential: `${this.baseURL}/credentials/v1/person`,
       evidence: `${this.baseURL}/evidence`,
       video: `${this.baseURL}/video`,
+      cardTap: `${this.baseURL}/cardtap`,
+      barcodes: `${this.baseURL}/device/barcodes`,
+      accountDevices: `${this.baseURL}/account/embedded/devices`,
+      account: `${this.baseURL}/account`,
     }
 
     // Add interceptors
@@ -145,9 +153,12 @@ class BCSCApiClient {
       savedServices: response.data['saved_services_endpoint'],
       token: response.data['token_endpoint'],
       credential: response.data['credential_endpoint'],
-      // TODO(bm): request backend team to add evidence and video endpoints to the response
-      evidence: `${this.baseURL}/evidence`,
-      video: `${this.baseURL}/video`,
+      evidence: response.data['evidence_endpoint'],
+      video: response.data['video_call_endpoint'],
+      cardTap: response.data['cardtap_endpoint'],
+      barcodes: response.data['barcodes_endpoint'],
+      accountDevices: response.data['account_devices_endpoint'],
+      account: response.data['account_endpoint'],
     }
   }
 

--- a/app/src/bcsc-theme/api/hooks/useConfigApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useConfigApi.tsx
@@ -27,9 +27,8 @@ const useConfigApi = (apiClient: BCSCApiClient) => {
    * @returns {*} {Promise<ServerStatusResponseData>} A promise that resolves to the server status data.
    */
   const getServerStatus = useCallback(async () => {
-    // this endpoint is not available through the .well-known/openid-configuration so it needs to be hardcoded
     const { data } = await apiClient.get<ServerStatusResponseData>(
-      `${apiClient.baseURL}/cardtap/v3/status/${Platform.OS}/mobile_card`,
+      `${apiClient.endpoints.cardTap}/v3/status/${Platform.OS}/mobile_card`,
       {
         skipBearerAuth: true, // this endpoint does not require an access token
       }
@@ -38,8 +37,7 @@ const useConfigApi = (apiClient: BCSCApiClient) => {
   }, [apiClient])
 
   const getTermsOfUse = useCallback(async () => {
-    // this endpoint is not available through the .well-known/openid-configuration so it needs to be hardcoded
-    const { data } = await apiClient.get<TermsOfUseResponseData>(`${apiClient.baseURL}/cardtap/v3/terms`)
+    const { data } = await apiClient.get<TermsOfUseResponseData>(`${apiClient.endpoints.cardTap}/v3/terms`)
     return data
   }, [apiClient])
 

--- a/app/src/bcsc-theme/api/hooks/useMetadataApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useMetadataApi.tsx
@@ -48,7 +48,7 @@ const useMetadataApi = (apiClient: BCSCApiClient) => {
    */
   const getBCSCClientMetadata = useCallback(async (): Promise<ClientMetadata | null> => {
     const clients = await getClientMetadata()
-    const bcscClient = clients.find((client) => client.client_uri === `${apiClient.baseURL}/account/`)
+    const bcscClient = clients.find((client) => client.client_uri === `${apiClient.endpoints.account}/`)
 
     if (!bcscClient) {
       throw new Error('BCSC client metadata not found')

--- a/app/src/bcsc-theme/api/hooks/usePairingApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/usePairingApi.tsx
@@ -32,8 +32,7 @@ const usePairingApi = (apiClient: BCSCApiClient) => {
         const { fcmDeviceToken, deviceToken } = await getNotificationTokens(logger)
         const signedCode = await signPairingCode(code, issuer, clientID, fcmDeviceToken, deviceToken)
         const response = await apiClient.post<PairingCodeLoginClientMetadata>(
-          // this endpoint is not available through the .well-known/openid-configuration so it needs to be hardcoded
-          `${apiClient.baseURL}/cardtap/v3/mobile/assertion`,
+          `${apiClient.endpoints.cardTap}/v3/mobile/assertion`,
           { assertion: signedCode },
           { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
         )
@@ -52,8 +51,7 @@ const usePairingApi = (apiClient: BCSCApiClient) => {
   const forgetAllPairings = useCallback(async () => {
     return withAccount<void>(async (account) => {
       const { clientID } = account
-      // this endpoint is not yet available through the .well-known/openid-configuration so it needs to be hardcoded
-      await apiClient.delete(`${apiClient.baseURL}/cardtap/v3/devices/${clientID}/pairings`)
+      await apiClient.delete(`${apiClient.endpoints.cardTap}/v3/devices/${clientID}/pairings`)
     })
   }, [apiClient])
 

--- a/app/src/bcsc-theme/features/account/Account.tsx
+++ b/app/src/bcsc-theme/features/account/Account.tsx
@@ -74,9 +74,8 @@ const Account: React.FC = () => {
 
   const handleMyDevicesPress = useCallback(async () => {
     try {
-      const fullUrl = `${client.baseURL}/account/embedded/devices`
       navigation.navigate(BCSCScreens.MainWebView, {
-        url: fullUrl,
+        url: client.endpoints.accountDevices,
         title: t('BCSC.Account.AccountInfo.ManageDevices'),
       })
       openedWebview.current = true

--- a/app/src/bcsc-theme/features/home/Home.tsx
+++ b/app/src/bcsc-theme/features/home/Home.tsx
@@ -22,10 +22,10 @@ const Home: React.FC<HomeProps> = ({ navigation }) => {
 
   const handleManageDevices = useCallback(() => {
     navigation.getParent()?.navigate(BCSCScreens.MainWebView, {
-      url: `${apiClient.baseURL}/account/embedded/devices`,
+      url: apiClient.endpoints.accountDevices,
       title: t('BCSC.Screens.ManageDevices'),
     })
-  }, [apiClient.baseURL, navigation, t])
+  }, [apiClient.endpoints.accountDevices, navigation, t])
 
   const styles = StyleSheet.create({
     buttonsContainer: {

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -45,10 +45,10 @@ const MainStack: React.FC = () => {
 
   const handleManageDevices = useCallback(() => {
     navigation.navigate(BCSCScreens.MainWebView, {
-      url: `${client.baseURL}/account/embedded/devices`,
+      url: client.endpoints.accountDevices,
       title: t('BCSC.Screens.ManageDevices'),
     })
-  }, [client.baseURL, navigation, t])
+  }, [client.endpoints.accountDevices, navigation, t])
 
   return (
     <View style={{ flex: 1 }} importantForAccessibility={hideElements}>

--- a/app/src/bcsc-theme/navigators/VerifyStack.tsx
+++ b/app/src/bcsc-theme/navigators/VerifyStack.tsx
@@ -70,10 +70,10 @@ const VerifyStack = () => {
 
   const handleManageDevices = useCallback(() => {
     navigation.navigate(BCSCScreens.VerifyWebView, {
-      url: `${client.baseURL}/account/embedded/devices`,
+      url: client.endpoints.accountDevices,
       title: t('BCSC.Screens.ManageDevices'),
     })
-  }, [client.baseURL, navigation, t])
+  }, [client.endpoints.accountDevices, navigation, t])
 
   return (
     <Stack.Navigator


### PR DESCRIPTION
# Summary of Changes

Updates our API client to use the newly added endpoints to .well-known/openid-config

FYI: I've requested that the /nonces and  /events endpoints be added as well but they have not been added quite yet

# Testing Instructions

API calls still work

# Acceptance Criteria

API calls still work and endpoints from the .well-known endpoint are used where applicable

# Screenshots, videos, or gifs

N/A

# Related Issues

#2722 

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes
