### PR TITLE
fix(deep-linking): handle custom URL schemes correctly

### DIFF
--- a/app/src/bcsc-theme/features/deep-linking/services/deep-linking.test.ts
+++ b/app/src/bcsc-theme/features/deep-linking/services/deep-linking.test.ts
@@ -211,11 +211,13 @@ describe('DeepLinkService', () => {
     await service.init()
 
     // Mock URL to return empty host for this specific URL pattern
-    const originalURL = global.URL
+    // Type assertion helper to avoid ESLint no-extra-semi issues
+    const globalWithURL = global as unknown as { URL: typeof URL }
+    const originalURL = globalWithURL.URL
     const customSchemeUrl =
       'ca.bc.gov.id.servicescard://pair/https%3A%2F%2Fexample.com%2Fdevice%2FTest+Service%2FABC123'
 
-    global.URL = class extends originalURL {
+    globalWithURL.URL = class extends originalURL {
       constructor(url: string) {
         super(url)
         // Simulate the behavior where custom schemes parse but return empty host
@@ -239,7 +241,7 @@ describe('DeepLinkService', () => {
         })
       )
     } finally {
-      global.URL = originalURL
+      globalWithURL.URL = originalURL
     }
   })
 })

--- a/app/src/bcsc-theme/features/deep-linking/services/deep-linking.test.ts
+++ b/app/src/bcsc-theme/features/deep-linking/services/deep-linking.test.ts
@@ -200,4 +200,46 @@ describe('DeepLinkService', () => {
     )
     expect(handler).toHaveBeenCalledWith(expect.not.objectContaining({ pairingCode: expect.any(String) }))
   })
+
+  it('falls back to custom scheme parsing when URL constructor returns empty host', async () => {
+    // This test covers the edge case where new URL() "succeeds" for custom schemes
+    // like ca.bc.gov.id.servicescard:// but returns an empty host, requiring fallback
+    // to the custom scheme parser
+    const handler = jest.fn()
+    const service = new DeepLinkService()
+    service.subscribe(handler)
+    await service.init()
+
+    // Mock URL to return empty host for this specific URL pattern
+    const originalURL = global.URL
+    const customSchemeUrl =
+      'ca.bc.gov.id.servicescard://pair/https%3A%2F%2Fexample.com%2Fdevice%2FTest+Service%2FABC123'
+
+    global.URL = class extends originalURL {
+      constructor(url: string) {
+        super(url)
+        // Simulate the behavior where custom schemes parse but return empty host
+        if (url.startsWith('ca.bc.gov.id.servicescard://')) {
+          Object.defineProperty(this, 'host', { value: '', writable: false })
+        }
+      }
+    } as typeof URL
+
+    try {
+      const eventHandler = mockLinking.addEventListener.mock.calls[0]?.[1]
+      eventHandler?.({ url: customSchemeUrl })
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rawUrl: customSchemeUrl,
+          host: 'pair',
+          path: '/https%3A%2F%2Fexample.com%2Fdevice%2FTest+Service%2FABC123',
+          serviceTitle: 'Test Service',
+          pairingCode: 'ABC123',
+        })
+      )
+    } finally {
+      global.URL = originalURL
+    }
+  })
 })

--- a/app/src/bcsc-theme/features/deep-linking/services/deep-linking.ts
+++ b/app/src/bcsc-theme/features/deep-linking/services/deep-linking.ts
@@ -67,6 +67,16 @@ export class DeepLinkService {
   private parseUrl(rawUrl: string): DeepLinkPayload {
     try {
       const url = new URL(rawUrl)
+
+      // new URL() may "succeed" for custom schemes but return empty/invalid host
+      // In that case, fall back to custom scheme parsing
+      if (!url.host) {
+        const fallback = this.parseCustomScheme(rawUrl)
+        if (fallback) {
+          return fallback
+        }
+      }
+
       return {
         rawUrl,
         host: url.host,


### PR DESCRIPTION
# Summary of Changes

Fix issue with deep link. 

# Testing Instructions

1. Open on-device browser and navigate to: https://idsit.gov.bc.ca/demo/
2. Open BC Parks (or other)
3. Select login with with Service Card App 
4. Work on iOS and Android
- [ ] The app is open, it should automatically navigate to the approval screen.
- [ ] The app is closed (cold start), the deep link is queued and is process on startup (auto navigation)
- [ ] The app is closed, at the account selection screen, he deep link is queued and is process on selection (auto navigation)

**NOTE: It can take 5-20 seconds for the BC Parks to do something once you return to that page. Be patient.**

# Acceptance Criteria

Testing works.

# Screenshots, videos, or gifs

n/a

# Related Issues

n/a