### PR TITLE
fix: fcm registration on iOS, nonce decode on android

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
@@ -93,7 +93,10 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           }
         )
-        attestation = await googleAttestation(nonce)
+        // Decode base64 nonce before passing to Play Integrity API
+        const decodedNonce = Buffer.from(nonce, 'base64').toString('utf8')
+        logger.debug(`Decoded nonce from ${nonce} to ${decodedNonce}`)
+        attestation = await googleAttestation(decodedNonce)
         logger.info('Obtained Android Play Integrity attestation')
       }
     } catch (error) {
@@ -134,6 +137,7 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
 
     const body = await getDynamicClientRegistrationBody(fcmDeviceToken, deviceToken, attestation)
     logger.info('Generated dynamic client registration body')
+    logger.debug(`body: ${body}`)
 
     const { data } = await apiClient.post<RegistrationResponseData>(apiClient.endpoints.registration, body, {
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
# Summary of Changes
This PR fixes two things.

### iOS failing to match card serial numbers and birthdates (blocker)
Lesson learned: In iOS App Store builds, FCM device registration must be done first before fetching FCM tokens will work. Was iOS FCM fetching ever working on the BCSC side? No. But we were catching it and passing in a dummy string as a token. I've added that behaviour back as a fall back, as well as the proper registration.

### Android attestation coming back as "malformed" (unnoticeable failure to the user)
The nonce we get to start attestation with was a base64 encoded string and we weren't accounting for that. So it would successfully attest the app but with the wrong nonce.

# Testing Instructions

Must be tested from the Play Store and App Store (Testflight) where attestations can actually succeed

# Acceptance Criteria

iOS users are unblocked and both iOS and Android successfully pass along attestation data that can be looked up from IAS support.

# Screenshots, videos, or gifs

N/A

# Related Issues

#2752

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes
