### PR TITLE
fix: remove from other device does not actually remove mobile card from other device

### DIFF
--- a/app/__tests__/services/system-checks/DeviceInvalidatedSystemCheck.test.ts
+++ b/app/__tests__/services/system-checks/DeviceInvalidatedSystemCheck.test.ts
@@ -84,7 +84,7 @@ describe('DeviceInvalidatedSystemCheck', () => {
       expect(getIdToken).toHaveBeenCalledTimes(1)
     })
 
-    it('should return true when device is not invalidated (Cancel event with different reason)', async () => {
+    it('should return false when device is invalidated by user (Cancel event with different reason)', async () => {
       const mockIdToken = createMockIdToken({
         bcsc_event: BCSCEvent.Cancel,
         bcsc_reason: BCSCReason.CanceledByUser,
@@ -95,7 +95,7 @@ describe('DeviceInvalidatedSystemCheck', () => {
 
       const result = await check.runCheck()
 
-      expect(result).toBe(true)
+      expect(result).toBe(false)
       expect(getIdToken).toHaveBeenCalledTimes(1)
     })
 
@@ -147,7 +147,7 @@ describe('DeviceInvalidatedSystemCheck', () => {
       check.onFail()
 
       expect(mockUtils.logger.warn).toHaveBeenCalledWith('DeviceInvalidatedSystemCheck: Device invalidated')
-      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCModals.DeviceInvalidated)
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCModals.DeviceInvalidated, { caseType: undefined })
     })
 
     it('should not navigate when modal is already visible', () => {

--- a/app/__tests__/services/system-checks/DeviceInvalidatedSystemCheck.test.ts
+++ b/app/__tests__/services/system-checks/DeviceInvalidatedSystemCheck.test.ts
@@ -147,7 +147,9 @@ describe('DeviceInvalidatedSystemCheck', () => {
       check.onFail()
 
       expect(mockUtils.logger.warn).toHaveBeenCalledWith('DeviceInvalidatedSystemCheck: Device invalidated')
-      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCModals.DeviceInvalidated, { caseType: undefined })
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCModals.DeviceInvalidated, {
+        invalidationReason: undefined,
+      })
     })
 
     it('should not navigate when modal is already visible', () => {

--- a/app/src/bcsc-theme/features/modal/DeviceInvalidated.tsx
+++ b/app/src/bcsc-theme/features/modal/DeviceInvalidated.tsx
@@ -27,9 +27,6 @@ export const DeviceInvalidated = ({ route }: DeviceInvalidatedProps): JSX.Elemen
    * Handles the factory reset operation.
    */
   const handleFactoryReset = useCallback(async () => {
-    if (!invalidationReason) {
-      logger.warn('DeviceInvalidated: invalidationReason is undefined')
-    }
     const factoryResetParams: Partial<Record<BCSCReason, Partial<BCSCState>>> = {
       // Can add more cases here for different BCSCReason types in the future
       [BCSCReason.CanceledByAgent]: {
@@ -39,7 +36,7 @@ export const DeviceInvalidated = ({ route }: DeviceInvalidatedProps): JSX.Elemen
       [BCSCReason.CanceledByUser]: {}, // Empty for a 'new install state'
     }
 
-    const result = await factoryReset(invalidationReason && factoryResetParams[invalidationReason])
+    const result = await factoryReset(factoryResetParams[invalidationReason])
 
     if (!result.success) {
       logger.error('Factory reset failed', result.error)

--- a/app/src/bcsc-theme/types/navigators.ts
+++ b/app/src/bcsc-theme/types/navigators.ts
@@ -214,7 +214,7 @@ export type BCSCMainStackParams = {
 
   [BCSCModals.InternetDisconnected]: undefined
   [BCSCModals.MandatoryUpdate]: undefined
-  [BCSCModals.DeviceInvalidated]: { caseType: BCSCReason }
+  [BCSCModals.DeviceInvalidated]: { invalidationReason: BCSCReason }
 }
 
 export type BCSCAuthStackParams = {

--- a/app/src/bcsc-theme/types/navigators.ts
+++ b/app/src/bcsc-theme/types/navigators.ts
@@ -1,6 +1,7 @@
 import { NavigatorScreenParams } from '@react-navigation/native'
 import { BCSCCardProcess } from 'react-native-bcsc-core'
 import { EvidenceType } from '../api/hooks/useEvidenceApi'
+import { BCSCReason } from '../utils/id-token'
 
 export enum BCSCStacks {
   Onboarding = 'BCSCOnboardingStack',
@@ -213,7 +214,7 @@ export type BCSCMainStackParams = {
 
   [BCSCModals.InternetDisconnected]: undefined
   [BCSCModals.MandatoryUpdate]: undefined
-  [BCSCModals.DeviceInvalidated]: undefined
+  [BCSCModals.DeviceInvalidated]: { caseType: BCSCReason }
 }
 
 export type BCSCAuthStackParams = {

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -198,8 +198,9 @@ const translation = {
       },
       "DeviceInvalidated": {
         "Header": "Device invalidated",
-        "ContentA": "This device has been invalidated. You must re-authorize the device to continue.",
-        "ContentB": "Tap OK to clear local data and restart setup on this device.",
+        "CancelledByAgent": "This device has been invalidated. You must re-authorize the device to continue.",
+        "CancelledByUser": "This device has been removed from your account by a user action.",
+        "ContentA": "Tap OK to clear local data and restart setup on this device.",
         "OKButton": "OK",
       }
     },

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -197,8 +197,9 @@ const translation = {
       } ,
       "DeviceInvalidated": {
         "Header": "Device invalidated (FR)",
-        "ContentA": "This device has been invalidated. You must re-authorize the device to continue. (FR)",
-        "ContentB": "Tap OK to clear local data and restart setup on this device. (FR)",
+        "CancelledByAgent": "This device has been invalidated. You must re-authorize the device to continue. (FR)",
+        "CancelledByUser": "This device has been removed from your account by a user action. (FR)",
+        "ContentA": "Tap OK to clear local data and restart setup on this device. (FR)",
         "OKButton": "OK (FR)",
       }  
     },

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -197,8 +197,9 @@ const translation = {
       },
       "DeviceInvalidated": {
         "Header": "Device invalidated (PT-BR)",
-        "ContentA": "This device has been invalidated. You must re-authorize the device to continue. (PT-BR)",
-        "ContentB": "Tap OK to clear local data and restart setup on this device. (PT-BR)",
+        "CancelledByAgent": "This device has been invalidated. You must re-authorize the device to continue. (PT-BR)",
+        "CancelledByUser": "This device has been removed from your account by a user action. (PT-BR)",
+        "ContentA": "Tap OK to clear local data and restart setup on this device. (PT-BR)",
         "OKButton": "OK (PT-BR)",
       }  
     },

--- a/app/src/services/system-checks/DeviceInvalidatedSystemCheck.ts
+++ b/app/src/services/system-checks/DeviceInvalidatedSystemCheck.ts
@@ -18,7 +18,7 @@ export class DeviceInvalidatedSystemCheck implements SystemCheckStrategy {
   private readonly getIdToken: () => Promise<IdToken>
   private readonly navigation: SystemCheckNavigation
   private readonly utils: SystemCheckUtils
-  private caseType?: BCSCReason
+  private invalidationReason?: BCSCReason
 
   constructor(getIdToken: () => Promise<IdToken>, navigation: SystemCheckNavigation, utils: SystemCheckUtils) {
     this.getIdToken = getIdToken
@@ -43,7 +43,7 @@ export class DeviceInvalidatedSystemCheck implements SystemCheckStrategy {
       const idToken = await this.getIdToken()
 
       if (idToken.bcsc_event === BCSCEvent.Cancel) {
-        this.caseType = idToken.bcsc_reason
+        this.invalidationReason = idToken.bcsc_reason
         return false
       }
 
@@ -69,7 +69,7 @@ export class DeviceInvalidatedSystemCheck implements SystemCheckStrategy {
       return
     }
 
-    this.navigation.navigate(BCSCModals.DeviceInvalidated, { caseType: this.caseType })
+    this.navigation.navigate(BCSCModals.DeviceInvalidated, { invalidationReason: this.invalidationReason })
   }
 
   /**

--- a/app/src/services/system-checks/DeviceInvalidatedSystemCheck.ts
+++ b/app/src/services/system-checks/DeviceInvalidatedSystemCheck.ts
@@ -18,6 +18,7 @@ export class DeviceInvalidatedSystemCheck implements SystemCheckStrategy {
   private readonly getIdToken: () => Promise<IdToken>
   private readonly navigation: SystemCheckNavigation
   private readonly utils: SystemCheckUtils
+  private caseType?: BCSCReason
 
   constructor(getIdToken: () => Promise<IdToken>, navigation: SystemCheckNavigation, utils: SystemCheckUtils) {
     this.getIdToken = getIdToken
@@ -41,8 +42,8 @@ export class DeviceInvalidatedSystemCheck implements SystemCheckStrategy {
     try {
       const idToken = await this.getIdToken()
 
-      if (idToken.bcsc_event === BCSCEvent.Cancel && idToken.bcsc_reason === BCSCReason.CanceledByAgent) {
-        // Device has been invalidated by the agent, user must re-authorize the device
+      if (idToken.bcsc_event === BCSCEvent.Cancel) {
+        this.caseType = idToken.bcsc_reason
         return false
       }
 
@@ -68,7 +69,7 @@ export class DeviceInvalidatedSystemCheck implements SystemCheckStrategy {
       return
     }
 
-    this.navigation.navigate(BCSCModals.DeviceInvalidated)
+    this.navigation.navigate(BCSCModals.DeviceInvalidated, { caseType: this.caseType })
   }
 
   /**


### PR DESCRIPTION
# Summary of Changes

This PR fixes the remove device button from `My devices` in the BCSC account page. the removed device now correctly has the account invalidated and is brought back to the onboarding steps as if a fresh install of the app.
# Testing Instructions

- with two devices setup with an account, on the first device navigate to account --> My devices(2) --> remove device
- load up the app on the second device, after selecting your nickname you will see a `Device Invalidated` page 
- on pressing okay the device performs a factory reset sending you back to onboarding.

# Acceptance Criteria

When the user opens the app on the "removed" device, the app check IAS to confirm status, and then removes the mobile card, and resetting the app.

# Screenshots, videos, or gifs

https://github.com/user-attachments/assets/e9a3af4e-675a-4970-bd8e-ff570320439b

# Related Issues

N/A
