### PR TITLE
fix: navigation error

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -70,7 +70,8 @@ const App = () => {
   // Wrap navigationRef.navigate to avoid accessing it before initialization
   const navigate = (stack: never, params: never) => {
     if (navigationRef.isReady()) {
-      ;(navigationRef.navigate as (stack: never, params: never) => void)(stack, params)
+      const nav = navigationRef.navigate as (stack: never, params: never) => void
+      nav(stack, params)
     }
   }
   const bcwContainer = new AppContainer(bifoldContainer, t, navigate, setSurveyVisible).init()

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -67,7 +67,13 @@ const App = () => {
   const logger = appLogger
   const bifoldContainer = new MainContainer(container.createChildContainer()).init()
   const [surveyVisible, setSurveyVisible] = useState(false)
-  const bcwContainer = new AppContainer(bifoldContainer, t, navigationRef.navigate, setSurveyVisible).init()
+  // Wrap navigationRef.navigate to avoid accessing it before initialization
+  const navigate = (stack: never, params: never) => {
+    if (navigationRef.isReady()) {
+      ;(navigationRef.navigate as (stack: never, params: never) => void)(stack, params)
+    }
+  }
+  const bcwContainer = new AppContainer(bifoldContainer, t, navigate, setSurveyVisible).init()
   const deepLinkViewModel = useMemo(() => {
     const service = new DeepLinkService()
     return new DeepLinkViewModel(service, logger)


### PR DESCRIPTION
# Summary of Changes

Fixed a navigation error where `navigation` as used before it was fully initialized.

```
 ERROR  The 'navigation' object hasn't been initialized yet. This might happen if you don't have a navigator mounted, or if the navigator hasn't finished mounting. See https://reactnavigation.org/docs/navigating-without-navigation-prop#handling-initialization for more details.
```
