### PR TITLE
fix: verify options ordering, heading, and spacing

### DIFF
--- a/app/src/bcsc-theme/features/verify/VerificationMethodSelectionScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/VerificationMethodSelectionScreen.test.tsx
@@ -1,12 +1,18 @@
+import { DeviceVerificationOption } from '@/bcsc-theme/api/hooks/useAuthorizationApi'
 import { render } from '@testing-library/react-native'
 import React from 'react'
 
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
+import useVerificationMethodModel from './_models/useVerificationMethodModel'
 import VerificationMethodSelectionScreen from './VerificationMethodSelectionScreen'
+
+jest.mock('./_models/useVerificationMethodModel')
 
 describe('VerificationMethodSelection', () => {
   let mockNavigation: any
+  const mockHandlePressSendVideo = jest.fn()
+  const mockHandlePressLiveCall = jest.fn()
 
   beforeEach(() => {
     mockNavigation = useNavigation()
@@ -18,7 +24,63 @@ describe('VerificationMethodSelection', () => {
     jest.useRealTimers()
   })
 
-  it('renders correctly', () => {
+  it('renders correctly with send_video as primary option', () => {
+    jest.mocked(useVerificationMethodModel).mockReturnValue({
+      handlePressSendVideo: mockHandlePressSendVideo,
+      handlePressLiveCall: mockHandlePressLiveCall,
+      sendVideoLoading: false,
+      liveCallLoading: false,
+      verificationOptions: [
+        DeviceVerificationOption.SEND_VIDEO,
+        DeviceVerificationOption.LIVE_VIDEO_CALL,
+        DeviceVerificationOption.IN_PERSON,
+      ],
+    })
+
+    const tree = render(
+      <BasicAppContext>
+        <VerificationMethodSelectionScreen navigation={mockNavigation as never} />
+      </BasicAppContext>
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders correctly with video_call as primary option', () => {
+    jest.mocked(useVerificationMethodModel).mockReturnValue({
+      handlePressSendVideo: mockHandlePressSendVideo,
+      handlePressLiveCall: mockHandlePressLiveCall,
+      sendVideoLoading: false,
+      liveCallLoading: false,
+      verificationOptions: [
+        DeviceVerificationOption.LIVE_VIDEO_CALL,
+        DeviceVerificationOption.SEND_VIDEO,
+        DeviceVerificationOption.IN_PERSON,
+      ],
+    })
+
+    const tree = render(
+      <BasicAppContext>
+        <VerificationMethodSelectionScreen navigation={mockNavigation as never} />
+      </BasicAppContext>
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders correctly with in_person as primary option', () => {
+    jest.mocked(useVerificationMethodModel).mockReturnValue({
+      handlePressSendVideo: mockHandlePressSendVideo,
+      handlePressLiveCall: mockHandlePressLiveCall,
+      sendVideoLoading: false,
+      liveCallLoading: false,
+      verificationOptions: [
+        DeviceVerificationOption.IN_PERSON,
+        DeviceVerificationOption.SEND_VIDEO,
+        DeviceVerificationOption.LIVE_VIDEO_CALL,
+      ],
+    })
+
     const tree = render(
       <BasicAppContext>
         <VerificationMethodSelectionScreen navigation={mockNavigation as never} />

--- a/app/src/bcsc-theme/features/verify/VerificationMethodSelectionScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/VerificationMethodSelectionScreen.tsx
@@ -1,7 +1,7 @@
 import { DeviceVerificationOption } from '@/bcsc-theme/api/hooks/useAuthorizationApi'
 import { Spacing } from '@/bcwallet-theme/theme'
 import { BCSCScreens, BCSCVerifyStackParams } from '@bcsc-theme/types/navigators'
-import { ScreenWrapper, ThemedText } from '@bifold/core'
+import { ScreenWrapper, ThemedText, TOKENS, useServices } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -15,12 +15,12 @@ type VerificationMethodSelectionScreenProps = {
 
 const VerificationMethodSelectionScreen = ({ navigation }: VerificationMethodSelectionScreenProps) => {
   const { t } = useTranslation()
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
 
   const { handlePressSendVideo, handlePressLiveCall, sendVideoLoading, liveCallLoading, verificationOptions } =
     useVerificationMethodModel({ navigation })
 
-  const primaryOption = verificationOptions[0]
-  const remainingOptions = verificationOptions.slice(1)
+  const [primaryOption, ...remainingOptions] = verificationOptions
 
   const headingText = useMemo(() => {
     if (primaryOption === DeviceVerificationOption.SEND_VIDEO) {
@@ -32,8 +32,10 @@ const VerificationMethodSelectionScreen = ({ navigation }: VerificationMethodSel
     if (primaryOption === DeviceVerificationOption.LIVE_VIDEO_CALL) {
       return t('BCSC.VerificationMethods.CannotVideoCall')
     }
+
+    logger.error(`Unknown primary verification option: ${primaryOption}`)
     return ''
-  }, [primaryOption, t])
+  }, [primaryOption, t, logger])
 
   const renderOption = (option: DeviceVerificationOption, borderBottomWidth?: number) => {
     if (option === DeviceVerificationOption.LIVE_VIDEO_CALL) {

--- a/app/src/bcsc-theme/features/verify/VerificationMethodSelectionScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/VerificationMethodSelectionScreen.tsx
@@ -87,7 +87,7 @@ const VerificationMethodSelectionScreen = ({ navigation }: VerificationMethodSel
     <ScreenWrapper padded={false}>
       {renderOption(primaryOption, 1)}
       <View style={{ marginTop: Spacing.xxl, paddingHorizontal: Spacing.md, marginBottom: Spacing.sm }}>
-        <ThemedText variant="headingThree">{headingText}</ThemedText>
+        <ThemedText variant="headingFour">{headingText}</ThemedText>
       </View>
       {remainingOptions.map((option, index) => {
         const borderBottomWidth = remainingOptions.length === index + 1 ? 1 : undefined

--- a/app/src/bcsc-theme/features/verify/VerificationMethodSelectionScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/VerificationMethodSelectionScreen.tsx
@@ -1,8 +1,11 @@
 import { DeviceVerificationOption } from '@/bcsc-theme/api/hooks/useAuthorizationApi'
+import { Spacing } from '@/bcwallet-theme/theme'
 import { BCSCScreens, BCSCVerifyStackParams } from '@bcsc-theme/types/navigators'
-import { ScreenWrapper } from '@bifold/core'
+import { ScreenWrapper, ThemedText } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
+import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { View } from 'react-native'
 import useVerificationMethodModel from './_models/useVerificationMethodModel'
 import VerifyMethodActionButton from './components/VerifyMethodActionButton'
 
@@ -16,58 +19,80 @@ const VerificationMethodSelectionScreen = ({ navigation }: VerificationMethodSel
   const { handlePressSendVideo, handlePressLiveCall, sendVideoLoading, liveCallLoading, verificationOptions } =
     useVerificationMethodModel({ navigation })
 
+  const primaryOption = verificationOptions[0]
+  const remainingOptions = verificationOptions.slice(1)
+
+  const headingText = useMemo(() => {
+    if (primaryOption === DeviceVerificationOption.SEND_VIDEO) {
+      return t('BCSC.VerificationMethods.CannotSendVideo')
+    }
+    if (primaryOption === DeviceVerificationOption.IN_PERSON) {
+      return t('BCSC.VerificationMethods.CannotMakeItToServiceBC')
+    }
+    if (primaryOption === DeviceVerificationOption.LIVE_VIDEO_CALL) {
+      return t('BCSC.VerificationMethods.CannotVideoCall')
+    }
+    return ''
+  }, [primaryOption, t])
+
+  const renderOption = (option: DeviceVerificationOption, borderBottomWidth?: number) => {
+    if (option === DeviceVerificationOption.LIVE_VIDEO_CALL) {
+      return (
+        <VerifyMethodActionButton
+          key="video_call"
+          title={t('BCSC.VerificationMethods.VideoCallTitle')}
+          description={t('BCSC.VerificationMethods.VideoCallDescription')}
+          icon={'video'}
+          onPress={handlePressLiveCall}
+          loading={liveCallLoading}
+          disabled={liveCallLoading || sendVideoLoading}
+          style={{ borderBottomWidth }}
+        />
+      )
+    }
+
+    if (option === DeviceVerificationOption.SEND_VIDEO) {
+      return (
+        <VerifyMethodActionButton
+          key="send_video"
+          title={t('BCSC.VerificationMethods.SendVideoTitle')}
+          description={t('BCSC.VerificationMethods.SendVideoDescription')}
+          icon={'send'}
+          onPress={handlePressSendVideo}
+          loading={sendVideoLoading}
+          disabled={sendVideoLoading || liveCallLoading}
+          style={{ borderBottomWidth }}
+        />
+      )
+    }
+
+    if (option === DeviceVerificationOption.IN_PERSON) {
+      return (
+        <VerifyMethodActionButton
+          key="in_person"
+          title={t('BCSC.VerificationMethods.InPersonTitle')}
+          description={t('BCSC.VerificationMethods.InPersonDescription')}
+          icon={'account'}
+          onPress={() => navigation.navigate(BCSCScreens.VerifyInPerson)}
+          disabled={liveCallLoading || sendVideoLoading}
+          style={{ borderBottomWidth }}
+        />
+      )
+    }
+
+    return null
+  }
+
   return (
     <ScreenWrapper padded={false}>
-      {verificationOptions
-        .map((option, index) => {
-          const borderBottomWidth = verificationOptions.length === index + 1 ? 1 : undefined
-
-          if (option === DeviceVerificationOption.LIVE_VIDEO_CALL) {
-            return (
-              <VerifyMethodActionButton
-                key="video_call"
-                title={t('BCSC.VerificationMethods.VideoCallTitle')}
-                description={t('BCSC.VerificationMethods.VideoCallDescription')}
-                icon={'video'}
-                onPress={handlePressLiveCall}
-                loading={liveCallLoading}
-                disabled={liveCallLoading || sendVideoLoading}
-                style={{ borderBottomWidth }}
-              />
-            )
-          }
-
-          if (option === DeviceVerificationOption.SEND_VIDEO) {
-            return (
-              <VerifyMethodActionButton
-                key="send_video"
-                title={t('BCSC.VerificationMethods.SendVideoTitle')}
-                description={t('BCSC.VerificationMethods.SendVideoDescription')}
-                icon={'send'}
-                onPress={handlePressSendVideo}
-                loading={sendVideoLoading}
-                disabled={sendVideoLoading || liveCallLoading}
-                style={{ borderBottomWidth }}
-              />
-            )
-          }
-
-          if (option === DeviceVerificationOption.IN_PERSON) {
-            return (
-              <VerifyMethodActionButton
-                key="in_person"
-                title={t('BCSC.VerificationMethods.InPersonTitle')}
-                description={t('BCSC.VerificationMethods.InPersonDescription')}
-                icon={'account'}
-                onPress={() => navigation.navigate(BCSCScreens.VerifyInPerson)}
-                disabled={liveCallLoading || sendVideoLoading}
-                style={{ borderBottomWidth }}
-              />
-            )
-          }
-          return null
-        })
-        .filter(Boolean)}
+      {renderOption(primaryOption, 1)}
+      <View style={{ marginTop: Spacing.xxl, paddingHorizontal: Spacing.md, marginBottom: Spacing.sm }}>
+        <ThemedText variant="headingThree">{headingText}</ThemedText>
+      </View>
+      {remainingOptions.map((option, index) => {
+        const borderBottomWidth = remainingOptions.length === index + 1 ? 1 : undefined
+        return renderOption(option, borderBottomWidth)
+      })}
     </ScreenWrapper>
   )
 }

--- a/app/src/bcsc-theme/features/verify/__snapshots__/VerificationMethodSelectionScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/__snapshots__/VerificationMethodSelectionScreen.test.tsx.snap
@@ -200,7 +200,7 @@ exports[`VerificationMethodSelection renders correctly with in_person as primary
               {
                 "color": "#313132",
                 "fontFamily": "BCSans-Regular",
-                "fontSize": 26,
+                "fontSize": 21,
                 "fontWeight": "bold",
               },
               undefined,
@@ -723,7 +723,7 @@ exports[`VerificationMethodSelection renders correctly with send_video as primar
               {
                 "color": "#313132",
                 "fontFamily": "BCSans-Regular",
-                "fontSize": 26,
+                "fontSize": 21,
                 "fontWeight": "bold",
               },
               undefined,
@@ -1246,7 +1246,7 @@ exports[`VerificationMethodSelection renders correctly with video_call as primar
               {
                 "color": "#313132",
                 "fontFamily": "BCSans-Regular",
-                "fontSize": 26,
+                "fontSize": 21,
                 "fontWeight": "bold",
               },
               undefined,

--- a/app/src/bcsc-theme/features/verify/__snapshots__/VerificationMethodSelectionScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/__snapshots__/VerificationMethodSelectionScreen.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`VerificationMethodSelection renders correctly 1`] = `
+exports[`VerificationMethodSelection renders correctly with in_person as primary option 1`] = `
 <RNCSafeAreaView
   edges={
     {
@@ -29,7 +29,1542 @@ exports[`VerificationMethodSelection renders correctly 1`] = `
     }
     showsVerticalScrollIndicator={false}
   >
-    <View />
+    <View>
+      <View
+        accessibilityLabel="BCSC.VerificationMethods.InPersonTitle verification method"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#FFFFFF",
+            "borderBottomColor": "#606060",
+            "borderBottomWidth": 1,
+            "borderTopColor": "#606060",
+            "borderTopWidth": 1,
+            "flexDirection": "row",
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/BCSC.VerificationMethods.InPersonTitle"
+      >
+        <View
+          style={
+            {
+              "flex": 1,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "flexShrink": 1,
+                "marginBottom": 8,
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#003366",
+                    "fontSize": 36,
+                  },
+                  undefined,
+                  {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              󰀄
+            </Text>
+            <Text
+              maxFontSizeMultiplier={2}
+              numberOfLines={0}
+              style={
+                [
+                  {
+                    "color": "#313132",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  },
+                  {
+                    "color": "#003366",
+                    "marginLeft": 8,
+                  },
+                ]
+              }
+            >
+              BCSC.VerificationMethods.InPersonTitle
+            </Text>
+          </View>
+          <Text
+            maxFontSizeMultiplier={2}
+            numberOfLines={0}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                },
+                {
+                  "flexShrink": 1,
+                },
+              ]
+            }
+          >
+            BCSC.VerificationMethods.InPersonDescription
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontSize": 36,
+                },
+                undefined,
+                {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                {},
+              ]
+            }
+          >
+            󰅂
+          </Text>
+        </View>
+      </View>
+      <View
+        style={
+          {
+            "marginBottom": 8,
+            "marginTop": 40,
+            "paddingHorizontal": 16,
+          }
+        }
+      >
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 26,
+                "fontWeight": "bold",
+              },
+              undefined,
+            ]
+          }
+        >
+          BCSC.VerificationMethods.CannotMakeItToServiceBC
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="BCSC.VerificationMethods.SendVideoTitle verification method"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#FFFFFF",
+            "borderBottomColor": "#606060",
+            "borderBottomWidth": undefined,
+            "borderTopColor": "#606060",
+            "borderTopWidth": 1,
+            "flexDirection": "row",
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/BCSC.VerificationMethods.SendVideoTitle"
+      >
+        <View
+          style={
+            {
+              "flex": 1,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "flexShrink": 1,
+                "marginBottom": 8,
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#003366",
+                    "fontSize": 36,
+                  },
+                  undefined,
+                  {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              󰒊
+            </Text>
+            <Text
+              maxFontSizeMultiplier={2}
+              numberOfLines={0}
+              style={
+                [
+                  {
+                    "color": "#313132",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  },
+                  {
+                    "color": "#003366",
+                    "marginLeft": 8,
+                  },
+                ]
+              }
+            >
+              BCSC.VerificationMethods.SendVideoTitle
+            </Text>
+          </View>
+          <Text
+            maxFontSizeMultiplier={2}
+            numberOfLines={0}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                },
+                {
+                  "flexShrink": 1,
+                },
+              ]
+            }
+          >
+            BCSC.VerificationMethods.SendVideoDescription
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontSize": 36,
+                },
+                undefined,
+                {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                {},
+              ]
+            }
+          >
+            󰅂
+          </Text>
+        </View>
+      </View>
+      <View
+        accessibilityLabel="BCSC.VerificationMethods.VideoCallTitle verification method"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#FFFFFF",
+            "borderBottomColor": "#606060",
+            "borderBottomWidth": 1,
+            "borderTopColor": "#606060",
+            "borderTopWidth": 1,
+            "flexDirection": "row",
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/BCSC.VerificationMethods.VideoCallTitle"
+      >
+        <View
+          style={
+            {
+              "flex": 1,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "flexShrink": 1,
+                "marginBottom": 8,
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#003366",
+                    "fontSize": 36,
+                  },
+                  undefined,
+                  {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              󰕧
+            </Text>
+            <Text
+              maxFontSizeMultiplier={2}
+              numberOfLines={0}
+              style={
+                [
+                  {
+                    "color": "#313132",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  },
+                  {
+                    "color": "#003366",
+                    "marginLeft": 8,
+                  },
+                ]
+              }
+            >
+              BCSC.VerificationMethods.VideoCallTitle
+            </Text>
+          </View>
+          <Text
+            maxFontSizeMultiplier={2}
+            numberOfLines={0}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                },
+                {
+                  "flexShrink": 1,
+                },
+              ]
+            }
+          >
+            BCSC.VerificationMethods.VideoCallDescription
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontSize": 36,
+                },
+                undefined,
+                {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                {},
+              ]
+            }
+          >
+            󰅂
+          </Text>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</RNCSafeAreaView>
+`;
+
+exports[`VerificationMethodSelection renders correctly with send_video as primary option 1`] = `
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "additive",
+      "right": "additive",
+      "top": "off",
+    }
+  }
+  style={
+    [
+      {
+        "backgroundColor": "#F2F2F2",
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <RCTScrollView
+    contentContainerStyle={
+      [
+        false,
+        undefined,
+      ]
+    }
+    showsVerticalScrollIndicator={false}
+  >
+    <View>
+      <View
+        accessibilityLabel="BCSC.VerificationMethods.SendVideoTitle verification method"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#FFFFFF",
+            "borderBottomColor": "#606060",
+            "borderBottomWidth": 1,
+            "borderTopColor": "#606060",
+            "borderTopWidth": 1,
+            "flexDirection": "row",
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/BCSC.VerificationMethods.SendVideoTitle"
+      >
+        <View
+          style={
+            {
+              "flex": 1,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "flexShrink": 1,
+                "marginBottom": 8,
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#003366",
+                    "fontSize": 36,
+                  },
+                  undefined,
+                  {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              󰒊
+            </Text>
+            <Text
+              maxFontSizeMultiplier={2}
+              numberOfLines={0}
+              style={
+                [
+                  {
+                    "color": "#313132",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  },
+                  {
+                    "color": "#003366",
+                    "marginLeft": 8,
+                  },
+                ]
+              }
+            >
+              BCSC.VerificationMethods.SendVideoTitle
+            </Text>
+          </View>
+          <Text
+            maxFontSizeMultiplier={2}
+            numberOfLines={0}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                },
+                {
+                  "flexShrink": 1,
+                },
+              ]
+            }
+          >
+            BCSC.VerificationMethods.SendVideoDescription
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontSize": 36,
+                },
+                undefined,
+                {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                {},
+              ]
+            }
+          >
+            󰅂
+          </Text>
+        </View>
+      </View>
+      <View
+        style={
+          {
+            "marginBottom": 8,
+            "marginTop": 40,
+            "paddingHorizontal": 16,
+          }
+        }
+      >
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 26,
+                "fontWeight": "bold",
+              },
+              undefined,
+            ]
+          }
+        >
+          BCSC.VerificationMethods.CannotSendVideo
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="BCSC.VerificationMethods.VideoCallTitle verification method"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#FFFFFF",
+            "borderBottomColor": "#606060",
+            "borderBottomWidth": undefined,
+            "borderTopColor": "#606060",
+            "borderTopWidth": 1,
+            "flexDirection": "row",
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/BCSC.VerificationMethods.VideoCallTitle"
+      >
+        <View
+          style={
+            {
+              "flex": 1,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "flexShrink": 1,
+                "marginBottom": 8,
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#003366",
+                    "fontSize": 36,
+                  },
+                  undefined,
+                  {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              󰕧
+            </Text>
+            <Text
+              maxFontSizeMultiplier={2}
+              numberOfLines={0}
+              style={
+                [
+                  {
+                    "color": "#313132",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  },
+                  {
+                    "color": "#003366",
+                    "marginLeft": 8,
+                  },
+                ]
+              }
+            >
+              BCSC.VerificationMethods.VideoCallTitle
+            </Text>
+          </View>
+          <Text
+            maxFontSizeMultiplier={2}
+            numberOfLines={0}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                },
+                {
+                  "flexShrink": 1,
+                },
+              ]
+            }
+          >
+            BCSC.VerificationMethods.VideoCallDescription
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontSize": 36,
+                },
+                undefined,
+                {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                {},
+              ]
+            }
+          >
+            󰅂
+          </Text>
+        </View>
+      </View>
+      <View
+        accessibilityLabel="BCSC.VerificationMethods.InPersonTitle verification method"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#FFFFFF",
+            "borderBottomColor": "#606060",
+            "borderBottomWidth": 1,
+            "borderTopColor": "#606060",
+            "borderTopWidth": 1,
+            "flexDirection": "row",
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/BCSC.VerificationMethods.InPersonTitle"
+      >
+        <View
+          style={
+            {
+              "flex": 1,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "flexShrink": 1,
+                "marginBottom": 8,
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#003366",
+                    "fontSize": 36,
+                  },
+                  undefined,
+                  {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              󰀄
+            </Text>
+            <Text
+              maxFontSizeMultiplier={2}
+              numberOfLines={0}
+              style={
+                [
+                  {
+                    "color": "#313132",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  },
+                  {
+                    "color": "#003366",
+                    "marginLeft": 8,
+                  },
+                ]
+              }
+            >
+              BCSC.VerificationMethods.InPersonTitle
+            </Text>
+          </View>
+          <Text
+            maxFontSizeMultiplier={2}
+            numberOfLines={0}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                },
+                {
+                  "flexShrink": 1,
+                },
+              ]
+            }
+          >
+            BCSC.VerificationMethods.InPersonDescription
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontSize": 36,
+                },
+                undefined,
+                {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                {},
+              ]
+            }
+          >
+            󰅂
+          </Text>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</RNCSafeAreaView>
+`;
+
+exports[`VerificationMethodSelection renders correctly with video_call as primary option 1`] = `
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "additive",
+      "right": "additive",
+      "top": "off",
+    }
+  }
+  style={
+    [
+      {
+        "backgroundColor": "#F2F2F2",
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <RCTScrollView
+    contentContainerStyle={
+      [
+        false,
+        undefined,
+      ]
+    }
+    showsVerticalScrollIndicator={false}
+  >
+    <View>
+      <View
+        accessibilityLabel="BCSC.VerificationMethods.VideoCallTitle verification method"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#FFFFFF",
+            "borderBottomColor": "#606060",
+            "borderBottomWidth": 1,
+            "borderTopColor": "#606060",
+            "borderTopWidth": 1,
+            "flexDirection": "row",
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/BCSC.VerificationMethods.VideoCallTitle"
+      >
+        <View
+          style={
+            {
+              "flex": 1,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "flexShrink": 1,
+                "marginBottom": 8,
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#003366",
+                    "fontSize": 36,
+                  },
+                  undefined,
+                  {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              󰕧
+            </Text>
+            <Text
+              maxFontSizeMultiplier={2}
+              numberOfLines={0}
+              style={
+                [
+                  {
+                    "color": "#313132",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  },
+                  {
+                    "color": "#003366",
+                    "marginLeft": 8,
+                  },
+                ]
+              }
+            >
+              BCSC.VerificationMethods.VideoCallTitle
+            </Text>
+          </View>
+          <Text
+            maxFontSizeMultiplier={2}
+            numberOfLines={0}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                },
+                {
+                  "flexShrink": 1,
+                },
+              ]
+            }
+          >
+            BCSC.VerificationMethods.VideoCallDescription
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontSize": 36,
+                },
+                undefined,
+                {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                {},
+              ]
+            }
+          >
+            󰅂
+          </Text>
+        </View>
+      </View>
+      <View
+        style={
+          {
+            "marginBottom": 8,
+            "marginTop": 40,
+            "paddingHorizontal": 16,
+          }
+        }
+      >
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 26,
+                "fontWeight": "bold",
+              },
+              undefined,
+            ]
+          }
+        >
+          BCSC.VerificationMethods.CannotVideoCall
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="BCSC.VerificationMethods.SendVideoTitle verification method"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#FFFFFF",
+            "borderBottomColor": "#606060",
+            "borderBottomWidth": undefined,
+            "borderTopColor": "#606060",
+            "borderTopWidth": 1,
+            "flexDirection": "row",
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/BCSC.VerificationMethods.SendVideoTitle"
+      >
+        <View
+          style={
+            {
+              "flex": 1,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "flexShrink": 1,
+                "marginBottom": 8,
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#003366",
+                    "fontSize": 36,
+                  },
+                  undefined,
+                  {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              󰒊
+            </Text>
+            <Text
+              maxFontSizeMultiplier={2}
+              numberOfLines={0}
+              style={
+                [
+                  {
+                    "color": "#313132",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  },
+                  {
+                    "color": "#003366",
+                    "marginLeft": 8,
+                  },
+                ]
+              }
+            >
+              BCSC.VerificationMethods.SendVideoTitle
+            </Text>
+          </View>
+          <Text
+            maxFontSizeMultiplier={2}
+            numberOfLines={0}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                },
+                {
+                  "flexShrink": 1,
+                },
+              ]
+            }
+          >
+            BCSC.VerificationMethods.SendVideoDescription
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontSize": 36,
+                },
+                undefined,
+                {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                {},
+              ]
+            }
+          >
+            󰅂
+          </Text>
+        </View>
+      </View>
+      <View
+        accessibilityLabel="BCSC.VerificationMethods.InPersonTitle verification method"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#FFFFFF",
+            "borderBottomColor": "#606060",
+            "borderBottomWidth": 1,
+            "borderTopColor": "#606060",
+            "borderTopWidth": 1,
+            "flexDirection": "row",
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/BCSC.VerificationMethods.InPersonTitle"
+      >
+        <View
+          style={
+            {
+              "flex": 1,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "flexShrink": 1,
+                "marginBottom": 8,
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#003366",
+                    "fontSize": 36,
+                  },
+                  undefined,
+                  {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              󰀄
+            </Text>
+            <Text
+              maxFontSizeMultiplier={2}
+              numberOfLines={0}
+              style={
+                [
+                  {
+                    "color": "#313132",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  },
+                  {
+                    "color": "#003366",
+                    "marginLeft": 8,
+                  },
+                ]
+              }
+            >
+              BCSC.VerificationMethods.InPersonTitle
+            </Text>
+          </View>
+          <Text
+            maxFontSizeMultiplier={2}
+            numberOfLines={0}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                },
+                {
+                  "flexShrink": 1,
+                },
+              ]
+            }
+          >
+            BCSC.VerificationMethods.InPersonDescription
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontSize": 36,
+                },
+                undefined,
+                {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                {},
+              ]
+            }
+          >
+            󰅂
+          </Text>
+        </View>
+      </View>
+    </View>
   </RCTScrollView>
 </RNCSafeAreaView>
 `;

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -901,7 +901,10 @@ const translation = {
       "VideoCallTitle": "Video call",
       "VideoCallDescription": "We will verify your identity during a video call.",
       "InPersonTitle": "In person",
-      "InPersonDescription": "Find out where to go and what to bring."
+      "InPersonDescription": "Find out where to go and what to bring.",
+      "CannotSendVideo": "Cannot send a video?",
+      "CannotMakeItToServiceBC": "Cannot make it to a Service BC Office?",
+      "CannotVideoCall": "Cannot video call?"
     },
   },
   "RemoteLogging": {

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -901,7 +901,10 @@ const translation = {
       "VideoCallTitle": "Video call (FR)",
       "VideoCallDescription": "We will verify your identity during a video call. (FR)",
       "InPersonTitle": "In person (FR)",
-      "InPersonDescription": "Find out where to go and what to bring. (FR)"
+      "InPersonDescription": "Find out where to go and what to bring. (FR)",
+      "CannotSendVideo": "Cannot send a video? (FR)",
+      "CannotMakeItToServiceBC": "Cannot make it to a Service BC Office? (FR)",
+      "CannotVideoCall": "Cannot video call? (FR)"
     },
   },
   "RemoteLogging": {

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -901,7 +901,10 @@ const translation = {
       "VideoCallTitle": "Video call (PT-BR)",
       "VideoCallDescription": "We will verify your identity during a video call. (PT-BR)",
       "InPersonTitle": "In person (PT-BR)",
-      "InPersonDescription": "Find out where to go and what to bring. (PT-BR)"
+      "InPersonDescription": "Find out where to go and what to bring. (PT-BR)",
+      "CannotSendVideo": "Cannot send a video? (PT-BR)",
+      "CannotMakeItToServiceBC": "Cannot make it to a Service BC Office? (PT-BR)",
+      "CannotVideoCall": "Cannot video call? (PT-BR)"
     },
   },
   "RemoteLogging": {


### PR DESCRIPTION
# Summary of Changes

The ordering is already there, it comes from the API. This PR really just adds the heading and spacing that v3 has, using the first returned option as the primary. See screenshot and i18n entries. So far it looks like the API is returning live call first, which doesn't seem right but I'll ask to make sure.

edit: Marcos confirmed he will be changing the order in SIT. Regardless, this code will handle that update without any further changes

# Testing Instructions

Check the VerificationMethodSelection screen

# Acceptance Criteria

VerificationMethodSelection screen looks as specified

# Screenshots, videos, or gifs

<img width="227" height="491" alt="verification_options" src="https://github.com/user-attachments/assets/e1b81d4a-4cd9-471e-8091-7b9329b87ce8" />

# Related Issues

#2891 