### PR TITLE
fix: DoB wheel picker to prevent incorrect value submission

### DIFF
--- a/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.test.tsx
@@ -1,7 +1,8 @@
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { render } from '@testing-library/react-native'
+import { act, fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
+import DatePicker from 'react-native-date-picker'
 import EnterBirthdateScreen from './EnterBirthdateScreen'
 
 describe('EnterBirthdate', () => {
@@ -26,5 +27,111 @@ describe('EnterBirthdate', () => {
     )
 
     expect(tree).toMatchSnapshot()
+  })
+
+  it('blocks Done button while picker is spinning (debounce pending)', () => {
+    const { getByTestId, UNSAFE_getByType } = render(
+      <BasicAppContext>
+        <EnterBirthdateScreen navigation={mockNavigation as never} />
+      </BasicAppContext>
+    )
+
+    const picker = UNSAFE_getByType(DatePicker)
+    const newDate = new Date('1990-06-15T12:00:00.000Z')
+
+    // Simulate date change — starts debounce, sets pickerState to 'spinning'
+    act(() => {
+      picker.props.onDateChange(newDate)
+    })
+
+    // Tap Done while debounce is still pending
+    const doneButton = getByTestId('com.ariesbifold:id/Done')
+    fireEvent.press(doneButton)
+
+    // handleSubmit should NOT have been called (no navigation, no error)
+    expect(mockNavigation.navigate).not.toHaveBeenCalled()
+    expect(mockNavigation.goBack).not.toHaveBeenCalled()
+  })
+
+  it('allows Done button after debounce settles', () => {
+    const { getByTestId, UNSAFE_getByType } = render(
+      <BasicAppContext>
+        <EnterBirthdateScreen navigation={mockNavigation as never} />
+      </BasicAppContext>
+    )
+
+    const picker = UNSAFE_getByType(DatePicker)
+    const newDate = new Date('1990-06-15T12:00:00.000Z')
+
+    act(() => {
+      picker.props.onDateChange(newDate)
+    })
+
+    // Advance past the 400ms debounce
+    act(() => {
+      jest.advanceTimersByTime(400)
+    })
+
+    // Done button should now be pressable (pickerState is 'idle')
+    const doneButton = getByTestId('com.ariesbifold:id/Done')
+    fireEvent.press(doneButton)
+
+    // handleSubmit runs — since vm.serial is undefined in test, it calls goBack
+    expect(mockNavigation.goBack).toHaveBeenCalled()
+  })
+
+  it('resets debounce timer on rapid date changes', () => {
+    const { getByTestId, UNSAFE_getByType } = render(
+      <BasicAppContext>
+        <EnterBirthdateScreen navigation={mockNavigation as never} />
+      </BasicAppContext>
+    )
+
+    const picker = UNSAFE_getByType(DatePicker)
+
+    // Simulate rapid intermediate values (wheel spinning through months)
+    act(() => {
+      picker.props.onDateChange(new Date('1990-01-15T12:00:00.000Z'))
+      jest.advanceTimersByTime(200)
+      picker.props.onDateChange(new Date('1990-02-15T12:00:00.000Z'))
+      jest.advanceTimersByTime(200)
+      picker.props.onDateChange(new Date('1990-03-15T12:00:00.000Z'))
+    })
+
+    // Only 200ms after last change — still spinning
+    act(() => {
+      jest.advanceTimersByTime(200)
+    })
+    const doneButton = getByTestId('com.ariesbifold:id/Done')
+    fireEvent.press(doneButton)
+    expect(mockNavigation.goBack).not.toHaveBeenCalled()
+
+    // Advance remaining 200ms — debounce settles
+    act(() => {
+      jest.advanceTimersByTime(200)
+    })
+    fireEvent.press(doneButton)
+    expect(mockNavigation.goBack).toHaveBeenCalled()
+  })
+
+  it('cleans up debounce timer on unmount', () => {
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout')
+
+    const { UNSAFE_getByType, unmount } = render(
+      <BasicAppContext>
+        <EnterBirthdateScreen navigation={mockNavigation as never} />
+      </BasicAppContext>
+    )
+
+    const picker = UNSAFE_getByType(DatePicker)
+    act(() => {
+      picker.props.onDateChange(new Date('1990-06-15T12:00:00.000Z'))
+    })
+
+    // Unmount while debounce is still pending
+    unmount()
+
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+    clearTimeoutSpy.mockRestore()
   })
 })

--- a/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.tsx
@@ -20,6 +20,8 @@ import DatePicker from 'react-native-date-picker'
 import { VerificationCardError } from '../verificationCardError'
 import { useEnterBirthdateViewModel } from './useEnterBirthdateViewModel'
 
+const PICKER_DEBOUNCE_MS = 400
+
 type EnterBirthdateScreenProps = {
   navigation: StackNavigationProp<BCSCVerifyStackParams, BCSCScreens.EnterBirthdate>
 }
@@ -60,7 +62,8 @@ const EnterBirthdateScreen: React.FC<EnterBirthdateScreenProps> = ({ navigation 
   // Update the controlled date prop immediately so the picker stays in sync,
   // but debounce the pickerState transition (spinning → idle) to block the
   // Done button until the wheel has settled. The picker fires intermediate
-  // values as it decelerates; dateRef always holds the latest value for submission.
+  // values as it decelerates; dateRef holds the latest value for submission
+  // to avoid stale closures in the async handleSubmit.
   // https://github.com/henninghall/react-native-date-picker/issues/724#issuecomment-2325661774
   const onDateChange = useCallback((newDate: Date) => {
     const year = newDate.getFullYear()
@@ -79,7 +82,7 @@ const EnterBirthdateScreen: React.FC<EnterBirthdateScreenProps> = ({ navigation 
 
     debounceTimerRef.current = setTimeout(() => {
       setPickerState('idle')
-    }, 400)
+    }, PICKER_DEBOUNCE_MS)
   }, [])
 
   const handleSubmit = async () => {
@@ -118,7 +121,7 @@ const EnterBirthdateScreen: React.FC<EnterBirthdateScreenProps> = ({ navigation 
         handleSubmit()
       }}
       buttonType={ButtonType.Primary}
-      disabled={loading}
+      disabled={loading || pickerState === 'spinning'}
     >
       {loading && <ButtonLoading />}
     </Button>

--- a/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.tsx
@@ -57,9 +57,10 @@ const EnterBirthdateScreen: React.FC<EnterBirthdateScreenProps> = ({ navigation 
     },
   })
 
-  // Debounce onDateChange to wait for the wheel picker to settle before
-  // committing the value. The picker fires intermediate values as the
-  // wheel decelerates; without this the submitted date can be wrong.
+  // Update the controlled date prop immediately so the picker stays in sync,
+  // but debounce the pickerState transition (spinning → idle) to block the
+  // Done button until the wheel has settled. The picker fires intermediate
+  // values as it decelerates; dateRef always holds the latest value for submission.
   // https://github.com/henninghall/react-native-date-picker/issues/724#issuecomment-2325661774
   const onDateChange = useCallback((newDate: Date) => {
     const year = newDate.getFullYear()
@@ -67,6 +68,7 @@ const EnterBirthdateScreen: React.FC<EnterBirthdateScreenProps> = ({ navigation 
     const day = newDate.getDate()
     const realDate = new Date(year, month, day, 12, 0, 0, 0)
 
+    setDate(realDate)
     dateRef.current = realDate
     setPickerState('spinning')
 
@@ -76,7 +78,6 @@ const EnterBirthdateScreen: React.FC<EnterBirthdateScreenProps> = ({ navigation 
     }
 
     debounceTimerRef.current = setTimeout(() => {
-      setDate(realDate)
       setPickerState('idle')
     }, 400)
   }, [])

--- a/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.tsx
@@ -43,6 +43,7 @@ const EnterBirthdateScreen: React.FC<EnterBirthdateScreenProps> = ({ navigation 
     return () => {
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current)
+        debounceTimerRef.current = null
       }
     }
   }, [])
@@ -71,6 +72,7 @@ const EnterBirthdateScreen: React.FC<EnterBirthdateScreenProps> = ({ navigation 
 
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current)
+      debounceTimerRef.current = null
     }
 
     debounceTimerRef.current = setTimeout(() => {
@@ -137,7 +139,6 @@ const EnterBirthdateScreen: React.FC<EnterBirthdateScreenProps> = ({ navigation 
           mode={'date'}
           date={date}
           onDateChange={onDateChange}
-          onStateChange={setPickerState}
         />
       </View>
     </ScreenWrapper>

--- a/app/src/bcsc-theme/features/verify/EnterBirthdate/__snapshots__/EnterBirthdateScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/EnterBirthdate/__snapshots__/EnterBirthdateScreen.test.tsx.snap
@@ -108,7 +108,6 @@ exports[`EnterBirthdate renders correctly 1`] = `
           date={2025-12-03T00:00:00.000Z}
           mode="date"
           onDateChange={[Function]}
-          onStateChange={[Function]}
           theme="light"
         />
       </View>

--- a/app/src/bcsc-theme/features/verify/EnterBirthdate/__snapshots__/EnterBirthdateScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/EnterBirthdate/__snapshots__/EnterBirthdateScreen.test.tsx.snap
@@ -78,38 +78,94 @@ exports[`EnterBirthdate renders correctly 1`] = `
       >
         BCSC.Birthdate.Heading
       </Text>
-      <Text
-        maxFontSizeMultiplier={2}
-        style={
-          [
-            {
-              "color": "#313132",
-              "fontFamily": "BCSans-Regular",
-              "fontSize": 18,
-              "fontWeight": "normal",
-            },
-            {
-              "marginBottom": 8,
-            },
-          ]
-        }
-      >
-        BCSC.Birthdate.Paragraph
-      </Text>
       <View
         style={
           {
-            "alignItems": "center",
-            "flex": 1,
+            "marginVertical": 16,
+            "width": "100%",
           }
         }
       >
         <DatePicker
+          accessibilityLabel="BCSC.Birthdate.Label"
           date={2025-12-03T00:00:00.000Z}
+          modal={true}
           mode="date"
-          onDateChange={[Function]}
-          theme="light"
+          onCancel={[Function]}
+          onConfirm={[Function]}
+          open={false}
+          testID="com.ariesbifold:id/BirthDatePicker"
+          title="BCSC.Birthdate.Label"
         />
+        <View>
+          <Text
+            maxFontSizeMultiplier={2}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 16,
+                  "fontWeight": "bold",
+                },
+                [
+                  {
+                    "marginBottom": 8,
+                  },
+                  undefined,
+                ],
+              ]
+            }
+            testID="com.ariesbifold:id/birthDate-label"
+          >
+            BCSC.Birthdate.Label
+          </Text>
+          <TextInput
+            accessibilityLabel="BCSC.Birthdate.Label"
+            onChange={[Function]}
+            onPressIn={[Function]}
+            placeholder="YYYY-MM-DD"
+            style={
+              [
+                {
+                  "backgroundColor": "#D3D3D3",
+                  "borderColor": "#D3D3D3",
+                  "borderRadius": 4,
+                  "borderWidth": 1,
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 16,
+                  "padding": 10,
+                },
+                undefined,
+              ]
+            }
+            testID="com.ariesbifold:id/birthDate-input"
+            value=""
+          />
+          <Text
+            maxFontSizeMultiplier={2}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 14,
+                  "fontWeight": "normal",
+                },
+                [
+                  {
+                    "marginTop": 8,
+                  },
+                  undefined,
+                ],
+              ]
+            }
+            testID="com.ariesbifold:id/birthDate-subtext"
+          >
+            BCSC.Birthdate.Paragraph
+          </Text>
+        </View>
       </View>
     </View>
   </RCTScrollView>
@@ -134,7 +190,7 @@ exports[`EnterBirthdate renders correctly 1`] = `
         {
           "busy": undefined,
           "checked": undefined,
-          "disabled": false,
+          "disabled": true,
           "expanded": undefined,
           "selected": undefined,
         }
@@ -149,7 +205,7 @@ exports[`EnterBirthdate renders correctly 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -159,7 +215,7 @@ exports[`EnterBirthdate renders correctly 1`] = `
       onStartShouldSetResponder={[Function]}
       style={
         {
-          "backgroundColor": "#003366",
+          "backgroundColor": "#757575",
           "borderRadius": 4,
           "opacity": 1,
           "padding": 16,
@@ -194,7 +250,13 @@ exports[`EnterBirthdate renders correctly 1`] = `
                   "fontWeight": "bold",
                   "textAlign": "center",
                 },
-                false,
+                {
+                  "color": "#FFFFFF",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                  "textAlign": "center",
+                },
                 false,
                 false,
               ],

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -544,6 +544,7 @@ const translation = {
       "CardSerialNumber": "Card serial number: {{ serial }}",
       "Heading": "Enter your birthdate",
       "Paragraph": "Your birthdate is only used to to set up this app. It is not shared.",
+      "Label": "Birthdate",
     },
     "AdditionalEvidence": {
       "PhotoRequired": "You must provide additional ID because your BC Services Card doesn't have a photo on it.",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -544,6 +544,7 @@ const translation = {
       "CardSerialNumber": "Card serial number: {{ serial }} (FR)",
       "Heading": "Enter your birthdate (FR)",
       "Paragraph": "Your birthdate is only used to to set up this app. It is not shared. (FR)",
+      "Label": "Birthdate (FR)",
     },
     "AdditionalEvidence": {
       "PhotoRequired": "You must provide additional ID because your BC Services Card doesn't have a photo on it. (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -544,6 +544,7 @@ const translation = {
       "CardSerialNumber": "Card serial number: {{ serial }} (PT-BR)",
       "Heading": "Enter your birthdate (PT-BR)",
       "Paragraph": "Your birthdate is only used to to set up this app. It is not shared. (PT-BR)",
+      "Label": "Birthdate (PT-BR)",
     },
     "AdditionalEvidence": {
       "PhotoRequired": "You must provide additional ID because your BC Services Card doesn't have a photo on it. (PT-BR)",


### PR DESCRIPTION
## Summary

- Debounces `onDateChange` by 400ms in `EnterBirthdateScreen` so the committed date value is only updated after the wheel picker has finished decelerating
- Sets picker state to `'spinning'` on each intermediate change and back to `'idle'` after the debounce settles, which blocks the "Done" button while the wheel is still in motion
- Cleans up the debounce timer on component unmount to prevent state updates on unmounted components
- Applies to both iOS and Android since both use `react-native-date-picker` with the same wheel interface

## Test plan

- [ ] Open the date-of-birth entry screen on iOS
- [ ] Spin the month wheel quickly and tap "Done" immediately — confirm the displayed month matches the settled value
- [ ] Repeat on Android
- [ ] Spin multiple wheels rapidly in succession; confirm final submitted date is correct
- [ ] Confirm "Done" button is disabled/blocked while a wheel is still decelerating
- [ ] Verify no console warnings about state updates on unmounted components after navigating away mid-spin
