### PR TITLE
fix: evidence metadata persistence

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useEvidenceApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useEvidenceApi.tsx
@@ -3,7 +3,7 @@ import { VIDEO_MP4_MIME_TYPE } from '@/constants'
 import { BCState } from '@/store'
 import { useStore } from '@bifold/core'
 import { useCallback, useMemo } from 'react'
-import { createPreVerificationJWT } from 'react-native-bcsc-core'
+import { createPreVerificationJWT, EvidenceType } from 'react-native-bcsc-core'
 import BCSCApiClient from '../client'
 import { withAccount } from './withAccountGuard'
 
@@ -59,25 +59,6 @@ export interface UploadEvidenceResponseData {
   upload_uri: string
 }
 
-export interface EvidenceImageSide {
-  image_side_name: 'FRONT_SIDE' | 'BACK_SIDE'
-  image_side_label: string
-  image_side_tip: string
-}
-
-export interface EvidenceType {
-  evidence_type: string
-  has_photo: boolean
-  group: 'BRITISH COLUMBIA' | 'CANADA, OR OTHER LOCATION IN CANADA' | 'UNITED STATES' | 'OTHER COUNTRIES'
-  group_sort_order: number
-  sort_order: number
-  collection_order: 'FIRST' | 'SECOND' | 'BOTH'
-  document_reference_input_mask: string // a regex mask for ID document reference input, number only can indicate to use a number only keyboard
-  document_reference_label: string
-  document_reference_sample: string
-  image_sides: EvidenceImageSide[]
-  evidence_type_label: string
-}
 export interface EvidenceMetadataResponseData {
   processes: {
     process: 'IDIM L3 Remote Non-BCSC Identity Verification' | 'IDIM L3 Remote Non-photo BCSC Identity Verification'

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.tsx
@@ -1,15 +1,15 @@
-import { EvidenceType } from '@/bcsc-theme/api/hooks/useEvidenceApi'
 import MaskedCamera from '@/bcsc-theme/components/MaskedCamera'
 import PhotoReview from '@/bcsc-theme/components/PhotoReview'
 import { CameraFormat } from '@/bcsc-theme/components/utils/camera-format'
 import { useCardScanner } from '@/bcsc-theme/hooks/useCardScanner'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
-import { getPhotoMetadata, PhotoMetadata } from '@/bcsc-theme/utils/file-info'
+import { getPhotoMetadata } from '@/bcsc-theme/utils/file-info'
 import { MaskType, TOKENS, useServices, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useState } from 'react'
 import { StyleSheet, useWindowDimensions, View } from 'react-native'
+import { EvidenceType, PhotoMetadata } from 'react-native-bcsc-core'
 import { useCodeScanner } from 'react-native-vision-camera'
 
 type EvidenceCaptureScreenProps = {

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
@@ -1,4 +1,3 @@
-import { EvidenceType } from '@/bcsc-theme/api/hooks/useEvidenceApi'
 import { InputWithValidation } from '@/bcsc-theme/components/InputWithValidation'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
@@ -19,7 +18,7 @@ import { StackNavigationProp } from '@react-navigation/stack'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Keyboard, View } from 'react-native'
-import { BCSCCardProcess } from 'react-native-bcsc-core'
+import { BCSCCardProcess, EvidenceType } from 'react-native-bcsc-core'
 import DatePicker from 'react-native-date-picker'
 
 type EvidenceCollectionFormState = {

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.tsx
@@ -1,5 +1,5 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
-import { EvidenceMetadataResponseData, EvidenceType } from '@/bcsc-theme/api/hooks/useEvidenceApi'
+import { EvidenceMetadataResponseData } from '@/bcsc-theme/api/hooks/useEvidenceApi'
 import useDataLoader from '@/bcsc-theme/hooks/useDataLoader'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
@@ -10,7 +10,7 @@ import { StackNavigationProp } from '@react-navigation/stack'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, Pressable, SectionList, StyleSheet, View } from 'react-native'
-import { BCSCCardProcess } from 'react-native-bcsc-core'
+import { BCSCCardProcess, EvidenceType } from 'react-native-bcsc-core'
 
 type EvidenceTypeListScreenProps = {
   navigation: StackNavigationProp<BCSCVerifyStackParams, BCSCScreens.EvidenceTypeList>

--- a/app/src/bcsc-theme/features/verify/non-photo/IDPhotoInformationScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/IDPhotoInformationScreen.tsx
@@ -1,4 +1,3 @@
-import { EvidenceType } from '@/bcsc-theme/api/hooks/useEvidenceApi'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import BulletPointWithText from '@/components/BulletPointWithText'
 import SCAN_ID_IMAGE from '@assets/img/credential-scan.png'
@@ -6,6 +5,7 @@ import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme 
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useTranslation } from 'react-i18next'
 import { Image, StyleSheet, View } from 'react-native'
+import { EvidenceType } from 'react-native-bcsc-core'
 
 type IDPhotoInformationScreenProps = {
   navigation: StackNavigationProp<BCSCVerifyStackParams, BCSCScreens.IDPhotoInformation>

--- a/app/src/bcsc-theme/types/navigators.ts
+++ b/app/src/bcsc-theme/types/navigators.ts
@@ -1,6 +1,5 @@
 import { NavigatorScreenParams } from '@react-navigation/native'
-import { BCSCCardProcess } from 'react-native-bcsc-core'
-import { EvidenceType } from '../api/hooks/useEvidenceApi'
+import { BCSCCardProcess, EvidenceType } from 'react-native-bcsc-core'
 import { BCSCReason } from '../utils/id-token'
 
 export enum BCSCStacks {

--- a/app/src/bcsc-theme/utils/file-info.ts
+++ b/app/src/bcsc-theme/utils/file-info.ts
@@ -1,19 +1,9 @@
 import { DEFAULT_SELFIE_VIDEO_FILENAME, VIDEO_MP4_MIME_TYPE } from '@/constants'
 import readFileInChunks from '@/utils/read-file'
 import { BifoldLogger } from '@bifold/core'
-import { hashBase64 } from 'react-native-bcsc-core'
+import { hashBase64, PhotoMetadata } from 'react-native-bcsc-core'
 import RNFS from 'react-native-fs'
 import { VerificationPrompt, VerificationVideoUploadPayload } from '../api/hooks/useEvidenceApi'
-
-export interface PhotoMetadata {
-  label: string
-  content_type: string
-  content_length: number
-  date: number
-  sha256: string // hashed copy of the photo
-  filename?: string
-  file_path: string
-}
 
 export const getFileInfo = async (filePath: string) => {
   const stats = await RNFS.stat(filePath)

--- a/app/src/hooks/useSetupSteps.ts
+++ b/app/src/hooks/useSetupSteps.ts
@@ -1,8 +1,8 @@
 import { formatAddressForDisplay } from '@/bcsc-theme/utils/address-utils'
-import { AccountSetupType, AdditionalEvidenceData, BCState } from '@/store'
+import { AccountSetupType, BCState } from '@/store'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { BCSCCardProcess } from 'react-native-bcsc-core'
+import { BCSCCardProcess, EvidenceMetadata } from 'react-native-bcsc-core'
 
 /**
  * Validates that an evidence item is fully completed.
@@ -10,7 +10,7 @@ import { BCSCCardProcess } from 'react-native-bcsc-core'
  * - It has at least 1 photo | NOTE: Some evidence types may only require a photo (e.g. passport)
  * - It has a document number entered
  */
-const isEvidenceComplete = (evidence: AdditionalEvidenceData): boolean => {
+const isEvidenceComplete = (evidence: EvidenceMetadata): boolean => {
   const hasRequiredPhotos = evidence.metadata.length >= 1
   const hasDocumentNumber = Boolean(evidence.documentNumber)
   return hasRequiredPhotos && hasDocumentNumber

--- a/app/src/store.tsx
+++ b/app/src/store.tsx
@@ -6,15 +6,13 @@ import {
   PersistentStorage,
   ReducerAction,
 } from '@bifold/core'
-
-import { BCSCCardProcess } from 'react-native-bcsc-core'
+import { BCSCCardProcess, EvidenceMetadata } from 'react-native-bcsc-core'
 import Config from 'react-native-config'
 import { getVersion } from 'react-native-device-info'
 import { DeviceVerificationOption } from './bcsc-theme/api/hooks/useAuthorizationApi'
-import { EvidenceType, VerificationPhotoUploadPayload, VerificationPrompt } from './bcsc-theme/api/hooks/useEvidenceApi'
+import { VerificationPhotoUploadPayload, VerificationPrompt } from './bcsc-theme/api/hooks/useEvidenceApi'
 import { BCSCBannerMessage } from './bcsc-theme/components/AppBanner'
 import { ProvinceCode } from './bcsc-theme/utils/address-utils'
-import { PhotoMetadata } from './bcsc-theme/utils/file-info'
 
 export interface IASEnvironment {
   name: string
@@ -142,7 +140,7 @@ export interface BCSCSecureState {
 
   // === from Evidence Data ===
   /** Additional evidence data for non-BCSC verification */
-  additionalEvidenceData: AdditionalEvidenceData[] // initialized as an empty array to prevent ?.length usage
+  additionalEvidenceData: EvidenceMetadata[] // initialized as an empty array to prevent ?.length usage
 
   // === Security ===
   /** PBKDF2 hash of PIN used for Askar wallet encryption */
@@ -153,12 +151,6 @@ export interface BCSCSecureState {
 export const initialBCSCSecureState: BCSCSecureState = {
   isHydrated: false,
   additionalEvidenceData: [], // initialized as an empty array to prevent ?.length usage
-}
-
-export interface AdditionalEvidenceData {
-  evidenceType: EvidenceType
-  metadata: PhotoMetadata[]
-  documentNumber: string
 }
 
 export enum Mode {
@@ -236,11 +228,7 @@ enum BCSCDispatchAction {
   UPDATE_SECURE_VERIFICATION_OPTIONS = 'bcsc/updateSecureVerificationOptions',
   UPDATE_SECURE_VERIFIED = 'bcsc/updateSecureVerified',
   UPDATE_SECURE_WALLET_KEY = 'bcsc/updateSecureWalletKey',
-  ADD_SECURE_EVIDENCE_TYPE = 'bcsc/addSecureEvidenceType',
-  UPDATE_SECURE_EVIDENCE_METADATA = 'bcsc/updateSecureEvidenceMetadata',
-  UPDATE_SECURE_EVIDENCE_DOCUMENT_NUMBER = 'bcsc/updateSecureEvidenceDocumentNumber',
-  REMOVE_INCOMPLETE_SECURE_EVIDENCE = 'bcsc/removeIncompleteSecureEvidence',
-  CLEAR_SECURE_ADDITIONAL_EVIDENCE = 'bcsc/clearSecureAdditionalEvidence',
+  UPDATE_SECURE_EVIDENCE_METADATA = 'bcsc/updateAdditionalEvidenceMetadata',
   ACCOUNT_SETUP_TYPE = 'bcsc/accountSetupType',
 }
 
@@ -653,44 +641,9 @@ const bcReducer = (state: BCState, action: ReducerAction<BCDispatchAction>): BCS
       const bcscSecure = { ...state.bcscSecure, walletKey }
       return { ...state, bcscSecure }
     }
-    case BCSCDispatchAction.ADD_SECURE_EVIDENCE_TYPE: {
-      const evidenceType: EvidenceType = (action?.payload || []).pop()
-      const newEvidenceData: AdditionalEvidenceData = {
-        evidenceType,
-        metadata: [],
-        documentNumber: '',
-      }
-      const additionalEvidenceData = [...state.bcscSecure.additionalEvidenceData, newEvidenceData]
-      const bcscSecure = { ...state.bcscSecure, additionalEvidenceData }
-      return { ...state, bcscSecure }
-    }
     case BCSCDispatchAction.UPDATE_SECURE_EVIDENCE_METADATA: {
-      const { evidenceType, metadata }: { evidenceType: EvidenceType; metadata: PhotoMetadata[] } =
-        (action?.payload || []).pop() ?? {}
-      const updatedEvidenceData = state.bcscSecure.additionalEvidenceData.map((item) =>
-        item.evidenceType.evidence_type === evidenceType.evidence_type ? { ...item, metadata } : item
-      )
-      const bcscSecure = { ...state.bcscSecure, additionalEvidenceData: updatedEvidenceData }
-      return { ...state, bcscSecure }
-    }
-    case BCSCDispatchAction.UPDATE_SECURE_EVIDENCE_DOCUMENT_NUMBER: {
-      const { evidenceType, documentNumber }: { evidenceType: EvidenceType; documentNumber: string } =
-        (action?.payload || []).pop() ?? {}
-      const updatedEvidenceData = state.bcscSecure.additionalEvidenceData.map((item) =>
-        item.evidenceType.evidence_type === evidenceType.evidence_type ? { ...item, documentNumber } : item
-      )
-      const bcscSecure = { ...state.bcscSecure, additionalEvidenceData: updatedEvidenceData }
-      return { ...state, bcscSecure }
-    }
-    case BCSCDispatchAction.REMOVE_INCOMPLETE_SECURE_EVIDENCE: {
-      const completeEvidence = state.bcscSecure.additionalEvidenceData.filter(
-        (item) => item.metadata.length >= 1 && Boolean(item.documentNumber)
-      )
-      const bcscSecure = { ...state.bcscSecure, additionalEvidenceData: completeEvidence }
-      return { ...state, bcscSecure }
-    }
-    case BCSCDispatchAction.CLEAR_SECURE_ADDITIONAL_EVIDENCE: {
-      const bcscSecure = { ...state.bcscSecure, additionalEvidenceData: [] }
+      const additionalEvidenceData: EvidenceMetadata[] = (action?.payload || []).pop()
+      const bcscSecure = { ...state.bcscSecure, additionalEvidenceData }
       return { ...state, bcscSecure }
     }
 

--- a/packages/bcsc-core/ios/StorageService.swift
+++ b/packages/bcsc-core/ios/StorageService.swift
@@ -115,7 +115,7 @@ class StorageService {
   ) -> T? { // Added file parameter
     do {
       guard let accountID = self.currentAccountID else {
-        logger.error("currentAccountID is nil. Cannot read data.")
+        logger.error("readData: currentAccountID is nil. Cannot read data for file: \(file.rawValue)")
         return nil
       }
       let rootDirectoryURL = try FileManager.default.url(
@@ -165,7 +165,7 @@ class StorageService {
     do {
       // Get the current account ID first
       guard let accountID = self.currentAccountID else {
-        logger.error("currentAccountID is nil. Cannot write data.")
+        logger.error("writeData: currentAccountID is nil. Cannot write data for file: \(file.rawValue)")
         return false
       }
 
@@ -190,7 +190,7 @@ class StorageService {
       logger.log("Successfully wrote data to file: \(fileUrl.path)")
       return true
     } catch {
-      logger.error("Error writing data: \(error)")
+      logger.error("writeData: Error writing data for file \(file.rawValue): \(error)")
       return false
     }
   }
@@ -273,8 +273,9 @@ class StorageService {
 
     // Prepare the object for archiving
     let objectToArchive: Any
-    if T.self != NSDictionary.self {
-      // Wrap the object in a dictionary with provider key (reverse of decode logic)
+    if !isFoundationCollectionType {
+      // Wrap custom objects in a dictionary with provider key (reverse of decode logic)
+      // Foundation collection types (NSArray, NSDictionary) don't need wrapping
       objectToArchive = [provider: object]
     } else {
       objectToArchive = object

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -717,6 +717,19 @@ export interface EvidenceImageSide {
 }
 
 /**
+ * Photo metadata for evidence documents.
+ */
+export interface PhotoMetadata {
+  label: string;
+  content_type: string;
+  content_length: number;
+  date: number;
+  sha256: string;
+  filename?: string;
+  file_path: string;
+}
+
+/**
  * Evidence type definition - matches the API response structure.
  */
 export interface EvidenceType {
@@ -734,22 +747,13 @@ export interface EvidenceType {
 }
 
 /**
- * Evidence metadata interface for type safety.
- * Matches the AdditionalEvidenceData structure from React Native state.
+ * Matches v3 storage structure as well as additionalEvidenceData field in React Native store
  */
 export interface EvidenceMetadata {
   /** Evidence type information - full EvidenceType object */
   evidenceType: EvidenceType;
-  /** Photo metadata array - matches PhotoMetadata interface from React Native */
-  metadata: {
-    label: string;
-    content_type: string;
-    content_length: number;
-    date: number;
-    sha256: string;
-    filename?: string;
-    file_path: string;
-  }[];
+  /** Photo metadata array */
+  metadata: PhotoMetadata[];
   /** Document number/reference */
   documentNumber: string;
 }


### PR DESCRIPTION
# Summary of Changes

This PR fixes issues with evidence metadata persistence. The problem was two-pronged
- The update methods were async and created race conditions, overwriting with incorrect data - affected both OS
- The iOS readData encoding was incorrect. It was unnecessarily adding a wrapper

I also many instances of duplicated types between bcsc-core and the main app, so I consolidated the types related to evidence collection to clean things up without making it too big of a PR.

I found repeating processing between the secure actions and the store actions for evidence data, so I consolidated that as well, removing a lot of unnecessary store actions.

# Testing Instructions

Add your non-BCSC evidence and restart the app!

# Acceptance Criteria

Evidence is persisted correctly.

# Screenshots, videos, or gifs

https://github.com/user-attachments/assets/fcbdb1af-3474-4cd3-966c-ae2a096d3589

# Related Issues

#3149 