### PR TITLE
chore: fixed email label and removed notifications button

### DIFF
--- a/app/src/bcsc-theme/features/settings/SettingsContent.tsx
+++ b/app/src/bcsc-theme/features/settings/SettingsContent.tsx
@@ -145,7 +145,8 @@ export const SettingsContent: React.FC<SettingsContentProps> = ({
                 onPress={onPressActionTodo}
                 endAdornmentText={`${store.preferences.autoLockTime} min`}
               />
-              <SettingsActionCard title={t('BCSC.Settings.Notifications')} onPress={onPressActionTodo} />
+              {/* TODO: (AR) Keeping this hidden for phase 1 */}
+              {/* <SettingsActionCard title={t('BCSC.Settings.Notifications')} onPress={onPressActionTodo} /> */}
               {onForgetAllPairings ? (
                 <SettingsActionCard title={t('BCSC.Settings.ForgetPairings')} onPress={onForgetAllPairings} />
               ) : null}

--- a/app/src/bcsc-theme/features/verify/email/EnterEmailScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EnterEmailScreen.tsx
@@ -130,8 +130,8 @@ const EnterEmailScreen = ({ navigation, route }: EnterEmailScreenProps) => {
             <Button
               buttonType={ButtonType.Secondary}
               onPress={handleSkip}
-              title={t('BCSC.EnterEmail.Skip')}
-              accessibilityLabel={t('BCSC.EnterEmail.Skip')}
+              title={t('BCSC.EnterEmail.EmailSkip')}
+              accessibilityLabel={t('BCSC.EnterEmail.EmailSkip')}
               testID={'SkipButton'}
             />
           ) : null}


### PR DESCRIPTION
# Summary of Changes

- Commented out notification settings
- Fixed language translation issue for email skip button

# Testing Instructions

- Launch app
- Get into Single App mode
- Go through verification steps
- 'Edit' email and see that button displays proper text 
- Once verified, open the settings menu, no 'Notifications' button should be seen

# Acceptance Criteria

- Notifications button in settings is removed

# Screenshots, videos, or gifs

n/a

# Related Issues

[BC-Wallet: 2916](https://github.com/bcgov/bc-wallet-mobile/issues/2916)

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] Related issues are included under the Related Issues section above
- [x] If applicable, screenshots, gifs, or video are included for UI changes
