### PR TITLE
fix(cicd): make TestFlight beta groups configurable per build type

### DIFF
--- a/.github/workflows/actions/ship-to-itunes/action.yml
+++ b/.github/workflows/actions/ship-to-itunes/action.yml
@@ -53,6 +53,11 @@ runs:
           [ -n "$group" ] && GROUPS+=("$group")
         done <<< "$BETA_GROUPS"
 
+        if [ ${#GROUPS[@]} -eq 0 ]; then
+          echo "Error: no beta groups provided"
+          exit 1
+        fi
+
         app-store-connect publish \
         --enable-package-validation \
         --max-build-processing-wait 10 \

--- a/.github/workflows/actions/ship-to-itunes/action.yml
+++ b/.github/workflows/actions/ship-to-itunes/action.yml
@@ -20,6 +20,11 @@ inputs:
     description: |
       The version name for the release notes. i.e 1.0.1
     required: true
+  beta_groups:
+    description: |
+      Space-separated, individually quoted TestFlight beta group names
+      to distribute the build to. e.g. '"The Team" "IDIM Team"'
+    required: true
 
 runs:
   using: composite
@@ -44,5 +49,5 @@ runs:
         --enable-package-validation \
         --max-build-processing-wait 10 \
         --testflight \
-        --beta-group "The Team" "IDIM Team" \
+        --beta-group ${{ inputs.beta_groups }} \
         --whats-new "Release ${VERSION_NAME}-${GITHUB_RUN_NUMBER}"

--- a/.github/workflows/actions/ship-to-itunes/action.yml
+++ b/.github/workflows/actions/ship-to-itunes/action.yml
@@ -43,11 +43,12 @@ runs:
         APP_STORE_CONNECT_PRIVATE_KEY: ${{ inputs.app_store_connect_private_key }}
         VERSION_CODE: ${{ inputs.version_code }}
         VERSION_NAME: ${{ inputs.version_name }}
+        BETA_GROUPS: ${{ inputs.beta_groups }}
       run: |
         export PATH=$PATH:/Library/Frameworks/Python.framework/Versions/3.11/bin
         app-store-connect publish \
         --enable-package-validation \
         --max-build-processing-wait 10 \
         --testflight \
-        --beta-group ${{ inputs.beta_groups }} \
+        --beta-group ${BETA_GROUPS} \
         --whats-new "Release ${VERSION_NAME}-${GITHUB_RUN_NUMBER}"

--- a/.github/workflows/actions/ship-to-itunes/action.yml
+++ b/.github/workflows/actions/ship-to-itunes/action.yml
@@ -22,8 +22,8 @@ inputs:
     required: true
   beta_groups:
     description: |
-      Space-separated, individually quoted TestFlight beta group names
-      to distribute the build to. e.g. '"The Team" "IDIM Team"'
+      Newline-separated TestFlight beta group names to distribute
+      the build to. One group per line.
     required: true
 
 runs:
@@ -46,9 +46,16 @@ runs:
         BETA_GROUPS: ${{ inputs.beta_groups }}
       run: |
         export PATH=$PATH:/Library/Frameworks/Python.framework/Versions/3.11/bin
+
+        GROUPS=()
+        while IFS= read -r group; do
+          group="$(echo "$group" | xargs)"
+          [ -n "$group" ] && GROUPS+=("$group")
+        done <<< "$BETA_GROUPS"
+
         app-store-connect publish \
         --enable-package-validation \
         --max-build-processing-wait 10 \
         --testflight \
-        --beta-group ${BETA_GROUPS} \
+        --beta-group "${GROUPS[@]}" \
         --whats-new "Release ${VERSION_NAME}-${GITHUB_RUN_NUMBER}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -140,13 +140,16 @@ jobs:
             export_options: 'export-options-bcw.plist'
             release_config: 'release-bcw.xcconfig'
             artifact_name: 'ios-bc-wallet-artifact'
-            beta_groups: '"The Team" "IDIM Team"'
+            beta_groups: |-
+              The Team
+              IDIM Team
           - build_type: 'single-app'
             app_version: '4.0.0'
             export_options: 'export-options-sa.plist'
             release_config: 'release-sa.xcconfig'
             artifact_name: 'ios-single-app-artifact'
-            beta_groups: '"IDIM testers for DEV env"'
+            beta_groups: |-
+              IDIM testers for DEV env
     env:
       REACT_NATIVE_NODE_BINARY: $(which node)
       NODE_BINARY: $(which node)

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -140,11 +140,13 @@ jobs:
             export_options: 'export-options-bcw.plist'
             release_config: 'release-bcw.xcconfig'
             artifact_name: 'ios-bc-wallet-artifact'
+            beta_groups: '"The Team" "IDIM Team"'
           - build_type: 'single-app'
             app_version: '4.0.0'
             export_options: 'export-options-sa.plist'
             release_config: 'release-sa.xcconfig'
             artifact_name: 'ios-single-app-artifact'
+            beta_groups: '"IDIM testers for DEV env"'
     env:
       REACT_NATIVE_NODE_BINARY: $(which node)
       NODE_BINARY: $(which node)
@@ -306,6 +308,7 @@ jobs:
           app_store_connect_private_key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY_95 }}
           version_code: ${{ env.APP_BUILD_NUMBER }}
           version_name: ${{ env.APP_VERSION }}
+          beta_groups: ${{ matrix.beta_groups }}
 
       - name: Save cache for derived data
         id: cache-dd-save


### PR DESCRIPTION
## Summary

- Added `beta_groups` required input to `.github/workflows/actions/ship-to-itunes/action.yml`, replacing the hardcoded `--beta-group "The Team" "IDIM Team"` with the configurable `${{ inputs.beta_groups }}`
- Added `beta_groups` to each iOS build matrix entry in `.github/workflows/main.yaml`: `bc-wallet` gets `"The Team" "IDIM Team"`, `single-app` gets `"IDIM testers for DEV env"`
- Passes `${{ matrix.beta_groups }}` through to the ship-to-itunes action call

Closes #3295

## Test plan

- [ ] Verify `bc-wallet` iOS build distributes to `The Team` and `IDIM Team` beta groups in TestFlight
- [ ] Verify `single-app` iOS build distributes to `IDIM testers for DEV env` beta group in TestFlight
- [ ] Confirm no regressions in existing iOS build pipeline
