### PR TITLE
fix: remove trailing slashes from video call API endpoints

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useVideoCallApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useVideoCallApi.tsx
@@ -77,7 +77,7 @@ const useVideoCallApi = (apiClient: BCSCApiClient) => {
       const deviceCode = _getDeviceCode()
       const body = { client_id: account.clientID, device_code: deviceCode }
       const token = await createPreVerificationJWT(deviceCode, account.clientID)
-      const { data } = await apiClient.post<VideoSession>(`${apiClient.endpoints.video}/v2/sessions/`, body, {
+      const { data } = await apiClient.post<VideoSession>(`${apiClient.endpoints.video}/v2/sessions`, body, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
@@ -119,7 +119,7 @@ const useVideoCallApi = (apiClient: BCSCApiClient) => {
 
         const token = await createPreVerificationJWT(_getDeviceCode(), account.clientID)
         const { data } = await apiClient.post<VideoCall>(
-          `${apiClient.endpoints.video}/v2/sessions/${sessionId}/calls/`,
+          `${apiClient.endpoints.video}/v2/sessions/${sessionId}/calls`,
           body,
           {
             headers: {


### PR DESCRIPTION
## Summary

- Removes trailing slashes from two video call API endpoint URLs in `useVideoCallApi.tsx`
- `POST /v2/sessions/` is now `POST /v2/sessions`
- `POST /v2/sessions/:id/calls/` is now `POST /v2/sessions/:id/calls`

## Background

After the backend R3.20.0 upgrade to Java 21 / Spring 6, `PathPatternParser` changed its default trailing slash matching behaviour from `true` to `false`. This caused HTTP 500 errors when the app called the video session and video call endpoints with trailing slashes.

Closes #3283

## Test plan

- [ ] Launch the app against the updated backend (R3.20.0+)
- [ ] Initiate a video call session and confirm the session is created successfully (no HTTP 500)
- [ ] Confirm the video call connection completes without error
