### PR TITLE
fix: notification prompt for android

### DIFF
--- a/app/src/bcsc-theme/features/onboarding/NotificationsScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/NotificationsScreen.tsx
@@ -58,10 +58,16 @@ export const NotificationsScreen = ({ navigation }: NotificationsScreenProps): J
 
   const checkPermissions = useCallback(async () => {
     const status = await PushNotifications.status()
-    if (
+    const hasPrompted = await PushNotifications.hasPromptedForNotifications()
+
+    // Only show PermissionDisabled if:
+    // 1. We have previously prompted the user (to work around React Native bug where status may be incorrect on fresh install)
+    // 2. The current status is DENIED or BLOCKED
+    const isDeniedOrBlocked =
       status === PushNotifications.NotificationPermissionStatus.DENIED ||
       status === PushNotifications.NotificationPermissionStatus.BLOCKED
-    ) {
+
+    if (hasPrompted && isDeniedOrBlocked) {
       setDeniedPermission(true)
     } else {
       setDeniedPermission(false)


### PR DESCRIPTION
# Summary of Changes

Handle unique case for android notification bug from react native. 
Re-utilize old unused function and persistant state for checking if notification prompt has been shown once before.

# Testing Instructions

Android clean build, deny notification prompt once.
Reset onboarding process, on notification screen, see permission disabled component to enable notifications.

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
