### PR TITLE
fix: unwanted autocorrect, no empty string assignment

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useEvidenceApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useEvidenceApi.tsx
@@ -67,7 +67,7 @@ export interface EvidenceMetadataResponseData {
 }
 export interface EvidenceMetadataPayload {
   type: string
-  number: string
+  number?: string
   images: VerificationPhotoUploadPayload[]
   barcodes?: {
     type: string

--- a/app/src/bcsc-theme/features/verify/ResidentialAddressScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/ResidentialAddressScreen.tsx
@@ -54,6 +54,7 @@ export const ResidentialAddressScreen = ({ navigation }: ResidentialAddressScree
         onChange={(value) => handleChange('city', value)}
         error={formErrors.city}
         subtext={t('BCSC.Address.CitySubtext')}
+        textInputProps={{ autoCorrect: false }}
       />
 
       <DropdownWithValidation
@@ -74,6 +75,7 @@ export const ResidentialAddressScreen = ({ navigation }: ResidentialAddressScree
         onChange={(value) => handleChange('postalCode', value)}
         error={formErrors.postalCode}
         subtext={t('BCSC.Address.PostalCodeSubtext')}
+        textInputProps={{ autoCorrect: false, autoCapitalize: 'characters' }}
       />
 
       <View style={{ marginTop: 48, width: '100%' }}>

--- a/app/src/bcsc-theme/features/verify/__snapshots__/ResidentialAddressScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/__snapshots__/ResidentialAddressScreen.test.tsx.snap
@@ -181,6 +181,7 @@ exports[`ResidentialAddress renders correctly 1`] = `
               BCSC.Address.CityLabel
             </Text>
             <TextInput
+              autoCorrect={false}
               onChange={[Function]}
               style={
                 [
@@ -389,6 +390,8 @@ exports[`ResidentialAddress renders correctly 1`] = `
               BCSC.Address.PostalCodeLabel
             </Text>
             <TextInput
+              autoCapitalize="characters"
+              autoCorrect={false}
               onChange={[Function]}
               style={
                 [

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
@@ -258,6 +258,7 @@ const EvidenceIDCollectionScreen = ({ navigation, route }: EvidenceIDCollectionS
           onChange={(value) => handleChange('documentNumber', value)}
           error={formErrors.documentNumber}
           subtext={`${t('BCSC.EvidenceIDCollection.DocumentNumberSubtext')} ${cardType.document_reference_sample}`}
+          textInputProps={{ autoCorrect: false }}
         />
 
         {additionalEvidenceRequired ? (

--- a/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/EvidenceIDCollectionScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/EvidenceIDCollectionScreen.test.tsx.snap
@@ -140,6 +140,7 @@ exports[`EvidenceIDCollection renders correctly 1`] = `
                 Passport Number
               </Text>
               <TextInput
+                autoCorrect={false}
                 onChange={[Function]}
                 style={
                   [

--- a/app/src/bcsc-theme/hooks/useSecureActions.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.tsx
@@ -542,10 +542,7 @@ export const useSecureActions = () => {
    */
   const addEvidenceType = useCallback(
     async (evidenceType: EvidenceType) => {
-      const updatedEvidence = [
-        ...store.bcscSecure.additionalEvidenceData,
-        { evidenceType, metadata: [], documentNumber: '' },
-      ]
+      const updatedEvidence = [...store.bcscSecure.additionalEvidenceData, { evidenceType, metadata: [] }]
 
       dispatch({
         type: BCDispatchAction.UPDATE_SECURE_EVIDENCE_METADATA,

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -755,7 +755,7 @@ export interface EvidenceMetadata {
   /** Photo metadata array */
   metadata: PhotoMetadata[];
   /** Document number/reference */
-  documentNumber: string;
+  documentNumber?: string;
 }
 
 /**


### PR DESCRIPTION
# Summary of Changes
Two small fixes:
- remove autocorrect on remaining input fields
- small change as per @jleach good suggestion of not assigning an empty string for initial object

# Testing Instructions

Go through non-bcsc flow and fill out forms, ensuring no fields autocorrect.

# Acceptance Criteria

Auto correct doesn't happen in form fields

# Screenshots, videos, or gifs

N/A

# Related Issues
#2978 
#3159 