### PR TITLE
fix: ios migration

### DIFF
--- a/app/__tests__/bcsc-theme/hooks/useFactoryReset.test.ts
+++ b/app/__tests__/bcsc-theme/hooks/useFactoryReset.test.ts
@@ -15,6 +15,7 @@ jest.mock('@/bcsc-theme/api/hooks/useApi')
 jest.mock('@bifold/core')
 jest.mock('@/bcsc-theme/hooks/useBCSCApiClient')
 jest.mock('@/bcsc-theme/hooks/useSecureActions')
+const warnMock = jest.fn()
 
 describe('useFactoryReset', () => {
   beforeEach(() => {
@@ -90,7 +91,7 @@ describe('useFactoryReset', () => {
 
   it.todo('should factory reset with custom state when provided')
 
-  it('should return an error if account is null', async () => {
+  it('should log a warning if account is null', async () => {
     const bcscCoreMock = jest.mocked(BcscCore)
     const useApiMock = jest.mocked(useApi)
     const useSecureActionsMock = jest.mocked(useSecureActions)
@@ -105,25 +106,20 @@ describe('useFactoryReset', () => {
       deleteSecureData: jest.fn().mockResolvedValue(undefined),
     } as any)
     bifoldMock.useStore.mockReturnValue([{ bcscSecure: { additionalEvidenceData: [] } } as any, jest.fn()])
-    bifoldMock.useServices.mockReturnValue([{ info: jest.fn(), error: jest.fn() }] as any)
+    bifoldMock.useServices.mockReturnValue([{ info: jest.fn(), error: jest.fn(), warn: warnMock }] as any)
 
     const hook = renderHook(() => useFactoryReset())
 
     await act(async () => {
-      const result = await hook.result.current()
-      if (result.success) {
-        expect(true).toBe(false) // Force fail if success is true
-      } else {
-        expect(result.success).toBe(false)
-        expect(result.error.message).toContain('Local account')
-      }
+      await hook.result.current()
     })
 
     expect(bcscCoreMock.getAccount).toHaveBeenCalled()
+    expect(warnMock).toHaveBeenCalled()
     expect(deleteRegistrationMock).not.toHaveBeenCalled()
   })
 
-  it('should return an error if IAS account deletion fails', async () => {
+  it('should log a warning if IAS account deletion fails', async () => {
     const bcscCoreMock = jest.mocked(BcscCore)
     const useApiMock = jest.mocked(useApi)
     const useSecureActionsMock = jest.mocked(useSecureActions)
@@ -138,22 +134,16 @@ describe('useFactoryReset', () => {
       deleteSecureData: jest.fn().mockResolvedValue(undefined),
     } as any)
     bifoldMock.useStore.mockReturnValue([{ bcscSecure: { additionalEvidenceData: [] } } as any, jest.fn()])
-    bifoldMock.useServices.mockReturnValue([{ info: jest.fn(), error: jest.fn() }] as any)
+    bifoldMock.useServices.mockReturnValue([{ info: jest.fn(), error: jest.fn(), warn: warnMock }] as any)
 
     const hook = renderHook(() => useFactoryReset())
 
     await act(async () => {
-      const result = await hook.result.current()
-      if (result.success) {
-        expect(true).toBe(false) // Force fail if success is true
-      } else {
-        expect(result.success).toBe(false)
-        expect(result.error.message).toContain('IAS')
-      }
+      await hook.result.current()
     })
 
     expect(bcscCoreMock.getAccount).toHaveBeenCalled()
-    expect(deleteRegistrationMock).toHaveBeenCalledWith('test-client-id')
+    expect(warnMock).toHaveBeenCalled()
   })
 
   it('should return an error if local account file deletion fails', async () => {

--- a/app/src/bcsc-theme/features/auth/AccountSelectorScreen.tsx
+++ b/app/src/bcsc-theme/features/auth/AccountSelectorScreen.tsx
@@ -4,7 +4,7 @@ import { BCSCAuthStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { BCDispatchAction, BCState } from '@/store'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useStore, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, View } from 'react-native'
 
@@ -34,27 +34,23 @@ const AccountSelectorScreen = ({ navigation }: AccountSelectorScreenProps) => {
   )
 
   // This handles the case where user has completed onboarding but has not set a nickname yet
-  const controls = useMemo(
-    () =>
-      store.bcsc.nicknames.length ? (
-        <>
-          <ThemedText variant={'headingFour'}>{t('BCSC.AccountSetup.ContinueAs')}</ThemedText>
-          <View style={{ gap: Spacing.sm }}>
-            {Array.from(store.bcsc.nicknames).map((nickname) => (
-              <CardButton key={nickname} title={nickname} onPress={() => handleAccountSelect(nickname)} />
-            ))}
-          </View>
-        </>
-      ) : (
-        <Button
-          buttonType={ButtonType.Primary}
-          testID={testIdWithKey('ContinueSetup')}
-          title={'Continue setting up account'}
-          accessibilityLabel={'Continue setting up account'}
-          onPress={() => navigation.navigate(BCSCScreens.EnterPIN)}
-        />
-      ),
-    [handleAccountSelect, navigation, store.bcsc.nicknames, Spacing.sm, t]
+  const controls = store.bcsc.nicknames.length ? (
+    <>
+      <ThemedText variant={'headingFour'}>{t('BCSC.AccountSetup.ContinueAs')}</ThemedText>
+      <View style={{ gap: Spacing.sm }}>
+        {Array.from(store.bcsc.nicknames).map((nickname) => (
+          <CardButton key={nickname} title={nickname} onPress={() => handleAccountSelect(nickname)} />
+        ))}
+      </View>
+    </>
+  ) : (
+    <Button
+      buttonType={ButtonType.Primary}
+      testID={testIdWithKey('ContinueSetup')}
+      title={'Continue setting up account'}
+      accessibilityLabel={'Continue setting up account'}
+      onPress={() => navigation.navigate(BCSCScreens.EnterPIN)}
+    />
   )
 
   return (

--- a/app/src/bcsc-theme/features/auth/AccountSelectorScreen.tsx
+++ b/app/src/bcsc-theme/features/auth/AccountSelectorScreen.tsx
@@ -4,7 +4,7 @@ import { BCSCAuthStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { BCDispatchAction, BCState } from '@/store'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useStore, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, View } from 'react-native'
 
@@ -34,23 +34,27 @@ const AccountSelectorScreen = ({ navigation }: AccountSelectorScreenProps) => {
   )
 
   // This handles the case where user has completed onboarding but has not set a nickname yet
-  const controls = store.bcsc.nicknames.length ? (
-    <>
-      <ThemedText variant={'headingFour'}>{t('BCSC.AccountSetup.ContinueAs')}</ThemedText>
-      <View style={{ gap: Spacing.sm }}>
-        {Array.from(store.bcsc.nicknames).map((nickname) => (
-          <CardButton key={nickname} title={nickname} onPress={() => handleAccountSelect(nickname)} />
-        ))}
-      </View>
-    </>
-  ) : (
-    <Button
-      buttonType={ButtonType.Primary}
-      testID={testIdWithKey('ContinueSetup')}
-      title={'Continue setting up account'}
-      accessibilityLabel={'Continue setting up account'}
-      onPress={() => navigation.navigate(BCSCScreens.EnterPIN)}
-    />
+  const controls = useMemo(
+    () =>
+      store.bcsc.nicknames.length ? (
+        <>
+          <ThemedText variant={'headingFour'}>{t('BCSC.AccountSetup.ContinueAs')}</ThemedText>
+          <View style={{ gap: Spacing.sm }}>
+            {Array.from(store.bcsc.nicknames).map((nickname) => (
+              <CardButton key={nickname} title={nickname} onPress={() => handleAccountSelect(nickname)} />
+            ))}
+          </View>
+        </>
+      ) : (
+        <Button
+          buttonType={ButtonType.Primary}
+          testID={testIdWithKey('ContinueSetup')}
+          title={'Continue setting up account'}
+          accessibilityLabel={'Continue setting up account'}
+          onPress={() => navigation.navigate(BCSCScreens.EnterPIN)}
+        />
+      ),
+    [handleAccountSelect, navigation, store.bcsc.nicknames, Spacing.sm, t]
   )
 
   return (

--- a/app/src/bcsc-theme/features/auth/LockoutScreen.tsx
+++ b/app/src/bcsc-theme/features/auth/LockoutScreen.tsx
@@ -103,9 +103,7 @@ export const LockoutScreen = ({ navigation }: LockoutScreenProps) => {
 
   const onPressRemoveAccount = useCallback(async () => {
     try {
-      // Don't delete from server when locked out - user hasn't authenticated yet
-      // This matches ias-ios behavior which only cleans up local storage
-      await factoryReset(undefined, false)
+      await factoryReset()
     } catch (error) {
       const errMessage = error instanceof Error ? error.message : String(error)
       logger.error(`Error removing account: ${errMessage}`)

--- a/app/src/bcsc-theme/navigators/RootStack.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.tsx
@@ -38,12 +38,12 @@ const BCSCRootStack: React.FC = () => {
     }
   }, [dispatch, loadState, t, store.stateLoaded])
 
-  // Check for existing account on initial load
+  // Check for existing account on initial load - only runs after state is loaded
   useEffect(() => {
+    if (!store.stateLoaded || !loading) return
+
     const asyncEffect = async () => {
       try {
-        if (!loading) return
-
         const account = await getAccount()
         if (account) {
           // adds nickname to store if migrating from v3 and isn't already present
@@ -62,7 +62,7 @@ const BCSCRootStack: React.FC = () => {
       }
     }
     asyncEffect()
-  }, [logger, dispatch, store.bcsc.nicknames, loading])
+  }, [logger, dispatch, store.bcsc.nicknames, store.stateLoaded, loading])
 
   // Show loading screen if state or API client or account status not ready yet
   if (!store.stateLoaded || !isClientReady || loading) {

--- a/packages/bcsc-core/ios/ClientRegistration.swift
+++ b/packages/bcsc-core/ios/ClientRegistration.swift
@@ -26,16 +26,7 @@ class ClientRegistration: NSObject, NSSecureCoding {
     _ = coder.decodeObject(forKey: .keys)
 
     let decodedCredential = coder.decodeObject(forKey: .credential)
-    print(
-      "ClientRegistration.init: Decoded credential object type: \(type(of: decodedCredential)), value: \(String(describing: decodedCredential))"
-    )
     self.credential = decodedCredential as? Credential
-    if self.credential == nil, decodedCredential != nil {
-      print(
-        "ClientRegistration.init: Failed to cast credential to Credential type, actual type: \(type(of: decodedCredential))"
-      )
-    }
-
     self.accessToken = coder.decodeObject(forKey: .accessToken) as? String
     self.accessTokenID = coder.decodeObject(forKey: .accessTokenID) as? String
     self.registrationClientURI = coder.decodeObject(forKey: .registrationClientURI) as? String

--- a/packages/bcsc-core/ios/ClientRegistration.swift
+++ b/packages/bcsc-core/ios/ClientRegistration.swift
@@ -25,8 +25,7 @@ class ClientRegistration: NSObject, NSSecureCoding {
     // V3 has a keys array we don't need in v4 - decode and ignore it
     _ = coder.decodeObject(forKey: .keys)
 
-    let decodedCredential = coder.decodeObject(forKey: .credential)
-    self.credential = decodedCredential as? Credential
+    self.credential = coder.decodeObject(forKey: .credential) as? Credential
     self.accessToken = coder.decodeObject(forKey: .accessToken) as? String
     self.accessTokenID = coder.decodeObject(forKey: .accessTokenID) as? String
     self.registrationClientURI = coder.decodeObject(forKey: .registrationClientURI) as? String

--- a/packages/bcsc-core/ios/Credential.swift
+++ b/packages/bcsc-core/ios/Credential.swift
@@ -14,8 +14,8 @@ class Credential: NSObject, NSSecureCoding {
   var updatedDate: Date?
 
   // BCSC specific fields
-  var bcscEvent: String
-  var bcscReason: String
+  var bcscEvent: String?
+  var bcscReason: String?
   var bcscStatusDate: Date?
   var bcscEventDate: Date?
 
@@ -49,8 +49,8 @@ class Credential: NSObject, NSSecureCoding {
     subject: String,
     label: String,
     created: Date,
-    bcscEvent: String,
-    bcscReason: String
+    bcscEvent: String? = nil,
+    bcscReason: String? = nil
   ) {
     self.issuer = issuer
     self.subject = subject
@@ -62,12 +62,16 @@ class Credential: NSObject, NSSecureCoding {
   }
 
   required init?(coder: NSCoder) {
-    guard let issuer = coder.decodeObject(forKey: .issuer) as? String,
-          let subject = coder.decodeObject(forKey: .subject) as? String,
-          let label = coder.decodeObject(forKey: .label) as? String,
-          let created = coder.decodeObject(forKey: .created) as? Date,
-          let bcscEvent = coder.decodeObject(forKey: .bcscEvent) as? String,
-          let bcscReason = coder.decodeObject(forKey: .bcscReason) as? String
+    let issuer = coder.decodeObject(forKey: .issuer) as? String
+    let subject = coder.decodeObject(forKey: .subject) as? String
+    let label = coder.decodeObject(forKey: .label) as? String
+    let created = coder.decodeObject(forKey: .created) as? Date
+
+    // Only require core fields
+    guard let issuer = issuer,
+          let subject = subject,
+          let label = label,
+          let created = created
     else {
       return nil
     }
@@ -76,10 +80,10 @@ class Credential: NSObject, NSSecureCoding {
     self.subject = subject
     self.label = label
     self.created = created
-    self.bcscEvent = bcscEvent
-    self.bcscReason = bcscReason
 
     // Optional fields
+    self.bcscEvent = coder.decodeObject(forKey: .bcscEvent) as? String
+    self.bcscReason = coder.decodeObject(forKey: .bcscReason) as? String
     self.lastUsed = coder.decodeObject(forKey: .lastUsed) as? Date
     self.updatedDate = coder.decodeObject(forKey: .updatedDate) as? Date
     self.bcscStatusDate = coder.decodeObject(forKey: .bcscStatusDate) as? Date


### PR DESCRIPTION
# Summary of Changes

This PR fixes migration from v3 from both a fully verified account and an account with an in progress verification. The changes are are almost entirely in native Swift code, adjusting the object unwrapping and adding more logging.

The two TS changes I made were:
1) adjusting the nickname setting effect in RootStack as the state load was overwriting the set nickname
2) making failed registration deletions in the factoryReset non-blocking, so the rest of the reset process continues to complete

Note:
- `requiringSecureCoding: false` is required because v3 uses deprecated archive methods that have requiringSecureCoding set to false by default

# Testing Instructions

Scenario 1:
- Fresh install previous Testflight build, 3.15.1, stop once you get past the serial number + birthdate step
- Do an iOS build from this branch
- Check that you can use the same PIN / device auth to log in and that you have the same access to setup steps with an in progress setup steps

Scenario 2:
- Fresh install previous Testflight build, 3.15.1, get fully verified
- Do an iOS build from this branch
- Check that you can use the same PIN / device auth to log in and that you have the same access to your full account

# Acceptance Criteria

The above two scenarios work

# Screenshots, videos, or gifs

Here is a v3 Testflight build, fully verified, being migrated to a build from this branch:

https://github.com/user-attachments/assets/c17ed85f-036a-4492-98d9-a1058c64cf0e

# Related Issues

#3091 