### PR TITLE
fix(service): surface keypair generation errors to user

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
@@ -150,7 +150,6 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
       } catch (error) {
         if (isBcscNativeError(error) && error.code === BcscNativeErrorCodes.KEYPAIR_GENERATION_FAILED) {
           emitError('KEYPAIR_GENERATION_ERROR', { error })
-          return
         }
         throw error
       }
@@ -219,7 +218,6 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
         } catch (error) {
           if (isBcscNativeError(error) && error.code === BcscNativeErrorCodes.KEYPAIR_GENERATION_FAILED) {
             emitError('KEYPAIR_GENERATION_ERROR', { error })
-            return
           }
           throw error
         }

--- a/app/src/errors/errorRegistry.ts
+++ b/app/src/errors/errorRegistry.ts
@@ -684,7 +684,7 @@ export const ErrorRegistry = {
   KEYPAIR_GENERATION_ERROR: {
     statusCode: 2707,
     appEvent: AppEventCode.ADD_CARD_KEYPAIR_GENERATION,
-    titleKey: 'BCWalletError.Device.Title',
+    titleKey: 'BCWalletError.Device.KeypairGenerationTitle',
     descriptionKey: 'BCWalletError.Device.KeypairGenerationError',
     severity: ErrorSeverity.ERROR,
     category: ErrorCategory.DEVICE,

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -1173,7 +1173,8 @@ const translation = {
       "ClockSkew": "Your device clock is not synchronized. Please check your date and time settings.",
       "AuthorizationError": "Device authorization failed. Please try again.",
       "IncorrectOS": "This app is not supported on your current operating system.",
-      "KeypairGenerationError": "Failed to generate device keys. Please try again.",
+      "KeypairGenerationError": "The app does not appear to be installed correctly. Please remove the app from your device and add it again.",
+      "KeypairGenerationTitle": "Problem with App",
     },
     "General": {
       "Title": "Something Went Wrong",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -1072,6 +1072,10 @@ const translation = {
 	},
   "BCWalletError": {
     // TODO (MD): Fill in translations once all english errors are completed
+    "Device": {
+      "KeypairGenerationError": "(FR) The app does not appear to be installed correctly. Please remove the app from your device and add it again.",
+      "KeypairGenerationTitle": "(FR) Problem with App",
+    },
   },
 }
 

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -1072,6 +1072,10 @@ const translation = {
 	},
   "BCWalletError": {
     // TODO (MD): Fill in translations once all english errors are completed
+    "Device": {
+      "KeypairGenerationError": "(PT-BR) The app does not appear to be installed correctly. Please remove the app from your device and add it again.",
+      "KeypairGenerationTitle": "(PT-BR) Problem with App",
+    },
   },
 }
 

--- a/app/src/services/system-checks/UpdateDeviceRegistrationSystemCheck.ts
+++ b/app/src/services/system-checks/UpdateDeviceRegistrationSystemCheck.ts
@@ -3,7 +3,7 @@ import { BCDispatchAction } from '@/store'
 import { getVersion } from 'react-native-device-info'
 import { SystemCheckStrategy, SystemCheckUtils } from './system-checks'
 
-type UpdateRegistrationFunction = () => Promise<RegistrationResponseData>
+type UpdateRegistrationFunction = () => Promise<RegistrationResponseData | undefined>
 
 /**
  * Checks conditions to determine if the device registration needs to be updated.

--- a/app/src/services/system-checks/UpdateDeviceRegistrationSystemCheck.ts
+++ b/app/src/services/system-checks/UpdateDeviceRegistrationSystemCheck.ts
@@ -3,7 +3,7 @@ import { BCDispatchAction } from '@/store'
 import { getVersion } from 'react-native-device-info'
 import { SystemCheckStrategy, SystemCheckUtils } from './system-checks'
 
-type UpdateRegistrationFunction = () => Promise<RegistrationResponseData | undefined>
+type UpdateRegistrationFunction = () => Promise<RegistrationResponseData>
 
 /**
  * Checks conditions to determine if the device registration needs to be updated.

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -64,6 +64,7 @@ import com.nimbusds.jwt.SignedJWT
 
 // BCSC KeyPair package imports
 import com.bcsccore.keypair.core.exceptions.BcscException
+import com.bcsccore.keypair.core.exceptions.KeypairGenerationException
 import com.bcsccore.keypair.core.interfaces.BcscKeyPairSource
 import com.bcsccore.keypair.core.interfaces.KeyPairInfoSource
 import com.bcsccore.keypair.core.models.BcscKeyPair
@@ -1235,6 +1236,13 @@ class BcscCoreModule(
 
             Log.d(NAME, "getDynamicClientRegistrationBody: Successfully created DCR body")
             promise.resolve(registrationBodyAsString)
+        } catch (e: KeypairGenerationException) {
+            Log.e(NAME, "getDynamicClientRegistrationBody: Keypair generation error: ${e.devMessage}", e)
+            promise.reject(
+                "E_KEYPAIR_GENERATION_FAILED",
+                "Failed to generate or retrieve key pair for client registration: ${e.devMessage}",
+                e,
+            )
         } catch (e: BcscException) {
             Log.e(NAME, "getDynamicClientRegistrationBody: BCSC error: ${e.devMessage}", e)
             promise.reject(

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/core/exceptions/BcscException.java
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/core/exceptions/BcscException.java
@@ -46,6 +46,20 @@ public class BcscException extends Exception {
   }
 
   /**
+   * Create an exception with an alert key, developer message, and cause.
+   * Preserves the original exception for debugging and stack trace chaining.
+   * @param key the alert key identifying the type of error
+   * @param devMessage the developer message describing the error
+   * @param cause the original throwable that caused this exception
+   */
+  public BcscException(@NonNull AlertKey key, String devMessage, Throwable cause) {
+    super(cause);
+    final String message = devMessage == null ? NO_MESSAGE : devMessage;
+    this.alertKey = key;
+    this.devMessage = message;
+  }
+
+  /**
    * Create an exception with just a developer message.
    * @param devMessage the developer message describing the error
    */

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/core/exceptions/KeypairGenerationException.java
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/core/exceptions/KeypairGenerationException.java
@@ -14,5 +14,15 @@ public class KeypairGenerationException extends BcscException {
   public KeypairGenerationException(String devMessage) {
     super(AlertKey.ADD_CARD_KEYPAIR_GENERATION, devMessage);
   }
+
+  /**
+   * Create a keypair generation exception with a developer message and cause.
+   * Preserves the original exception for debugging and stack trace chaining.
+   * @param devMessage the message describing what went wrong during key generation
+   * @param cause the original throwable that caused the failure
+   */
+  public KeypairGenerationException(String devMessage, Throwable cause) {
+    super(AlertKey.ADD_CARD_KEYPAIR_GENERATION, devMessage, cause);
+  }
   
 }

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
@@ -99,7 +99,7 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
       SimpleLog.d(TAG, "Current active key pair " + info.getAlias());
       return new BcscKeyPair(keyPair, info);
     } catch (Exception e) {
-      throw new KeypairGenerationException(e.getMessage());
+      throw new KeypairGenerationException(e.getMessage(), e);
     }
   }
 
@@ -153,7 +153,7 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
       SimpleLog.d(TAG, "Generated new key pair " + alias);
       return new BcscKeyPair(keyPair, newInfo);
     } catch (Exception e) {
-      throw new KeypairGenerationException(e.getMessage());
+      throw new KeypairGenerationException(e.getMessage(), e);
     }
   }
 
@@ -259,7 +259,7 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
         | NoSuchAlgorithmException
         | NoSuchProviderException e) {
       SimpleLog.e(TAG, "Failed to generate key pair", e);
-      throw new KeypairGenerationException("Failed to generate key pair for alias '" + alias + "': " + e.getMessage());
+      throw new KeypairGenerationException("Failed to generate key pair for alias '" + alias + "': " + e.getMessage(), e);
     }
   }
 

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
@@ -227,8 +227,9 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
    * Creates a 4096-bit RSA key with SHA-512 digest for signing.
    * 
    * @param alias the alias to store the key pair under
+   * @throws KeypairGenerationException if key generation fails
    */
-  private void generateKeyPair(String alias) {
+  private void generateKeyPair(String alias) throws KeypairGenerationException {
     try {
 
       final KeyGenParameterSpec.Builder builder = new KeyGenParameterSpec.Builder(
@@ -258,6 +259,7 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
         | NoSuchAlgorithmException
         | NoSuchProviderException e) {
       SimpleLog.e(TAG, "Failed to generate key pair", e);
+      throw new KeypairGenerationException("Failed to generate key pair for alias '" + alias + "': " + e.getMessage());
     }
   }
 

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
@@ -98,6 +98,8 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
       final KeyPair keyPair = getKeyPair(keyStore, info.getAlias());
       SimpleLog.d(TAG, "Current active key pair " + info.getAlias());
       return new BcscKeyPair(keyPair, info);
+    } catch (KeypairGenerationException e) {
+      throw e;
     } catch (Exception e) {
       throw new KeypairGenerationException(e.getMessage(), e);
     }
@@ -152,6 +154,8 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
       final KeyPair keyPair = getKeyPair(keyStore, alias);
       SimpleLog.d(TAG, "Generated new key pair " + alias);
       return new BcscKeyPair(keyPair, newInfo);
+    } catch (KeypairGenerationException e) {
+      throw e;
     } catch (Exception e) {
       throw new KeypairGenerationException(e.getMessage(), e);
     }

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -126,7 +126,7 @@ class BcscCore: NSObject {
       signer = RSASigner(privateKey: keyPair.private)
     } catch {
       reject(
-        "E_GET_KEYPAIR_FAILED", "Failed to retrieve key pair: \(error.localizedDescription)", error
+        "E_KEYPAIR_RETRIEVAL_FAILED", "Failed to retrieve key pair: \(error.localizedDescription)", error
       )
       return nil
     }
@@ -871,7 +871,7 @@ class BcscCore: NSObject {
         keyId = latestKeyInfo.tag
       } catch {
         reject(
-          "E_GET_KEYPAIR_FAILED", "Failed to retrieve key pair: \(error.localizedDescription)",
+          "E_KEYPAIR_RETRIEVAL_FAILED", "Failed to retrieve key pair: \(error.localizedDescription)",
           error
         )
         return
@@ -880,7 +880,7 @@ class BcscCore: NSObject {
       // No keys found, generate a new one
       guard let newKeyId = generateKeyPair() else {
         reject(
-          "E_KEY_GENERATION_FAILED",
+          "E_KEYPAIR_GENERATION_FAILED",
           "Failed to generate or retrieve key pair for client registration", nil
         )
         return
@@ -891,7 +891,7 @@ class BcscCore: NSObject {
         keyId = newKeyId
       } catch {
         reject(
-          "E_GET_KEYPAIR_FAILED",
+          "E_KEYPAIR_RETRIEVAL_FAILED",
           "Failed to retrieve newly generated key pair: \(error.localizedDescription)", error
         )
         return

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -34,7 +34,6 @@ export const BcscNativeErrorCodes = {
  */
 export interface BcscNativeError extends Error {
   code: string;
-  message: string;
 }
 
 /**

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -15,6 +15,35 @@ export type {
   NativeAddress,
 } from './NativeBcscCore';
 export { AccountSecurityMethod, BCSCCardProcess } from './NativeBcscCore';
+
+/**
+ * Standard error codes used by native modules when rejecting promises.
+ * These codes are consistent across iOS and Android platforms.
+ * Access via `error.code` on caught native module errors.
+ */
+export const BcscNativeErrorCodes = {
+  /** Secure hardware / keystore could not generate a new keypair */
+  KEYPAIR_GENERATION_FAILED: 'E_KEYPAIR_GENERATION_FAILED',
+  /** Keypair exists but could not be retrieved from secure storage */
+  KEYPAIR_RETRIEVAL_FAILED: 'E_KEYPAIR_RETRIEVAL_FAILED',
+} as const;
+
+/**
+ * Shape of errors thrown by React Native native module promise rejections.
+ * The `code` property corresponds to the first argument passed to `reject()` / `promise.reject()`.
+ */
+export interface BcscNativeError extends Error {
+  code: string;
+  message: string;
+}
+
+/**
+ * Type guard to check if an unknown error is a native module error with a `code` property.
+ */
+export const isBcscNativeError = (error: unknown): error is BcscNativeError => {
+  return error instanceof Error && 'code' in error;
+};
+
 export interface TokenInfo {
   id: string;
   type: TokenType;


### PR DESCRIPTION
# Summary of Changes

Standardizes keypair generation error handling across iOS and Android native modules so failures are surfaced to the user via the existing error modal system.

# Testing Instructions

1. Add the following at like 1151 in `BcscCoreModule.kt`:
```
            // DEBUG: Force keypair generation error to test UI error handling
            throw KeypairGenerationException("DEBUG: Simulated keypair generation failure for UI testing")
```
2. Setup a new account.
3. You will see the error as expected.

# Acceptance Criteria

n/a

# Screenshots, videos, or gifs



# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
