### PR TITLE
fix: send video failing after automatic workflow detection

### DIFF
--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.tsx
@@ -109,7 +109,7 @@ const EvidenceCaptureScreen = ({ navigation, route }: EvidenceCaptureScreenProps
     }
 
     /**
-     * Combo card or dual barcode - (ie: serial + birthdate)
+     * Combo card
      * Additional evidence: Not needed
      * Next Step: Navigate to setup steps verification
      */
@@ -122,7 +122,7 @@ const EvidenceCaptureScreen = ({ navigation, route }: EvidenceCaptureScreenProps
     }
 
     /**
-     * BC Services card - (ie: serial)
+     * BC Services card
      * Additional evidence: Not needed
      * Next Step: Navigate to birthdate entry -> setup steps verification
      */
@@ -132,7 +132,7 @@ const EvidenceCaptureScreen = ({ navigation, route }: EvidenceCaptureScreenProps
     }
 
     /**
-     * Driver's License - (ie: birthdate)
+     * Driver's License
      * Additional evidence: Required
      * Next Step: Navigate to evidence ID collection (after all photos captured)
      */

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.tsx
@@ -5,11 +5,12 @@ import { CameraFormat } from '@/bcsc-theme/components/utils/camera-format'
 import { useCardScanner } from '@/bcsc-theme/hooks/useCardScanner'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
+import { DriversLicenseMetadata } from '@/bcsc-theme/utils/decoder-strategy/DecoderStrategy'
 import { getPhotoMetadata } from '@/bcsc-theme/utils/file-info'
 import { useAutoRequestPermission } from '@/hooks/useAutoRequestPermission'
-import { MaskType, TOKENS, useServices, useTheme } from '@bifold/core'
+import { MaskType, testIdWithKey, TOKENS, useServices, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { StyleSheet, useWindowDimensions, View } from 'react-native'
 import { EvidenceType, PhotoMetadata } from 'react-native-bcsc-core'
 import { useCameraPermission, useCodeScanner } from 'react-native-vision-camera'
@@ -27,7 +28,7 @@ enum CaptureState {
 
 const EvidenceCaptureScreen = ({ navigation, route }: EvidenceCaptureScreenProps) => {
   const { cardType } = route.params
-  const { updateEvidenceMetadata } = useSecureActions()
+  const { clearAdditionalEvidence, updateEvidenceMetadata } = useSecureActions()
   const [currentIndex, setCurrentIndex] = useState(0)
   const [captureState, setCaptureState] = useState<CaptureState>(CaptureState.CAPTURING)
   const [currentPhotoPath, setCurrentPhotoPath] = useState<string>()
@@ -37,6 +38,9 @@ const EvidenceCaptureScreen = ({ navigation, route }: EvidenceCaptureScreenProps
   const { ColorPalette } = useTheme()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const scanner = useCardScanner()
+  const bcscSerialRef = useRef<string | null>(null)
+  const licenseRef = useRef<DriversLicenseMetadata | null>(null)
+  const { isLoading: isCameraLoading } = useAutoRequestPermission(hasPermission, requestPermission)
   const codeScanner = useCodeScanner({
     codeTypes: scanner.codeTypes,
     onCodeScanned: async (codes) => {
@@ -44,23 +48,18 @@ const EvidenceCaptureScreen = ({ navigation, route }: EvidenceCaptureScreenProps
         return
       }
 
-      await scanner.scanCard(codes, async (bcscSerial, license) => {
-        if (bcscSerial && license) {
-          scanner.completeScan()
-          await scanner.handleScanComboCard(bcscSerial, license)
-          return
-        }
+      // If we have already captured both values, no need to keep scanning
+      if (bcscSerialRef.current && licenseRef.current) {
+        return
+      }
 
+      await scanner.scanCard(codes, async (bcscSerial, license) => {
         if (bcscSerial) {
-          scanner.completeScan()
-          await scanner.handleScanBCServicesCard(bcscSerial)
-          return
+          bcscSerialRef.current = bcscSerial
         }
 
         if (license) {
-          scanner.completeScan()
-          scanner.handleScanDriversLicense(license)
-          return
+          licenseRef.current = license
         }
       })
     },
@@ -99,9 +98,46 @@ const EvidenceCaptureScreen = ({ navigation, route }: EvidenceCaptureScreenProps
     setCaptureState(CaptureState.REVIEWING)
   }
 
+  /**
+   * Handles accepting the captured photo and proceeding to the next step.
+   *
+   * @returns A promise that resolves when the process is complete.
+   */
   const handleAcceptPhoto = async () => {
     if (!currentPhotoPath || !currentSide) {
       return
+    }
+
+    /**
+     * Combo card or dual barcode - (ie: serial + birthdate)
+     * Additional evidence: Not needed
+     * Next Step: Navigate to setup steps verification
+     */
+    if (bcscSerialRef.current && licenseRef.current) {
+      await Promise.all([
+        clearAdditionalEvidence(),
+        scanner.handleScanComboCard(bcscSerialRef.current, licenseRef.current),
+      ])
+      return
+    }
+
+    /**
+     * BC Services card - (ie: serial)
+     * Additional evidence: Not needed
+     * Next Step: Navigate to birthdate entry -> setup steps verification
+     */
+    if (bcscSerialRef.current) {
+      await Promise.all([clearAdditionalEvidence(), scanner.handleScanBCServicesCard(bcscSerialRef.current)])
+      return
+    }
+
+    /**
+     * Driver's License - (ie: birthdate)
+     * Additional evidence: Required
+     * Next Step: Navigate to evidence ID collection (after all photos captured)
+     */
+    if (licenseRef.current) {
+      scanner.handleScanDriversLicense(licenseRef.current)
     }
 
     const photoMetadata = await getPhotoMetadata(currentPhotoPath, logger)
@@ -113,12 +149,13 @@ const EvidenceCaptureScreen = ({ navigation, route }: EvidenceCaptureScreenProps
       await updateEvidenceMetadata(route.params.cardType, newPhotos)
       // All photos captured, navigate to form screen
       navigation.navigate(BCSCScreens.EvidenceIDCollection, { cardType })
-    } else {
-      // Move to next side
-      setCurrentIndex((prev) => prev + 1)
-      setCaptureState(CaptureState.CAPTURING)
-      setCurrentPhotoPath(undefined)
+      return
     }
+
+    // Move to next side
+    setCurrentIndex((prev) => prev + 1)
+    setCaptureState(CaptureState.CAPTURING)
+    setCurrentPhotoPath(undefined)
   }
 
   const handleRetakePhoto = () => {
@@ -126,15 +163,13 @@ const EvidenceCaptureScreen = ({ navigation, route }: EvidenceCaptureScreenProps
     setCurrentPhotoPath(undefined)
   }
 
-  const { isLoading } = useAutoRequestPermission(hasPermission, requestPermission)
-
   if (!currentSide) {
     // needs to throw an error instead...
     return <></>
   }
 
-  if (isLoading) {
-    return <LoadingScreenContent loading={isLoading} onLoaded={() => {}} />
+  if (isCameraLoading) {
+    return <LoadingScreenContent loading={isCameraLoading} onLoaded={() => {}} />
   }
 
   if (!hasPermission) {
@@ -144,7 +179,7 @@ const EvidenceCaptureScreen = ({ navigation, route }: EvidenceCaptureScreenProps
   return (
     <>
       {captureState === CaptureState.CAPTURING ? (
-        <View style={styles.container}>
+        <View style={styles.container} testID={testIdWithKey('EvidenceCaptureScreenMaskedCamera')}>
           <MaskedCamera
             navigation={navigation}
             cameraFace={'back'}

--- a/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/EvidenceCaptureScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/EvidenceCaptureScreen.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`EvidenceCapture renders correctly 1`] = `
       "position": "relative",
     }
   }
+  testID="com.ariesbifold:id/EvidenceCaptureScreenMaskedCamera"
 >
   <RNCSafeAreaView
     edges={


### PR DESCRIPTION
# Summary of Changes

1. Fixed issue with evidence not being properly cleaned up when app automatically switches workflow during evidence capture.
2. Delayed the workflow switching till after the user confirms their evidence. This improves the chance the system has captured all visible barcodes.

# Testing Instructions
Script to generate BC barcode based on JSON file https://github.com/MacDeluca/barcode 

### Steps to reproduce
1. Select oop flow
2. SCAN a BCSC as primary ID in Step 2
3. In step 5 select send video
4. Capture Selfie
5. Capture video
6. Click Send to Service BC Now button

# Acceptance Criteria

Captured video sent to Service BC (without error)

# Screenshots, videos, or gifs

### Barcode metadata:
CSN: C068011351
Birthdate: 25-06-1951

### Android BC services card barcode
<img width="284" height="46" alt="bcsc_barcode_android_code39" src="https://github.com/user-attachments/assets/35dd6ec7-9df3-47d8-a1c9-50f3e030c116" />

### iOS BC services card barcode
<img width="284" height="46" alt="bcsc_barcode_ios_code39" src="https://github.com/user-attachments/assets/d9dc74e6-ef0e-43bb-bc0a-7e3fcdb7799e" />

### Combo card barcode
<img width="376" height="57" alt="license_barcode_pdf417" src="https://github.com/user-attachments/assets/42b3f85e-90f2-4c36-a910-da9217cb5e04" />

### Drivers license barcode
<img width="342" height="63" alt="license_combo_barcode_pdf417" src="https://github.com/user-attachments/assets/c7e1173c-067f-4c83-ab5f-3fa157bb90dd" />

# Related Issues

https://github.com/bcgov/bc-wallet-mobile/issues/3216
