### PR TITLE
chore: update axios 1.4.0 -> 1.13.2

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -78,7 +78,7 @@
     "@react-navigation/devtools": "~6.0.27",
     "@react-navigation/native": "~6.0.16",
     "@react-navigation/stack": "~6.3.29",
-    "axios": "~1.4.0",
+    "axios": "~1.13.2",
     "base-64": "~1.0.0",
     "buffer": "~6.0.3",
     "credo-ts-indy-vdr-proxy-client": "0.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8807,6 +8807,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:~1.13.2":
+  version: 1.13.2
+  resolution: "axios@npm:1.13.2"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.4"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/e8a42e37e5568ae9c7a28c348db0e8cf3e43d06fcbef73f0048669edfe4f71219664da7b6cc991b0c0f01c28a48f037c515263cb79be1f1ae8ff034cd813867b
+  languageName: node
+  linkType: hard
+
 "axios@npm:~1.4.0":
   version: 1.4.0
   resolution: "axios@npm:1.4.0"
@@ -9235,7 +9246,7 @@ __metadata:
     "@types/react-test-renderer": "npm:~18.0.7"
     "@typescript-eslint/eslint-plugin": "npm:~7.18.0"
     "@typescript-eslint/parser": "npm:~7.18.0"
-    axios: "npm:~1.4.0"
+    axios: "npm:~1.13.2"
     babel-jest: "npm:~27.5.1"
     babel-plugin-module-resolver: "npm:~5.0.2"
     base-64: "npm:~1.0.0"
@@ -13351,6 +13362,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"follow-redirects@npm:^1.15.6":
+  version: 1.15.11
+  resolution: "follow-redirects@npm:1.15.11"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 10c0/d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
+  languageName: node
+  linkType: hard
+
 "for-each@npm:^0.3.3":
   version: 0.3.3
   resolution: "for-each@npm:0.3.3"
@@ -13419,6 +13440,19 @@ __metadata:
     combined-stream: "npm:^1.0.8"
     mime-types: "npm:^2.1.12"
   checksum: 10c0/cb6f3ac49180be03ff07ba3ff125f9eba2ff0b277fb33c7fc47569fc5e616882c5b1c69b9904c4c4187e97dd0419dd03b134174756f296dec62041e6527e2c6e
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.4":
+  version: 4.0.5
+  resolution: "form-data@npm:4.0.5"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.2"
+    mime-types: "npm:^2.1.12"
+  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary of Changes

This PR bumps the axios version from 1.4.0 to 1.13.2 in order to upgrade the transitive dependency form-data 4.0.0 -> 4.0.4 which is effected by [CVE-2025-7783 ](https://nvd.nist.gov/vuln/detail/CVE-2025-7783). Axios resolved this in 1.11.0 https://github.com/axios/axios/pull/6970

# Testing Instructions

Replace this text with detailed instructions on how to test the changes included in this PR.

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

https://github.com/bcgov/bc-wallet-mobile/issues/3041
