### PR TITLE
feat: live call cellular network warning alert (31)

### DIFF
--- a/app/src/bcsc-theme/features/verify/live-call/BeforeYouCallScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/BeforeYouCallScreen.test.tsx
@@ -4,6 +4,7 @@ import { testIdWithKey } from '@bifold/core'
 import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 
+import { ErrorAlertProvider } from '@/contexts/ErrorAlertContext'
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
 import BeforeYouCallScreen from './BeforeYouCallScreen'
@@ -14,17 +15,14 @@ describe('BeforeYouCall', () => {
   beforeEach(() => {
     mockNavigation = useNavigation()
     jest.clearAllMocks()
-    jest.useFakeTimers()
-  })
-
-  afterEach(() => {
-    jest.useRealTimers()
   })
 
   it('renders correctly', () => {
     const tree = render(
       <BasicAppContext>
-        <BeforeYouCallScreen navigation={mockNavigation as never} route={{ params: {} } as never} />
+        <ErrorAlertProvider>
+          <BeforeYouCallScreen navigation={mockNavigation as never} route={{ params: {} } as never} />
+        </ErrorAlertProvider>
       </BasicAppContext>
     )
 
@@ -34,7 +32,9 @@ describe('BeforeYouCall', () => {
   it('navigates to VerifyWebView with verify-by-call help when Assistance is pressed', () => {
     const tree = render(
       <BasicAppContext>
-        <BeforeYouCallScreen navigation={mockNavigation as never} route={{ params: {} } as never} />
+        <ErrorAlertProvider>
+          <BeforeYouCallScreen navigation={mockNavigation as never} route={{ params: {} } as never} />
+        </ErrorAlertProvider>
       </BasicAppContext>
     )
 

--- a/app/src/bcsc-theme/features/verify/live-call/BeforeYouCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/BeforeYouCallScreen.tsx
@@ -1,5 +1,6 @@
 import { HelpCentreUrl } from '@/constants'
 import { useErrorAlert } from '@/contexts/ErrorAlertContext'
+import { AppError, ErrorRegistry } from '@/errors'
 import { BCSCScreens, BCSCVerifyStackParams } from '@bcsc-theme/types/navigators'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import NetInfo, { useNetInfo } from '@react-native-community/netinfo'
@@ -18,7 +19,7 @@ const BeforeYouCallScreen = ({ navigation, route }: BeforeYouCallScreenProps) =>
   const { Spacing } = useTheme()
   const { type: networkType, isConnected } = useNetInfo()
   const { t } = useTranslation()
-  const { emitAlert } = useErrorAlert()
+  const { emitErrorAlert } = useErrorAlert()
   const { formattedHours } = route.params || {}
 
   // Use the passed formatted hours or fallback to default
@@ -45,7 +46,9 @@ const BeforeYouCallScreen = ({ navigation, route }: BeforeYouCallScreenProps) =>
     const netInfo = await NetInfo.refresh()
 
     if (netInfo.type === 'cellular') {
-      emitAlert(t('Alerts.CellularDetected.Title'), t('Alerts.CellularDetected.Description'), {
+      // Note: Intentionally not tracking error event, only tracking the alert event.
+      const appError = AppError.fromErrorDefinition(ErrorRegistry.VIDEO_CALL_DATA_USE_WARNING, { track: false })
+      emitErrorAlert(appError, {
         actions: [
           {
             text: t('Alerts.Actions.Cancel'),

--- a/app/src/bcsc-theme/features/verify/live-call/BeforeYouCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/BeforeYouCallScreen.tsx
@@ -50,11 +50,11 @@ const BeforeYouCallScreen = ({ navigation, route }: BeforeYouCallScreenProps) =>
         event: AppEventCode.DATA_USE_WARNING,
         actions: [
           {
-            text: t('Alerts.DataUseWarning.Primary'),
+            text: t('Alerts.DataUseWarning.Action1'),
             style: 'cancel',
           },
           {
-            text: t('Alerts.DataUseWarning.Secondary'),
+            text: t('Alerts.DataUseWarning.Action2'),
             onPress: navigateToCamera,
             style: 'destructive',
           },

--- a/app/src/bcsc-theme/features/verify/live-call/BeforeYouCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/BeforeYouCallScreen.tsx
@@ -1,6 +1,6 @@
 import { HelpCentreUrl } from '@/constants'
 import { useErrorAlert } from '@/contexts/ErrorAlertContext'
-import { AppError, ErrorRegistry } from '@/errors'
+import { AppEventCode } from '@/events/appEventCode'
 import { BCSCScreens, BCSCVerifyStackParams } from '@bcsc-theme/types/navigators'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import NetInfo, { useNetInfo } from '@react-native-community/netinfo'
@@ -19,7 +19,7 @@ const BeforeYouCallScreen = ({ navigation, route }: BeforeYouCallScreenProps) =>
   const { Spacing } = useTheme()
   const { type: networkType, isConnected } = useNetInfo()
   const { t } = useTranslation()
-  const { emitErrorAlert } = useErrorAlert()
+  const { emitAlert } = useErrorAlert()
   const { formattedHours } = route.params || {}
 
   // Use the passed formatted hours or fallback to default
@@ -46,16 +46,15 @@ const BeforeYouCallScreen = ({ navigation, route }: BeforeYouCallScreenProps) =>
     const netInfo = await NetInfo.refresh()
 
     if (netInfo.type === 'cellular') {
-      // Note: Intentionally not tracking error event, only tracking the alert event.
-      const appError = AppError.fromErrorDefinition(ErrorRegistry.VIDEO_CALL_DATA_USE_WARNING, { track: false })
-      emitErrorAlert(appError, {
+      emitAlert(t('Alerts.DataUseWarning.Title'), t('Alerts.DataUseWarning.Description'), {
+        event: AppEventCode.DATA_USE_WARNING,
         actions: [
           {
-            text: t('Alerts.Actions.Cancel'),
+            text: t('Alerts.DataUseWarning.Primary'),
             style: 'cancel',
           },
           {
-            text: t('Alerts.Actions.UseData'),
+            text: t('Alerts.DataUseWarning.Secondary'),
             onPress: navigateToCamera,
             style: 'destructive',
           },

--- a/app/src/errors/errorRegistry.ts
+++ b/app/src/errors/errorRegistry.ts
@@ -421,14 +421,6 @@ export const ErrorRegistry = {
     severity: ErrorSeverity.WARNING,
     category: ErrorCategory.VERIFICATION,
   },
-  VIDEO_CALL_DATA_USE_WARNING: {
-    statusCode: 2410,
-    appEvent: AppEventCode.DATA_USE_WARNING,
-    titleKey: 'BCWalletError.Verification.VideoCallCellularDetectedTitle',
-    descriptionKey: 'BCWalletError.Verification.VideoCallCellularDetectedDescription',
-    severity: ErrorSeverity.WARNING,
-    category: ErrorCategory.VERIFICATION,
-  },
 
   // ============================================
   // Token/Crypto Errors (2500-2599)

--- a/app/src/errors/errorRegistry.ts
+++ b/app/src/errors/errorRegistry.ts
@@ -421,6 +421,14 @@ export const ErrorRegistry = {
     severity: ErrorSeverity.WARNING,
     category: ErrorCategory.VERIFICATION,
   },
+  VIDEO_CALL_DATA_USE_WARNING: {
+    statusCode: 2410,
+    appEvent: AppEventCode.DATA_USE_WARNING,
+    titleKey: 'BCWalletError.Verification.VideoCallCellularDetectedTitle',
+    descriptionKey: 'BCWalletError.Verification.VideoCallCellularDetectedDescription',
+    severity: ErrorSeverity.WARNING,
+    category: ErrorCategory.VERIFICATION,
+  },
 
   // ============================================
   // Token/Crypto Errors (2500-2599)

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -1040,8 +1040,8 @@ const translation = {
     "DataUseWarning": {
       "Title": "Data Use",
       "Description": "The app detected that you’re on a cellular network. Calls are free over Wi-Fi. Standard data charges apply for calls over a cellular network.",
-      "Primary": "Cancel",
-      "Secondary": "Use Data",
+      "Action1": "Cancel",
+      "Action2": "Use Data",
     }
 	},
   "BCWalletError": {

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -1039,10 +1039,6 @@ const translation = {
       "RemoveAccount": "Remove Account",
       "UseData": "Use Data",
 		},
-    "CellularDetected": {
-      "Title": "Data Use",
-      "Description": "The app detected that you’re on a cellular network. Calls are free over Wi-Fi. Standard data charges apply for calls over a cellular network.",
-    }
 	},
   "BCWalletError": {
     "Camera": {
@@ -1107,6 +1103,8 @@ const translation = {
       "VideoServiceHoursNull": "Video service hours could not be retrieved. Please try again later.",
       "VerifyRequestExpiredTitle": "Setup Expired",
       "VerifyRequestExpiredDescription": "You must start set up again.",
+      "VideoCallCellularDetectedTitle": "Data Use",
+      "VideoCallCellularDetectedDescription": "The app detected that you’re on a cellular network. Calls are free over Wi-Fi. Standard data charges apply for calls over a cellular network.",
     },
     "Token": {
       "Title": "Authentication Error",

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -1034,11 +1034,15 @@ const translation = {
 		"Actions": {
 			"DefaultOK": "OK",
       "Close": "Close",
-      "Cancel": "Cancel",
       "GoToAppStore": "Go to App Store",
       "RemoveAccount": "Remove Account",
-      "UseData": "Use Data",
 		},
+    "DataUseWarning": {
+      "Title": "Data Use",
+      "Description": "The app detected that you’re on a cellular network. Calls are free over Wi-Fi. Standard data charges apply for calls over a cellular network.",
+      "Primary": "Cancel",
+      "Secondary": "Use Data",
+    }
 	},
   "BCWalletError": {
     "Camera": {
@@ -1103,8 +1107,6 @@ const translation = {
       "VideoServiceHoursNull": "Video service hours could not be retrieved. Please try again later.",
       "VerifyRequestExpiredTitle": "Setup Expired",
       "VerifyRequestExpiredDescription": "You must start set up again.",
-      "VideoCallCellularDetectedTitle": "Data Use",
-      "VideoCallCellularDetectedDescription": "The app detected that you’re on a cellular network. Calls are free over Wi-Fi. Standard data charges apply for calls over a cellular network.",
     },
     "Token": {
       "Title": "Authentication Error",

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -1034,9 +1034,15 @@ const translation = {
 		"Actions": {
 			"DefaultOK": "OK",
       "Close": "Close",
+      "Cancel": "Cancel",
       "GoToAppStore": "Go to App Store",
       "RemoveAccount": "Remove Account",
-		}
+      "UseData": "Use Data",
+		},
+    "CellularDetected": {
+      "Title": "Data Use",
+      "Description": "The app detected that you’re on a cellular network. Calls are free over Wi-Fi. Standard data charges apply for calls over a cellular network.",
+    }
 	},
   "BCWalletError": {
     "Camera": {

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -1036,7 +1036,13 @@ const translation = {
       "Close": "Close (FR)",
       "GoToAppStore": "Go to App Store (FR)",
       "RemoveAccount": "Remove Account (FR)",
-		}
+		},
+    "DataUseWarning": {
+      "Title": "Data Use (FR)",
+      "Description": "The app detected that you’re on a cellular network. Calls are free over Wi-Fi. Standard data charges apply for calls over a cellular network. (FR)",
+      "Primary": "Cancel (FR)",
+      "Secondary": "Use Data (FR)",
+    }
 	},
   "BCWalletError": {
     // TODO (MD): Fill in translations once all english errors are completed

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -1040,8 +1040,8 @@ const translation = {
     "DataUseWarning": {
       "Title": "Data Use (FR)",
       "Description": "The app detected that you’re on a cellular network. Calls are free over Wi-Fi. Standard data charges apply for calls over a cellular network. (FR)",
-      "Primary": "Cancel (FR)",
-      "Secondary": "Use Data (FR)",
+      "Action1": "Cancel (FR)",
+      "Action2": "Use Data (FR)",
     }
 	},
   "BCWalletError": {

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -1036,7 +1036,13 @@ const translation = {
       "Close": "Close (PT-BR)",
       "GoToAppStore": "Go to App Store (PT-BR)",
       "RemoveAccount": "Remove Account (PT-BR)",
-		}
+		},
+    "DataUseWarning": {
+      "Title": "Data Use (PT-BR)",
+      "Description": "The app detected that you’re on a cellular network. Calls are free over Wi-Fi. Standard data charges apply for calls over a cellular network. (PT-BR)",
+      "Primary": "Cancel (PT-BR)",
+      "Secondary": "Use Data (PT-BR)",
+    }
 	},
   "BCWalletError": {
     // TODO (MD): Fill in translations once all english errors are completed

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -1040,8 +1040,8 @@ const translation = {
     "DataUseWarning": {
       "Title": "Data Use (PT-BR)",
       "Description": "The app detected that you’re on a cellular network. Calls are free over Wi-Fi. Standard data charges apply for calls over a cellular network. (PT-BR)",
-      "Primary": "Cancel (PT-BR)",
-      "Secondary": "Use Data (PT-BR)",
+      "Action1": "Cancel (PT-BR)",
+      "Action2": "Use Data (PT-BR)",
     }
 	},
   "BCWalletError": {


### PR DESCRIPTION
# Summary of Changes

This PR adds alert #31 cellular data warning on live call.

Also a slight improvement to the AppError class in regards to Analytics tracking.

# Testing Instructions

1. Disable Wifi + enable cellular data
2. Verify by live video
3. Press continue
4. Alert renders. Cancel closes, Use Data navigates to photo screen

# Acceptance Criteria

Follow testing instructions

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
