### PR TITLE
chore: log fcm token in debug level

### DIFF
--- a/app/src/bcsc-theme/utils/push-notification-tokens.ts
+++ b/app/src/bcsc-theme/utils/push-notification-tokens.ts
@@ -67,6 +67,7 @@ export const getNotificationTokens = async (logger: BifoldLogger): Promise<Notif
 
   const [fcmDeviceToken, deviceToken] = await Promise.all([fetchFcmToken(), fetchDeviceToken()])
 
+  logger.debug(`Retrieved FCM Device Token: ${fcmDeviceToken}`)
   logger.info('Successfully retrieved notification tokens for registration')
 
   return {


### PR DESCRIPTION
# Summary of Changes

Log the fcm token when log level set to DEBUG so we can test push notifications from the Firebase console.

# Testing Instructions

n/a

# Acceptance Criteria

n/a

# Screenshots, videos, or gifs

n/a

# Related Issues


