### PR TITLE
chore: update terms of use interface in onboarding.

### DIFF
--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
@@ -36,6 +36,13 @@ export const TermsOfUseScreen = ({ navigation }: TermsOfUseScreenProps): JSX.Ele
     },
     buttonContainer: {
       padding: Spacing.md,
+      elevation: 6,
+      borderRadius: 12,
+      shadowColor: '#000',
+      shadowRadius: 8,
+      shadowOpacity: 0.12,
+      shadowOffset: { width: 0, height: 0 },
+      backgroundColor: ColorPalette.brand.primaryBackground,
     },
     activityIndicator: {
       flex: 1,

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
@@ -36,13 +36,6 @@ export const TermsOfUseScreen = ({ navigation }: TermsOfUseScreenProps): JSX.Ele
     },
     buttonContainer: {
       padding: Spacing.md,
-      // android shadow
-      elevation: 5,
-      backgroundColor: ColorPalette.brand.primaryBackground,
-      // iOS shadow
-      shadowRadius: 4,
-      shadowOpacity: 0.4,
-      shadowOffset: { width: 0, height: -2 },
     },
     activityIndicator: {
       flex: 1,

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
@@ -36,13 +36,13 @@ export const TermsOfUseScreen = ({ navigation }: TermsOfUseScreenProps): JSX.Ele
     },
     buttonContainer: {
       padding: Spacing.md,
+      // android shadow
       elevation: 6,
-      borderRadius: 12,
-      shadowColor: '#000',
-      shadowRadius: 8,
-      shadowOpacity: 0.12,
-      shadowOffset: { width: 0, height: 0 },
       backgroundColor: ColorPalette.brand.primaryBackground,
+      // iOS shadow
+      shadowRadius: 8,
+      shadowOpacity: 0.2,
+      shadowOffset: { width: 0, height: 4 },
     },
     activityIndicator: {
       flex: 1,

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
@@ -46,18 +46,20 @@ export const TermsOfUseScreen = ({ navigation }: TermsOfUseScreenProps): JSX.Ele
   })
 
   // JavaScript to adjust font scaling on iOS devices
-  const iosFontScaling = 
-    Platform.OS === 'ios' ? `
+  const iosFontScaling =
+    Platform.OS === 'ios'
+      ? `
     const fontScale = ${fontScale};
     document.documentElement.style.fontSize = (16 * fontScale) + 'px';
     document.body.style.fontSize = (16 * fontScale) + 'px';
-  ` : '';
+  `
+      : ''
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
       <WebViewContent
         url={TERMS_OF_USE_URL}
-        injectedJavascript={ createTermsOfUseWebViewJavascriptInjection(ColorPalette) + iosFontScaling}
+        injectedJavascript={createTermsOfUseWebViewJavascriptInjection(ColorPalette) + iosFontScaling}
         onLoaded={() => setWebViewIsLoaded(true)}
       />
 

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
@@ -5,7 +5,7 @@ import { Button, ButtonType, testIdWithKey, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, View } from 'react-native'
+import { Platform, StyleSheet, View, useWindowDimensions } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { WebViewContent } from '../webview/WebViewContent'
 
@@ -22,6 +22,7 @@ export const TermsOfUseScreen = ({ navigation }: TermsOfUseScreenProps): JSX.Ele
   const { t } = useTranslation()
   const { Spacing, ColorPalette } = useTheme()
   const [webViewIsLoaded, setWebViewIsLoaded] = useState(false)
+  const { fontScale } = useWindowDimensions()
 
   const styles = StyleSheet.create({
     container: {
@@ -44,11 +45,19 @@ export const TermsOfUseScreen = ({ navigation }: TermsOfUseScreenProps): JSX.Ele
     },
   })
 
+  // JavaScript to adjust font scaling on iOS devices
+  const iosFontScaling = 
+    Platform.OS === 'ios' ? `
+    const fontScale = ${fontScale};
+    document.documentElement.style.fontSize = (16 * fontScale) + 'px';
+    document.body.style.fontSize = (16 * fontScale) + 'px';
+  ` : '';
+
   return (
     <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
       <WebViewContent
         url={TERMS_OF_USE_URL}
-        injectedJavascript={createTermsOfUseWebViewJavascriptInjection(ColorPalette)}
+        injectedJavascript={ createTermsOfUseWebViewJavascriptInjection(ColorPalette) + iosFontScaling}
         onLoaded={() => setWebViewIsLoaded(true)}
       />
 

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
@@ -37,12 +37,12 @@ export const TermsOfUseScreen = ({ navigation }: TermsOfUseScreenProps): JSX.Ele
     buttonContainer: {
       padding: Spacing.md,
       // android shadow
-      elevation: 6,
+      elevation: 5,
       backgroundColor: ColorPalette.brand.primaryBackground,
       // iOS shadow
-      shadowRadius: 8,
-      shadowOpacity: 0.2,
-      shadowOffset: { width: 0, height: 4 },
+      shadowRadius: 4,
+      shadowOpacity: 0.4,
+      shadowOffset: { width: 0, height: -2 },
     },
     activityIndicator: {
       flex: 1,

--- a/app/src/bcsc-theme/utils/webview-utils.ts
+++ b/app/src/bcsc-theme/utils/webview-utils.ts
@@ -14,7 +14,7 @@ export const createTermsOfUseWebViewJavascriptInjection = (colorPalette: IColorP
     document.addEventListener('DOMContentLoaded', function() {
       const style = document.createElement('style');
 
-      document.querySelectorAll('footer, header, nav[aria-label="breadcrumb"]').forEach(el => el.remove());
+      document.querySelectorAll('footer, header, h1, nav[aria-label="breadcrumb"]').forEach(el => el.remove());
       document.body.style.backgroundColor = '${colorPalette.brand.primaryBackground}';
       document.body.style.color = '${colorPalette.brand.secondary}';
 


### PR DESCRIPTION
# Summary of Changes

This PR removes the `Terms of Use` title from the web view and adds a shadow to the `accept and continue` button at the bottom.

# Testing Instructions

During initial onboarding, when reaching the terms of use screen the `h1` title is now removed from the web view, and the button has a shadow at the bottom.

# Acceptance Criteria

- Remove the 'Terms of Use' title from the content area (webview). We already display the title in the header of the application layout.
- Bottom button container should include a shadow to ensure users know the content is scrollable.
- Verify that the content can scale (e.g. when user's increase font or display size).

# Screenshots, videos, or gifs

<img width="300" alt="Screenshot 2025-11-20 at 3 17 29 PM" src="https://github.com/user-attachments/assets/305637cf-ca64-47a5-a81a-71b4c64c6b7d" />

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes
