### PR TITLE
fix: circular navigation on external service link

### DIFF
--- a/app/src/bcsc-theme/features/services/hooks/useServiceLoginState.ts
+++ b/app/src/bcsc-theme/features/services/hooks/useServiceLoginState.ts
@@ -154,6 +154,23 @@ export const useServiceLoginState = ({
     })
   }, [serviceClientId, logger, state.pairingCode, state.serviceTitle, pairingService])
 
+  // Listen for live pairing events while the screen is mounted.
+  // This handles the case where the user opens an external browser, logs in,
+  // and a deep link arrives while they're still on ServiceLoginScreen.
+  useEffect(() => {
+    const unsubscribe = pairingService.onNavigationRequest((event) => {
+      const { serviceTitle, pairingCode } = event.params
+      logger.info(`ServiceLoginScreen: Received live pairing event for ${serviceTitle}`)
+
+      dispatch({
+        serviceTitle,
+        pairingCode,
+      })
+    })
+
+    return unsubscribe
+  }, [pairingService, logger])
+
   return {
     state,
     isLoading,


### PR DESCRIPTION
# Summary of Changes

Fix navigation when doing a deep link from the a services screen. See video in #3218 for more information.

# Testing Instructions

1. Open the app with a setup account
2. Go to the services screen / tab
3. Select BC Parks (needs to Link to an external service, this one I know does)
4. Open the external link
5. Logon with BC Services App. This will deep link to the app
6. The app should open and show you the correct "Do you want to logon ..." screen. It should **not** be showing you the screen with the link anymore (what you saw when you left the app).

# Acceptance Criteria

Instructions pass

# Screenshots, videos, or gifs

n/a

# Related Issues

#3218