### PR TITLE
feat(fcm): trigger device invalidation check on status notification

### DIFF
--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
@@ -21,6 +21,7 @@ import {
 export class FcmViewModel {
   private serverJwk: JWK | null = null
   private lastJwkBaseUrl: string | null = null
+  private initialized = false
 
   constructor(
     private readonly fcmService: FcmService,
@@ -29,6 +30,12 @@ export class FcmViewModel {
   ) {}
 
   public initialize() {
+    if (this.initialized) {
+      this.logger.info('[FcmViewModel] Already initialized, skipping')
+      return
+    }
+    this.initialized = true
+
     this.logger.info('[FcmViewModel] Initializing...')
     // Subscribe BEFORE init so we don't miss any messages
     this.fcmService.subscribe(this.handleMessage.bind(this))

--- a/app/src/bcsc-theme/features/modal/DeviceInvalidated.tsx
+++ b/app/src/bcsc-theme/features/modal/DeviceInvalidated.tsx
@@ -19,7 +19,7 @@ type DeviceInvalidatedProps = StackScreenProps<BCSCMainStackParams, BCSCModals.D
 export const DeviceInvalidated = ({ route }: DeviceInvalidatedProps): JSX.Element => {
   const { t } = useTranslation()
   const [store] = useStore<BCState>()
-  const invalidationReason = route.params.invalidationReason
+  const invalidationReason = route.params?.invalidationReason
   const factoryReset = useFactoryReset()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
 
@@ -29,6 +29,10 @@ export const DeviceInvalidated = ({ route }: DeviceInvalidatedProps): JSX.Elemen
   const handleFactoryReset = useCallback(async () => {
     const factoryResetParams: Partial<Record<BCSCReason, Partial<BCSCState>>> = {
       // Can add more cases here for different BCSCReason types in the future
+      [BCSCReason.Cancel]: {
+        nicknames: store.bcsc.nicknames,
+        selectedNickname: store.bcsc.selectedNickname,
+      },
       [BCSCReason.CanceledByAgent]: {
         nicknames: store.bcsc.nicknames,
         selectedNickname: store.bcsc.selectedNickname,
@@ -45,6 +49,7 @@ export const DeviceInvalidated = ({ route }: DeviceInvalidatedProps): JSX.Elemen
 
   const contentTextMap: Partial<Record<BCSCReason, string>> = {
     // Can add more cases here for different BCSCReason types in the future
+    [BCSCReason.Cancel]: t('BCSC.Modals.DeviceInvalidated.CancelledByCardCancel'),
     [BCSCReason.CanceledByAgent]: t('BCSC.Modals.DeviceInvalidated.CancelledByAgent'),
     [BCSCReason.CanceledByUser]: t('BCSC.Modals.DeviceInvalidated.CancelledByUser'),
   }

--- a/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
+++ b/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
@@ -97,8 +97,8 @@ export const SystemModal = ({
         <Icon name={iconName} size={iconSize} color={ColorPalette.brand.icon} style={styles.icon} />
         <View style={styles.textContainer}>
           <ThemedText variant="headingThree">{headerText}</ThemedText>
-          {contentText.map((text) => (
-            <ThemedText key={text} style={styles.textContent}>
+          {contentText.map((text, index) => (
+            <ThemedText key={`content-${index}`} style={styles.textContent}>
               {text}
             </ThemedText>
           ))}

--- a/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
+++ b/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
@@ -97,8 +97,8 @@ export const SystemModal = ({
         <Icon name={iconName} size={iconSize} color={ColorPalette.brand.icon} style={styles.icon} />
         <View style={styles.textContainer}>
           <ThemedText variant="headingThree">{headerText}</ThemedText>
-          {contentText.map((text, index) => (
-            <ThemedText key={`content-${index}`} style={styles.textContent}>
+          {contentText.filter(Boolean).map((text) => (
+            <ThemedText key={text} style={styles.textContent}>
               {text}
             </ThemedText>
           ))}

--- a/app/src/bcsc-theme/hooks/useSystemChecks.tsx
+++ b/app/src/bcsc-theme/hooks/useSystemChecks.tsx
@@ -77,7 +77,8 @@ export const useSystemChecks = (scope: SystemCheckScope) => {
         const navigation = await getSystemCheckNavigation()
         const utils = { dispatch, translation: t, logger }
 
-        // Use refreshCache: true to get the latest ID token after the token refresh
+        // Tokens have already been refreshed before this event; use refreshCache: false
+        // to reuse the freshly updated ID token from cache without forcing another refresh.
         const getIdToken = () => tokenApi.getCachedIdTokenMetadata({ refreshCache: false })
 
         await runSystemChecks([new DeviceInvalidatedSystemCheck(getIdToken, navigation, utils)])

--- a/app/src/bcsc-theme/hooks/useSystemChecks.tsx
+++ b/app/src/bcsc-theme/hooks/useSystemChecks.tsx
@@ -1,4 +1,5 @@
 import { navigationRef } from '@/contexts/NavigationContainerContext'
+import { BCSCEventTypes } from '@/events/eventTypes'
 import { useEventListener } from '@/hooks/useEventListener'
 import { AccountExpirySystemCheck } from '@/services/system-checks/AccountExpirySystemCheck'
 import { AnalyticsSystemCheck } from '@/services/system-checks/AnalyticsSystemCheck'
@@ -15,6 +16,7 @@ import { TOKENS, useServices, useStore } from '@bifold/core'
 import NetInfo from '@react-native-community/netinfo'
 import { useContext, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import { DeviceEventEmitter } from 'react-native'
 import { getBundleId } from 'react-native-device-info'
 import BCSCApiClient from '../api/client'
 import useConfigApi from '../api/hooks/useConfigApi'
@@ -61,6 +63,31 @@ export const useSystemChecks = (scope: SystemCheckScope) => {
       await runSystemChecks([new InternetStatusSystemCheck(netInfo, navigation, logger)])
     })
   }, scope === SystemCheckScope.STARTUP)
+
+  // Listen for token refresh events (e.g., from FCM status notifications) and run device invalidation check
+  useEffect(() => {
+    if (scope !== SystemCheckScope.MAIN_STACK || !isClientReady || !client) {
+      return
+    }
+
+    const subscription = DeviceEventEmitter.addListener(BCSCEventTypes.TOKENS_REFRESHED, async () => {
+      logger.info('useSystemChecks: Tokens refreshed, running device invalidation check')
+
+      try {
+        const navigation = await getSystemCheckNavigation()
+        const utils = { dispatch, translation: t, logger }
+
+        // Use refreshCache: true to get the latest ID token after the token refresh
+        const getIdToken = () => tokenApi.getCachedIdTokenMetadata({ refreshCache: false })
+
+        await runSystemChecks([new DeviceInvalidatedSystemCheck(getIdToken, navigation, utils)])
+      } catch (error) {
+        logger.error(`Device invalidation check failed after token refresh: ${(error as Error).message}`)
+      }
+    })
+
+    return () => subscription.remove()
+  }, [scope, isClientReady, client, tokenApi, dispatch, t, logger])
 
   /**
    * Checks to run on app startup to ensure system is operational.

--- a/app/src/bcsc-theme/utils/id-token.ts
+++ b/app/src/bcsc-theme/utils/id-token.ts
@@ -25,10 +25,10 @@ export enum BCSCReason {
   ApprovedByAgent = 'Approved by Agent',
   Renew = 'Renewed by Card Renew',
   Replace = 'Replaced by Card Replace',
-  Cancel = 'Canceled by Card Cancel',
+  Cancel = 'Canceled by Card Cancel', // i.e agent via web portal.
   ExpiredBySystem = 'Expired by System',
-  CanceledByAgent = 'Canceled by Agent',
-  CanceledByUser = 'Canceled by User',
+  CanceledByAgent = 'Canceled by Agent', // i.e automatic, too many cards.
+  CanceledByUser = 'Canceled by User', // i.e user manually removes a card.
   CanceledByAdditionalCard = 'Canceled by Additional Card',
   CanceledByCardTypeChange = 'Canceled by Card Type Change',
   CanceledDueToInactivity = 'Canceled due to Inactivity',

--- a/app/src/events/eventTypes.ts
+++ b/app/src/events/eventTypes.ts
@@ -1,3 +1,7 @@
 export enum BCWalletEventTypes {
   ADD_CREDENTIAL_PRESSED = 'AddCredentialPressed',
 }
+
+export enum BCSCEventTypes {
+  TOKENS_REFRESHED = 'BCSCTokensRefreshed',
+}

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -211,6 +211,7 @@ const translation = {
       },
       "DeviceInvalidated": {
         "Header": "Device invalidated",
+        "CancelledByCardCancel": "This device has been invalidated by an agent. You must contact BC Services to continue.",
         "CancelledByAgent": "This device has been invalidated. You must re-authorize the device to continue.",
         "CancelledByUser": "This device has been removed from your account by a user action.",
         "ContentA": "Tap OK to clear local data and restart setup on this device.",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -211,6 +211,7 @@ const translation = {
       } ,
       "DeviceInvalidated": {
         "Header": "Device invalidated (FR)",
+        "CancelledByCardCancel": "This device has been invalidated by an agent. You must contact BC Services to continue. (FR)",
         "CancelledByAgent": "This device has been invalidated. You must re-authorize the device to continue. (FR)",
         "CancelledByUser": "This device has been removed from your account by a user action. (FR)",
         "ContentA": "Tap OK to clear local data and restart setup on this device. (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -211,6 +211,7 @@ const translation = {
       },
       "DeviceInvalidated": {
         "Header": "Device invalidated (PT-BR)",
+        "CancelledByCardCancel": "This device has been invalidated by an agent. You must contact BC Services to continue. (PT-BR)",
         "CancelledByAgent": "This device has been invalidated. You must re-authorize the device to continue. (PT-BR)",
         "CancelledByUser": "This device has been removed from your account by a user action. (PT-BR)",
         "ContentA": "Tap OK to clear local data and restart setup on this device. (PT-BR)",


### PR DESCRIPTION
# Summary of Changes

This PR fixes an issue where users had to restart the app to see the device invalidation screen after their device was canceled. The app now detects this immediately when receiving a push notification.

When a status notification comes in, the app refreshes the OAuth tokens and checks the new token data. If it finds the device was canceled, it shows the invalidation screen right away instead of waiting for the next app launch.
Testing Checklist

# Testing Instructions

1. Crate a new test account via the management UI
2. Add the newly created test account to your device
3. Verify the account (in person, send video, etc)
4. With the app setup and ready:
5. go back to the management UI and cancel the card (**WARNING: THIS CANNOT BE UNDONE**). 

You should receive a push notification and the device should automatically detect the card was canceled and show the invalidation screen.

-  Push notification received while device is active
-  DeviceInvalidated screen appears immediately (no restart needed)
-  Account data updates correctly after token refresh

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

https://github.com/user-attachments/assets/110f7a3d-b1dc-4acb-92ae-85da74f0871f

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
