### PR TITLE
fix(cicd): update patches with exact google service config

### DIFF
--- a/patch/0001-chore-android-app-to-bcsc-dev.patch
+++ b/patch/0001-chore-android-app-to-bcsc-dev.patch
@@ -1,6 +1,6 @@
-From f22d655b99f143e0080adfea23ec4472355e3b9a Mon Sep 17 00:00:00 2001
+From fbe9fcd1763a40da87b70c4040cfa5d571b29268 Mon Sep 17 00:00:00 2001
 From: Bryce McMath <bryce.j.mcmath@gmail.com>
-Date: Tue, 2 Dec 2025 15:30:47 -0800
+Date: Tue, 2 Dec 2025 16:03:59 -0800
 Subject: [PATCH] chore: android app to bcsc dev
 
 Signed-off-by: Bryce McMath <bryce.j.mcmath@gmail.com>
@@ -127,7 +127,7 @@ index f552ceb7..12914cd9 100644
          targetSdkVersion rootProject.ext.targetSdkVersion
          versionCode System.getenv("VERSION_CODE") ? System.getenv("VERSION_CODE").toInteger() : 1
 diff --git a/app/android/app/google-services.json b/app/android/app/google-services.json
-index a3a58790..a237cc51 100644
+index a3a58790..8643db07 100644
 --- a/app/android/app/google-services.json
 +++ b/app/android/app/google-services.json
 @@ -1,33 +1,34 @@
@@ -148,7 +148,7 @@ index a3a58790..a237cc51 100644
 +        "mobilesdk_app_id": "1:209333430748:android:1c4641260a97bfe5",
          "android_client_info": {
 -          "package_name": "ca.bc.gov.BCWallet"
-+          "package_name": "ca.bc.gov.id.servicescard"
++          "package_name": "ca.bc.gov.id.servicescard.dev"
          }
        },
        "oauth_client": [

--- a/patch/0001-chore-android-app-to-bcsc-dev.patch
+++ b/patch/0001-chore-android-app-to-bcsc-dev.patch
@@ -1,54 +1,54 @@
-From 9054961cd1c760b4598ffcb762e8d07e79d27151 Mon Sep 17 00:00:00 2001
+From f22d655b99f143e0080adfea23ec4472355e3b9a Mon Sep 17 00:00:00 2001
 From: Bryce McMath <bryce.j.mcmath@gmail.com>
-Date: Fri, 7 Nov 2025 15:43:46 -0800
+Date: Tue, 2 Dec 2025 15:30:47 -0800
 Subject: [PATCH] chore: android app to bcsc dev
 
 Signed-off-by: Bryce McMath <bryce.j.mcmath@gmail.com>
 ---
- app/android/app/BUCK                          |   4 +--
- app/android/app/build.gradle                  |   4 +--
- app/android/app/google-services.json          |  30 ++++++++++--------
- app/android/app/src/main/AndroidManifest.xml  |   4 +--
- .../src/main/ic_launcher_mono-playstore.png   | Bin 0 -> 18297 bytes
- .../java/ca/bc/gov/BCWallet/MainActivity.kt   |   2 +-
- .../ca/bc/gov/BCWallet/MainApplication.kt     |   2 +-
- .../app/src/main/res/layout/launch_screen.xml |   2 +-
- .../res/mipmap-anydpi-v26/ic_launcher.xml     |   6 ----
- .../mipmap-anydpi-v26/ic_launcher_mono.xml    |   5 +++
- .../ic_launcher_mono_round.xml                |   5 +++
- .../mipmap-anydpi-v26/ic_launcher_round.xml   |   6 ----
- .../src/main/res/mipmap-hdpi/ic_launcher.png  | Bin 2306 -> 0 bytes
- .../mipmap-hdpi/ic_launcher_foreground.png    | Bin 3269 -> 0 bytes
- .../res/mipmap-hdpi/ic_launcher_mono.webp     | Bin 0 -> 1186 bytes
- .../ic_launcher_mono_foreground.webp          | Bin 0 -> 1148 bytes
- .../mipmap-hdpi/ic_launcher_mono_round.webp   | Bin 0 -> 2562 bytes
- .../res/mipmap-hdpi/ic_launcher_round.png     | Bin 4262 -> 0 bytes
- .../src/main/res/mipmap-mdpi/ic_launcher.png  | Bin 1603 -> 0 bytes
- .../mipmap-mdpi/ic_launcher_foreground.png    | Bin 2176 -> 0 bytes
- .../res/mipmap-mdpi/ic_launcher_mono.webp     | Bin 0 -> 1008 bytes
- .../ic_launcher_mono_foreground.webp          | Bin 0 -> 746 bytes
- .../mipmap-mdpi/ic_launcher_mono_round.webp   | Bin 0 -> 1778 bytes
- .../res/mipmap-mdpi/ic_launcher_round.png     | Bin 2670 -> 0 bytes
- .../src/main/res/mipmap-xhdpi/ic_launcher.png | Bin 3163 -> 0 bytes
- .../mipmap-xhdpi/ic_launcher_foreground.png   | Bin 4373 -> 0 bytes
- .../res/mipmap-xhdpi/ic_launcher_mono.webp    | Bin 0 -> 1612 bytes
- .../ic_launcher_mono_foreground.webp          | Bin 0 -> 1538 bytes
- .../mipmap-xhdpi/ic_launcher_mono_round.webp  | Bin 0 -> 3456 bytes
- .../res/mipmap-xhdpi/ic_launcher_round.png    | Bin 5956 -> 0 bytes
- .../main/res/mipmap-xxhdpi/ic_launcher.png    | Bin 4765 -> 0 bytes
- .../mipmap-xxhdpi/ic_launcher_foreground.png  | Bin 6808 -> 0 bytes
- .../res/mipmap-xxhdpi/ic_launcher_mono.webp   | Bin 0 -> 2304 bytes
- .../ic_launcher_mono_foreground.webp          | Bin 0 -> 2458 bytes
- .../mipmap-xxhdpi/ic_launcher_mono_round.webp | Bin 0 -> 5252 bytes
- .../res/mipmap-xxhdpi/ic_launcher_round.png   | Bin 9125 -> 0 bytes
- .../main/res/mipmap-xxxhdpi/ic_launcher.png   | Bin 6282 -> 0 bytes
- .../mipmap-xxxhdpi/ic_launcher_foreground.png | Bin 9598 -> 0 bytes
- .../res/mipmap-xxxhdpi/ic_launcher_mono.webp  | Bin 0 -> 3176 bytes
- .../ic_launcher_mono_foreground.webp          | Bin 0 -> 3586 bytes
- .../ic_launcher_mono_round.webp               | Bin 0 -> 7468 bytes
- .../res/mipmap-xxxhdpi/ic_launcher_round.png  | Bin 12903 -> 0 bytes
- .../app/src/main/res/values/strings.xml       |   2 +-
- 43 files changed, 37 insertions(+), 35 deletions(-)
+ app/android/app/BUCK                           |   4 ++--
+ app/android/app/build.gradle                   |   4 ++--
+ app/android/app/google-services.json           |  17 +++++++++--------
+ app/android/app/src/main/AndroidManifest.xml   |   4 ++--
+ .../src/main/ic_launcher_mono-playstore.png    | Bin 0 -> 18297 bytes
+ .../java/ca/bc/gov/BCWallet/MainActivity.kt    |   2 +-
+ .../java/ca/bc/gov/BCWallet/MainApplication.kt |   2 +-
+ .../app/src/main/res/layout/launch_screen.xml  |   2 +-
+ .../main/res/mipmap-anydpi-v26/ic_launcher.xml |   6 ------
+ .../res/mipmap-anydpi-v26/ic_launcher_mono.xml |   5 +++++
+ .../ic_launcher_mono_round.xml                 |   5 +++++
+ .../mipmap-anydpi-v26/ic_launcher_round.xml    |   6 ------
+ .../src/main/res/mipmap-hdpi/ic_launcher.png   | Bin 2306 -> 0 bytes
+ .../res/mipmap-hdpi/ic_launcher_foreground.png | Bin 3269 -> 0 bytes
+ .../main/res/mipmap-hdpi/ic_launcher_mono.webp | Bin 0 -> 1186 bytes
+ .../ic_launcher_mono_foreground.webp           | Bin 0 -> 1148 bytes
+ .../mipmap-hdpi/ic_launcher_mono_round.webp    | Bin 0 -> 2562 bytes
+ .../main/res/mipmap-hdpi/ic_launcher_round.png | Bin 4262 -> 0 bytes
+ .../src/main/res/mipmap-mdpi/ic_launcher.png   | Bin 1603 -> 0 bytes
+ .../res/mipmap-mdpi/ic_launcher_foreground.png | Bin 2176 -> 0 bytes
+ .../main/res/mipmap-mdpi/ic_launcher_mono.webp | Bin 0 -> 1008 bytes
+ .../ic_launcher_mono_foreground.webp           | Bin 0 -> 746 bytes
+ .../mipmap-mdpi/ic_launcher_mono_round.webp    | Bin 0 -> 1778 bytes
+ .../main/res/mipmap-mdpi/ic_launcher_round.png | Bin 2670 -> 0 bytes
+ .../src/main/res/mipmap-xhdpi/ic_launcher.png  | Bin 3163 -> 0 bytes
+ .../mipmap-xhdpi/ic_launcher_foreground.png    | Bin 4373 -> 0 bytes
+ .../res/mipmap-xhdpi/ic_launcher_mono.webp     | Bin 0 -> 1612 bytes
+ .../ic_launcher_mono_foreground.webp           | Bin 0 -> 1538 bytes
+ .../mipmap-xhdpi/ic_launcher_mono_round.webp   | Bin 0 -> 3456 bytes
+ .../res/mipmap-xhdpi/ic_launcher_round.png     | Bin 5956 -> 0 bytes
+ .../src/main/res/mipmap-xxhdpi/ic_launcher.png | Bin 4765 -> 0 bytes
+ .../mipmap-xxhdpi/ic_launcher_foreground.png   | Bin 6808 -> 0 bytes
+ .../res/mipmap-xxhdpi/ic_launcher_mono.webp    | Bin 0 -> 2304 bytes
+ .../ic_launcher_mono_foreground.webp           | Bin 0 -> 2458 bytes
+ .../mipmap-xxhdpi/ic_launcher_mono_round.webp  | Bin 0 -> 5252 bytes
+ .../res/mipmap-xxhdpi/ic_launcher_round.png    | Bin 9125 -> 0 bytes
+ .../main/res/mipmap-xxxhdpi/ic_launcher.png    | Bin 6282 -> 0 bytes
+ .../mipmap-xxxhdpi/ic_launcher_foreground.png  | Bin 9598 -> 0 bytes
+ .../res/mipmap-xxxhdpi/ic_launcher_mono.webp   | Bin 0 -> 3176 bytes
+ .../ic_launcher_mono_foreground.webp           | Bin 0 -> 3586 bytes
+ .../mipmap-xxxhdpi/ic_launcher_mono_round.webp | Bin 0 -> 7468 bytes
+ .../res/mipmap-xxxhdpi/ic_launcher_round.png   | Bin 12903 -> 0 bytes
+ .../app/src/main/res/values/strings.xml        |   2 +-
+ 43 files changed, 29 insertions(+), 30 deletions(-)
  create mode 100644 app/android/app/src/main/ic_launcher_mono-playstore.png
  delete mode 100644 app/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
  create mode 100644 app/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_mono.xml
@@ -127,12 +127,11 @@ index f552ceb7..12914cd9 100644
          targetSdkVersion rootProject.ext.targetSdkVersion
          versionCode System.getenv("VERSION_CODE") ? System.getenv("VERSION_CODE").toInteger() : 1
 diff --git a/app/android/app/google-services.json b/app/android/app/google-services.json
-index a3a58790..d1ffc681 100644
+index a3a58790..a237cc51 100644
 --- a/app/android/app/google-services.json
 +++ b/app/android/app/google-services.json
-@@ -1,36 +1,40 @@
+@@ -1,33 +1,34 @@
  {
-+
    "project_info": {
 -    "project_number": "1008044298583",
 -    "project_id": "bc-wallet-mobile",
@@ -140,7 +139,7 @@ index a3a58790..d1ffc681 100644
 +    "project_number": "209333430748",
 +    "firebase_url": "https://bcsc-app-test-fcm.firebaseio.com",
 +    "project_id": "bcsc-app-test-fcm",
-+    "storage_bucket": "bcsc-app-test-fcm.appspot.com"
++    "storage_bucket": "bcsc-app-test-fcm.firebasestorage.app"
    },
    "client": [
      {
@@ -149,7 +148,7 @@ index a3a58790..d1ffc681 100644
 +        "mobilesdk_app_id": "1:209333430748:android:1c4641260a97bfe5",
          "android_client_info": {
 -          "package_name": "ca.bc.gov.BCWallet"
-+          "package_name": "ca.bc.gov.id.servicescard.dev"
++          "package_name": "ca.bc.gov.id.servicescard"
          }
        },
        "oauth_client": [
@@ -166,24 +165,14 @@ index a3a58790..d1ffc681 100644
          }
        ],
        "services": {
-+        "analytics_service": {
-+          "status": 1
-+        },
          "appinvite_service": {
--          "other_platform_oauth_client": [
--            {
+           "other_platform_oauth_client": [
+             {
 -              "client_id": "1008044298583-12lpkisi403oa5bc5hs0800o48cl4nhj.apps.googleusercontent.com",
--              "client_type": 3
--            }
--          ]
-+          "status": 1,
-+          "other_platform_oauth_client": []
-+        },
-+        "ads_service": {
-+          "status": 2
-         }
-       }
-     }
++              "client_id": "209333430748-f89kks1sr4an87kmkilim6e1jj2gd0nc.apps.googleusercontent.com",
+               "client_type": 3
+             }
+           ]
 diff --git a/app/android/app/src/main/AndroidManifest.xml b/app/android/app/src/main/AndroidManifest.xml
 index cd4c656c..dc895efe 100644
 --- a/app/android/app/src/main/AndroidManifest.xml

--- a/patch/0002-chore-ios-app-to-bcsc-dev.patch
+++ b/patch/0002-chore-ios-app-to-bcsc-dev.patch
@@ -1,16 +1,16 @@
-From 555679429aaf6ec8be06b80d654938e2eecb98f5 Mon Sep 17 00:00:00 2001
-From: "Jason C. Leach" <jason.leach@fullboar.ca>
-Date: Tue, 19 Aug 2025 15:43:19 -0700
+From 5646e441013957a527e0abaf9edccccc323478a0 Mon Sep 17 00:00:00 2001
+From: Bryce McMath <bryce.j.mcmath@gmail.com>
+Date: Tue, 2 Dec 2025 15:31:51 -0800
 Subject: [PATCH] chore: ios app to bcsc dev
 
-Signed-off-by: Jason C. Leach <jason.leach@fullboar.ca>
+Signed-off-by: Bryce McMath <bryce.j.mcmath@gmail.com>
 ---
  app/ios/AriesBifold.xcodeproj/project.pbxproj |  18 +++++++++---------
  .../xcschemes/AriesBifold.xcscheme            |   6 +++---
  app/ios/AriesBifold/Info.plist                |   4 ++--
- app/ios/GoogleService-Info.plist              |  18 ++++++++++++------
+ app/ios/GoogleService-Info.plist              |  14 ++++++++------
  .../AppIcon.appiconset/iTunesArtwork.png      | Bin 40899 -> 26160 bytes
- 5 files changed, 26 insertions(+), 20 deletions(-)
+ 5 files changed, 22 insertions(+), 20 deletions(-)
 
 diff --git a/app/ios/AriesBifold.xcodeproj/project.pbxproj b/app/ios/AriesBifold.xcodeproj/project.pbxproj
 index 7cbd6bc4..276ca261 100644
@@ -116,7 +116,7 @@ index bc517c67..05d5afce 100644
           </BuildableReference>
        </BuildableProductRunnable>
 diff --git a/app/ios/AriesBifold/Info.plist b/app/ios/AriesBifold/Info.plist
-index 5ecad104..2e5913cf 100644
+index 94cbcab0..c13867e9 100644
 --- a/app/ios/AriesBifold/Info.plist
 +++ b/app/ios/AriesBifold/Info.plist
 @@ -5,7 +5,7 @@
@@ -128,7 +128,7 @@ index 5ecad104..2e5913cf 100644
  	<key>CFBundleExecutable</key>
  	<string>$(EXECUTABLE_NAME)</string>
  	<key>CFBundleIdentifier</key>
-@@ -69,7 +69,7 @@
+@@ -73,7 +73,7 @@
  	<key>NSFaceIDUsageDescription</key>
  	<string>$(PRODUCT_NAME) wants to use your FaceID/TouchID to authenticate your identity</string>
  	<key>NSLocationWhenInUseUsageDescription</key>
@@ -138,17 +138,12 @@ index 5ecad104..2e5913cf 100644
  	<string>$(PRODUCT_NAME) needs access to your microphone to enable video calls</string>
  	<key>UIAppFonts</key>
 diff --git a/app/ios/GoogleService-Info.plist b/app/ios/GoogleService-Info.plist
-index 0d2b4e52..e4b0a7bc 100644
+index 0d2b4e52..506abd7c 100644
 --- a/app/ios/GoogleService-Info.plist
 +++ b/app/ios/GoogleService-Info.plist
-@@ -2,18 +2,22 @@
- <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+@@ -3,17 +3,17 @@
  <plist version="1.0">
  <dict>
-+	<key>CLIENT_ID</key>
-+	<string>27280337469-sandmglpe2viuf4p5u122tp4kc0hgqb7.apps.googleusercontent.com</string>
-+	<key>REVERSED_CLIENT_ID</key>
-+	<string>com.googleusercontent.apps.27280337469-sandmglpe2viuf4p5u122tp4kc0hgqb7</string>
  	<key>API_KEY</key>
 -	<string>AIzaSyCL37I5zpWEauPopROBm6d64bGDiimAvZE</string>
 +	<string>AIzaSyBYE9-AFaGgXjS9wMXxkQcvR0gb-1L36ak</string>
@@ -165,11 +160,11 @@ index 0d2b4e52..e4b0a7bc 100644
 +	<string>bcsc-ios-app</string>
  	<key>STORAGE_BUCKET</key>
 -	<string>bc-wallet-mobile.appspot.com</string>
-+	<string>bcsc-ios-app.appspot.com</string>
++	<string>bcsc-ios-app.firebasestorage.app</string>
  	<key>IS_ADS_ENABLED</key>
  	<false></false>
  	<key>IS_ANALYTICS_ENABLED</key>
-@@ -25,6 +29,8 @@
+@@ -25,6 +25,8 @@
  	<key>IS_SIGNIN_ENABLED</key>
  	<true></true>
  	<key>GOOGLE_APP_ID</key>
@@ -1170,5 +1165,5 @@ zE5;uz@q;CPxcP)1afz7#;E%|UII8gff+hGQ_R&|$993CA9Q?O!%dX8?n_U0+KT9K=
 A=l}o!
 
 -- 
-2.49.0
+2.50.1
 


### PR DESCRIPTION
# Summary of Changes

This PR just updates the patch files for BCSC iOS and Android to use the exact Google Services files from the Firebase Console.

Note: I noticed some oddities in the patch, we are kind of switching from AriesBifold to BCWallet in some places but not all? There's a good chance that could cause unforeseen issues as well. Will deal with in a later PR.

# Testing Instructions

Nothing to test from this branch, only from Testflight / Beta

# Acceptance Criteria

Testflight and Beta builds maybe start getting push notifications

# Screenshots, videos, or gifs

N/A

# Related Issues

#2997
#2986 