### PR TITLE
feat: selective notification processing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -426,7 +426,6 @@ jobs:
           PROOF_TEMPLATE_URL: ${{ vars.PROOF_TEMPLATE_URL }}
           REMOTE_LOGGING_URL: ${{ secrets.REMOTE_LOGGING_URL }}
           INDY_VDR_PROXY_URL: ${{ vars.INDY_VDR_PROXY_URL }}
-          ENTITLEMENTS_PATH: "ios/AriesBifold/AriesBifold.entitlements"
         run: |
           # 1. Create .env file
           echo "BUILD_TARGET=${BUILD_TARGET}" >.env
@@ -438,9 +437,6 @@ jobs:
           echo "PROOF_TEMPLATE_URL=${PROOF_TEMPLATE_URL}" >>.env
           echo "REMOTE_LOGGING_URL=${REMOTE_LOGGING_URL}" >>.env
           echo "INDY_VDR_PROXY_URL=${INDY_VDR_PROXY_URL}" >>.env
-
-          # 2. Update iOS entitlements for FCM
-          plutil -replace aps-environment -string production $ENTITLEMENTS_PATH
 
       - name: Create release keystore
         # This step will not work in a `fork` because it will not have access

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -426,7 +426,9 @@ jobs:
           PROOF_TEMPLATE_URL: ${{ vars.PROOF_TEMPLATE_URL }}
           REMOTE_LOGGING_URL: ${{ secrets.REMOTE_LOGGING_URL }}
           INDY_VDR_PROXY_URL: ${{ vars.INDY_VDR_PROXY_URL }}
+          ENTITLEMENTS_PATH: "ios/AriesBifold/AriesBifold.entitlements"
         run: |
+          # 1. Create .env file
           echo "BUILD_TARGET=${BUILD_TARGET}" >.env
           echo "MEDIATOR_USE_PUSH_NOTIFICATIONS=${MEDIATOR_USE_PUSH_NOTIFICATIONS}" >>.env
           echo "MEDIATOR_URL=${MEDIATOR_URL}" >>.env
@@ -436,6 +438,9 @@ jobs:
           echo "PROOF_TEMPLATE_URL=${PROOF_TEMPLATE_URL}" >>.env
           echo "REMOTE_LOGGING_URL=${REMOTE_LOGGING_URL}" >>.env
           echo "INDY_VDR_PROXY_URL=${INDY_VDR_PROXY_URL}" >>.env
+
+          # 2. Update iOS entitlements for FCM
+          plutil -replace aps-environment -string production $ENTITLEMENTS_PATH
 
       - name: Create release keystore
         # This step will not work in a `fork` because it will not have access

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -427,7 +427,6 @@ jobs:
           REMOTE_LOGGING_URL: ${{ secrets.REMOTE_LOGGING_URL }}
           INDY_VDR_PROXY_URL: ${{ vars.INDY_VDR_PROXY_URL }}
         run: |
-          # 1. Create .env file
           echo "BUILD_TARGET=${BUILD_TARGET}" >.env
           echo "MEDIATOR_USE_PUSH_NOTIFICATIONS=${MEDIATOR_USE_PUSH_NOTIFICATIONS}" >>.env
           echo "MEDIATOR_URL=${MEDIATOR_URL}" >>.env

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -45,7 +45,9 @@ initLanguages(localization)
 // All platform interactions happen in initialize() methods
 const pairingService = new PairingService(appLogger)
 const deepLinkViewModel = new DeepLinkViewModel(new DeepLinkService(), appLogger, pairingService)
-const fcmViewModel = new FcmViewModel(new FcmService(), appLogger, pairingService)
+// TODO(JL): Remove mode parameter when BCWallet mode is deprecated and only BCSC remains
+const appMode = Config.BUILD_TARGET === Mode.BCSC ? Mode.BCSC : Mode.BCWallet
+const fcmViewModel = new FcmViewModel(new FcmService(), appLogger, pairingService, appMode)
 
 const App = () => {
   const { t } = useTranslation()

--- a/app/__mocks__/@react-native-firebase/messaging.ts
+++ b/app/__mocks__/@react-native-firebase/messaging.ts
@@ -1,6 +1,8 @@
 const messaging = jest.fn().mockReturnValue({
   setBackgroundMessageHandler: jest.fn(),
   onMessage: jest.fn(),
+  onNotificationOpenedApp: jest.fn(),
+  getInitialNotification: jest.fn().mockResolvedValue(null),
   requestPermission: jest.fn(),
 })
 

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
@@ -1,5 +1,4 @@
 import { AbstractBifoldLogger } from '@bifold/core'
-import messaging from '@react-native-firebase/messaging'
 import { DeviceEventEmitter } from 'react-native'
 import { decodeLoginChallenge, JWK, showLocalNotification } from 'react-native-bcsc-core'
 

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
@@ -1,4 +1,5 @@
 import { AbstractBifoldLogger } from '@bifold/core'
+import messaging from '@react-native-firebase/messaging'
 import { DeviceEventEmitter } from 'react-native'
 import { decodeLoginChallenge, JWK, showLocalNotification } from 'react-native-bcsc-core'
 


### PR DESCRIPTION
# Summary of Changes

Only show foreground notifications when running BCSC mode, ignore them in BCWALLET mode.

# Testing Instructions

When running in `BCSC` mode all notifications should be shown when the app is in the foreground. When in `BCWALLET` mode notifications should only be shown when the app is backgrounded. 

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
