### PR TITLE
refactor: return dummy fcm token rather than throwing, add logs

### DIFF
--- a/app/__tests__/bcsc-theme/utils/push-notification-tokens.test.ts
+++ b/app/__tests__/bcsc-theme/utils/push-notification-tokens.test.ts
@@ -97,36 +97,46 @@ describe('getNotificationTokens', () => {
   })
 
   describe('when FCM token fails', () => {
-    it('throws error when FCM token is null', async () => {
+    it('returns dummy token when FCM token is null', async () => {
       setPlatformOS('ios')
       mockGetToken.mockResolvedValue(null)
       mockGetAPNSToken.mockResolvedValue('mock_apns_token')
 
-      await expect(getNotificationTokens(mockLogger)).rejects.toThrow(
-        'FCM token fetch failed: FCM token is null or undefined'
-      )
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        'Failed to retrieve notification tokens: FCM token fetch failed: FCM token is null or undefined'
-      )
+      const result = await getNotificationTokens(mockLogger)
+
+      expect(result).toEqual({
+        fcmDeviceToken: 'missing_token_due_to_fetch_failure',
+        deviceToken: 'mock_apns_token',
+      })
+      expect(mockLogger.error).toHaveBeenCalledWith('FCM token fetch failed: FCM token is null or undefined')
     })
 
-    it('throws error when FCM token is undefined', async () => {
+    it('returns dummy token when FCM token is undefined', async () => {
       setPlatformOS('ios')
       mockGetToken.mockResolvedValue(undefined)
       mockGetAPNSToken.mockResolvedValue('mock_apns_token')
 
-      await expect(getNotificationTokens(mockLogger)).rejects.toThrow(
-        'FCM token fetch failed: FCM token is null or undefined'
-      )
+      const result = await getNotificationTokens(mockLogger)
+
+      expect(result).toEqual({
+        fcmDeviceToken: 'missing_token_due_to_fetch_failure',
+        deviceToken: 'mock_apns_token',
+      })
     })
 
-    it('throws error when FCM token fetch throws exception', async () => {
+    it('returns dummy token when FCM token fetch throws exception', async () => {
       setPlatformOS('ios')
       const mockError = new Error('FCM service unavailable')
       mockGetToken.mockRejectedValue(mockError)
       mockGetAPNSToken.mockResolvedValue('mock_apns_token')
 
-      await expect(getNotificationTokens(mockLogger)).rejects.toThrow('FCM token fetch failed: FCM service unavailable')
+      const result = await getNotificationTokens(mockLogger)
+
+      expect(result).toEqual({
+        fcmDeviceToken: 'missing_token_due_to_fetch_failure',
+        deviceToken: 'mock_apns_token',
+      })
+      expect(mockLogger.error).toHaveBeenCalledWith('FCM token fetch failed: FCM service unavailable')
     })
 
     it('succeeds with null deviceToken when APNS token is null on iOS', async () => {
@@ -157,14 +167,17 @@ describe('getNotificationTokens', () => {
       expect(mockLogger.warn).toHaveBeenCalledWith('APNS token fetch failed: APNS service unavailable')
     })
 
-    it('throws error when FCM fails even if APNS succeeds', async () => {
+    it('returns dummy FCM token when FCM fails even if APNS succeeds', async () => {
       setPlatformOS('ios')
       mockGetToken.mockResolvedValue(null)
       mockGetAPNSToken.mockResolvedValue('mock_apns_token')
 
-      await expect(getNotificationTokens(mockLogger)).rejects.toThrow(
-        'FCM token fetch failed: FCM token is null or undefined'
-      )
+      const result = await getNotificationTokens(mockLogger)
+
+      expect(result).toEqual({
+        fcmDeviceToken: 'missing_token_due_to_fetch_failure',
+        deviceToken: 'mock_apns_token',
+      })
     })
 
     it('handles non-Error exceptions (string messages)', async () => {
@@ -172,7 +185,13 @@ describe('getNotificationTokens', () => {
       mockGetToken.mockRejectedValue('String error message')
       mockGetAPNSToken.mockResolvedValue('mock_apns_token')
 
-      await expect(getNotificationTokens(mockLogger)).rejects.toThrow('FCM token fetch failed: String error message')
+      const result = await getNotificationTokens(mockLogger)
+
+      expect(result).toEqual({
+        fcmDeviceToken: 'missing_token_due_to_fetch_failure',
+        deviceToken: 'mock_apns_token',
+      })
+      expect(mockLogger.error).toHaveBeenCalledWith('FCM token fetch failed: String error message')
     })
   })
 
@@ -208,14 +227,17 @@ describe('getNotificationTokens', () => {
   })
 
   describe('edge cases with empty strings', () => {
-    it('treats empty string FCM token as invalid', async () => {
+    it('treats empty string FCM token as invalid and returns dummy token', async () => {
       setPlatformOS('ios')
       mockGetToken.mockResolvedValue('')
       mockGetAPNSToken.mockResolvedValue('mock_apns_token')
 
-      await expect(getNotificationTokens(mockLogger)).rejects.toThrow(
-        'FCM token fetch failed: FCM token is null or undefined'
-      )
+      const result = await getNotificationTokens(mockLogger)
+
+      expect(result).toEqual({
+        fcmDeviceToken: 'missing_token_due_to_fetch_failure',
+        deviceToken: 'mock_apns_token',
+      })
     })
 
     it('succeeds with null deviceToken when APNS token is empty string on iOS', async () => {

--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
@@ -79,7 +79,7 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
       if (Platform.OS === 'ios') {
         attestation = await getAppStoreReceipt()
         logger.info('Obtained iOS App Store Receipt attestation')
-        // remove this debug log once confirmed working in app store build
+        // TODO (BM): remove this debug log once confirmed working in app store build
         logger.debug(`Obtained iOS App Store Receipt attestation: ${attestation}`)
       } else if (Platform.OS === 'android') {
         const deviceId = await getDeviceId()
@@ -95,7 +95,7 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           }
         )
-        // remove these debug logs once confirmed working in play store build
+        // TODO (BM): remove these debug logs once confirmed working in play store build
         logger.debug(`Received nonce for Android Play Integrity attestation: ${nonce}`)
         attestation = await googleAttestation(nonce)
         logger.info('Obtained Android Play Integrity attestation')

--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
@@ -1,5 +1,4 @@
 import { getAppStoreReceipt, googleAttestation } from '@bifold/react-native-attestation'
-import { Buffer } from 'buffer'
 import { useCallback, useMemo } from 'react'
 import { Platform } from 'react-native'
 import {
@@ -80,6 +79,8 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
       if (Platform.OS === 'ios') {
         attestation = await getAppStoreReceipt()
         logger.info('Obtained iOS App Store Receipt attestation')
+        // remove this debug log once confirmed working in app store build
+        logger.debug(`Obtained iOS App Store Receipt attestation: ${attestation}`)
       } else if (Platform.OS === 'android') {
         const deviceId = await getDeviceId()
         const {
@@ -94,11 +95,11 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           }
         )
-        // Decode base64 nonce before passing to Play Integrity API
-        const decodedNonce = Buffer.from(nonce, 'base64').toString('utf8')
-        logger.debug(`Decoded nonce from ${nonce} to ${decodedNonce}`)
-        attestation = await googleAttestation(decodedNonce)
+        // remove these debug logs once confirmed working in play store build
+        logger.debug(`Received nonce for Android Play Integrity attestation: ${nonce}`)
+        attestation = await googleAttestation(nonce)
         logger.info('Obtained Android Play Integrity attestation')
+        logger.debug(`Obtained Android Play Integrity attestation: ${attestation}`)
       }
     } catch (error) {
       // attestation in BCSC v3 (and v4 phase 1) is non-blocking, so we log and continue
@@ -138,7 +139,6 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
 
     const body = await getDynamicClientRegistrationBody(fcmDeviceToken, deviceToken, attestation)
     logger.info('Generated dynamic client registration body')
-    logger.debug(`body: ${body}`)
 
     const { data } = await apiClient.post<RegistrationResponseData>(apiClient.endpoints.registration, body, {
       headers: { 'Content-Type': 'application/json' },

--- a/app/src/bcsc-theme/utils/push-notification-tokens.ts
+++ b/app/src/bcsc-theme/utils/push-notification-tokens.ts
@@ -65,21 +65,12 @@ export const getNotificationTokens = async (logger: BifoldLogger): Promise<Notif
     }
   }
 
-  try {
-    const [fcmDeviceToken, deviceToken] = await Promise.all([fetchFcmToken(), fetchDeviceToken()])
+  const [fcmDeviceToken, deviceToken] = await Promise.all([fetchFcmToken(), fetchDeviceToken()])
 
-    logger.info('Successfully retrieved notification tokens for registration')
+  logger.info('Successfully retrieved notification tokens for registration')
 
-    return {
-      fcmDeviceToken,
-      deviceToken,
-    }
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
-    logger.error(`Failed to retrieve notification tokens: ${errorMessage}`)
-    return {
-      fcmDeviceToken: 'missing_token_due_to_fetch_failure',
-      deviceToken: null,
-    }
+  return {
+    fcmDeviceToken,
+    deviceToken,
   }
 }

--- a/app/src/bcsc-theme/utils/push-notification-tokens.ts
+++ b/app/src/bcsc-theme/utils/push-notification-tokens.ts
@@ -13,12 +13,14 @@ export interface NotificationTokens {
  * deviceToken (APNS) is optional and iOS only.
  * @param logger
  * @returns NotificationTokens object containing fcmDeviceToken and deviceToken
- * @throws with the failure message if no fcmDeviceToken is not retrieved
+ * unless it fails in which case it returns a dummy fcmDeviceToken and null deviceToken
  */
 export const getNotificationTokens = async (logger: BifoldLogger): Promise<NotificationTokens> => {
   if (!messaging().isDeviceRegisteredForRemoteMessages) {
     try {
+      logger.debug('Attempting to register device for remote messages...')
       await messaging().registerDeviceForRemoteMessages()
+      logger.debug('Device successfully registered for remote messages')
     } catch (error) {
       // This is the extremely rare case react-native-firebase fails to register
       // We log the error but continue with a dummy string as registration will still work
@@ -29,6 +31,8 @@ export const getNotificationTokens = async (logger: BifoldLogger): Promise<Notif
         deviceToken: null,
       }
     }
+  } else {
+    logger.debug('Device already registered for remote messages')
   }
 
   const fetchFcmToken = async (): Promise<string> => {
@@ -40,7 +44,8 @@ export const getNotificationTokens = async (logger: BifoldLogger): Promise<Notif
       return token
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      throw new Error(`FCM token fetch failed: ${message}`)
+      logger.error(`FCM token fetch failed: ${message}`)
+      return 'missing_token_due_to_fetch_failure' // Return dummy token on failure
     }
   }
 
@@ -61,17 +66,20 @@ export const getNotificationTokens = async (logger: BifoldLogger): Promise<Notif
   }
 
   try {
-    const [fcmToken, deviceToken] = await Promise.all([fetchFcmToken(), fetchDeviceToken()])
+    const [fcmDeviceToken, deviceToken] = await Promise.all([fetchFcmToken(), fetchDeviceToken()])
 
     logger.info('Successfully retrieved notification tokens for registration')
 
     return {
-      fcmDeviceToken: fcmToken,
+      fcmDeviceToken,
       deviceToken,
     }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)
     logger.error(`Failed to retrieve notification tokens: ${errorMessage}`)
-    throw new Error(errorMessage)
+    return {
+      fcmDeviceToken: 'missing_token_due_to_fetch_failure',
+      deviceToken: null,
+    }
   }
 }


### PR DESCRIPTION
# Summary of Changes

There is something missing from our BCSC FCM config preventing us from getting FCM tokens (and thus push notifications). In the meantime this change makes that non-blocking and provides a dummy token when FCM isn't available. It also adds more logs to help troubleshoot FCM / attestation details.

# Testing Instructions

No change in local builds, but fixes nickname edit in Testflight (currently hangs in Testflight builds)

# Acceptance Criteria

N/A

# Screenshots, videos, or gifs

N/A

# Related Issues

#2752 