### PR TITLE
feat: selective foreground notification handling

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -45,7 +45,9 @@ initLanguages(localization)
 // All platform interactions happen in initialize() methods
 const pairingService = new PairingService(appLogger)
 const deepLinkViewModel = new DeepLinkViewModel(new DeepLinkService(), appLogger, pairingService)
-const fcmViewModel = new FcmViewModel(new FcmService(), appLogger, pairingService)
+// TODO(JL): Remove mode parameter when BCWallet mode is deprecated and only BCSC remains
+const appMode = Config.BUILD_TARGET === Mode.BCSC ? Mode.BCSC : Mode.BCWallet
+const fcmViewModel = new FcmViewModel(new FcmService(), appLogger, pairingService, appMode)
 
 const App = () => {
   const { t } = useTranslation()

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -45,7 +45,6 @@ initLanguages(localization)
 // All platform interactions happen in initialize() methods
 const pairingService = new PairingService(appLogger)
 const deepLinkViewModel = new DeepLinkViewModel(new DeepLinkService(), appLogger, pairingService)
-// TODO(JL): Remove mode parameter when BCWallet mode is deprecated and only BCSC remains
 const appMode = Config.BUILD_TARGET === Mode.BCSC ? Mode.BCSC : Mode.BCWallet
 const fcmViewModel = new FcmViewModel(new FcmService(), appLogger, pairingService, appMode)
 

--- a/app/__mocks__/@react-native-firebase/messaging.ts
+++ b/app/__mocks__/@react-native-firebase/messaging.ts
@@ -1,6 +1,8 @@
 const messaging = jest.fn().mockReturnValue({
   setBackgroundMessageHandler: jest.fn(),
   onMessage: jest.fn(),
+  onNotificationOpenedApp: jest.fn(),
+  getInitialNotification: jest.fn().mockResolvedValue(null),
   requestPermission: jest.fn(),
 })
 

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
@@ -182,7 +182,8 @@ export class FcmViewModel {
   private async handleGenericNotification(data: BasicNotification) {
     const { title, body } = data
 
-    // In BCWallet mode, the OS handles notifications when the app is in the background
+    // In BCWallet mode, the OS handles notifications when the
+    // app is in the background
     if (this.mode !== Mode.BCSC) {
       this.logger.info(
         '[FcmViewModel] Skipping local notification in BCWallet mode - OS handles background notifications'

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
@@ -30,7 +30,6 @@ export class FcmViewModel {
    * @param logger - Logger instance
    * @param pairingService - Service for handling pairing requests
    * @param mode - App mode (BCSC or BCWallet). Local notifications are only shown in BCSC mode.
-   *               TODO: Remove mode parameter when BCWallet mode is deprecated and only BCSC remains.
    */
   constructor(
     private readonly fcmService: FcmService,
@@ -46,8 +45,8 @@ export class FcmViewModel {
     }
     this.initialized = true
 
-    // TODO: Remove mode check when BCWallet mode is deprecated and only BCSC remains
-    // In BCWallet mode, we don't process FCM messages - the OS handles notifications
+    // Early return in BCWallet mode, we don't process FCM
+    // messages the OS handles notifications
     if (this.mode !== Mode.BCSC) {
       this.logger.info('[FcmViewModel] Skipping FCM initialization in BCWallet mode - OS handles notifications')
       return


### PR DESCRIPTION
# Summary of Changes

Only show foreground notifications when running `BCSC` mode, ignore them in `BCWALLET` mode.

# Testing Instructions

When running in `BCSC` mode all notifications should be shown when the app is in the foreground. When in `BCWALLET` mode notifications should only be shown when the app is backgrounded. 

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
