### PR TITLE
feat: verification request denied screen

### DIFF
--- a/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
+++ b/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
@@ -99,7 +99,7 @@ export const SystemModal = ({
   return (
     <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
       <ScrollView contentContainerStyle={styles.scollContainer}>
-        {iconName && <Icon name={iconName} size={iconSize} color={ColorPalette.brand.icon} style={styles.icon} />}
+        {iconName ? <Icon name={iconName} size={iconSize} color={ColorPalette.brand.icon} style={styles.icon} /> : null}
         <View style={styles.textContainer}>
           <ThemedText variant="headingThree">{headerText}</ThemedText>
           {contentText.filter(Boolean).map((text) => (

--- a/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
+++ b/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
@@ -9,7 +9,7 @@ export interface SystemModalProps {
   /**
    * Name of the MaterialIcons icon to display
    */
-  iconName: string
+  iconName?: string
   /**
    * Size of the icon (default: 200)
    */
@@ -99,7 +99,7 @@ export const SystemModal = ({
   return (
     <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
       <ScrollView contentContainerStyle={styles.scollContainer}>
-        <Icon name={iconName} size={iconSize} color={ColorPalette.brand.icon} style={styles.icon} />
+        {iconName && <Icon name={iconName} size={iconSize} color={ColorPalette.brand.icon} style={styles.icon} />}
         <View style={styles.textContainer}>
           <ThemedText variant="headingThree">{headerText}</ThemedText>
           {contentText.filter(Boolean).map((text) => (

--- a/app/src/bcsc-theme/features/verify/SetupStepsScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/SetupStepsScreen.tsx
@@ -20,7 +20,7 @@ import { ActivityIndicator, StyleSheet, TouchableOpacity, View } from 'react-nat
 import { BCSCCardProcess } from 'react-native-bcsc-core'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 import useSetupStepsModel from './_models/useSetupStepsModel'
-import { SetupStep } from './components/SetupStep'
+import { SetupStep, shouldStepBeDisabled } from './components/SetupStep'
 
 type SetupStepsScreenProps = {
   navigation: StackNavigationProp<BCSCVerifyStackParams, BCSCScreens.SetupSteps>
@@ -86,6 +86,7 @@ const SetupStepsScreen: React.FC<SetupStepsScreenProps> = ({ navigation }) => {
       subtext={steps.nickname.subtext}
       isComplete={steps.nickname.completed}
       isFocused={steps.nickname.focused}
+      isDisabled={shouldStepBeDisabled(steps.nickname.completed, steps.nickname.focused)}
       onPress={stepActions.nickname}
     />
   )
@@ -96,6 +97,7 @@ const SetupStepsScreen: React.FC<SetupStepsScreenProps> = ({ navigation }) => {
       subtext={steps.id.subtext}
       isComplete={steps.id.completed}
       isFocused={steps.id.focused}
+      isDisabled={shouldStepBeDisabled(steps.id.completed, steps.id.focused)}
       onPress={stepActions.id}
     >
       {
@@ -125,6 +127,7 @@ const SetupStepsScreen: React.FC<SetupStepsScreenProps> = ({ navigation }) => {
       subtext={steps.address.subtext}
       isComplete={steps.address.completed}
       isFocused={steps.address.focused}
+      isDisabled={shouldStepBeDisabled(steps.address.completed, steps.address.focused)}
       onPress={stepActions.address}
     />
   )
@@ -135,6 +138,7 @@ const SetupStepsScreen: React.FC<SetupStepsScreenProps> = ({ navigation }) => {
       subtext={steps.email.subtext}
       isComplete={steps.email.completed}
       isFocused={steps.email.focused}
+      isDisabled={shouldStepBeDisabled(steps.email.completed, steps.email.focused)}
       onPress={stepActions.email}
     >
       {
@@ -173,8 +177,9 @@ const SetupStepsScreen: React.FC<SetupStepsScreenProps> = ({ navigation }) => {
     <SetupStep
       title={t('BCSC.Steps.Step5')}
       subtext={steps.verify.subtext}
-      isComplete={steps.verify.completed}
+      isComplete={false} // The user won't see this step completed, they'll be veriified or need to re submit
       isFocused={steps.verify.focused}
+      isDisabled={!steps.email.completed || Boolean(store.bcscSecure.userSubmittedVerificationVideo)}
       onPress={stepActions.verify}
     />
   )
@@ -185,6 +190,7 @@ const SetupStepsScreen: React.FC<SetupStepsScreenProps> = ({ navigation }) => {
       subtext={steps.transfer.subtext}
       isComplete={steps.transfer.completed}
       isFocused={steps.transfer.focused}
+      isDisabled={shouldStepBeDisabled(steps.transfer.completed, steps.transfer.focused)}
       onPress={stepActions.transfer}
     />
   )

--- a/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
@@ -40,7 +40,6 @@ const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParam
       const { status, status_message } = await evidence.getVerificationRequestStatus(
         store.bcscSecure.verificationRequestId
       )
-      console.log('VERIFICATION STATUS: ', status)
       if (status === 'verified') {
         if (!store.bcscSecure.deviceCode || !store.bcscSecure.userCode) {
           throw new Error(t('BCSC.Steps.DeviceCodeOrUserCodeMissing'))

--- a/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
@@ -53,9 +53,6 @@ const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParam
 
         navigation.navigate(BCSCScreens.VerificationSuccess)
       } else if (status === 'cancelled') {
-        // navigate to a canclled screen
-        // clean up collected evidence
-        // open a modal
         navigation.navigate(BCSCScreens.CancelledReview, {
           agentReason: status_message ?? 'Verification request denied',
         })

--- a/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
@@ -53,7 +53,7 @@ const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParam
         navigation.navigate(BCSCScreens.VerificationSuccess)
       } else if (status === 'cancelled') {
         navigation.navigate(BCSCScreens.CancelledReview, {
-          agentReason: status_message ?? 'Verification request denied',
+          agentReason: status_message,
         })
       } else {
         navigation.navigate(BCSCScreens.PendingReview)

--- a/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
@@ -37,8 +37,10 @@ const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParam
         throw new Error(t('BCSC.Steps.VerificationIDMissing'))
       }
 
-      const { status } = await evidence.getVerificationRequestStatus(store.bcscSecure.verificationRequestId)
-
+      const { status, status_message } = await evidence.getVerificationRequestStatus(
+        store.bcscSecure.verificationRequestId
+      )
+      console.log('VERIFICATION STATUS: ', status)
       if (status === 'verified') {
         if (!store.bcscSecure.deviceCode || !store.bcscSecure.userCode) {
           throw new Error(t('BCSC.Steps.DeviceCodeOrUserCodeMissing'))
@@ -50,6 +52,13 @@ const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParam
         }
 
         navigation.navigate(BCSCScreens.VerificationSuccess)
+      } else if (status === 'cancelled') {
+        // navigate to a canclled screen
+        // clean up collected evidence
+        // open a modal
+        navigation.navigate(BCSCScreens.CancelledReview, {
+          agentReason: status_message ?? 'Verification request denied',
+        })
       } else {
         navigation.navigate(BCSCScreens.PendingReview)
       }

--- a/app/src/bcsc-theme/features/verify/components/SetupStep.tsx
+++ b/app/src/bcsc-theme/features/verify/components/SetupStep.tsx
@@ -9,24 +9,37 @@ interface SetupStepProps {
   onPress: (event: GestureResponderEvent) => void
   isComplete: boolean
   isFocused: boolean
+  isDisabled: boolean
+}
+
+/**
+ * A helper function to determine if a Setup Step should be disabled.
+ *
+ * @param isComplete
+ * @param isFocused
+ * @returns
+ */
+export const shouldStepBeDisabled = (isComplete: boolean, isFocused: boolean): boolean => {
+  return isComplete || !isFocused
 }
 
 /**
  * Renders a Setup Step component.
  *
  * Rules:
- *  1. When the Step is focused is can be pressed
+ *  1. When the Step is focused is will be highlited
  *  2. When the Step is complete is can not be pressed, and a green check will appear
  *  3. Subtext will be rendered below the Step header
  *  4. Additional children can be provided to be rendered below the subtext. ie: stepHeader->subtext->children
+ *  5. When the Step is disabled, it will not be pressable
  *
  *  @param {PropsWithChildren<SetupStepProps>} props - The SetupStep props
  *  @returns {*} {React.ReactElement}
  */
-export const SetupStep = (props: PropsWithChildren<SetupStepProps>) => {
+export const SetupStep: React.FC<PropsWithChildren<SetupStepProps>> = (props) => {
   const { TextTheme, ColorPalette } = useTheme()
 
-  const canBeFocused = props.isFocused && !props.isComplete
+  const canBeFocused = props.isFocused
   const backgroundColor = canBeFocused ? ColorPalette.brand.primary : ColorPalette.brand.secondaryBackground
   const textColor = canBeFocused ? ColorPalette.brand.text : TextTheme.headingFour.color
 
@@ -35,7 +48,7 @@ export const SetupStep = (props: PropsWithChildren<SetupStepProps>) => {
       onPress={props.onPress}
       testID={testIdWithKey(props.title)}
       accessibilityLabel={props.title}
-      disabled={props.isComplete || !props.isFocused}
+      disabled={props.isDisabled}
       style={{
         paddingVertical: 24,
         paddingHorizontal: 24,

--- a/app/src/bcsc-theme/features/verify/components/SetupStep.tsx
+++ b/app/src/bcsc-theme/features/verify/components/SetupStep.tsx
@@ -27,7 +27,7 @@ export const shouldStepBeDisabled = (isComplete: boolean, isFocused: boolean): b
  * Renders a Setup Step component.
  *
  * Rules:
- *  1. When the Step is focused is will be highlited
+ *  1. When the Step is focused is will be highlighted
  *  2. When the Step is complete is can not be pressed, and a green check will appear
  *  3. Subtext will be rendered below the Step header
  *  4. Additional children can be provided to be rendered below the subtext. ie: stepHeader->subtext->children

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledRerivewViewModel.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledRerivewViewModel.ts
@@ -1,6 +1,7 @@
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCDispatchAction, BCState } from '@/store'
 import { useStore } from '@bifold/core'
+import { useCallback } from 'react'
 
 /**
  * ViewModel hook for the CancelledReview component that provides
@@ -9,14 +10,14 @@ import { useStore } from '@bifold/core'
 const useCancelledReviewViewModel = () => {
   const [, dispatch] = useStore<BCState>()
   const { updateAccountFlags } = useSecureActions()
-  const cleanUpVerificationData = () => {
+  const cleanUpVerificationData = useCallback(() => {
     dispatch({ type: BCDispatchAction.RESET_SEND_VIDEO })
     dispatch({
       type: BCDispatchAction.UPDATE_SECURE_USER_SUBMITTED_VERIFICATION_VIDEO,
       payload: [false],
     })
     updateAccountFlags({ userSubmittedVerificationVideo: false })
-  }
+  }, [dispatch, updateAccountFlags])
   return {
     cleanUpVerificationData,
   }

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledRerivewViewModel.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledRerivewViewModel.ts
@@ -12,10 +12,6 @@ const useCancelledReviewViewModel = () => {
   const { updateAccountFlags } = useSecureActions()
   const cleanUpVerificationData = useCallback(() => {
     dispatch({ type: BCDispatchAction.RESET_SEND_VIDEO })
-    dispatch({
-      type: BCDispatchAction.UPDATE_SECURE_USER_SUBMITTED_VERIFICATION_VIDEO,
-      payload: [false],
-    })
     updateAccountFlags({ userSubmittedVerificationVideo: false })
   }, [dispatch, updateAccountFlags])
   return {

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledRerivewViewModel.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledRerivewViewModel.ts
@@ -2,6 +2,10 @@ import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCDispatchAction, BCState } from '@/store'
 import { useStore } from '@bifold/core'
 
+/**
+ * ViewModel hook for the CancelledReview component that provides
+ * the method to clean up verification related data from storage
+ */
 const useCancelledReviewViewModel = () => {
   const [, dispatch] = useStore<BCState>()
   const { updateAccountFlags } = useSecureActions()

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledRerivewViewModel.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledRerivewViewModel.ts
@@ -1,0 +1,21 @@
+import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
+import { BCDispatchAction, BCState } from '@/store'
+import { useStore } from '@bifold/core'
+
+const useCancelledReviewViewModel = () => {
+  const [, dispatch] = useStore<BCState>()
+  const { updateAccountFlags } = useSecureActions()
+  const cleanUpVerificationData = () => {
+    dispatch({ type: BCDispatchAction.RESET_SEND_VIDEO })
+    dispatch({
+      type: BCDispatchAction.UPDATE_SECURE_USER_SUBMITTED_VERIFICATION_VIDEO,
+      payload: [false],
+    })
+    updateAccountFlags({ userSubmittedVerificationVideo: false })
+  }
+  return {
+    cleanUpVerificationData,
+  }
+}
+
+export default useCancelledReviewViewModel

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
+import React from 'react'
+
+import { useNavigation } from '@mocks/@react-navigation/core'
+import { BasicAppContext } from '@mocks/helpers/app'
+import CancelledReview from './CancelledReview'
+
+describe('CancelledReview', () => {
+  let mockNavigation: any
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+    mockNavigation = useNavigation()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('renders correctly with agent reason', () => {
+    const agentReason = 'Face does not match ID document'
+    const route = {
+      params: {
+        agentReason,
+      },
+    } as any
+
+    const tree = render(
+      <BasicAppContext>
+        <CancelledReview navigation={mockNavigation} route={route} />
+      </BasicAppContext>
+    )
+
+    expect(tree).toMatchSnapshot()
+    expect(tree.getByText("Your identity couldn't be verified")).toBeTruthy()
+    expect(tree.getByText(/Face does not match ID document/)).toBeTruthy()
+  })
+
+  it('renders with default message when no agent reason provided', () => {
+    const route = {
+      params: {
+        agentReason: undefined,
+      },
+    } as any
+
+    const tree = render(
+      <BasicAppContext>
+        <CancelledReview navigation={mockNavigation} route={route} />
+      </BasicAppContext>
+    )
+
+    expect(tree.getByText("Your identity couldn't be verified")).toBeTruthy()
+    expect(tree.getByText(/No reason provided/)).toBeTruthy()
+  })
+
+  it('renders with empty object params', () => {
+    const route = {
+      params: {},
+    } as any
+
+    const tree = render(
+      <BasicAppContext>
+        <CancelledReview navigation={mockNavigation} route={route} />
+      </BasicAppContext>
+    )
+
+    expect(tree.getByText("Your identity couldn't be verified")).toBeTruthy()
+    expect(tree.getByText(/No reason provided/)).toBeTruthy()
+  })
+
+  it('navigates back when OK button is pressed', async () => {
+    const agentReason = 'Test reason'
+    const route = {
+      params: {
+        agentReason,
+      },
+    } as any
+
+    const tree = render(
+      <BasicAppContext>
+        <CancelledReview navigation={mockNavigation} route={route} />
+      </BasicAppContext>
+    )
+    await waitFor(() => {
+      const okButton = tree.getByText('OK')
+      expect(okButton).toBeTruthy()
+    })
+
+    const okButton = tree.getByText('OK')
+    fireEvent.press(okButton)
+
+    await waitFor(() => {
+      expect(mockNavigation.goBack).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('displays OK button', () => {
+    const route = {
+      params: {
+        agentReason: 'Test reason',
+      },
+    } as any
+
+    const tree = render(
+      <BasicAppContext>
+        <CancelledReview navigation={mockNavigation} route={route} />
+      </BasicAppContext>
+    )
+
+    expect(tree.getByText('OK')).toBeTruthy()
+  })
+
+  it('renders SystemModal component', () => {
+    const agentReason = 'Test reason'
+    const route = {
+      params: {
+        agentReason,
+      },
+    } as any
+
+    const tree = render(
+      <BasicAppContext>
+        <CancelledReview navigation={mockNavigation} route={route} />
+      </BasicAppContext>
+    )
+
+    // SystemModal should render with the header text
+    expect(tree.getByText("Your identity couldn't be verified")).toBeTruthy()
+  })
+})

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
@@ -32,8 +32,8 @@ describe('CancelledReview', () => {
     )
 
     expect(tree).toMatchSnapshot()
-    expect(tree.getByText("Your identity couldn't be verified")).toBeTruthy()
-    expect(tree.getByText(/Face does not match ID document/)).toBeTruthy()
+    expect(tree.getByText('BCSC.CancelledVerification.Title')).toBeTruthy()
+    expect(tree.getByText('BCSC.CancelledVerification.Label')).toBeTruthy()
   })
 
   it('renders with default message when no agent reason provided', () => {
@@ -49,8 +49,8 @@ describe('CancelledReview', () => {
       </BasicAppContext>
     )
 
-    expect(tree.getByText("Your identity couldn't be verified")).toBeTruthy()
-    expect(tree.getByText(/No reason provided/)).toBeTruthy()
+    expect(tree.getByText('BCSC.CancelledVerification.Title')).toBeTruthy()
+    expect(tree.getByText('BCSC.CancelledVerification.Label')).toBeTruthy()
   })
 
   it('renders with empty object params', () => {
@@ -64,8 +64,8 @@ describe('CancelledReview', () => {
       </BasicAppContext>
     )
 
-    expect(tree.getByText("Your identity couldn't be verified")).toBeTruthy()
-    expect(tree.getByText(/No reason provided/)).toBeTruthy()
+    expect(tree.getByText('BCSC.CancelledVerification.Title')).toBeTruthy()
+    expect(tree.getByText('BCSC.CancelledVerification.Label')).toBeTruthy()
   })
 
   it('navigates back when OK button is pressed', async () => {
@@ -82,11 +82,11 @@ describe('CancelledReview', () => {
       </BasicAppContext>
     )
     await waitFor(() => {
-      const okButton = tree.getByText('OK')
+      const okButton = tree.getByText('BCSC.CancelledVerification.Button')
       expect(okButton).toBeTruthy()
     })
 
-    const okButton = tree.getByText('OK')
+    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
     fireEvent.press(okButton)
 
     await waitFor(() => {
@@ -107,7 +107,7 @@ describe('CancelledReview', () => {
       </BasicAppContext>
     )
 
-    expect(tree.getByText('OK')).toBeTruthy()
+    expect(tree.getByText('BCSC.CancelledVerification.Button')).toBeTruthy()
   })
 
   it('renders SystemModal component', () => {
@@ -125,6 +125,6 @@ describe('CancelledReview', () => {
     )
 
     // SystemModal should render with the header text
-    expect(tree.getByText("Your identity couldn't be verified")).toBeTruthy()
+    expect(tree.getByText('BCSC.CancelledVerification.Title')).toBeTruthy()
   })
 })

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -1,11 +1,13 @@
-import { useNavigation } from '@react-navigation/native'
 import React, { useEffect } from 'react'
 
+import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { BCDispatchAction, BCState } from '@/store'
 import { useStore } from '@bifold/core'
+import { StackNavigationProp } from '@react-navigation/stack'
 import { SystemModal } from '../../modal/components/SystemModal'
 
 interface CancelledReviewProps {
+  navigation: StackNavigationProp<BCSCVerifyStackParams, BCSCScreens.CancelledReview>
   route: {
     params: {
       agentReason?: string
@@ -13,9 +15,8 @@ interface CancelledReviewProps {
   }
 }
 
-const CancelledReview = ({ route }: CancelledReviewProps) => {
+const CancelledReview = ({ navigation, route }: CancelledReviewProps) => {
   const { agentReason } = route.params
-  const navigation = useNavigation()
   const [_, dispatch] = useStore<BCState>()
 
   useEffect(() => {

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -5,18 +5,31 @@ import { BCDispatchAction, BCState } from '@/store'
 import { useStore } from '@bifold/core'
 import { SystemModal } from '../../modal/components/SystemModal'
 
-const CancelledReview: React.FC<{ agent_reason?: string }> = ({ agent_reason }) => {
+interface CancelledReviewProps {
+  route: {
+    params: {
+      agentReason?: string
+    }
+  }
+}
+
+const CancelledReview = ({ route }: CancelledReviewProps) => {
+  const { agentReason } = route.params
   const navigation = useNavigation()
   const [_, dispatch] = useStore<BCState>()
 
   useEffect(() => {
     dispatch({ type: BCDispatchAction.RESET_SEND_VIDEO })
+    dispatch({
+      type: BCDispatchAction.UPDATE_SECURE_USER_SUBMITTED_VERIFICATION_VIDEO,
+      payload: [undefined],
+    })
   }, [])
 
   return (
     <SystemModal
       headerText="Your identity couldn't be verified"
-      contentText={[`Details from Service BC agent: ${agent_reason ?? 'No reason provided'}`]}
+      contentText={[`Details from Service BC agent: \n ${agentReason ?? 'No reason provided'}`]}
       buttonText="OK"
       onButtonPress={() => {
         navigation.goBack()

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -1,23 +1,25 @@
 import { useNavigation } from '@react-navigation/native'
-import React from 'react'
+import React, { useEffect } from 'react'
 
+import { BCDispatchAction, BCState } from '@/store'
+import { useStore } from '@bifold/core'
 import { SystemModal } from '../../modal/components/SystemModal'
 
-const CancelledReview: React.FC = () => {
+const CancelledReview: React.FC<{ agent_reason?: string }> = ({ agent_reason }) => {
   const navigation = useNavigation()
+  const [_, dispatch] = useStore<BCState>()
 
-  const handleReturnHome = () => {
-    navigation.navigate('Home' as never)
-  }
+  useEffect(() => {
+    dispatch({ type: BCDispatchAction.RESET_SEND_VIDEO })
+  }, [])
 
   return (
     <SystemModal
-      iconName="phonelink-erase"
-      headerText="Butts"
-      contentText={['Where does this go', 'What about this one']}
+      headerText="Your identity couldn't be verified"
+      contentText={[`Details from Service BC agent: ${agent_reason ?? 'No reason provided'}`]}
       buttonText="OK"
       onButtonPress={() => {
-        console.log('OK WAS PRESSED')
+        navigation.goBack()
       }}
     />
   )

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -1,0 +1,26 @@
+import { useNavigation } from '@react-navigation/native'
+import React from 'react'
+
+import { SystemModal } from '../../modal/components/SystemModal'
+
+const CancelledReview: React.FC = () => {
+  const navigation = useNavigation()
+
+  const handleReturnHome = () => {
+    navigation.navigate('Home' as never)
+  }
+
+  return (
+    <SystemModal
+      iconName="phonelink-erase"
+      headerText="Butts"
+      contentText={['Where does this go', 'What about this one']}
+      buttonText="OK"
+      onButtonPress={() => {
+        console.log('OK WAS PRESSED')
+      }}
+    />
+  )
+}
+
+export default CancelledReview

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -1,12 +1,10 @@
 import React, { useEffect } from 'react'
 
-import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
-import { BCDispatchAction, BCState } from '@/store'
-import { useStore } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useTranslation } from 'react-i18next'
 import { SystemModal } from '../../modal/components/SystemModal'
+import useCancelledReviewViewModel from './CancelledRerivewViewModel'
 
 interface CancelledReviewProps {
   navigation: StackNavigationProp<BCSCVerifyStackParams, BCSCScreens.CancelledReview>
@@ -16,21 +14,21 @@ interface CancelledReviewProps {
     }
   }
 }
-
+/**
+ * A SystemModal wrapper that displays a cancellation message when a video verification request is cancelled.
+ * This component will also clean up related values (video path, metadata, prompts, etc.) from the store.
+ *
+ * @param agentReason - A reason provided by the reviewing agent on why the verification request was cancelled
+ * @returns
+ */
 const CancelledReview = ({ navigation, route }: CancelledReviewProps) => {
   const { agentReason } = route.params
   const { t } = useTranslation()
-  const [, dispatch] = useStore<BCState>()
-  const { updateAccountFlags } = useSecureActions()
+  const { cleanUpVerificationData } = useCancelledReviewViewModel()
 
   useEffect(() => {
-    dispatch({ type: BCDispatchAction.RESET_SEND_VIDEO })
-    dispatch({
-      type: BCDispatchAction.UPDATE_SECURE_USER_SUBMITTED_VERIFICATION_VIDEO,
-      payload: [false],
-    })
-    updateAccountFlags({ userSubmittedVerificationVideo: false })
-  }, [dispatch, updateAccountFlags])
+    cleanUpVerificationData()
+  }, [cleanUpVerificationData])
 
   return (
     <SystemModal

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect } from 'react'
 
+import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { BCDispatchAction, BCState } from '@/store'
 import { useStore } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
+import { useTranslation } from 'react-i18next'
 import { SystemModal } from '../../modal/components/SystemModal'
 
 interface CancelledReviewProps {
@@ -17,21 +19,29 @@ interface CancelledReviewProps {
 
 const CancelledReview = ({ navigation, route }: CancelledReviewProps) => {
   const { agentReason } = route.params
-  const [_, dispatch] = useStore<BCState>()
+  const { t } = useTranslation()
+  const [, dispatch] = useStore<BCState>()
+  const { updateAccountFlags } = useSecureActions()
 
   useEffect(() => {
     dispatch({ type: BCDispatchAction.RESET_SEND_VIDEO })
     dispatch({
       type: BCDispatchAction.UPDATE_SECURE_USER_SUBMITTED_VERIFICATION_VIDEO,
-      payload: [undefined],
+      payload: [false],
     })
-  }, [])
+    updateAccountFlags({ userSubmittedVerificationVideo: false })
+  }, [dispatch, updateAccountFlags])
 
   return (
     <SystemModal
-      headerText="Your identity couldn't be verified"
-      contentText={[`Details from Service BC agent: \n ${agentReason ?? 'No reason provided'}`]}
-      buttonText="OK"
+      headerText={t('BCSC.CancelledVerification.Title')}
+      contentText={[
+        t('BCSC.CancelledVerification.Label', {
+          reason: agentReason ?? t('BCSC.CancelledVerification.NoReason'),
+          interpolation: { escapeValue: false }, // this allows special characters to be rendered properly
+        }),
+      ]}
+      buttonText={t('BCSC.CancelledVerification.Button')}
       onButtonPress={() => {
         navigation.goBack()
       }}

--- a/app/src/bcsc-theme/features/verify/send-video/__snapshots__/CancelledReview.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/send-video/__snapshots__/CancelledReview.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`CancelledReview renders correctly with agent reason 1`] = `
             ]
           }
         >
-          Your identity couldn't be verified
+          BCSC.CancelledVerification.Title
         </Text>
         <Text
           maxFontSizeMultiplier={2}
@@ -65,8 +65,7 @@ exports[`CancelledReview renders correctly with agent reason 1`] = `
             ]
           }
         >
-          Details from Service BC agent: 
- Face does not match ID document
+          BCSC.CancelledVerification.Label
         </Text>
       </View>
     </View>
@@ -150,7 +149,7 @@ exports[`CancelledReview renders correctly with agent reason 1`] = `
             ]
           }
         >
-          OK
+          BCSC.CancelledVerification.Button
         </Text>
       </View>
     </View>

--- a/app/src/bcsc-theme/features/verify/send-video/__snapshots__/CancelledReview.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/send-video/__snapshots__/CancelledReview.test.tsx.snap
@@ -1,0 +1,159 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CancelledReview renders correctly with agent reason 1`] = `
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "additive",
+      "right": "additive",
+      "top": "off",
+    }
+  }
+  style={
+    {
+      "backgroundColor": "#FFFFFF",
+      "flex": 1,
+    }
+  }
+>
+  <RCTScrollView
+    contentContainerStyle={
+      {
+        "alignItems": "center",
+      }
+    }
+  >
+    <View>
+      <View
+        style={
+          {
+            "gap": 24,
+            "padding": 16,
+          }
+        }
+      >
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 26,
+                "fontWeight": "bold",
+              },
+              undefined,
+            ]
+          }
+        >
+          Your identity couldn't be verified
+        </Text>
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              {
+                "lineHeight": 30,
+              },
+            ]
+          }
+        >
+          Details from Service BC agent: 
+ Face does not match ID document
+        </Text>
+      </View>
+    </View>
+  </RCTScrollView>
+  <View
+    style={
+      {
+        "padding": 16,
+      }
+    }
+  >
+    <View
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "backgroundColor": "#003366",
+          "borderRadius": 4,
+          "opacity": 1,
+          "padding": 16,
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              [
+                {
+                  "color": "#FFFFFF",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                  "textAlign": "center",
+                },
+                false,
+                false,
+                false,
+              ],
+            ]
+          }
+        >
+          OK
+        </Text>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaView>
+`;

--- a/app/src/bcsc-theme/features/verify/send-video/__snapshots__/CancelledReview.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/send-video/__snapshots__/CancelledReview.test.tsx.snap
@@ -78,6 +78,7 @@ exports[`CancelledReview renders correctly with agent reason 1`] = `
     }
   >
     <View
+      accessibilityLabel="BCSC.CancelledVerification.Button"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -114,6 +115,7 @@ exports[`CancelledReview renders correctly with agent reason 1`] = `
           "padding": 16,
         }
       }
+      testID="com.ariesbifold:id/SystemModalButton"
     >
       <View
         style={

--- a/app/src/bcsc-theme/navigators/VerifyStack.tsx
+++ b/app/src/bcsc-theme/navigators/VerifyStack.tsx
@@ -59,7 +59,6 @@ import { ContactUsScreen } from '../features/settings/ContactUsScreen'
 import { SettingsPrivacyPolicyScreen } from '../features/settings/SettingsPrivacyPolicyScreen'
 import { VerifySettingsScreen } from '../features/settings/VerifySettingsScreen'
 import EnterBirthdateScreen from '../features/verify/EnterBirthdate/EnterBirthdateScreen'
-
 import CancelledReview from '../features/verify/send-video/CancelledReview'
 import { VerifyWebViewScreen } from '../features/webview/VerifyWebViewScreen'
 

--- a/app/src/bcsc-theme/navigators/VerifyStack.tsx
+++ b/app/src/bcsc-theme/navigators/VerifyStack.tsx
@@ -59,6 +59,8 @@ import { ContactUsScreen } from '../features/settings/ContactUsScreen'
 import { SettingsPrivacyPolicyScreen } from '../features/settings/SettingsPrivacyPolicyScreen'
 import { VerifySettingsScreen } from '../features/settings/VerifySettingsScreen'
 import EnterBirthdateScreen from '../features/verify/EnterBirthdate/EnterBirthdateScreen'
+
+import CancelledReview from '../features/verify/send-video/CancelledReview'
 import { VerifyWebViewScreen } from '../features/webview/VerifyWebViewScreen'
 
 const VerifyStack = () => {
@@ -169,6 +171,7 @@ const VerifyStack = () => {
       <Stack.Screen name={BCSCScreens.TakeVideo} component={TakeVideoScreen} options={{ headerShown: false }} />
       <Stack.Screen name={BCSCScreens.VideoReview} component={VideoReviewScreen} options={{ headerShown: false }} />
       <Stack.Screen name={BCSCScreens.PendingReview} component={PendingReviewScreen} />
+      <Stack.Screen name={BCSCScreens.CancelledReview} component={CancelledReview} />
       <Stack.Screen name={BCSCScreens.VideoTooLong} component={VideoTooLongScreen} options={{ headerShown: false }} />
       <Stack.Screen
         name={BCSCScreens.SuccessfullySent}

--- a/app/src/bcsc-theme/types/navigators.ts
+++ b/app/src/bcsc-theme/types/navigators.ts
@@ -42,6 +42,7 @@ export enum BCSCScreens {
   VideoReview = 'BCSCVideoReview',
   VideoTooLong = 'BCSCVideoTooLong',
   PendingReview = 'BCSCPendingReview',
+  CancelledReview = 'BCSCCancelledReview',
   SuccessfullySent = 'BCSCSuccessfullySent',
   VerificationSuccess = 'BCSCVerificationSuccess',
   ManualPairingCode = 'BCSCManualPairingCode',
@@ -159,6 +160,7 @@ export type BCSCVerifyStackParams = {
   [BCSCScreens.VideoTooLong]: { videoLengthSeconds: number }
   [BCSCScreens.SuccessfullySent]: undefined
   [BCSCScreens.PendingReview]: undefined
+  [BCSCScreens.CancelledReview]: { agentReason?: string }
   [BCSCScreens.VerificationSuccess]: undefined
   [BCSCScreens.AdditionalIdentificationRequired]: undefined
   [BCSCScreens.DualIdentificationRequired]: undefined

--- a/app/src/hooks/useSetupSteps.test.tsx
+++ b/app/src/hooks/useSetupSteps.test.tsx
@@ -382,7 +382,7 @@ describe('useSetupSteps Hook', () => {
 
       const hook = renderHook(() => useSetupSteps(store))
 
-      expect(hook.result.current.verify.focused).toBe(false)
+      expect(hook.result.current.verify.focused).toBe(true)
       expect(hook.result.current.verify.completed).toBe(true)
     })
 
@@ -401,7 +401,7 @@ describe('useSetupSteps Hook', () => {
 
       const hook = renderHook(() => useSetupSteps(store))
 
-      expect(hook.result.current.verify.focused).toBe(false)
+      expect(hook.result.current.verify.focused).toBe(true)
       expect(hook.result.current.verify.completed).toBe(true)
     })
   })
@@ -472,7 +472,7 @@ describe('useSetupSteps Hook', () => {
       hook.rerender(store)
 
       expect(hook.result.current.verify.completed).toBe(true)
-      expect(hook.result.current.verify.focused).toBe(false)
+      expect(hook.result.current.verify.focused).toBe(true)
     })
   })
 
@@ -519,20 +519,6 @@ describe('useSetupSteps Hook', () => {
       store.bcscSecure.isEmailVerified = true
       const hook = renderHook(() => useSetupSteps(store))
       expect(hook.result.current.currentStep).toBe('verify')
-    })
-
-    it('should return null when all steps are completed', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.deviceCode = 'ABCDEFGH'
-      store.bcscSecure.email = 'test@email.com'
-      store.bcscSecure.isEmailVerified = true
-      store.bcscSecure.verified = true
-      store.bcscSecure.userSubmittedVerificationVideo = false
-      const hook = renderHook(() => useSetupSteps(store))
-      expect(hook.result.current.currentStep).toBe(null)
     })
   })
 

--- a/app/src/hooks/useSetupSteps.ts
+++ b/app/src/hooks/useSetupSteps.ts
@@ -106,7 +106,7 @@ export const useSetupSteps = (store: BCState): SetupStepsResult => {
     const step2Focused = step1Completed && !step2Completed
     const step3Focused = step2Completed && !step3Completed
     const step4Focused = step2Completed && step3Completed && !step4Completed
-    const step5Focused = step2Completed && step3Completed && step4Completed && !step5Completed
+    const step5Focused = step2Completed && step3Completed && step4Completed
     const step6Focused = step1Completed && store.bcsc.accountSetupType === AccountSetupType.TransferAccount // this is used for the account transfer process
 
     // ---- Subtext generators ----

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -841,6 +841,12 @@ const translation = {
       "ExtraText": "Remember, it is not a health card, vaccine card, driver's license, or photo ID.",
       "ButtonText": "Ok"
     },
+    "CancelledVerification": {
+      "Title": "Your identity couldn't be verified",
+      "Label": "Details from Service BC agent: \n {{reason}}",
+      "Button": "Ok",
+      "NoReason": "No reason provided"
+    },
     "DualNonBCSCEvidence": {
       "Heading": "You must provide two government-issued IDs",
       "Description": "It's needed to verify your identity.",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -841,6 +841,12 @@ const translation = {
       "ExtraText": "Remember, it is not a health card, vaccine card, driver's license, or photo ID. (FR)",
       "ButtonText": "Ok (FR)"
     },
+    "CancelledVerification": {
+      "Title": "Your identity couldn't be verified (FR)",
+      "Label": "Details from Service BC agent: \n {{reason}} (FR)",
+      "Button": "Ok (FR)",
+      "NoReason": "No reason provided (FR)"
+    },
     "DualNonBCSCEvidence": {
       "Heading": "You must provide two government-issued IDs (FR)",
       "Description": "It's needed to verify your identity. (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -841,6 +841,12 @@ const translation = {
       "ExtraText": "Remember, it is not a health card, vaccine card, driver's license, or photo ID. (PT-BR)",
       "ButtonText": "Ok (PT-BR)"
     },
+    "CancelledVerification": {
+      "Title": "Your identity couldn't be verified (PT-BR)",
+      "Label": "Details from Service BC agent: \n {{reason}} (PT-BR)",
+      "Button": "Ok (PT-BR)",
+      "NoReason": "No reason provided (PT-BR)"
+    },
     "DualNonBCSCEvidence": {
       "Heading": "You must provide two government-issued IDs (PT-BR)",
       "Description": "It's needed to verify your identity. (PT-BR)",

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -2954,7 +2954,6 @@ class BcscCoreModule(
             if (prefs.contains("email_address")) {
                 result.putString("emailAddress", prefs.getString("email_address", null))
             }
-
             if (prefs.contains("user_submitted_verification_video")) {
                 result.putBoolean(
                     "userSubmittedVerificationVideo",

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -2955,6 +2955,13 @@ class BcscCoreModule(
                 result.putString("emailAddress", prefs.getString("email_address", null))
             }
 
+            if (prefs.contains("user_submitted_verification_video")) {
+                result.putBoolean(
+                    "userSubmittedVerificationVideo",
+                    prefs.getBoolean("user_submitted_verification_video", false),
+                )
+            }
+
             Log.d(NAME, "getAccountFlags: Successfully read account flags")
             promise.resolve(result)
         } catch (e: Exception) {
@@ -3011,6 +3018,9 @@ class BcscCoreModule(
                         } else {
                             editor.remove("email_address")
                         }
+                    }
+                    "userSubmittedVerificationVideo" -> {
+                        editor.putBoolean("user_submitted_verification_video", flags.getBoolean(key))
                     }
                     // Add more flag mappings as needed
                 }

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -3018,6 +3018,7 @@ class BcscCoreModule(
                             editor.remove("email_address")
                         }
                     }
+
                     "userSubmittedVerificationVideo" -> {
                         editor.putBoolean("user_submitted_verification_video", flags.getBoolean(key))
                     }


### PR DESCRIPTION
# Summary of Changes

- added new `CancelledReview` screen for denied verification requests
- added supporting `CancelledReviewViewModel`
- Modified setup steps behaviour for the final step
    - Step 5 is never complete as the user won't see the setup steps when they are verified
    - Modified logic so Step 5 is still highlighted while the verification request is pending
- added test files
- fixed an issue on android: core files were not saving flag to indicate that "user has sent a request"

# Testing Instructions

- go through onboarding
- complete setup steps
- choose send video for verification
- log into id check 
- cancel the request
- back on the device, 'check status' and see new screen
- select 'Ok' and see Step 5 of setup steps is reset

# Acceptance Criteria

- new screen is visible when check status is clicked

# Screenshots, videos, or gifs

https://github.com/user-attachments/assets/83a6e6cc-a02d-41eb-8b59-f9b3981f53ac

# Related Issues

[BC-Wallet: 3175](https://github.com/bcgov/bc-wallet-mobile/issues/3175)
[BC-Wallet: 3209](https://github.com/bcgov/bc-wallet-mobile/issues/3209)
[BC-Wallet: 2988](https://github.com/bcgov/bc-wallet-mobile/issues/2988)
