### PR TITLE
fix: two persistence / storage issues

### DIFF
--- a/app/__tests__/screens/EvidenceCaptureScreen.test.tsx
+++ b/app/__tests__/screens/EvidenceCaptureScreen.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react-native'
+import { render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 
 import { useNavigation } from '../../__mocks__/custom/@react-navigation/core'
@@ -18,7 +18,7 @@ describe('EvidenceCapture', () => {
     jest.useRealTimers()
   })
 
-  it('renders correctly', () => {
+  it('renders correctly', async () => {
     const mockEvidenceType = {
       evidence_type: 'passport',
       has_photo: true,
@@ -46,6 +46,11 @@ describe('EvidenceCapture', () => {
         />
       </BasicAppContext>
     )
+
+    // Wait for useFocusEffect to complete and camera to be rendered
+    await waitFor(async () => {
+      expect(tree.queryAllByText('BCSC.CameraDisclosure.NoCameraAvailable')).toBeDefined()
+    })
 
     expect(tree).toMatchSnapshot()
   })

--- a/app/__tests__/screens/__snapshots__/EvidenceCaptureScreen.test.tsx.snap
+++ b/app/__tests__/screens/__snapshots__/EvidenceCaptureScreen.test.tsx.snap
@@ -8,42 +8,5 @@ exports[`EvidenceCapture renders correctly 1`] = `
       "position": "relative",
     }
   }
->
-  <RNCSafeAreaView
-    edges={
-      {
-        "bottom": "additive",
-        "left": "additive",
-        "right": "additive",
-        "top": "additive",
-      }
-    }
-    style={
-      {
-        "flex": 1,
-        "position": "relative",
-      }
-    }
-  >
-    <View
-      style={
-        {
-          "alignItems": "center",
-          "flex": 1,
-          "justifyContent": "center",
-        }
-      }
-    >
-      <Text
-        style={
-          {
-            "color": "white",
-          }
-        }
-      >
-        BCSC.CameraDisclosure.NoCameraAvailable
-      </Text>
-    </View>
-  </RNCSafeAreaView>
-</View>
+/>
 `;

--- a/packages/bcsc-core/ios/StorageService.swift
+++ b/packages/bcsc-core/ios/StorageService.swift
@@ -258,13 +258,15 @@ class StorageService {
   ) throws -> Data {
     let className = String(describing: T.self)
 
-    // Skip class registration if the expected type is NSDictionary
-    if T.self != NSDictionary.self {
+    // Skip class registration for Foundation collection types (NSDictionary, NSArray)
+    // Modifying the global class name for these types can corrupt other frameworks
+    let isFoundationCollectionType = T.self == NSDictionary.self || T.self == NSArray.self
+    if !isFoundationCollectionType {
       let archivedClassName = "\(nativeModuleName).\(className)"
       NSKeyedArchiver.setClassName(archivedClassName, for: T.self)
       logger.log("Encoding class: \(archivedClassName)")
     } else {
-      logger.log("Skipping class registration for NSDictionary")
+      logger.log("Skipping class registration for Foundation collection type: \(className)")
     }
 
     let archiver = NSKeyedArchiver(requiringSecureCoding: false)
@@ -289,8 +291,10 @@ class StorageService {
   ) throws -> T? {
     let className = String(describing: T.self)
 
-    // Skip class registration if the expected type is NSDictionary
-    if T.self != NSDictionary.self {
+    // Skip class registration for Foundation collection types (NSDictionary, NSArray)
+    // Modifying the global class name for these types can corrupt other frameworks
+    let isFoundationCollectionType = T.self == NSDictionary.self || T.self == NSArray.self
+    if !isFoundationCollectionType {
       // Register both production and dev module names for compatibility
       let prodClassName = "bc_services_card.\(className)"
       let devClassName = "bc_services_card_dev.\(className)"
@@ -298,7 +302,7 @@ class StorageService {
       NSKeyedUnarchiver.setClass(T.self, forClassName: devClassName)
       logger.log("Decoding class - registered mappings for: \(prodClassName) and \(devClassName)")
     } else {
-      logger.log("Skipping class registration for NSDictionary")
+      logger.log("Skipping class registration for Foundation collection type: \(className)")
     }
 
     let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
@@ -306,7 +310,9 @@ class StorageService {
 
     let decoded = try unarchiver.decodeTopLevelObject(forKey: NSKeyedArchiveRootObjectKey)
 
-    if T.self != NSDictionary.self {
+    // For custom types, unwrap from provider dictionary
+    // For Foundation collection types, return directly
+    if !isFoundationCollectionType {
       if let decodedDict = decoded as? [String: T] {
         return decodedDict[provider]
       }


### PR DESCRIPTION
# Summary of Changes

Two issues:
1) We were not persisting or properly fetching the verification request ID, which was causing verifications to get lost between lockouts / app restarts
2) We were overwriting the NSArray class, which was blowing up the camera (and who knows what else) (my b lol) 

Another good example of where native code tests would help, taking stuff from v3 doesn't always work with some adaptation

# Testing Instructions

Go through non-BCSC flow
Go through send video, when you have a pending request, restart the app, check you can still "Check status" of it

# Acceptance Criteria

You can use the camera in non-BCSC flow
You can have a send video request pending, restart the app, and still check it successfully

# Screenshots, videos, or gifs

N/A

# Related Issues

#3121 
#3117 