### PR TITLE
feat: add remove account button to transfer success screen

### DIFF
--- a/app/__tests__/screens/TransferSuccessScreen.test.tsx
+++ b/app/__tests__/screens/TransferSuccessScreen.test.tsx
@@ -1,11 +1,18 @@
-import { render } from '@testing-library/react-native'
+import { testIdWithKey } from '@bifold/core'
+import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 
+import { act } from 'react-test-renderer'
+import { useNavigation } from '../../__mocks__/@react-navigation/native'
 import { BasicAppContext } from '../../__mocks__/helpers/app'
 import TransferSuccessScreen from '../../src/bcsc-theme/features/account-transfer/TransferSuccessScreen'
+import { BCSCScreens, BCSCStacks } from '../../src/bcsc-theme/types/navigators'
 
 describe('TransferSuccess', () => {
+  let mockNavigation: any
+
   beforeEach(() => {
+    mockNavigation = useNavigation()
     jest.clearAllMocks()
     jest.useFakeTimers()
   })
@@ -14,13 +21,47 @@ describe('TransferSuccess', () => {
     jest.useRealTimers()
   })
 
-  it('renders correctly', () => {
-    const tree = render(
-      <BasicAppContext>
-        <TransferSuccessScreen />
-      </BasicAppContext>
-    )
+  describe('Render tests', () => {
+    it('renders correctly', () => {
+      const tree = render(
+        <BasicAppContext>
+          <TransferSuccessScreen />
+        </BasicAppContext>
+      )
 
-    expect(tree).toMatchSnapshot()
+      expect(tree).toMatchSnapshot()
+    })
+  })
+
+  describe('Navigation tests', () => {
+    it('navigates to Home when primary button is pressed', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <TransferSuccessScreen />
+        </BasicAppContext>
+      )
+
+      const homeButton = getByTestId(testIdWithKey('BCSC.TransferSuccess.ButtonText'))
+      act(() => {
+        fireEvent.press(homeButton)
+      })
+
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCStacks.Tab, { screen: BCSCScreens.Home })
+    })
+
+    it('navigates to RemoveAccountConfirmation when remove account button is pressed', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <TransferSuccessScreen />
+        </BasicAppContext>
+      )
+
+      const removeAccountButton = getByTestId(testIdWithKey('BCSC.Account.RemoveAccount'))
+      act(() => {
+        fireEvent.press(removeAccountButton)
+      })
+
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.RemoveAccountConfirmation)
+    })
   })
 })

--- a/app/__tests__/screens/__snapshots__/TransferSuccessScreen.test.tsx.snap
+++ b/app/__tests__/screens/__snapshots__/TransferSuccessScreen.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TransferSuccess renders correctly 1`] = `
+exports[`TransferSuccess Render tests renders correctly 1`] = `
 <RNCSafeAreaView
   edges={
     {
@@ -204,6 +204,83 @@ exports[`TransferSuccess renders correctly 1`] = `
           }
         >
           BCSC.TransferSuccess.ButtonText
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "backgroundColor": "#D8292F",
+          "borderRadius": 4,
+          "opacity": 1,
+          "padding": 16,
+        }
+      }
+      testID="com.ariesbifold:id/BCSC.Account.RemoveAccount"
+    >
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              [
+                {
+                  "color": "#FFFFFF",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                  "textAlign": "center",
+                },
+                false,
+                false,
+                false,
+              ],
+            ]
+          }
+        >
+          BCSC.Account.RemoveAccount
         </Text>
       </View>
     </View>

--- a/app/src/bcsc-theme/features/account-transfer/TransferSuccessScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/TransferSuccessScreen.tsx
@@ -1,3 +1,4 @@
+import { useFactoryReset } from '@/bcsc-theme/api/hooks/useFactoryReset'
 import StatusDetails from '@/bcsc-theme/components/StatusDetails'
 import { BCSCMainStackParams, BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey } from '@bifold/core'
@@ -10,6 +11,7 @@ import { StyleSheet } from 'react-native'
 const TransferSuccessScreen: React.FC = () => {
   const navigation = useNavigation<StackNavigationProp<BCSCMainStackParams>>()
   const { t } = useTranslation()
+  const factoryReset = useFactoryReset()
 
   const styles = StyleSheet.create({
     contentContainer: {
@@ -19,13 +21,23 @@ const TransferSuccessScreen: React.FC = () => {
   })
 
   const controls = (
-    <Button
-      testID={testIdWithKey(t('BCSC.TransferSuccess.ButtonText'))}
-      accessibilityLabel={t('BCSC.TransferSuccess.ButtonText')}
-      title={t('BCSC.TransferSuccess.ButtonText')}
-      buttonType={ButtonType.Primary}
-      onPress={() => navigation.navigate(BCSCStacks.Tab, { screen: BCSCScreens.Home })}
-    />
+    <>
+      <Button
+        testID={testIdWithKey(t('BCSC.TransferSuccess.ButtonText'))}
+        accessibilityLabel={t('BCSC.TransferSuccess.ButtonText')}
+        title={t('BCSC.TransferSuccess.ButtonText')}
+        buttonType={ButtonType.Primary}
+        onPress={() => navigation.navigate(BCSCStacks.Tab, { screen: BCSCScreens.Home })}
+      />
+      <Button
+        testID={testIdWithKey(t('BCSC.Account.RemoveAcount'))}
+        buttonType={ButtonType.Critical}
+        title={t('BCSC.Account.RemoveAccount')}
+        onPress={() => {
+          navigation.navigate(BCSCScreens.RemoveAccountConfirmation)
+        }}
+      />
+    </>
   )
 
   return (

--- a/app/src/bcsc-theme/features/account-transfer/TransferSuccessScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/TransferSuccessScreen.tsx
@@ -1,4 +1,3 @@
-import { useFactoryReset } from '@/bcsc-theme/api/hooks/useFactoryReset'
 import StatusDetails from '@/bcsc-theme/components/StatusDetails'
 import { BCSCMainStackParams, BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey } from '@bifold/core'
@@ -11,7 +10,6 @@ import { StyleSheet } from 'react-native'
 const TransferSuccessScreen: React.FC = () => {
   const navigation = useNavigation<StackNavigationProp<BCSCMainStackParams>>()
   const { t } = useTranslation()
-  const factoryReset = useFactoryReset()
 
   const styles = StyleSheet.create({
     contentContainer: {

--- a/app/src/bcsc-theme/features/account-transfer/TransferSuccessScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/TransferSuccessScreen.tsx
@@ -28,7 +28,7 @@ const TransferSuccessScreen: React.FC = () => {
         onPress={() => navigation.navigate(BCSCStacks.Tab, { screen: BCSCScreens.Home })}
       />
       <Button
-        testID={testIdWithKey(t('BCSC.Account.RemoveAcount'))}
+        testID={testIdWithKey(t('BCSC.Account.RemoveAccount'))}
         buttonType={ButtonType.Critical}
         title={t('BCSC.Account.RemoveAccount')}
         onPress={() => {


### PR DESCRIPTION
# Summary of Changes

This pr adds a button to navigate to the remove account confirmations screen from the QR Transfer Success Screen.

# Testing Instructions

1. Navigate to the transfer account feature from the account screen.
2. Transfer your account to another device (or edit the TransferQRDisplayScreen to navigate you)
3. See that the remove account button is present and that it navigates you to the confirmation screen.

# Acceptance Criteria

> Expectation: In BCSC V3.x, after the source device's QR code has been scanned, the screen proceeds to the completion screen, and contains a button to remove the account from that device (as well as the usual "OK" button.

# Screenshots, videos, or gifs

[untitled.webm](https://github.com/user-attachments/assets/f9dd6ac4-00a2-463a-9b95-46e66b0a33a2)


# Related Issues

https://github.com/bcgov/bc-wallet-mobile/issues/2970
