### PR TITLE
feat (shai-hulud): virus scanner

### DIFF
--- a/.github/workflows/scanner.yml
+++ b/.github/workflows/scanner.yml
@@ -1,4 +1,6 @@
 name: Virus Scanner
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/scanner.yml
+++ b/.github/workflows/scanner.yml
@@ -1,0 +1,29 @@
+name: Virus Scanner
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  shai-hulud-scan:
+    runs-on: ubuntu-22.04
+    name: Scan code for Shai-hulud virus
+    steps:
+      - name: Checkout bc-wallet-mobile
+        uses: actions/checkout@v4
+        with:
+          path: bc-wallet-mobile
+
+      - name: Checkout Shai-hulud scanner
+        uses: actions/checkout@v4
+        with:
+          repository: CyberDracula/shai-hulud-2-scanner
+          path: shai-hulud-2-scanner
+
+      - name: Run Shai-hulud virus scanner
+        working-directory: shai-hulud-2-scanner
+        run: node scan.js --fail-on=critical ../bc-wallet-mobile
+
+


### PR DESCRIPTION
# Summary of Changes

This adds a github action to scan the codebase for viruses, specifically the 'shai-hulud' worm. This will only fail on "critical" or "high" detections.

https://github.com/CyberDracula/shai-hulud-2-scanner

Note: If you investigate the action you will see a false positive detected related to the native android code. It's detecting directories labeled "debug" as incomplete virus initializations.

https://github.com/CyberDracula/shai-hulud-2-scanner?tab=readme-ov-file#-known-false-positives-safe-to-ignorereact-native-projects-contentsjson-files-in-the-ios-folder-are-standard-ios-asset-catalog-files-xcode-resources-not-malware-indicators-these-are-safe-to-ignore

# Testing Instructions

I would recommend pulling https://github.com/CyberDracula/shai-hulud-2-scanner and running locally. 

From within the shai-hulud-2-scanner directory run:
`node scan.js --fail-on=critical ../bc-wallet-mobile`

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
