### PR TITLE
fix: ios to process notification from background

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -426,7 +426,6 @@ jobs:
           PROOF_TEMPLATE_URL: ${{ vars.PROOF_TEMPLATE_URL }}
           REMOTE_LOGGING_URL: ${{ secrets.REMOTE_LOGGING_URL }}
           INDY_VDR_PROXY_URL: ${{ vars.INDY_VDR_PROXY_URL }}
-          ENTITLEMENTS_PATH: "ios/AriesBifold/AriesBifold.entitlements"
         run: |
           # 1. Create .env file
           echo "BUILD_TARGET=${BUILD_TARGET}" >.env
@@ -438,9 +437,6 @@ jobs:
           echo "PROOF_TEMPLATE_URL=${PROOF_TEMPLATE_URL}" >>.env
           echo "REMOTE_LOGGING_URL=${REMOTE_LOGGING_URL}" >>.env
           echo "INDY_VDR_PROXY_URL=${INDY_VDR_PROXY_URL}" >>.env
-
-          # 2. Update iOS entitlements for FCM
-          plutil -replace aps-environment -string production $ENTITLEMENTS_PATH
 
       - name: Create release keystore
         # This step will not work in a `fork` because it will not have access

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -426,7 +426,9 @@ jobs:
           PROOF_TEMPLATE_URL: ${{ vars.PROOF_TEMPLATE_URL }}
           REMOTE_LOGGING_URL: ${{ secrets.REMOTE_LOGGING_URL }}
           INDY_VDR_PROXY_URL: ${{ vars.INDY_VDR_PROXY_URL }}
+          ENTITLEMENTS_PATH: "ios/AriesBifold/AriesBifold.entitlements"
         run: |
+          # 1. Create .env file
           echo "BUILD_TARGET=${BUILD_TARGET}" >.env
           echo "MEDIATOR_USE_PUSH_NOTIFICATIONS=${MEDIATOR_USE_PUSH_NOTIFICATIONS}" >>.env
           echo "MEDIATOR_URL=${MEDIATOR_URL}" >>.env
@@ -436,6 +438,9 @@ jobs:
           echo "PROOF_TEMPLATE_URL=${PROOF_TEMPLATE_URL}" >>.env
           echo "REMOTE_LOGGING_URL=${REMOTE_LOGGING_URL}" >>.env
           echo "INDY_VDR_PROXY_URL=${INDY_VDR_PROXY_URL}" >>.env
+
+          # 2. Update iOS entitlements for FCM
+          plutil -replace aps-environment -string production $ENTITLEMENTS_PATH
 
       - name: Create release keystore
         # This step will not work in a `fork` because it will not have access

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -427,7 +427,6 @@ jobs:
           REMOTE_LOGGING_URL: ${{ secrets.REMOTE_LOGGING_URL }}
           INDY_VDR_PROXY_URL: ${{ vars.INDY_VDR_PROXY_URL }}
         run: |
-          # 1. Create .env file
           echo "BUILD_TARGET=${BUILD_TARGET}" >.env
           echo "MEDIATOR_USE_PUSH_NOTIFICATIONS=${MEDIATOR_USE_PUSH_NOTIFICATIONS}" >>.env
           echo "MEDIATOR_URL=${MEDIATOR_URL}" >>.env

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
@@ -1,5 +1,4 @@
 import { AbstractBifoldLogger } from '@bifold/core'
-import messaging from '@react-native-firebase/messaging'
 import { DeviceEventEmitter } from 'react-native'
 import { decodeLoginChallenge, JWK, showLocalNotification } from 'react-native-bcsc-core'
 

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
@@ -166,8 +166,10 @@ export class FcmViewModel {
   private async handleGenericNotification(data: BasicNotification) {
     const { title, body } = data
 
+    this.logger.info(`[FcmViewModel] Showing local notification: title="${title}", body="${body}"`)
     try {
       await showLocalNotification(title, body)
+      this.logger.info(`[FcmViewModel] Local notification shown successfully`)
     } catch (error) {
       this.logger.error(`[FcmViewModel] Failed to show local notification: ${error}`)
     }

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
@@ -1,4 +1,5 @@
 import { AbstractBifoldLogger } from '@bifold/core'
+import messaging from '@react-native-firebase/messaging'
 import { DeviceEventEmitter } from 'react-native'
 import { decodeLoginChallenge, JWK, showLocalNotification } from 'react-native-bcsc-core'
 


### PR DESCRIPTION
# Summary of Changes

Implement the necessary logic so that iOS will process notifications when in the background.

# Testing Instructions

Setup BC Parks with paring code from: https://idsit.gov.bc.ca/demo/
Go back, and re-auth with the device while the app is backgrounded
Tapping the received notification should open the app and process the notificaiton.

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs
 
https://github.com/user-attachments/assets/2d6cee77-ef5f-4037-906f-219e53ceb482

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
