### PR TITLE
fix(dob): birthdate off by one and minimum age validation

### DIFF
--- a/app/src/bcsc-theme/components/InputWithValidation.tsx
+++ b/app/src/bcsc-theme/components/InputWithValidation.tsx
@@ -10,6 +10,7 @@ type InputWithValidationProps = {
   onChange: (value: string) => void
   label: string
   onFocus?: () => void
+  onPressIn?: () => void
   subtext?: string
   error?: string
   labelProps?: StyleProp<TextStyle>
@@ -53,6 +54,7 @@ export const InputWithValidation: React.FC<InputWithValidationProps> = (props: I
           props.onChange(e.nativeEvent.text)
         }}
         onFocus={props.onFocus}
+        onPressIn={props.onPressIn}
         accessibilityLabel={props.label}
         testID={testIdWithKey(`${props.id}-input`)}
         {...props.textInputProps}

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -112,3 +112,6 @@ export const VERIFY_DEVICE_ASSERTION_PATH = 'v3/mobile/assertion'
 
 // Error constants
 export const UNKNOWN_APP_ERROR_STATUS_CODE = 9999
+
+// Validation constants
+export const MINIMUM_VERIFICATION_AGE = 12

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -952,6 +952,7 @@ const translation = {
       "BirthDateLabel": "Birth date",
       "BirthDateSubtext": "Enter your birth date",
       "BirthDateError": "Please enter a valid birth date (YYYY-MM-DD)",
+      "BirthDateAgeError": "You must be {{ minimumAge }} years or older to set up a mobile card",
       "BirthDatePickerLabel": "Select birth date",
       "BirthDatePickerAccessibilityLabel": "Birth date picker",
       "MiddleNamesLabel": "Middle names",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -952,6 +952,7 @@ const translation = {
       "BirthDateLabel": "Birth date (FR)",
       "BirthDateSubtext": "Enter your birth date (FR)",
       "BirthDateError": "Please enter a valid birth date (YYYY-MM-DD) (FR)",
+      "BirthDateAgeError": "You must be {{ minimumAge }} years or older to set up a mobile card (FR)",
       "BirthDatePickerLabel": "Select birth date (FR)",
       "BirthDatePickerAccessibilityLabel": "Birth date picker (FR)",
       "MiddleNamesLabel": "Middle names (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -952,6 +952,7 @@ const translation = {
       "BirthDateLabel": "Birth date (PT-BR)",
       "BirthDateSubtext": "Enter your birth date (PT-BR)",
       "BirthDateError": "Please enter a valid birth date (YYYY-MM-DD) (PT-BR)",
+      "BirthDateAgeError": "You must be {{ minimumAge }} years or older to set up a mobile card (PT-BR)",
       "BirthDatePickerLabel": "Select birth date (PT-BR)",
       "BirthDatePickerAccessibilityLabel": "Birth date picker (PT-BR)",
       "MiddleNamesLabel": "Middle names (PT-BR)",


### PR DESCRIPTION
# Summary of Changes

Adds validation (age >= 12) to the age input for the OOP flow.
Fixes issue with the date picker being one day off when opened.

# Testing Instructions

1. Enter less age less than 12 years (see validation error on form submission)
2. Enter age exactly 12 years (no validation error on form submission)
3. Enter age older than 12 years (no validation error on form submission)
# Acceptance Criteria

1. Date input shows validation error when age less than 12 years.
2. Can submit non-bcsc flow after entering a age of 12 years.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
