### PR TITLE
fix: check status after verification success

### DIFF
--- a/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
@@ -33,6 +33,13 @@ const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParam
   const handleCheckStatus = useCallback(async () => {
     setIsCheckingStatus(true)
     try {
+      if (store.bcscSecure.refreshToken) {
+        // If we have a refresh token we can assume verification is complete
+        // Scenario: user checked their status but closed the app before completing VerificationSuccess
+        navigation.navigate(BCSCScreens.VerificationSuccess)
+        return
+      }
+
       if (!store.bcscSecure.verificationRequestId) {
         throw new Error(t('BCSC.Steps.VerificationIDMissing'))
       }
@@ -65,6 +72,7 @@ const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParam
       setIsCheckingStatus(false)
     }
   }, [
+    store.bcscSecure.refreshToken,
     store.bcscSecure.verificationRequestId,
     store.bcscSecure.deviceCode,
     store.bcscSecure.userCode,


### PR DESCRIPTION
# Summary of Changes

Waiting on #3207

This PR fixes a bug where the check status button would not work after a previous successful status check (and app close).

# Testing Instructions

1. Go through setup steps and use "Send Video" verification
2. Verify using "ID Check" portal
3. Press check status
4. Fully close app before pressing "OK" button on successful verification screen
5. Open app and press "Check Status" -> press "OK"
6. Verified and can see home screen

# Acceptance Criteria

Can follow testing instructions and verify.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
