### PR TITLE
fix: dynamic scaling on webview content

### DIFF
--- a/app/__tests__/screens/__snapshots__/MainWebViewScreen.test.tsx.snap
+++ b/app/__tests__/screens/__snapshots__/MainWebViewScreen.test.tsx.snap
@@ -5,6 +5,13 @@ exports[`MainWebView renders correctly 1`] = `
   allowsBackForwardNavigationGestures={true}
   bounces={false}
   domStorageEnabled={true}
+  injectedJavaScriptBeforeContentLoaded="
+    (function() {
+      const fontScale = 2;
+      document.documentElement.style.fontSize = (16 * fontScale) + 'px';
+      document.body.style.fontSize = (16 * fontScale) + 'px';
+    })();
+  "
   javaScriptEnabled={true}
   mixedContentMode="compatibility"
   onError={[Function]}

--- a/app/__tests__/screens/__snapshots__/OnboardingWebViewScreen.test.tsx.snap
+++ b/app/__tests__/screens/__snapshots__/OnboardingWebViewScreen.test.tsx.snap
@@ -5,6 +5,13 @@ exports[`OnboardingWebView renders correctly 1`] = `
   allowsBackForwardNavigationGestures={true}
   bounces={false}
   domStorageEnabled={true}
+  injectedJavaScriptBeforeContentLoaded="
+    (function() {
+      const fontScale = 2;
+      document.documentElement.style.fontSize = (16 * fontScale) + 'px';
+      document.body.style.fontSize = (16 * fontScale) + 'px';
+    })();
+  "
   javaScriptEnabled={true}
   mixedContentMode="compatibility"
   onError={[Function]}

--- a/app/__tests__/screens/__snapshots__/TermsOfUseScreen.test.tsx.snap
+++ b/app/__tests__/screens/__snapshots__/TermsOfUseScreen.test.tsx.snap
@@ -40,6 +40,12 @@ exports[`TermsOfUse renders correctly 1`] = `
         bounces={false}
         domStorageEnabled={true}
         injectedJavaScriptBeforeContentLoaded="
+    (function() {
+      const fontScale = 2;
+      document.documentElement.style.fontSize = (16 * fontScale) + 'px';
+      document.body.style.fontSize = (16 * fontScale) + 'px';
+    })();
+  
     document.addEventListener('DOMContentLoaded', function() {
       const style = document.createElement('style');
 
@@ -56,10 +62,6 @@ exports[`TermsOfUse renders correctly 1`] = `
 
       document.head.appendChild(style);
     });
-  
-    const fontScale = 2;
-    document.documentElement.style.fontSize = (16 * fontScale) + 'px';
-    document.body.style.fontSize = (16 * fontScale) + 'px';
   "
         javaScriptEnabled={true}
         mixedContentMode="compatibility"

--- a/app/__tests__/screens/__snapshots__/VerifyWebViewScreen.test.tsx.snap
+++ b/app/__tests__/screens/__snapshots__/VerifyWebViewScreen.test.tsx.snap
@@ -5,6 +5,13 @@ exports[`VerifyWebView renders correctly 1`] = `
   allowsBackForwardNavigationGestures={true}
   bounces={false}
   domStorageEnabled={true}
+  injectedJavaScriptBeforeContentLoaded="
+    (function() {
+      const fontScale = 2;
+      document.documentElement.style.fontSize = (16 * fontScale) + 'px';
+      document.body.style.fontSize = (16 * fontScale) + 'px';
+    })();
+  "
   javaScriptEnabled={true}
   mixedContentMode="compatibility"
   onError={[Function]}

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
@@ -5,7 +5,7 @@ import { Button, ButtonType, ScreenWrapper, testIdWithKey, useTheme } from '@bif
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Platform, StyleSheet, useWindowDimensions } from 'react-native'
+import { StyleSheet } from 'react-native'
 import * as PushNotifications from '../../../utils/PushNotificationsHelper'
 import { WebViewContent } from '../webview/WebViewContent'
 
@@ -22,7 +22,6 @@ export const TermsOfUseScreen = ({ navigation }: TermsOfUseScreenProps): JSX.Ele
   const { t } = useTranslation()
   const { Spacing, ColorPalette } = useTheme()
   const [webViewIsLoaded, setWebViewIsLoaded] = useState(false)
-  const { fontScale } = useWindowDimensions()
 
   const styles = StyleSheet.create({
     scrollContainer: {
@@ -53,21 +52,12 @@ export const TermsOfUseScreen = ({ navigation }: TermsOfUseScreenProps): JSX.Ele
       disabled={!webViewIsLoaded}
     />
   )
-  // JavaScript to adjust font scaling on iOS devices
-  const iosFontScaling =
-    Platform.OS === 'ios'
-      ? `
-    const fontScale = ${fontScale};
-    document.documentElement.style.fontSize = (16 * fontScale) + 'px';
-    document.body.style.fontSize = (16 * fontScale) + 'px';
-  `
-      : ''
 
   return (
     <ScreenWrapper controls={controls} scrollViewContainerStyle={styles.scrollContainer}>
       <WebViewContent
         url={TERMS_OF_USE_URL}
-        injectedJavascript={createTermsOfUseWebViewJavascriptInjection(ColorPalette) + iosFontScaling}
+        injectedJavascript={createTermsOfUseWebViewJavascriptInjection(ColorPalette)}
         onLoaded={() => setWebViewIsLoaded(true)}
       />
     </ScreenWrapper>

--- a/app/src/bcsc-theme/features/webview/WebViewContent.tsx
+++ b/app/src/bcsc-theme/features/webview/WebViewContent.tsx
@@ -1,5 +1,5 @@
 import { useBCSCApiClient } from '@/bcsc-theme/hooks/useBCSCApiClient'
-import { combineAccessibilityScriptWithInjectedJS, getAndroidTextZoom } from '@/bcsc-theme/utils/webview-utils'
+import { getWebViewAccessibilityProps } from '@/bcsc-theme/utils/webview-utils'
 import { TOKENS, useServices, useTheme } from '@bifold/core'
 import React, { useCallback, useMemo } from 'react'
 import { ActivityIndicator, Platform, StyleSheet, useWindowDimensions, View } from 'react-native'
@@ -43,15 +43,12 @@ const WebViewContent: React.FC<WebViewContentProps> = ({ url, injectedJavascript
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const { fontScale } = useWindowDimensions()
 
-  // Combine accessibility font scaling with any custom injected JavaScript
-  // iOS requires JavaScript injection for font scaling, Android uses textZoom prop
-  const combinedInjectedJavascript = useMemo(
-    () => combineAccessibilityScriptWithInjectedJS(Platform.OS, fontScale, injectedJavascript),
+  // Platform-specific accessibility text scaling:
+  // iOS uses JavaScript injection, Android uses native textZoom prop
+  const { injectedJavaScript, textZoom } = useMemo(
+    () => getWebViewAccessibilityProps(Platform.OS, fontScale, injectedJavascript),
     [fontScale, injectedJavascript]
   )
-
-  // Android textZoom: converts fontScale (e.g., 1.0, 1.5, 2.0) to percentage (100, 150, 200)
-  const androidTextZoom = getAndroidTextZoom(Platform.OS, fontScale)
 
   const styles = StyleSheet.create({
     loadingContainer: {
@@ -111,8 +108,8 @@ const WebViewContent: React.FC<WebViewContentProps> = ({ url, injectedJavascript
       thirdPartyCookiesEnabled={true}
       userAgent="Single App"
       // Accessibility: Apply font scaling for dynamic text sizing
-      textZoom={androidTextZoom}
-      injectedJavaScriptBeforeContentLoaded={combinedInjectedJavascript}
+      textZoom={textZoom}
+      injectedJavaScriptBeforeContentLoaded={injectedJavaScript}
       onMessage={() => {}} // Required for injectedJavaScript to work
       onLoad={onLoaded}
     />

--- a/app/src/bcsc-theme/utils/webview-utils.ts
+++ b/app/src/bcsc-theme/utils/webview-utils.ts
@@ -44,3 +44,50 @@ export const createSecuringAppWebViewJavascriptInjection = (): string => {
     });
   `
 }
+
+/**
+ * Creates JavaScript to apply accessibility font scaling on iOS.
+ * This ensures web content respects the device's text size accessibility settings.
+ *
+ * @param fontScale - The device's current font scale multiplier from useWindowDimensions()
+ * @returns JavaScript string to inject into the WebView
+ */
+export const createAccessibilityFontScalingScript = (fontScale: number): string => {
+  return `
+    (function() {
+      const fontScale = ${fontScale};
+      document.documentElement.style.fontSize = (16 * fontScale) + 'px';
+      document.body.style.fontSize = (16 * fontScale) + 'px';
+    })();
+  `
+}
+
+/**
+ * Combines accessibility font scaling script with any custom injected JavaScript for iOS.
+ * Android uses the textZoom prop instead of JavaScript injection.
+ *
+ * @param platform - The current platform ('ios' or 'android')
+ * @param fontScale - The device's current font scale multiplier from useWindowDimensions()
+ * @param injectedJavascript - Optional custom JavaScript to inject
+ * @returns Combined JavaScript string to inject into the WebView
+ */
+export const combineAccessibilityScriptWithInjectedJS = (
+  platform: string,
+  fontScale: number,
+  injectedJavascript?: string
+): string => {
+  const accessibilityScript = platform === 'ios' ? createAccessibilityFontScalingScript(fontScale) : ''
+  return injectedJavascript ? `${accessibilityScript}${injectedJavascript}` : accessibilityScript
+}
+
+/**
+ * Calculates the Android textZoom value from the font scale.
+ * Converts fontScale (e.g., 1.0, 1.5, 2.0) to percentage (100, 150, 200).
+ *
+ * @param platform - The current platform ('ios' or 'android')
+ * @param fontScale - The device's current font scale multiplier from useWindowDimensions()
+ * @returns The textZoom percentage for Android, or undefined for other platforms
+ */
+export const getAndroidTextZoom = (platform: string, fontScale: number): number | undefined => {
+  return platform === 'android' ? Math.round(fontScale * 100) : undefined
+}

--- a/app/src/bcsc-theme/utils/webview-utils.ts
+++ b/app/src/bcsc-theme/utils/webview-utils.ts
@@ -62,32 +62,29 @@ export const createAccessibilityFontScalingScript = (fontScale: number): string 
   `
 }
 
-/**
- * Combines accessibility font scaling script with any custom injected JavaScript for iOS.
- * Android uses the textZoom prop instead of JavaScript injection.
- *
- * @param platform - The current platform ('ios' or 'android')
- * @param fontScale - The device's current font scale multiplier from useWindowDimensions()
- * @param injectedJavascript - Optional custom JavaScript to inject
- * @returns Combined JavaScript string to inject into the WebView
- */
-export const combineAccessibilityScriptWithInjectedJS = (
-  platform: string,
-  fontScale: number,
-  injectedJavascript?: string
-): string => {
-  const accessibilityScript = platform === 'ios' ? createAccessibilityFontScalingScript(fontScale) : ''
-  return injectedJavascript ? `${accessibilityScript}${injectedJavascript}` : accessibilityScript
+interface WebViewAccessibilityProps {
+  injectedJavaScript: string
+  textZoom: number | undefined
 }
 
 /**
- * Calculates the Android textZoom value from the font scale.
- * Converts fontScale (e.g., 1.0, 1.5, 2.0) to percentage (100, 150, 200).
+ * Returns platform-specific accessibility props for WebView text scaling.
+ * - iOS: Uses JavaScript injection to scale fonts
+ * - Android: Uses the native textZoom prop
  *
  * @param platform - The current platform ('ios' or 'android')
  * @param fontScale - The device's current font scale multiplier from useWindowDimensions()
- * @returns The textZoom percentage for Android, or undefined for other platforms
+ * @param injectedJavascript - Optional custom JavaScript to inject (will be combined with accessibility script)
+ * @returns WebView props for accessibility text scaling
  */
-export const getAndroidTextZoom = (platform: string, fontScale: number): number | undefined => {
-  return platform === 'android' ? Math.round(fontScale * 100) : undefined
+export const getWebViewAccessibilityProps = (
+  platform: string,
+  fontScale: number,
+  injectedJavascript?: string
+): WebViewAccessibilityProps => {
+  const accessibilityScript = platform === 'ios' ? createAccessibilityFontScalingScript(fontScale) : ''
+  return {
+    injectedJavaScript: injectedJavascript ? `${accessibilityScript}${injectedJavascript}` : accessibilityScript,
+    textZoom: platform === 'android' ? Math.round(fontScale * 100) : undefined,
+  }
 }


### PR DESCRIPTION
# Summary of Changes

Accessibility Scaling not consistent through the BCSC app #3025 

# Testing Instructions

Access any webview page with scaling on device set to high

# Acceptance Criteria

Webview content scales accordingly to zoom level

# Screenshots

<img width="375" height="667" alt="image" src="https://github.com/user-attachments/assets/59e5e7b5-c3d9-42a4-aace-425e90fbb51f" />

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
