### PR TITLE
fix: various UI tweaks

### DIFF
--- a/app/__tests__/screens/EnterEmailScreen.test.tsx
+++ b/app/__tests__/screens/EnterEmailScreen.test.tsx
@@ -1,0 +1,381 @@
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native'
+import React from 'react'
+import { Alert } from 'react-native'
+
+import { useNavigation } from '../../__mocks__/custom/@react-navigation/core'
+import { BasicAppContext } from '../../__mocks__/helpers/app'
+import { BCSCCardType } from '../../src/bcsc-theme/types/cards'
+import { BCSCScreens } from '../../src/bcsc-theme/types/navigators'
+import EnterEmailScreen from '../../src/bcsc-theme/features/verify/email/EnterEmailScreen'
+
+const mockCreateEmailVerification = jest.fn()
+jest.mock('@/bcsc-theme/api/hooks/useApi', () => {
+  return {
+    __esModule: true,
+    default: jest.fn(() => ({
+      evidence: {
+        createEmailVerification: mockCreateEmailVerification,
+      },
+    })),
+  }
+})
+
+describe('EnterEmailScreen', () => {
+  let mockNavigation: any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockNavigation = useNavigation()
+
+    jest.spyOn(Alert, 'alert')
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('should render correctly', () => {
+      const { getByText } = render(
+        <BasicAppContext>
+          <EnterEmailScreen
+            navigation={mockNavigation}
+            route={{ params: { cardType: BCSCCardType.Combined } }}
+          />
+        </BasicAppContext>
+      )
+
+      expect(getByText('BCSC.EnterEmail.EnterEmailAddress')).toBeTruthy()
+      expect(getByText('BCSC.EnterEmail.EmailDescription2')).toBeTruthy()
+    })
+
+    it('should display description for non-Other card types i.e combined', () => {
+      const { getByText } = render(
+        <BasicAppContext>
+          <EnterEmailScreen
+            navigation={mockNavigation}
+            route={{ params: { cardType: BCSCCardType.Combined } }}
+          />
+        </BasicAppContext>
+      )
+
+      expect(getByText('BCSC.EnterEmail.EmailDescription1')).toBeTruthy()
+    })
+
+    it('should not display description for Other card type', () => {
+      const { queryByText } = render(
+        <BasicAppContext>
+          <EnterEmailScreen navigation={mockNavigation} route={{ params: { cardType: BCSCCardType.Other } }} />
+        </BasicAppContext>
+      )
+
+      expect(queryByText('BCSC.EnterEmail.EmailDescription1')).toBeNull()
+    })
+
+    it('should display Skip button for non-Other card types i.e combined', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <EnterEmailScreen
+            navigation={mockNavigation}
+            route={{ params: { cardType: BCSCCardType.Combined } }}
+          />
+        </BasicAppContext>
+      )
+
+      expect(getByTestId('SkipButton')).toBeTruthy()
+    })
+
+    it('should not display Skip button for Other card type', () => {
+      const { queryByTestId } = render(
+        <BasicAppContext>
+          <EnterEmailScreen navigation={mockNavigation} route={{ params: { cardType: BCSCCardType.Other } }} />
+        </BasicAppContext>
+      )
+
+      expect(queryByTestId('SkipButton')).toBeNull()
+    })
+  })
+
+  describe('Email validation', () => {
+    it('should show error when submitting empty email', async () => {
+      const { getByTestId, getByText } = render(
+        <BasicAppContext>
+          <EnterEmailScreen
+            navigation={mockNavigation}
+            route={{ params: { cardType: BCSCCardType.Combined } }}
+          />
+        </BasicAppContext>
+      )
+
+      const continueButton = getByTestId('ContinueButton')
+      act(() => {
+        fireEvent.press(continueButton)
+      })
+
+      await waitFor(() => {
+        expect(getByText('BCSC.EmailConfirmation.EmailError')).toBeTruthy()
+      })
+    })
+
+    it('should show error when submitting invalid email format', async () => {
+      const { getByTestId, getByText } = render(
+        <BasicAppContext>
+          <EnterEmailScreen
+            navigation={mockNavigation}
+            route={{ params: { cardType: BCSCCardType.Combined } }}
+          />
+        </BasicAppContext>
+      )
+
+      const emailInput = getByTestId('EmailInput')
+      act(() => {
+        fireEvent.changeText(emailInput, 'invalidemail')
+      })
+
+      const continueButton = getByTestId('ContinueButton')
+      act(() => {
+        fireEvent.press(continueButton)
+      })
+
+      await waitFor(() => {
+        expect(getByText('BCSC.EmailConfirmation.EmailError')).toBeTruthy()
+      })
+    })
+
+    it('should clear error when valid email is entered', async () => {
+      mockCreateEmailVerification.mockResolvedValue({ email_address_id: 'test-id' })
+
+      const { getByTestId, getByText, queryByText } = render(
+        <BasicAppContext>
+          <EnterEmailScreen
+            navigation={mockNavigation}
+            route={{ params: { cardType: BCSCCardType.Combined } }}
+          />
+        </BasicAppContext>
+      )
+
+      // First submit with empty email to trigger error
+      const continueButton = getByTestId('ContinueButton')
+      act(() => {
+        fireEvent.press(continueButton)
+      })
+
+      await waitFor(() => {
+        expect(getByText('BCSC.EmailConfirmation.EmailError')).toBeTruthy()
+      })
+
+      // Enter valid email
+      const emailInput = getByTestId('EmailInput')
+      act(() => {
+        fireEvent.changeText(emailInput, 'test@example.com')
+      })
+
+      // Submit again with valid email
+      act(() => {
+        fireEvent.press(continueButton)
+      })
+
+      await waitFor(() => {
+        expect(queryByText('BCSC.EmailConfirmation.EmailError')).toBeNull()
+      })
+    })
+  })
+
+  describe('Email submission', () => {
+    it('should call API with email and navigate on success', async () => {
+      mockCreateEmailVerification.mockResolvedValue({ email_address_id: 'test-id-123' })
+
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <EnterEmailScreen
+            navigation={mockNavigation}
+            route={{ params: { cardType: BCSCCardType.Combined } }}
+          />
+        </BasicAppContext>
+      )
+
+      const emailInput = getByTestId('EmailInput')
+      act(() => {
+        fireEvent.changeText(emailInput, 'test@example.com')
+      })
+
+      const continueButton = getByTestId('ContinueButton')
+      act(() => {
+        fireEvent.press(continueButton)
+      })
+
+      await waitFor(() => {
+        expect(mockCreateEmailVerification).toHaveBeenCalledWith('test@example.com')
+        expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.EmailConfirmation, {
+          emailAddressId: 'test-id-123',
+        })
+      })
+    })
+
+    it('should update store with email on success', async () => {
+      mockCreateEmailVerification.mockResolvedValue({ email_address_id: 'test-id' })
+
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <EnterEmailScreen
+            navigation={mockNavigation}
+            route={{ params: { cardType: BCSCCardType.Combined } }}
+          />
+        </BasicAppContext>
+      )
+
+      const emailInput = getByTestId('EmailInput')
+      act(() => {
+        fireEvent.changeText(emailInput, 'user@test.com')
+      })
+
+      const continueButton = getByTestId('ContinueButton')
+      act(() => {
+        fireEvent.press(continueButton)
+      })
+
+      await waitFor(() => {
+        expect(mockNavigation.navigate).toHaveBeenCalled()
+      })
+
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        BCSCScreens.EmailConfirmation,
+        expect.objectContaining({
+          emailAddressId: 'test-id',
+        })
+      )
+    })
+
+    it('should show error on API failure', async () => {
+      mockCreateEmailVerification.mockRejectedValue(new Error('API Error'))
+
+      const { getByTestId, getByText } = render(
+        <BasicAppContext>
+          <EnterEmailScreen
+            navigation={mockNavigation}
+            route={{ params: { cardType: BCSCCardType.Combined } }}
+          />
+        </BasicAppContext>
+      )
+
+      const emailInput = getByTestId('EmailInput')
+      act(() => {
+        fireEvent.changeText(emailInput, 'test@example.com')
+      })
+
+      const continueButton = getByTestId('ContinueButton')
+      act(() => {
+        fireEvent.press(continueButton)
+      })
+
+      await waitFor(() => {
+        expect(getByText('BCSC.EmailConfirmation.ErrorTitle')).toBeTruthy()
+      })
+    })
+
+    it('should stop loading after error', async () => {
+      mockCreateEmailVerification.mockRejectedValue(new Error('API Error'))
+
+      const { getByTestId, getByText } = render(
+        <BasicAppContext>
+          <EnterEmailScreen
+            navigation={mockNavigation}
+            route={{ params: { cardType: BCSCCardType.Combined } }}
+          />
+        </BasicAppContext>
+      )
+
+      const emailInput = getByTestId('EmailInput')
+      act(() => {
+        fireEvent.changeText(emailInput, 'test@example.com')
+      })
+
+      const continueButton = getByTestId('ContinueButton')
+      act(() => {
+        fireEvent.press(continueButton)
+      })
+
+      await waitFor(() => {
+        expect(getByText('BCSC.EmailConfirmation.ErrorTitle')).toBeTruthy()
+      })
+
+      expect(continueButton.props.accessibilityState.disabled).toBe(false)
+    })
+  })
+
+  describe('Skip functionality', () => {
+    it('should show alert when Skip button is pressed', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <EnterEmailScreen
+            navigation={mockNavigation}
+            route={{ params: { cardType: BCSCCardType.Combined } }}
+          />
+        </BasicAppContext>
+      )
+
+      const skipButton = getByTestId('SkipButton')
+      act(() => {
+        fireEvent.press(skipButton)
+      })
+
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'BCSC.EnterEmail.EmailSkip',
+        'BCSC.EnterEmail.EmailSkipMessage',
+        expect.arrayContaining([
+          expect.objectContaining({ text: 'BCSC.EnterEmail.EmailSkipButton' }),
+          expect.objectContaining({ text: 'BCSC.EnterEmail.EmailSkipButton2' }),
+        ])
+      )
+    })
+
+    it('should not navigate when alert is cancelled', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <EnterEmailScreen
+            navigation={mockNavigation}
+            route={{ params: { cardType: BCSCCardType.Combined } }}
+          />
+        </BasicAppContext>
+      )
+
+      const skipButton = getByTestId('SkipButton')
+      act(() => {
+        fireEvent.press(skipButton)
+      })
+
+      // Get the cancel button callback
+      const alertCall = (Alert.alert as jest.Mock).mock.calls[0]
+      const cancelButton = alertCall[2][0]
+
+      // Cancel button should not have an onPress handler (or it should not navigate)
+      expect(cancelButton.onPress).toBeUndefined()
+      expect(mockNavigation.goBack).not.toHaveBeenCalled()
+    })
+
+    it('should navigate back when skip is confirmed', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <EnterEmailScreen
+            navigation={mockNavigation}
+            route={{ params: { cardType: BCSCCardType.Combined } }}
+          />
+        </BasicAppContext>
+      )
+
+      const skipButton = getByTestId('SkipButton')
+      act(() => {
+        fireEvent.press(skipButton)
+      })
+
+      // Get the confirm button callback and execute it
+      const alertCall = (Alert.alert as jest.Mock).mock.calls[0]
+      const confirmButton = alertCall[2][1]
+      act(() => {
+        confirmButton.onPress()
+      })
+
+      expect(mockNavigation.goBack).toHaveBeenCalled()
+    })
+  })
+})

--- a/app/__tests__/screens/EnterEmailScreen.test.tsx
+++ b/app/__tests__/screens/EnterEmailScreen.test.tsx
@@ -4,9 +4,9 @@ import { Alert } from 'react-native'
 
 import { useNavigation } from '../../__mocks__/custom/@react-navigation/core'
 import { BasicAppContext } from '../../__mocks__/helpers/app'
+import EnterEmailScreen from '../../src/bcsc-theme/features/verify/email/EnterEmailScreen'
 import { BCSCCardType } from '../../src/bcsc-theme/types/cards'
 import { BCSCScreens } from '../../src/bcsc-theme/types/navigators'
-import EnterEmailScreen from '../../src/bcsc-theme/features/verify/email/EnterEmailScreen'
 
 const mockCreateEmailVerification = jest.fn()
 jest.mock('@/bcsc-theme/api/hooks/useApi', () => {
@@ -38,10 +38,7 @@ describe('EnterEmailScreen', () => {
     it('should render correctly', () => {
       const { getByText } = render(
         <BasicAppContext>
-          <EnterEmailScreen
-            navigation={mockNavigation}
-            route={{ params: { cardType: BCSCCardType.Combined } }}
-          />
+          <EnterEmailScreen navigation={mockNavigation} route={{ params: { cardType: BCSCCardType.Combined } }} />
         </BasicAppContext>
       )
 
@@ -52,10 +49,7 @@ describe('EnterEmailScreen', () => {
     it('should display description for non-Other card types i.e combined', () => {
       const { getByText } = render(
         <BasicAppContext>
-          <EnterEmailScreen
-            navigation={mockNavigation}
-            route={{ params: { cardType: BCSCCardType.Combined } }}
-          />
+          <EnterEmailScreen navigation={mockNavigation} route={{ params: { cardType: BCSCCardType.Combined } }} />
         </BasicAppContext>
       )
 
@@ -75,10 +69,7 @@ describe('EnterEmailScreen', () => {
     it('should display Skip button for non-Other card types i.e combined', () => {
       const { getByTestId } = render(
         <BasicAppContext>
-          <EnterEmailScreen
-            navigation={mockNavigation}
-            route={{ params: { cardType: BCSCCardType.Combined } }}
-          />
+          <EnterEmailScreen navigation={mockNavigation} route={{ params: { cardType: BCSCCardType.Combined } }} />
         </BasicAppContext>
       )
 
@@ -100,10 +91,7 @@ describe('EnterEmailScreen', () => {
     it('should show error when submitting empty email', async () => {
       const { getByTestId, getByText } = render(
         <BasicAppContext>
-          <EnterEmailScreen
-            navigation={mockNavigation}
-            route={{ params: { cardType: BCSCCardType.Combined } }}
-          />
+          <EnterEmailScreen navigation={mockNavigation} route={{ params: { cardType: BCSCCardType.Combined } }} />
         </BasicAppContext>
       )
 
@@ -120,10 +108,7 @@ describe('EnterEmailScreen', () => {
     it('should show error when submitting invalid email format', async () => {
       const { getByTestId, getByText } = render(
         <BasicAppContext>
-          <EnterEmailScreen
-            navigation={mockNavigation}
-            route={{ params: { cardType: BCSCCardType.Combined } }}
-          />
+          <EnterEmailScreen navigation={mockNavigation} route={{ params: { cardType: BCSCCardType.Combined } }} />
         </BasicAppContext>
       )
 
@@ -147,10 +132,7 @@ describe('EnterEmailScreen', () => {
 
       const { getByTestId, getByText, queryByText } = render(
         <BasicAppContext>
-          <EnterEmailScreen
-            navigation={mockNavigation}
-            route={{ params: { cardType: BCSCCardType.Combined } }}
-          />
+          <EnterEmailScreen navigation={mockNavigation} route={{ params: { cardType: BCSCCardType.Combined } }} />
         </BasicAppContext>
       )
 
@@ -187,10 +169,7 @@ describe('EnterEmailScreen', () => {
 
       const { getByTestId } = render(
         <BasicAppContext>
-          <EnterEmailScreen
-            navigation={mockNavigation}
-            route={{ params: { cardType: BCSCCardType.Combined } }}
-          />
+          <EnterEmailScreen navigation={mockNavigation} route={{ params: { cardType: BCSCCardType.Combined } }} />
         </BasicAppContext>
       )
 
@@ -217,10 +196,7 @@ describe('EnterEmailScreen', () => {
 
       const { getByTestId } = render(
         <BasicAppContext>
-          <EnterEmailScreen
-            navigation={mockNavigation}
-            route={{ params: { cardType: BCSCCardType.Combined } }}
-          />
+          <EnterEmailScreen navigation={mockNavigation} route={{ params: { cardType: BCSCCardType.Combined } }} />
         </BasicAppContext>
       )
 
@@ -251,10 +227,7 @@ describe('EnterEmailScreen', () => {
 
       const { getByTestId, getByText } = render(
         <BasicAppContext>
-          <EnterEmailScreen
-            navigation={mockNavigation}
-            route={{ params: { cardType: BCSCCardType.Combined } }}
-          />
+          <EnterEmailScreen navigation={mockNavigation} route={{ params: { cardType: BCSCCardType.Combined } }} />
         </BasicAppContext>
       )
 
@@ -278,10 +251,7 @@ describe('EnterEmailScreen', () => {
 
       const { getByTestId, getByText } = render(
         <BasicAppContext>
-          <EnterEmailScreen
-            navigation={mockNavigation}
-            route={{ params: { cardType: BCSCCardType.Combined } }}
-          />
+          <EnterEmailScreen navigation={mockNavigation} route={{ params: { cardType: BCSCCardType.Combined } }} />
         </BasicAppContext>
       )
 
@@ -307,10 +277,7 @@ describe('EnterEmailScreen', () => {
     it('should show alert when Skip button is pressed', () => {
       const { getByTestId } = render(
         <BasicAppContext>
-          <EnterEmailScreen
-            navigation={mockNavigation}
-            route={{ params: { cardType: BCSCCardType.Combined } }}
-          />
+          <EnterEmailScreen navigation={mockNavigation} route={{ params: { cardType: BCSCCardType.Combined } }} />
         </BasicAppContext>
       )
 
@@ -332,10 +299,7 @@ describe('EnterEmailScreen', () => {
     it('should not navigate when alert is cancelled', () => {
       const { getByTestId } = render(
         <BasicAppContext>
-          <EnterEmailScreen
-            navigation={mockNavigation}
-            route={{ params: { cardType: BCSCCardType.Combined } }}
-          />
+          <EnterEmailScreen navigation={mockNavigation} route={{ params: { cardType: BCSCCardType.Combined } }} />
         </BasicAppContext>
       )
 
@@ -356,10 +320,7 @@ describe('EnterEmailScreen', () => {
     it('should navigate back when skip is confirmed', () => {
       const { getByTestId } = render(
         <BasicAppContext>
-          <EnterEmailScreen
-            navigation={mockNavigation}
-            route={{ params: { cardType: BCSCCardType.Combined } }}
-          />
+          <EnterEmailScreen navigation={mockNavigation} route={{ params: { cardType: BCSCCardType.Combined } }} />
         </BasicAppContext>
       )
 

--- a/app/__tests__/screens/NewSetupScreen.test.tsx
+++ b/app/__tests__/screens/NewSetupScreen.test.tsx
@@ -4,8 +4,8 @@ import React from 'react'
 
 import { useNavigation } from '../../__mocks__/custom/@react-navigation/core'
 import { BasicAppContext } from '../../__mocks__/helpers/app'
-import { BCSCScreens } from '../../src/bcsc-theme/types/navigators'
 import NewSetupScreen from '../../src/bcsc-theme/features/verify/NewSetupScreen'
+import { BCSCScreens } from '../../src/bcsc-theme/types/navigators'
 
 describe('NewSetupScreen', () => {
   let mockNavigation: any
@@ -41,8 +41,8 @@ describe('NewSetupScreen', () => {
     })
   })
 
-  describe('Someone else\'s ID flow', () => {
-    it('should have Yes selected by default when Someone else\'s ID is clicked', () => {
+  describe("Someone else's ID flow", () => {
+    it("should have Yes selected by default when Someone else's ID is clicked", () => {
       const { getByText, getByTestId } = render(
         <BasicAppContext>
           <NewSetupScreen navigation={mockNavigation} />
@@ -60,7 +60,7 @@ describe('NewSetupScreen', () => {
       expect(noOption.props.accessibilityState.selected).toBe(false)
     })
 
-    it('should display help information when Someone else\'s ID is selected and Yes is chosen', () => {
+    it("should display help information when Someone else's ID is selected and Yes is chosen", () => {
       const { getByText, queryByText } = render(
         <BasicAppContext>
           <NewSetupScreen navigation={mockNavigation} />
@@ -89,7 +89,7 @@ describe('NewSetupScreen', () => {
       expect(getByText('BCSC.NewSetup.YouCannotBeInVideo')).toBeTruthy()
     })
 
-    it('should display error when Someone else\'s ID is selected and No is chosen', () => {
+    it("should display error when Someone else's ID is selected and No is chosen", () => {
       const { getByText, queryByText } = render(
         <BasicAppContext>
           <NewSetupScreen navigation={mockNavigation} />
@@ -145,7 +145,7 @@ describe('NewSetupScreen', () => {
       expect(continueButton.props.accessibilityState.disabled).toBe(false)
     })
 
-    it.todo('should disable continue button when Someone else\'s ID is selected and No is chosen')
+    it.todo("should disable continue button when Someone else's ID is selected and No is chosen")
   })
 
   describe('Navigation', () => {

--- a/app/__tests__/screens/NewSetupScreen.test.tsx
+++ b/app/__tests__/screens/NewSetupScreen.test.tsx
@@ -1,0 +1,185 @@
+import { testIdWithKey } from '@bifold/core'
+import { fireEvent, render } from '@testing-library/react-native'
+import React from 'react'
+
+import { useNavigation } from '../../__mocks__/custom/@react-navigation/core'
+import { BasicAppContext } from '../../__mocks__/helpers/app'
+import { BCSCScreens } from '../../src/bcsc-theme/types/navigators'
+import NewSetupScreen from '../../src/bcsc-theme/features/verify/NewSetupScreen'
+
+describe('NewSetupScreen', () => {
+  let mockNavigation: any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockNavigation = useNavigation()
+  })
+
+  describe('Rendering', () => {
+    it('should render correctly', () => {
+      const tree = render(
+        <BasicAppContext>
+          <NewSetupScreen navigation={mockNavigation} />
+        </BasicAppContext>
+      )
+
+      expect(tree).toMatchSnapshot()
+    })
+
+    it('should have My own ID selected by default when screen loads', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <NewSetupScreen navigation={mockNavigation} />
+        </BasicAppContext>
+      )
+
+      const myOwnIdOption = getByTestId(testIdWithKey('MyOwnIdRadioGroup-option-BCSC.NewSetup.MyOwnID'))
+      const someoneElsesIdOption = getByTestId(testIdWithKey('MyOwnIdRadioGroup-option-BCSC.NewSetup.SomeoneElsesID'))
+
+      expect(myOwnIdOption.props.accessibilityState.selected).toBe(true)
+      expect(someoneElsesIdOption.props.accessibilityState.selected).toBe(false)
+    })
+  })
+
+  describe('Someone else\'s ID flow', () => {
+    it('should have Yes selected by default when Someone else\'s ID is clicked', () => {
+      const { getByText, getByTestId } = render(
+        <BasicAppContext>
+          <NewSetupScreen navigation={mockNavigation} />
+        </BasicAppContext>
+      )
+
+      // Select "Someone else's ID"
+      fireEvent.press(getByText('BCSC.NewSetup.SomeoneElsesID'))
+
+      // Check that "Yes" is selected by default
+      const yesOption = getByTestId(testIdWithKey('OtherPersonPresentRadioGroup-option-BCSC.NewSetup.Yes'))
+      const noOption = getByTestId(testIdWithKey('OtherPersonPresentRadioGroup-option-BCSC.NewSetup.No'))
+
+      expect(yesOption.props.accessibilityState.selected).toBe(true)
+      expect(noOption.props.accessibilityState.selected).toBe(false)
+    })
+
+    it('should display help information when Someone else\'s ID is selected and Yes is chosen', () => {
+      const { getByText, queryByText } = render(
+        <BasicAppContext>
+          <NewSetupScreen navigation={mockNavigation} />
+        </BasicAppContext>
+      )
+
+      // Initially, help information should not be visible
+      expect(queryByText('BCSC.NewSetup.OKToGiveHelp')).toBeNull()
+
+      // Select "Someone else's ID"
+      fireEvent.press(getByText('BCSC.NewSetup.SomeoneElsesID'))
+
+      // Now the "Is other person with you" should appear
+      expect(getByText('BCSC.NewSetup.IsOtherPersonWithYou')).toBeTruthy()
+
+      // Select "Yes" to display help information
+      fireEvent.press(getByText('BCSC.NewSetup.Yes'))
+
+      // Help information should now be visible
+      expect(getByText('BCSC.NewSetup.OKToGiveHelp')).toBeTruthy()
+      expect(getByText('BCSC.NewSetup.YouCan')).toBeTruthy()
+      expect(getByText('BCSC.NewSetup.YouCannot')).toBeTruthy()
+      expect(getByText('BCSC.NewSetup.YouCanReadInstructions')).toBeTruthy()
+      expect(getByText('BCSC.NewSetup.YouCanNavigateApp')).toBeTruthy()
+      expect(getByText('BCSC.NewSetup.YouCanTypeOrScan')).toBeTruthy()
+      expect(getByText('BCSC.NewSetup.YouCannotBeInVideo')).toBeTruthy()
+    })
+
+    it('should display error when Someone else\'s ID is selected and No is chosen', () => {
+      const { getByText, queryByText } = render(
+        <BasicAppContext>
+          <NewSetupScreen navigation={mockNavigation} />
+        </BasicAppContext>
+      )
+
+      // Error should not be visible initially
+      expect(queryByText('BCSC.NewSetup.CannotFinishWithoutOtherPerson')).toBeNull()
+
+      // Select "Someone else's ID"
+      fireEvent.press(getByText('BCSC.NewSetup.SomeoneElsesID'))
+
+      // Select "No"
+      fireEvent.press(getByText('BCSC.NewSetup.No'))
+
+      // Error message should now be visible
+      expect(getByText('BCSC.NewSetup.CannotFinishWithoutOtherPerson')).toBeTruthy()
+    })
+
+    it('should clear otherPersonPresent state when switching back to My own ID', () => {
+      const { getByText, queryByText, getByTestId } = render(
+        <BasicAppContext>
+          <NewSetupScreen navigation={mockNavigation} />
+        </BasicAppContext>
+      )
+
+      // Select "Someone else's ID"
+      fireEvent.press(getByText('BCSC.NewSetup.SomeoneElsesID'))
+
+      // Verify the "Is other person with you" question appears
+      expect(getByText('BCSC.NewSetup.IsOtherPersonWithYou')).toBeTruthy()
+
+      // Select "No" to trigger the error state
+      fireEvent.press(getByText('BCSC.NewSetup.No'))
+
+      // Verify error is displayed
+      expect(getByText('BCSC.NewSetup.CannotFinishWithoutOtherPerson')).toBeTruthy()
+
+      // Switch back to "My own ID"
+      fireEvent.press(getByText('BCSC.NewSetup.MyOwnID'))
+
+      // Verify the "Is other person with you" question is hidden
+      expect(queryByText('BCSC.NewSetup.IsOtherPersonWithYou')).toBeNull()
+
+      // Verify error message is hidden
+      expect(queryByText('BCSC.NewSetup.CannotFinishWithoutOtherPerson')).toBeNull()
+
+      // Verify help information is hidden
+      expect(queryByText('BCSC.NewSetup.OKToGiveHelp')).toBeNull()
+
+      // Verify continue button is enabled
+      const continueButton = getByTestId(testIdWithKey('Continue'))
+      expect(continueButton.props.accessibilityState.disabled).toBe(false)
+    })
+
+    it.todo('should disable continue button when Someone else\'s ID is selected and No is chosen')
+  })
+
+  describe('Navigation', () => {
+    it('should navigate to SetupSteps screen when Continue button is pressed', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <NewSetupScreen navigation={mockNavigation} />
+        </BasicAppContext>
+      )
+
+      const continueButton = getByTestId(testIdWithKey('Continue'))
+
+      // Button should be enabled by default since "My own ID" is pre-selected
+      expect(continueButton.props.accessibilityState.disabled).toBe(false)
+
+      fireEvent.press(continueButton)
+
+      // Should navigate to SetupSteps screen
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.SetupSteps)
+      expect(mockNavigation.navigate).toHaveBeenCalledTimes(1)
+    })
+
+    it('should navigate back when Cancel button is pressed', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <NewSetupScreen navigation={mockNavigation} />
+        </BasicAppContext>
+      )
+
+      const cancelButton = getByTestId(testIdWithKey('Cancel'))
+
+      fireEvent.press(cancelButton)
+
+      expect(mockNavigation.goBack).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/app/__tests__/screens/TransferQRInformationScreen.test.tsx
+++ b/app/__tests__/screens/TransferQRInformationScreen.test.tsx
@@ -1,12 +1,12 @@
 import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 
+import { act } from 'react-test-renderer'
 import { useNavigation } from '../../__mocks__/@react-navigation/native'
 import { BasicAppContext } from '../../__mocks__/helpers/app'
+import TransferQRInformationScreen from '../../src/bcsc-theme/features/account-transfer/TransferQRInformationScreen'
 import { BCSCScreens } from '../../src/bcsc-theme/types/navigators'
 import { HelpCentreUrl } from '../../src/constants'
-import TransferQRInformationScreen from '../../src/bcsc-theme/features/account-transfer/TransferQRInformationScreen'
-import { act } from 'react-test-renderer'
 
 describe('TransferQRInformationScreen', () => {
   let mockNavigation: any
@@ -17,7 +17,6 @@ describe('TransferQRInformationScreen', () => {
   })
 
   describe('Render tests', () => {
-
     it('render matches snapshot', () => {
       const tree = render(
         <BasicAppContext>
@@ -29,7 +28,6 @@ describe('TransferQRInformationScreen', () => {
   })
 
   describe('Navigation tests', () => {
-
     it('Get QR Code navigates', () => {
       const { getByTestId } = render(
         <BasicAppContext>

--- a/app/__tests__/screens/TransferQRInformationScreen.test.tsx
+++ b/app/__tests__/screens/TransferQRInformationScreen.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render } from '@testing-library/react-native'
+import React from 'react'
+
+import { useNavigation } from '../../__mocks__/@react-navigation/native'
+import { BasicAppContext } from '../../__mocks__/helpers/app'
+import { BCSCScreens } from '../../src/bcsc-theme/types/navigators'
+import { HelpCentreUrl } from '../../src/constants'
+import TransferQRInformationScreen from '../../src/bcsc-theme/features/account-transfer/TransferQRInformationScreen'
+import { act } from 'react-test-renderer'
+
+describe('TransferQRInformationScreen', () => {
+  let mockNavigation: any
+
+  beforeEach(() => {
+    mockNavigation = useNavigation()
+    jest.clearAllMocks()
+  })
+
+  describe('Render tests', () => {
+
+    it('render matches snapshot', () => {
+      const tree = render(
+        <BasicAppContext>
+          <TransferQRInformationScreen />
+        </BasicAppContext>
+      )
+      expect(tree).toMatchSnapshot()
+    })
+  })
+
+  describe('Navigation tests', () => {
+
+    it('Get QR Code navigates', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <TransferQRInformationScreen />
+        </BasicAppContext>
+      )
+      const getQRCodeButton = getByTestId('GetQRCodeButton')
+      act(() => {
+        fireEvent.press(getQRCodeButton)
+      })
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.TransferAccountQRDisplay)
+    })
+
+    it('Help centre button navigates', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <TransferQRInformationScreen />
+        </BasicAppContext>
+      )
+      const learnMoreButton = getByTestId('LearnMoreButton')
+      act(() => {
+        fireEvent.press(learnMoreButton)
+      })
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.MainWebView, {
+        url: HelpCentreUrl.QUICK_SETUP_OF_ADDITIONAL_DEVICES,
+        title: 'HelpCentre.Title',
+      })
+    })
+  })
+})

--- a/app/__tests__/screens/__snapshots__/NewSetupScreen.test.tsx.snap
+++ b/app/__tests__/screens/__snapshots__/NewSetupScreen.test.tsx.snap
@@ -1,0 +1,524 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NewSetupScreen Rendering should render correctly 1`] = `
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "additive",
+      "right": "additive",
+      "top": "off",
+    }
+  }
+  style={
+    {
+      "backgroundColor": "#F2F2F2",
+      "flex": 1,
+      "justifyContent": "space-between",
+      "padding": 16,
+    }
+  }
+>
+  <RCTScrollView
+    contentContainerStyle={
+      {
+        "flexGrow": 1,
+      }
+    }
+    showsVerticalScrollIndicator={false}
+  >
+    <View>
+      <Text
+        maxFontSizeMultiplier={2}
+        style={
+          [
+            {
+              "color": "#313132",
+              "fontFamily": "BCSans-Regular",
+              "fontSize": 26,
+              "fontWeight": "bold",
+            },
+            {
+              "marginBottom": 16,
+            },
+          ]
+        }
+      >
+        BCSC.NewSetup.Title
+      </Text>
+      <Text
+        maxFontSizeMultiplier={2}
+        style={
+          [
+            {
+              "color": "#313132",
+              "fontFamily": "BCSans-Regular",
+              "fontSize": 18,
+              "fontWeight": "bold",
+            },
+            {
+              "marginBottom": 16,
+            },
+          ]
+        }
+      >
+        BCSC.NewSetup.YouWillNeedTo
+      </Text>
+      <View
+        style={
+          {
+            "flexDirection": "row",
+            "flexShrink": 1,
+            "marginBottom": 16,
+            "marginLeft": 8,
+          }
+        }
+      >
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              {
+                "marginRight": 4,
+              },
+            ]
+          }
+        >
+          •
+        </Text>
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              undefined,
+            ]
+          }
+        >
+          BCSC.NewSetup.AddPhotoID
+        </Text>
+      </View>
+      <View
+        style={
+          [
+            {
+              "flexDirection": "row",
+              "flexShrink": 1,
+              "marginBottom": 16,
+              "marginLeft": 8,
+            },
+            {
+              "marginBottom": 24,
+            },
+          ]
+        }
+      >
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              {
+                "marginRight": 4,
+              },
+            ]
+          }
+        >
+          •
+        </Text>
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              undefined,
+            ]
+          }
+        >
+          BCSC.NewSetup.RecordVideoOrVisit
+        </Text>
+      </View>
+      <Text
+        maxFontSizeMultiplier={2}
+        style={
+          [
+            {
+              "color": "#313132",
+              "fontFamily": "BCSans-Regular",
+              "fontSize": 18,
+              "fontWeight": "bold",
+            },
+            undefined,
+          ]
+        }
+      >
+        BCSC.NewSetup.WhoseIDQuestion
+      </Text>
+      <View
+        style={
+          {
+            "marginVertical": 16,
+          }
+        }
+        testID="com.ariesbifold:id/MyOwnIdRadioGroup"
+      >
+        <View
+          style={
+            {
+              "paddingBottom": 4,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="BCSC.NewSetup.MyOwnID"
+            accessibilityRole="radio"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": true,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "backgroundColor": "#FFFFFF",
+                "flexDirection": "row",
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
+            }
+            testID="com.ariesbifold:id/MyOwnIdRadioGroup-option-BCSC.NewSetup.MyOwnID"
+          >
+            <Text
+              style={
+                {
+                  "color": "#FFFFFF",
+                  "flex": 1,
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                }
+              }
+            >
+              BCSC.NewSetup.MyOwnID
+            </Text>
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "borderColor": "#003366",
+                  "borderRadius": 12,
+                  "borderWidth": 3,
+                  "height": 24,
+                  "justifyContent": "center",
+                  "width": 24,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "backgroundColor": "#003366",
+                    "borderRadius": 6,
+                    "height": 12,
+                    "width": 12,
+                  }
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              {
+                "height": 8,
+              }
+            }
+          />
+          <View
+            accessibilityLabel="BCSC.NewSetup.SomeoneElsesID"
+            accessibilityRole="radio"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": false,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "backgroundColor": "#FFFFFF",
+                "flexDirection": "row",
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
+            }
+            testID="com.ariesbifold:id/MyOwnIdRadioGroup-option-BCSC.NewSetup.SomeoneElsesID"
+          >
+            <Text
+              style={
+                {
+                  "color": "#FFFFFF",
+                  "flex": 1,
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                }
+              }
+            >
+              BCSC.NewSetup.SomeoneElsesID
+            </Text>
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "borderColor": "#003366",
+                  "borderRadius": 12,
+                  "borderWidth": 3,
+                  "height": 24,
+                  "justifyContent": "center",
+                  "width": 24,
+                }
+              }
+            />
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          {
+            "gap": 16,
+            "marginTop": "auto",
+          }
+        }
+      >
+        <View
+          accessibilityLabel="Global.Continue"
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": false,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "backgroundColor": "#003366",
+              "borderRadius": 4,
+              "opacity": 1,
+              "padding": 16,
+            }
+          }
+          testID="com.ariesbifold:id/Continue"
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <Text
+              maxFontSizeMultiplier={2}
+              style={
+                [
+                  {
+                    "color": "#313132",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "normal",
+                  },
+                  [
+                    {
+                      "color": "#FFFFFF",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                      "textAlign": "center",
+                    },
+                    false,
+                    false,
+                    false,
+                  ],
+                ]
+              }
+            >
+              Global.Continue
+            </Text>
+          </View>
+        </View>
+        <View
+          accessibilityLabel="Global.Cancel"
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": false,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "borderColor": "#003366",
+              "borderRadius": 4,
+              "borderWidth": 2,
+              "opacity": 1,
+              "padding": 16,
+            }
+          }
+          testID="com.ariesbifold:id/Cancel"
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <Text
+              maxFontSizeMultiplier={2}
+              style={
+                [
+                  {
+                    "color": "#313132",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "normal",
+                  },
+                  [
+                    {
+                      "color": "#003366",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                      "textAlign": "center",
+                    },
+                    false,
+                    false,
+                    false,
+                  ],
+                ]
+              }
+            >
+              Global.Cancel
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</RNCSafeAreaView>
+`;

--- a/app/__tests__/screens/__snapshots__/TransferQRInformationScreen.test.tsx.snap
+++ b/app/__tests__/screens/__snapshots__/TransferQRInformationScreen.test.tsx.snap
@@ -1,0 +1,252 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TransferQRInformationScreen Render tests render matches snapshot 1`] = `
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "additive",
+      "right": "additive",
+      "top": "off",
+    }
+  }
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <RCTScrollView
+    contentContainerStyle={
+      {
+        "flex": 1,
+        "justifyContent": "space-between",
+        "padding": 16,
+      }
+    }
+  >
+    <View>
+      <View
+        style={
+          {
+            "flex": 1,
+            "gap": 16,
+          }
+        }
+      >
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 26,
+                "fontWeight": "bold",
+              },
+              undefined,
+            ]
+          }
+        >
+          BCSC.TransferQRInformation.Title
+        </Text>
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              undefined,
+            ]
+          }
+        >
+          BCSC.TransferQRInformation.Instructions
+        </Text>
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 18,
+                "fontWeight": "bold",
+              },
+              undefined,
+            ]
+          }
+        >
+          BCSC.TransferQRInformation.Warning
+        </Text>
+      </View>
+      <View
+        style={
+          {
+            "gap": 16,
+          }
+        }
+      >
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": false,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "backgroundColor": "#003366",
+              "borderRadius": 4,
+              "opacity": 1,
+              "padding": 16,
+            }
+          }
+          testID="GetQRCodeButton"
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <Text
+              maxFontSizeMultiplier={2}
+              style={
+                [
+                  {
+                    "color": "#313132",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "normal",
+                  },
+                  [
+                    {
+                      "color": "#FFFFFF",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                      "textAlign": "center",
+                    },
+                    false,
+                    false,
+                    false,
+                  ],
+                ]
+              }
+            >
+              BCSC.TransferQRInformation.GetQRCode
+            </Text>
+          </View>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": false,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "borderColor": "#003366",
+              "borderRadius": 4,
+              "borderWidth": 2,
+              "opacity": 1,
+              "padding": 16,
+            }
+          }
+          testID="LearnMoreButton"
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <Text
+              maxFontSizeMultiplier={2}
+              style={
+                [
+                  {
+                    "color": "#313132",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "normal",
+                  },
+                  [
+                    {
+                      "color": "#003366",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                      "textAlign": "center",
+                    },
+                    false,
+                    false,
+                    false,
+                  ],
+                ]
+              }
+            >
+              BCSC.TransferQRInformation.LearnMore
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</RNCSafeAreaView>
+`;

--- a/app/src/bcsc-theme/features/account-transfer/TransferQRInformationScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/TransferQRInformationScreen.tsx
@@ -43,6 +43,7 @@ const TransferQRInformationScreen: React.FC = () => {
             onPress={() => {
               navigation.navigate(BCSCScreens.TransferAccountQRDisplay)
             }}
+            testID="GetQRCodeButton"
           />
           <Button
             buttonType={ButtonType.Secondary}
@@ -53,6 +54,7 @@ const TransferQRInformationScreen: React.FC = () => {
                 title: t('HelpCentre.Title'),
               })
             }}
+            testID="LearnMoreButton"
           />
         </View>
       </ScrollView>

--- a/app/src/bcsc-theme/features/account-transfer/TransferQRInformationScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/TransferQRInformationScreen.tsx
@@ -1,5 +1,5 @@
 import { BCSCMainStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
-
+import { HelpCentreUrl } from '@/constants'
 import { Button, ButtonType, ThemedText, useTheme } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -48,7 +48,10 @@ const TransferQRInformationScreen: React.FC = () => {
             buttonType={ButtonType.Secondary}
             title={t('BCSC.TransferQRInformation.LearnMore')}
             onPress={() => {
-              // TODO: (Alfred) BCSC opens a web page inside the app, it doesn't open the page in the mobile browser
+              navigation.navigate(BCSCScreens.MainWebView, {
+                url: HelpCentreUrl.QUICK_SETUP_OF_ADDITIONAL_DEVICES,
+                title: t('HelpCentre.Title'),
+              })
             }}
           />
         </View>

--- a/app/src/bcsc-theme/features/verify/NewSetupScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/NewSetupScreen.tsx
@@ -28,7 +28,7 @@ const NewSetupScreen = ({ navigation }: NewSetupScreenProps) => {
   const { ColorPalette, Spacing } = useTheme()
   const [, dispatch] = useStore<BCState>()
   const { t } = useTranslation()
-  const [myOwnId, setMyOwnId] = useState<boolean>()
+  const [myOwnId, setMyOwnId] = useState<boolean>(true)
   const [otherPersonPresent, setOtherPersonPresent] = useState<boolean>()
   const canContinue = useMemo(
     () => myOwnId !== undefined && (myOwnId === true || otherPersonPresent !== undefined),
@@ -105,6 +105,8 @@ const NewSetupScreen = ({ navigation }: NewSetupScreenProps) => {
           onValueChange={(value) => {
             if (value) {
               setOtherPersonPresent(undefined)
+            } else {
+              setOtherPersonPresent(true)
             }
 
             setMyOwnId(value)

--- a/app/src/bcsc-theme/features/verify/email/EnterEmailScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EnterEmailScreen.tsx
@@ -113,7 +113,7 @@ const EnterEmailScreen = ({ navigation, route }: EnterEmailScreenProps) => {
             <ThemedText style={{ marginBottom: Spacing.md }}>{t('BCSC.EnterEmail.EmailDescription1')}</ThemedText>
           ) : null}
           <ThemedText style={{ marginBottom: Spacing.md }}>{t('BCSC.EnterEmail.EmailDescription2')}</ThemedText>
-          <EmailTextInput handleChangeEmail={handleChangeEmail} />
+          <EmailTextInput handleChangeEmail={handleChangeEmail} testID={'EmailInput'} />
           {error && <ThemedText variant={'inlineErrorText'}>{error}</ThemedText>}
         </View>
         <View style={styles.controlsContainer}>
@@ -124,7 +124,7 @@ const EnterEmailScreen = ({ navigation, route }: EnterEmailScreenProps) => {
             accessibilityLabel={t('Global.Continue')}
             testID={'ContinueButton'}
           >
-            {loading && <ButtonLoading />}
+            {loading && <ButtonLoading/>}
           </Button>
           {cardType !== BCSCCardType.Other ? (
             <Button

--- a/app/src/bcsc-theme/features/verify/email/EnterEmailScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EnterEmailScreen.tsx
@@ -124,7 +124,7 @@ const EnterEmailScreen = ({ navigation, route }: EnterEmailScreenProps) => {
             accessibilityLabel={t('Global.Continue')}
             testID={'ContinueButton'}
           >
-            {loading && <ButtonLoading/>}
+            {loading && <ButtonLoading />}
           </Button>
           {cardType !== BCSCCardType.Other ? (
             <Button

--- a/app/src/bcsc-theme/features/verify/email/EnterEmailScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EnterEmailScreen.tsx
@@ -130,8 +130,8 @@ const EnterEmailScreen = ({ navigation, route }: EnterEmailScreenProps) => {
             <Button
               buttonType={ButtonType.Secondary}
               onPress={handleSkip}
-              title={t('BCSC.EnterEmail.EmailSkip')}
-              accessibilityLabel={t('BCSC.EnterEmail.EmailSkip')}
+              title={t('BCSC.EnterEmail.EmailSkipButton2')}
+              accessibilityLabel={t('BCSC.EnterEmail.EmailSkipButton2')}
               testID={'SkipButton'}
             />
           ) : null}

--- a/app/src/bcsc-theme/theme.ts
+++ b/app/src/bcsc-theme/theme.ts
@@ -9,9 +9,9 @@ export const BCSCNotificationColors: INotificationColors = {
   infoBorder: GrayscaleColors.lightGrey,
   infoIcon: '#FCBA19',
   infoText: GrayscaleColors.lightGrey,
-  error: '#CE3E39',
+  error: '#A2312D',
   errorText: GrayscaleColors.white,
-  errorBorder: '#CE3E39',
+  errorBorder: '#A2312D',
   errorIcon: GrayscaleColors.white,
 }
 

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -59,6 +59,7 @@ export enum HelpCentreUrl {
   ACCEPTED_IDENTITY_DOCUMENTS = 'https://id.gov.bc.ca/static/help/accepted-id.html?fromapp=1',
   VERIFICATION_METHODS = 'https://id.gov.bc.ca/static/help/verify_why.html?fromapp=1#section-options-app',
   VERIFY_IN_PERSON = 'https://id.gov.bc.ca/static/help/verify_why.html?fromapp=1#section-inperson',
+  QUICK_SETUP_OF_ADDITIONAL_DEVICES = 'https://id.gov.bc.ca/static/help/setup_qrcode.html?fromapp=1',
 }
 
 export const formStringLengths = {

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -481,6 +481,7 @@ const translation = {
     },
     "EmailConfirmation": {
       "ErrorTitle": "Error verifying confirmation code",
+      "EmailError": "Please enter a valid email address (name@host.com).",
       "CodeError": "Please enter a six digit verification code",
       "ErrorResendingCode": "Error resending code",
       "CodeResent": "Code resent",

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -470,7 +470,6 @@ const translation = {
     },
     "EnterEmail": {
       "ErrorTitle": "Error submitting email",
-      "EmailError": "Please enter a valid email address",
       "EmailSkip": "Are you sure you don't want to provide it?",
       "EmailSkipMessage": "It is less secure without it as we can't notify you of logins or changes to your account.",
       "EmailSkipButton": "Provide email address",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -469,7 +469,6 @@ const translation = {
     },
     "EnterEmail": {
       "ErrorTitle": "Error submitting email (FR)",
-      "EmailError": "Please enter a valid email address (name@host.com). (FR)",
       "EmailSkip": "Are you sure you don't want to provide it? (FR)",
       "EmailSkipMessage": "It is less secure without it as we can't notify you of logins or changes to your account. (FR)",
       "EmailSkipButton": "Provide email address (FR)",
@@ -480,6 +479,7 @@ const translation = {
     },
     "EmailConfirmation": {
       "ErrorTitle": "Error verifying confirmation code (FR)",
+      "EmailError": "Please enter a valid email address (name@host.com). (FR)",
       "CodeError": "Please enter a six digit verification code (FR)",
       "ErrorResendingCode": "Error resending code (FR)",
       "CodeResent": "Code resent (FR)",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -469,7 +469,7 @@ const translation = {
     },
     "EnterEmail": {
       "ErrorTitle": "Error submitting email (FR)",
-      "EmailError": "Please enter a valid email address (FR)",
+      "EmailError": "Please enter a valid email address (name@host.com). (FR)",
       "EmailSkip": "Are you sure you don't want to provide it? (FR)",
       "EmailSkipMessage": "It is less secure without it as we can't notify you of logins or changes to your account. (FR)",
       "EmailSkipButton": "Provide email address (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -469,7 +469,6 @@ const translation = {
     },
     "EnterEmail": {
       "ErrorTitle": "Error submitting email (PT-BR)",
-      "EmailError": "Please enter a valid email address (PT-BR)",
       "EmailSkip": "Are you sure you don't want to provide it? (PT-BR)",
       "EmailSkipMessage": "It is less secure without it as we can't notify you of logins or changes to your account. (PT-BR)",
       "EmailSkipButton": "Provide email address (PT-BR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -480,6 +480,7 @@ const translation = {
     },
     "EmailConfirmation": {
       "ErrorTitle": "Error verifying confirmation code (PT-BR)",
+      "EmailError": "Please enter a valid email address (name@host.com). (PT-BR)",
       "CodeError": "Please enter a six digit verification code (PT-BR)",
       "ErrorResendingCode": "Error resending code (PT-BR)",
       "CodeResent": "Code resent (PT-BR)",


### PR DESCRIPTION
# Summary of Changes

This PR includes the following changes to the UI

- EnterEmailScreen
  - Skip button uses correct localization string
  - Email error localization string added for en, pt-br, and updated for fr
- TransferQRInformationScreen
  - Learn more button opens to the correct guide using in-app webview
- NewSetupScreen
  - By default "My own ID" is selected
  - When selecting "Someone else's ID", "Yes" is selected by default
  - When selecting "No", the warning is now a different shade of red
- misc
  - added coverage for the 3 screens changed
  - changes error notification banner colour along with the warning on NewSetupScreen

# Testing Instructions

Navigate to the affected screens and view the changes.

NewSetupScreen is accessible in the verification flow.
To access the EnterEmailScreen, go through the verification flow with both a bcsc and non-bcsc id and stop before verification. There on the Verification steps screen, click edit on the email step in order to see the screen. Be sure to enter an invalid email to see the error localization change.
The TransferQRInformation screen is accessible after verification from settings > transfer to a new device

# Acceptance Criteria

EnterEmailScreen
- [ ] The Skip button has the correct localization rendered (only present in non-other card types i.e. combined)

TransferQRInformationScreen
- [ ] The learn more button opens the [appropriate guide ](https://id.gov.bc.ca/static/help/setup_qrcode.html) in the in app webview

NewSetupScreen
- [ ] "My own ID" option should be selected by default.
- [ ] "Is this person with you" option should be selected by default.
- [ ] Update warning box visual as per design specifications: color should be #A2312D


# Screenshots, videos, or gifs

NewAccountScreen

[newaccount.webm](https://github.com/user-attachments/assets/2a48ea23-b00c-46e9-9c38-a00e25a6258e)

EnterEmailScreen

<img width="449" height="964" alt="Screenshot 2025-11-25 141332" src="https://github.com/user-attachments/assets/8f6e4255-f7a8-40e8-920d-a26c38379f9b" />

TransferQRInformationScreen

[untitled.webm](https://github.com/user-attachments/assets/ea633917-0785-4a8d-ba11-387a9ddbe1a3)

Error Notification Banner

<img width="463" height="974" alt="banner" src="https://github.com/user-attachments/assets/2d3b58a1-838c-4767-a5a4-dd8f58a485cb" />


# Related Issues

https://github.com/bcgov/bc-wallet-mobile/issues/2877
https://github.com/bcgov/bc-wallet-mobile/issues/2914
https://github.com/bcgov/bc-wallet-mobile/issues/2910
