### PR TITLE
fix: better cleanup of video call

### DIFF
--- a/app/src/bcsc-theme/features/verify/live-call/hooks/useVideoCallFlow.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/hooks/useVideoCallFlow.tsx
@@ -111,6 +111,13 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
     }
 
     try {
+      connection?.releaseLocalStream()
+      connection?.closePeerConnection()
+    } catch (error) {
+      logger.error('Error closing peer connection:', error as Error)
+    }
+
+    try {
       if (!session || !clientCallId) {
         throw new Error('Missing required parameters to end call')
       }
@@ -130,6 +137,8 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
       logger.error('Failed to end video session:', error as Error)
     }
 
+    setLocalStream(null)
+    setRemoteStream(null)
     setSession(null)
     setClientCallId(null)
     setConnection(null)

--- a/app/src/bcsc-theme/features/verify/live-call/hooks/useVideoCallFlow.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/hooks/useVideoCallFlow.tsx
@@ -98,7 +98,6 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
       return
     }
     cleanupCompletedRef.current = true
-    stopAllMedia()
     connection?.setAppInitiatedDisconnect(true)
     connection?.stopPexipKeepAlive()
     clearIntervalIfExists(backendKeepAliveTimerRef)
@@ -116,6 +115,11 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
     } catch (error) {
       logger.error('Error closing peer connection:', error as Error)
     }
+
+    // Clear stream state immediately after releasing
+    // to prevent stale references
+    setLocalStream(null)
+    setRemoteStream(null)
 
     try {
       if (!session || !clientCallId) {
@@ -137,13 +141,11 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
       logger.error('Failed to end video session:', error as Error)
     }
 
-    setLocalStream(null)
-    setRemoteStream(null)
     setSession(null)
     setClientCallId(null)
     setConnection(null)
     setVideoCallError(null)
-  }, [video, stopAllMedia, clientCallId, session, connection, logger, t])
+  }, [video, clientCallId, session, connection, logger, t])
 
   const startBackendKeepAlive = useCallback(() => {
     clearIntervalIfExists(backendKeepAliveTimerRef)

--- a/app/src/bcsc-theme/features/verify/live-call/hooks/useVideoCallFlow.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/hooks/useVideoCallFlow.tsx
@@ -121,7 +121,7 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
       logger.error('Error closing peer connection:', error as Error)
     }
 
-    // Clear stream state immediately after releasing
+    // Clear stream state after releasing local streams and closing peer connections
     // to prevent stale references
     setLocalStream(null)
     setRemoteStream(null)

--- a/app/src/bcsc-theme/features/verify/live-call/hooks/useVideoCallFlow.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/hooks/useVideoCallFlow.tsx
@@ -111,6 +111,11 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
 
     try {
       connection?.releaseLocalStream()
+    } catch (error) {
+      logger.error('Error releasing local stream:', error as Error)
+    }
+
+    try {
       connection?.closePeerConnection()
     } catch (error) {
       logger.error('Error closing peer connection:', error as Error)

--- a/app/src/bcsc-theme/features/verify/live-call/types/live-call.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/types/live-call.ts
@@ -30,6 +30,8 @@ export interface ConnectResult {
   disconnectPexip: () => Promise<void>
   stopPexipKeepAlive: () => void
   setAppInitiatedDisconnect: (value: boolean) => void
+  closePeerConnection: () => void
+  releaseLocalStream: () => void
 }
 
 export enum VideoCallFlowState {

--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
@@ -238,10 +238,12 @@ export const connect = async (
       logger.warn('No local stream to release')
       return
     }
+
     logger.info('Releasing local stream tracks...')
     localStream.getTracks().forEach((track) => {
       track.stop()
     })
+
     logger.info('Local stream tracks released')
   }
 

--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
@@ -225,6 +225,8 @@ export const connect = async (
 
   const closePeerConnection = () => {
     logger.info('Closing peer connection...')
+    // Prevent stale disconnect callbacks from firing
+    disconnectHandled = true
     if (disconnectTimeout) {
       clearTimeout(disconnectTimeout)
       disconnectTimeout = null

--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
@@ -234,6 +234,10 @@ export const connect = async (
   }
 
   const releaseLocalStream = () => {
+    if (!localStream) {
+      logger.warn('No local stream to release')
+      return
+    }
     logger.info('Releasing local stream tracks...')
     localStream.getTracks().forEach((track) => {
       track.stop()

--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
@@ -223,6 +223,24 @@ export const connect = async (
     participantUuid,
   })
 
+  const closePeerConnection = () => {
+    logger.info('Closing peer connection...')
+    if (disconnectTimeout) {
+      clearTimeout(disconnectTimeout)
+      disconnectTimeout = null
+    }
+    peerConnection.close()
+    logger.info('Peer connection closed')
+  }
+
+  const releaseLocalStream = () => {
+    logger.info('Releasing local stream tracks...')
+    localStream.getTracks().forEach((track) => {
+      track.stop()
+    })
+    logger.info('Local stream tracks released')
+  }
+
   return {
     localStream,
     callUuid,
@@ -231,6 +249,8 @@ export const connect = async (
     disconnectPexip,
     stopPexipKeepAlive,
     setAppInitiatedDisconnect,
+    closePeerConnection,
+    releaseLocalStream,
   }
 }
 


### PR DESCRIPTION
# Summary of Changes

When a live call is ented by the user the microphone is remaining open. This prevents other video related verification methods from being used for verification.  This PR just cleans up any video call artifacts. 

# Testing Instructions

1. Try a video call
2. Cancel the call before connected
3. Try again, with send video.
4. Record a video.

# Acceptance Criteria

Step 4 above should complete allow recording a video. 

# Screenshots, videos, or gifs

https://fullboarca-my.sharepoint.com/:v:/g/personal/jason_leach_fullboar_ca/IQDEbXmOC3UORqdm6g6M7xHBAa7EA-pa3wOSErtYw-2WjBg?e=4GZvrp

# Related Issues

#3030 

#