### PR TITLE
fix(hot-reload): happy holidays

### DIFF
--- a/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
@@ -49,7 +49,7 @@ export const BCSCApiClientProvider: React.FC<{ children: React.ReactNode }> = ({
     const configureClient = async () => {
       setError(null)
 
-      // Use the singleton as reference to prevent infinite loops
+      // Use the singleton as reference to prevent infinite re-renders
       let newClient = BCSC_API_CLIENT_SINGLETON
 
       try {
@@ -89,9 +89,9 @@ export const BCSCApiClientProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const contextValue = useMemo(
     () => ({
-      client,
+      client: client,
       isClientReady: Boolean(client),
-      error,
+      error: error,
     }),
     [client, error]
   )

--- a/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
@@ -30,7 +30,7 @@ export const BCSCApiClientContext = createContext<BCSCApiClientContextType | nul
  */
 export const BCSCApiClientProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [store, dispatch] = useStore<BCState>()
-  const [isClientReady, setIsClientReady] = useState(false)
+  const [isClientReady, setIsClientReady] = useState(Boolean(BCSC_API_CLIENT_SINGLETON))
   const [error, setError] = useState<string | null>(null)
 
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
@@ -48,7 +48,7 @@ export const BCSCApiClientProvider: React.FC<{ children: React.ReactNode }> = ({
     }
 
     const configureClient = async () => {
-      setIsClientReady(false)
+      setIsClientReady(Boolean(BCSC_API_CLIENT_SINGLETON))
       setError(null)
 
       let newClient = BCSC_API_CLIENT_SINGLETON

--- a/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
@@ -49,11 +49,15 @@ export const BCSCApiClientProvider: React.FC<{ children: React.ReactNode }> = ({
     const configureClient = async () => {
       setError(null)
 
-      let newClient = client
+      // Use the singleton as reference to prevent infinite loops
+      let newClient = BCSC_API_CLIENT_SINGLETON
 
       try {
         // If the singleton doesn't exist or the base URL has changed, create a new instance
-        if (!client || client.baseURL !== store.developer.environment.iasApiBaseUrl) {
+        if (
+          !BCSC_API_CLIENT_SINGLETON ||
+          BCSC_API_CLIENT_SINGLETON.baseURL !== store.developer.environment.iasApiBaseUrl
+        ) {
           newClient = new BCSCApiClient(store.developer.environment.iasApiBaseUrl, logger as RemoteLogger)
           await newClient.fetchEndpointsAndConfig()
 
@@ -81,14 +85,7 @@ export const BCSCApiClientProvider: React.FC<{ children: React.ReactNode }> = ({
     }
 
     configureClient()
-  }, [
-    store.stateLoaded,
-    store.developer.environment.name,
-    store.developer.environment.iasApiBaseUrl,
-    logger,
-    dispatch,
-    client,
-  ])
+  }, [store.stateLoaded, store.developer.environment.name, store.developer.environment.iasApiBaseUrl, logger, dispatch])
 
   const contextValue = useMemo(
     () => ({

--- a/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
@@ -30,15 +30,14 @@ export const BCSCApiClientContext = createContext<BCSCApiClientContextType | nul
  */
 export const BCSCApiClientProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [store, dispatch] = useStore<BCState>()
-  const [isClientReady, setIsClientReady] = useState(Boolean(BCSC_API_CLIENT_SINGLETON))
+  const [client, setClient] = useState<BCSCApiClient | null>(BCSC_API_CLIENT_SINGLETON)
   const [error, setError] = useState<string | null>(null)
 
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
 
-  const handleNewClient = (client: BCSCApiClient | null, errorMessage?: string) => {
+  const setClientAndSingleton = (client: BCSCApiClient | null) => {
     BCSC_API_CLIENT_SINGLETON = client
-    setIsClientReady(Boolean(client))
-    setError(errorMessage ?? null)
+    setClient(client)
   }
 
   useEffect(() => {
@@ -48,21 +47,17 @@ export const BCSCApiClientProvider: React.FC<{ children: React.ReactNode }> = ({
     }
 
     const configureClient = async () => {
-      setIsClientReady(Boolean(BCSC_API_CLIENT_SINGLETON))
       setError(null)
 
-      let newClient = BCSC_API_CLIENT_SINGLETON
+      let newClient = client
 
       try {
         // If the singleton doesn't exist or the base URL has changed, create a new instance
-        if (
-          !BCSC_API_CLIENT_SINGLETON ||
-          BCSC_API_CLIENT_SINGLETON.baseURL !== store.developer.environment.iasApiBaseUrl
-        ) {
+        if (!client || client.baseURL !== store.developer.environment.iasApiBaseUrl) {
           newClient = new BCSCApiClient(store.developer.environment.iasApiBaseUrl, logger as RemoteLogger)
           await newClient.fetchEndpointsAndConfig()
 
-          handleNewClient(newClient)
+          setClientAndSingleton(newClient)
         }
       } catch (err) {
         /**
@@ -72,27 +67,36 @@ export const BCSCApiClientProvider: React.FC<{ children: React.ReactNode }> = ({
          * while also alowing the Internet Disconnected modal to be displayed.
          */
         if (isNetworkError(err)) {
-          handleNewClient(newClient)
+          setClientAndSingleton(newClient)
           return
         }
 
         const errorMessage = `Failed to configure BCSC client for ${store.developer.environment.name}: ${
           (err as Error)?.message
         }`
-        handleNewClient(null, errorMessage)
+
+        setClientAndSingleton(null)
+        setError(errorMessage)
       }
     }
 
     configureClient()
-  }, [store.stateLoaded, store.developer.environment.name, store.developer.environment.iasApiBaseUrl, logger, dispatch])
+  }, [
+    store.stateLoaded,
+    store.developer.environment.name,
+    store.developer.environment.iasApiBaseUrl,
+    logger,
+    dispatch,
+    client,
+  ])
 
   const contextValue = useMemo(
     () => ({
-      client: BCSC_API_CLIENT_SINGLETON,
-      isClientReady,
+      client,
+      isClientReady: Boolean(client),
       error,
     }),
-    [isClientReady, error]
+    [client, error]
   )
 
   return <BCSCApiClientContext.Provider value={contextValue}>{children}</BCSCApiClientContext.Provider>


### PR DESCRIPTION
# Summary of Changes

I got the Devs this PR as present for the holidays. 🎄

It fixes the issue where the application would need to be hard-restarted after an error hit the error boundary. Previously it would hang on the infinite loading spinner.

The issue was caused by the BCSCApiClientProvider incorrectly setting the client readiness state to false when it hot-reloads. It now just checks if the singleton is set when configuring the client readiness.

# Testing Instructions

- Hit the error boundary (throw at the top of a component)
- Close error
- App should not be stuck loading

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

https://github.com/user-attachments/assets/eab5199c-5dc9-4562-a74c-7563f0807bc3

https://github.com/user-attachments/assets/fc771102-290c-428f-96ea-2cb3b702762c


# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
