### PR TITLE
fix: live call issues

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -20,8 +20,6 @@
   <uses-permission android:name="android.permission.WAKE_LOCK" />
   <uses-permission android:name="android.permission.BLUETOOTH" />
   <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />
 
   <queries>
     <intent>

--- a/app/ios/AriesBifold/Info.plist
+++ b/app/ios/AriesBifold/Info.plist
@@ -67,16 +67,10 @@
 			</dict>
 		</dict>
 	</dict>
-	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>$(PRODUCT_NAME) needs access to Bluetooth to manage audio routing during calls</string>
-	<key>NSBluetoothPeripheralUsageDescription</key>
-	<string>$(PRODUCT_NAME) needs access to Bluetooth to connect to audio devices during calls</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Camera used for QR Code scanning and video calls</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>$(PRODUCT_NAME) wants to use your FaceID/TouchID to authenticate your identity</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>We include this permission because a library our app uses references it, even though we don't use it directly</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>$(PRODUCT_NAME) needs access to your microphone to enable video calls</string>
 	<key>RCTNewArchEnabled</key>
@@ -94,7 +88,6 @@
 	<array>
 		<string>remote-notification</string>
 		<string>audio</string>
-		<string>voip</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/app/package.json
+++ b/app/package.json
@@ -135,6 +135,7 @@
     "react-native-screenguard": "~1.1.0",
     "react-native-screens": "~4.16.0",
     "react-native-splash-screen": "~3.3.0",
+    "react-native-sse": "~1.2.1",
     "react-native-svg": "~15.12.1",
     "react-native-tcp-socket": "~6.0.6",
     "react-native-toast-message": "~2.1.10",

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -162,6 +162,17 @@ export const verifyNotCompletedErrorPolicy: ErrorHandlingPolicy = {
   },
 }
 
+// Error policy for video session endpoint failures (e.g. 503 service unavailable).
+// Suppresses the global error popup so the video call screen can show its own error UI.
+export const videoSessionErrorPolicy: ErrorHandlingPolicy = {
+  matches: (_, context) => {
+    return (context.statusCode === 500 || context.statusCode === 503) && context.endpoint.includes(context.apiEndpoints.video)
+  },
+  handle: (_error, context) => {
+    context.logger.info('[VideoSessionErrorPolicy] Suppressing global alert — video call screen will handle this error')
+  },
+}
+
 // Error policy for unexpected server errors (http status: 500, 503)
 export const unexpectedServerErrorPolicy: ErrorHandlingPolicy = {
   matches: (_, context) => {
@@ -314,6 +325,7 @@ export const ClientErrorHandlingPolicies: ErrorHandlingPolicy[] = [
   loginRejectedOnDeviceAuthorizationErrorPolicy,
   alreadyVerifiedErrorPolicy,
   invalidTokenReturnedPolicy,
+  videoSessionErrorPolicy,
   // Specific polices listed above, followed by global policies
   globalAlertErrorPolicy,
   unexpectedServerErrorPolicy,

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -166,7 +166,10 @@ export const verifyNotCompletedErrorPolicy: ErrorHandlingPolicy = {
 // Suppresses the global error popup so the video call screen can show its own error UI.
 export const videoSessionErrorPolicy: ErrorHandlingPolicy = {
   matches: (_, context) => {
-    return (context.statusCode === 500 || context.statusCode === 503) && context.endpoint.includes(context.apiEndpoints.video)
+    return (
+      (context.statusCode === 500 || context.statusCode === 503) &&
+      context.endpoint.includes(context.apiEndpoints.video)
+    )
   },
   handle: (_error, context) => {
     context.logger.info('[VideoSessionErrorPolicy] Suppressing global alert — video call screen will handle this error')

--- a/app/src/bcsc-theme/features/verify/live-call/BeforeYouCallScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/BeforeYouCallScreen.test.tsx
@@ -1,5 +1,4 @@
 import { BCSCScreens } from '@/bcsc-theme/types/navigators'
-import { HelpCentreUrl } from '@/constants'
 import { testIdWithKey } from '@bifold/core'
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
@@ -25,7 +24,7 @@ describe('BeforeYouCall', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  it('navigates to VerifyWebView with verify-by-call help when Assistance is pressed', () => {
+  it('navigates to ContactUs when Assistance is pressed', () => {
     const tree = render(
       <BasicAppContext>
         <BeforeYouCallScreen navigation={mockNavigation as never} route={{ params: {} } as never} />
@@ -34,9 +33,6 @@ describe('BeforeYouCall', () => {
 
     fireEvent.press(tree.getByTestId(testIdWithKey('Assistance')))
 
-    expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.VerifyWebView, {
-      url: HelpCentreUrl.VERIFY_CALL,
-      title: expect.any(String),
-    })
+    expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.VerifyContactUs)
   })
 })

--- a/app/src/bcsc-theme/features/verify/live-call/BeforeYouCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/BeforeYouCallScreen.tsx
@@ -1,11 +1,10 @@
-import { HelpCentreUrl } from '@/constants'
 import { useAlerts } from '@/hooks/useAlerts'
 import { BCSCScreens, BCSCVerifyStackParams } from '@bcsc-theme/types/navigators'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import NetInfo, { useNetInfo } from '@react-native-community/netinfo'
 import { RouteProp } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, View } from 'react-native'
 
@@ -48,15 +47,8 @@ const BeforeYouCallScreen = ({ navigation, route }: BeforeYouCallScreenProps) =>
     })
   }
 
-  const navigateToWebView = useCallback(
-    (url: string, title: string) => {
-      navigation.navigate(BCSCScreens.VerifyWebView, { url, title })
-    },
-    [navigation]
-  )
-
   const onPressAssistance = () => {
-    navigateToWebView(HelpCentreUrl.VERIFY_CALL, t('HelpCentre.Title'))
+    navigation.navigate(BCSCScreens.VerifyContactUs)
   }
 
   return (

--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
@@ -216,7 +216,7 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
       startVideoCall()
       // Clear the forced-speaker override before start() so that start()
       // does not force audio to the speaker on Android. This allows audio
-      // to route to Bluetooth/wired headsets on the very first call.
+      // to route to Bluetooth/wired headsets
       InCallManager.setForceSpeakerphoneOn(false)
       InCallManager.start({ media: 'video', auto: true })
     }

--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
@@ -222,6 +222,7 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
     }
   }, [flowState, startVideoCall])
 
+  // disconnect any active call when unmounting
   useEffect(() => {
     return () => {
       InCallManager.stop()

--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
@@ -215,6 +215,9 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
     if (flowState === VideoCallFlowState.IDLE) {
       startVideoCall()
       InCallManager.start({ media: 'video', auto: true })
+      // InCallManager forces speaker on for video media type on Android.
+      // This clears the override so audio routes to Bluetooth/wired headsets when connected.
+      InCallManager.setForceSpeakerphoneOn(false)
     }
   }, [flowState, startVideoCall])
 
@@ -227,6 +230,8 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
   // loading / error user-facing state message
   const stateMessage = useMemo(() => {
     switch (flowState) {
+      case VideoCallFlowState.UPLOADING_DOCUMENTS:
+        return t('BCSC.VideoCall.CallStates.UploadingDocuments')
       case VideoCallFlowState.CREATING_SESSION:
         return t('BCSC.VideoCall.CallStates.CreatingSession')
       case VideoCallFlowState.CONNECTING_WEBRTC:
@@ -312,6 +317,7 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
   if (flowState === VideoCallFlowState.ERROR) {
     return (
       <CallErrorView
+        title={videoCallError?.title}
         message={stateMessage || t('BCSC.VideoCall.Errors.GenericError')}
         onGoBack={() => navigation.goBack()}
         onRetry={videoCallError?.retryable ? retryConnection : undefined}

--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
@@ -214,10 +214,11 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
   useEffect(() => {
     if (flowState === VideoCallFlowState.IDLE) {
       startVideoCall()
-      InCallManager.start({ media: 'video', auto: true })
-      // InCallManager forces speaker on for video media type on Android.
-      // This clears the override so audio routes to Bluetooth/wired headsets when connected.
+      // Clear the forced-speaker override before start() so that start()
+      // does not force audio to the speaker on Android. This allows audio
+      // to route to Bluetooth/wired headsets on the very first call.
       InCallManager.setForceSpeakerphoneOn(false)
+      InCallManager.start({ media: 'video', auto: true })
     }
   }, [flowState, startVideoCall])
 

--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
@@ -218,6 +218,12 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
     }
   }, [flowState, startVideoCall])
 
+  useEffect(() => {
+    return () => {
+      InCallManager.stop()
+    }
+  }, [])
+
   // loading / error user-facing state message
   const stateMessage = useMemo(() => {
     switch (flowState) {
@@ -252,6 +258,57 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
     liveCallHavingTroubleAlert(handleEndCall)
   }, [handleEndCall, liveCallHavingTroubleAlert])
 
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flex: 1,
+          backgroundColor: 'black',
+        },
+        agentVideo: {
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: '15%',
+          flex: 1,
+          transform: [{ scale: 1.5 }], // zoom
+        },
+        // just helpful labels, no properties needed
+        upperContainer: {},
+        lowerContainer: {},
+        timeAndLabelContainer: {
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          padding: Spacing.md,
+          backgroundColor: ColorPalette.notification.popupOverlay,
+        },
+        controlsContainer: {
+          flexDirection: 'row',
+          justifyContent: 'space-around',
+          alignItems: 'center',
+          padding: Spacing.md,
+          backgroundColor: ColorPalette.notification.popupOverlay,
+        },
+        lowerContentContainer: {
+          flexDirection: 'row',
+          height: (width / 4) * 1.5,
+        },
+        hasTroubleContainer: {
+          marginLeft: 'auto',
+        },
+        selfieVideoContainer: {
+          width: width / 4,
+          height: '100%',
+          overflow: 'hidden',
+        },
+        selfieVideo: {
+          flex: 1,
+        },
+      }),
+    [width, Spacing, ColorPalette]
+  )
+
   if (flowState === VideoCallFlowState.ERROR) {
     return (
       <CallErrorView
@@ -269,53 +326,6 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
   if (flowState !== VideoCallFlowState.IN_CALL) {
     return <CallLoadingView onCancel={handleEndCall} message={stateMessage || undefined} />
   }
-
-  const styles = StyleSheet.create({
-    container: {
-      flex: 1,
-      backgroundColor: 'black',
-    },
-    agentVideo: {
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: '15%',
-      flex: 1,
-      transform: [{ scale: 1.5 }], // zoom
-    },
-    // just helpful labels, no properties needed
-    upperContainer: {},
-    lowerContainer: {},
-    timeAndLabelContainer: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      padding: Spacing.md,
-      backgroundColor: ColorPalette.notification.popupOverlay,
-    },
-    controlsContainer: {
-      flexDirection: 'row',
-      justifyContent: 'space-around',
-      alignItems: 'center',
-      padding: Spacing.md,
-      backgroundColor: ColorPalette.notification.popupOverlay,
-    },
-    lowerContentContainer: {
-      flexDirection: 'row',
-      height: (width / 4) * 1.5,
-    },
-    hasTroubleContainer: {
-      marginLeft: 'auto',
-    },
-    selfieVideoContainer: {
-      width: width / 4,
-      height: '100%',
-      overflow: 'hidden',
-    },
-    selfieVideo: {
-      flex: 1,
-    },
-  })
 
   return (
     <View style={styles.container}>

--- a/app/src/bcsc-theme/features/verify/live-call/__snapshots__/LiveCallScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/live-call/__snapshots__/LiveCallScreen.test.tsx.snap
@@ -14,88 +14,121 @@ exports[`LiveCall renders correctly 1`] = `
     {
       "backgroundColor": "#F2F2F2",
       "flex": 1,
-      "padding": 16,
+      "justifyContent": "space-between",
     }
   }
 >
   <View
     style={
       {
-        "alignItems": "center",
         "flex": 1,
-        "justifyContent": "center",
-      }
-    }
-  >
-    <Text
-      allowFontScaling={false}
-      selectable={false}
-      style={
-        [
-          {
-            "color": "#D8292F",
-            "fontSize": 64,
-          },
-          undefined,
-          {
-            "fontFamily": "Material Design Icons",
-            "fontStyle": "normal",
-            "fontWeight": "normal",
-          },
-          {},
-        ]
-      }
-    >
-      󰀨
-    </Text>
-    <Text
-      maxFontSizeMultiplier={2}
-      style={
-        [
-          {
-            "color": "#313132",
-            "fontFamily": "BCSans-Regular",
-            "fontSize": 32,
-            "fontWeight": "bold",
-          },
-          {
-            "marginTop": 24,
-            "textAlign": "center",
-          },
-        ]
-      }
-    >
-      BCSC.VideoCall.Errors.ConnectionError
-    </Text>
-    <Text
-      maxFontSizeMultiplier={2}
-      style={
-        [
-          {
-            "color": "#313132",
-            "fontFamily": "BCSans-Regular",
-            "fontSize": 18,
-            "fontWeight": "normal",
-          },
-          {
-            "marginTop": 16,
-            "textAlign": "center",
-          },
-        ]
-      }
-    >
-      Service is unavailable.
-    </Text>
-  </View>
-  <View
-    style={
-      {
-        "gap": 8,
       }
     }
   >
     <View
-      accessibilityLabel="BCSC.VideoCall.Errors.TryAgain"
+      style={
+        {
+          "backgroundColor": "#001e3d",
+          "height": 11,
+          "width": "100%",
+        }
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          {
+            "backgroundColor": "#FCBA19",
+            "bottom": 0,
+            "height": "100%",
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "transform": [
+              {
+                "translateX": -375,
+              },
+              {
+                "scaleX": 0,
+              },
+              {
+                "translateX": 375,
+              },
+            ],
+            "width": "100%",
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "padding": 16,
+        }
+      }
+    >
+      <Text
+        maxFontSizeMultiplier={2}
+        style={
+          [
+            {
+              "color": "#313132",
+              "fontFamily": "BCSans-Regular",
+              "fontSize": 32,
+              "fontWeight": "bold",
+            },
+            {
+              "marginTop": 80,
+              "textAlign": "center",
+            },
+          ]
+        }
+      >
+        BCSC.VideoCall.Loading.OneMomentPlease
+      </Text>
+      <Text
+        maxFontSizeMultiplier={2}
+        style={
+          [
+            {
+              "color": "#313132",
+              "fontFamily": "BCSans-Regular",
+              "fontSize": 18,
+              "fontWeight": "normal",
+            },
+            {
+              "marginTop": 80,
+              "textAlign": "center",
+            },
+          ]
+        }
+      >
+        BCSC.VideoCall.CallStates.UploadingDocuments
+      </Text>
+      <
+        height={200}
+        style={
+          {
+            "alignSelf": "center",
+            "marginVertical": 16,
+          }
+        }
+        width={200}
+      />
+    </View>
+  </View>
+  <View
+    style={
+      {
+        "marginTop": "auto",
+        "padding": 16,
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Global.Cancel"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -132,7 +165,7 @@ exports[`LiveCall renders correctly 1`] = `
           "padding": 16,
         }
       }
-      testID="com.ariesbifold:id/TryAgain"
+      testID="com.ariesbifold:id/Cancel"
     >
       <View
         style={
@@ -168,86 +201,7 @@ exports[`LiveCall renders correctly 1`] = `
             ]
           }
         >
-          BCSC.VideoCall.Errors.TryAgain
-        </Text>
-      </View>
-    </View>
-    <View
-      accessibilityLabel="BCSC.VideoCall.Errors.GoBack"
-      accessibilityRole="button"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        {
-          "borderColor": "#003366",
-          "borderRadius": 4,
-          "borderWidth": 2,
-          "opacity": 1,
-          "padding": 16,
-        }
-      }
-      testID="com.ariesbifold:id/GoBack"
-    >
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "flexDirection": "row",
-            "justifyContent": "center",
-          }
-        }
-      >
-        <Text
-          maxFontSizeMultiplier={2}
-          style={
-            [
-              {
-                "color": "#313132",
-                "fontFamily": "BCSans-Regular",
-                "fontSize": 18,
-                "fontWeight": "normal",
-              },
-              [
-                {
-                  "color": "#003366",
-                  "fontFamily": "BCSans-Regular",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
-                  "textAlign": "center",
-                },
-                false,
-                false,
-                false,
-              ],
-            ]
-          }
-        >
-          BCSC.VideoCall.Errors.GoBack
+          Global.Cancel
         </Text>
       </View>
     </View>

--- a/app/src/bcsc-theme/features/verify/live-call/components/CallErrorView.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/components/CallErrorView.tsx
@@ -5,12 +5,13 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
 type CallErrorViewProps = {
+  title?: string
   message: string
   onRetry?: () => void
   onGoBack: () => void
 }
 
-const CallErrorView = ({ message, onRetry, onGoBack }: CallErrorViewProps) => {
+const CallErrorView = ({ title, message, onRetry, onGoBack }: CallErrorViewProps) => {
   const { ColorPalette, Spacing } = useTheme()
   const { t } = useTranslation()
   return (
@@ -18,7 +19,7 @@ const CallErrorView = ({ message, onRetry, onGoBack }: CallErrorViewProps) => {
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
         <Icon name="alert-circle" size={64} color={ColorPalette.semantic.error} />
         <ThemedText variant={'headingTwo'} style={{ marginTop: Spacing.lg, textAlign: 'center' }}>
-          {t('BCSC.VideoCall.Errors.ConnectionError')}
+          {title || t('BCSC.VideoCall.Errors.ConnectionError')}
         </ThemedText>
         <ThemedText style={{ marginTop: Spacing.md, textAlign: 'center' }}>{message}</ThemedText>
       </View>

--- a/app/src/bcsc-theme/features/verify/live-call/hooks/useVideoCallFlow.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/hooks/useVideoCallFlow.tsx
@@ -73,22 +73,6 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
     setFlowState(VideoCallFlowState.CALL_ENDED)
   }, [])
 
-  // immediately stops all video and audio
-  const stopAllMedia = useCallback(() => {
-    if (localStream) {
-      logger.info('Stopping local stream tracks...')
-      localStream.getTracks().forEach((track) => track.stop())
-    }
-
-    if (remoteStream) {
-      logger.info('Stopping remote stream tracks...')
-      remoteStream.getTracks().forEach((track) => track.stop())
-    }
-
-    logger.info('Media stopped successfully')
-  }, [localStream, remoteStream, logger])
-
-  // stops media
   // stops keep-alives
   // disconnects from pexip conference
   // updates call and session via API
@@ -196,12 +180,10 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
       setVideoCallError(videoCallError)
       setFlowState(VideoCallFlowState.ERROR)
 
-      stopAllMedia()
-      setSession(null)
-      setClientCallId(null)
-      setConnection(null)
+      // Trigger full cleanup (disconnects Pexip, releases media, updates API)
+      cleanup()
     },
-    [stopAllMedia, logger]
+    [cleanup, logger]
   )
 
   // 1. a session must be created before anything else

--- a/app/src/bcsc-theme/features/verify/live-call/types/live-call.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/types/live-call.ts
@@ -11,12 +11,14 @@ export enum VideoCallErrorType {
   CONNECTION_FAILED = 'connection_failed',
   SESSION_FAILED = 'session_failed',
   CALL_FAILED = 'call_failed',
+  DOCUMENT_UPLOAD_FAILED = 'document_upload_failed',
   NETWORK_ERROR = 'network_error',
   PERMISSION_DENIED = 'permission_denied',
 }
 
 export interface VideoCallError {
   type: VideoCallErrorType
+  title?: string
   message: string
   retryable: boolean
   technicalDetails?: string
@@ -29,6 +31,7 @@ export interface ConnectResult {
   peerConnection: RTCPeerConnection
   disconnectPexip: () => Promise<void>
   stopPexipKeepAlive: () => void
+  closePexipEventSource: () => void
   setAppInitiatedDisconnect: (value: boolean) => void
   closePeerConnection: () => void
   releaseLocalStream: () => void
@@ -37,6 +40,7 @@ export interface ConnectResult {
 export enum VideoCallFlowState {
   IDLE = 'idle',
   CREATING_SESSION = 'creating_session',
+  UPLOADING_DOCUMENTS = 'uploading_documents',
   CONNECTING_WEBRTC = 'connecting_webrtc',
   WAITING_FOR_AGENT = 'waiting_for_agent',
   IN_CALL = 'in_call',

--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
@@ -203,9 +203,11 @@ export const connect = async (
         currentToken = response.data.result.token
         logger.info('Pexip token refreshed successfully')
       } else {
-        logger.warn('Token refresh returned unexpected response', { status: response.status })
+        logger.warn('Token refresh returned non-200 response, conference likely ended', { status: response.status })
+        handleDisconnect()
       }
     } catch (err) {
+      // Network errors may be transient — WebRTC state changes will catch persistent issues
       logger.error('Pexip token refresh failed:', err as Error)
     }
   }, KEEP_ALIVE_INTERVAL_MS)

--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
@@ -235,7 +235,13 @@ export const connect = async (
   const eventSource = new EventSource<'disconnect'>(pexipEventsUrl)
 
   eventSource.addEventListener('disconnect', (event) => {
-    const reason = event.data ? JSON.parse(event.data)?.reason : 'unknown'
+    let reason = 'unknown'
+    try {
+      reason = event.data ? (JSON.parse(event.data)?.reason ?? reason) : reason
+    } catch (error) {
+      // Malformed JSON in SSE payload — proceed with disconnect regardless
+      logger.warn('Failed to parse Pexip disconnect event data', { data: event.data, error: error as Error })
+    }
     logger.info('Pexip SSE disconnect event received', { reason })
     handleDisconnect()
   })

--- a/app/src/bcsc-theme/features/verify/live-call/utils/createVideoCallError.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/createVideoCallError.ts
@@ -14,7 +14,16 @@ export const createVideoCallError = (type: VideoCallErrorType, technicalDetails?
     case VideoCallErrorType.SESSION_FAILED:
       return {
         type,
-        message: 'Service is unavailable.',
+        title: 'Service Unavailable',
+        message: 'The video call service is temporarily unavailable. Please try again later.',
+        retryable: true,
+        technicalDetails,
+      }
+    // Evidence/photo upload failed
+    case VideoCallErrorType.DOCUMENT_UPLOAD_FAILED:
+      return {
+        type,
+        message: 'Failed to upload your documents. Please try again.',
         retryable: true,
         technicalDetails,
       }

--- a/app/src/bcsc-theme/features/verify/send-video/useEvidenceUploadModel.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/useEvidenceUploadModel.tsx
@@ -1,11 +1,11 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import {
-  UploadEvidenceResponseData,
   VerificationPhotoUploadPayload,
   VerificationPrompt,
   VerificationVideoUploadPayload,
 } from '@/bcsc-theme/api/hooks/useEvidenceApi'
 import { useLoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
+import useEvidenceUpload from '@/bcsc-theme/hooks/useEvidenceUpload'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { getVideoMetadata } from '@/bcsc-theme/utils/file-info'
@@ -28,6 +28,7 @@ const useEvidenceUploadModel = (
   const [store] = useStore<BCState>()
   const { evidence } = useApi()
   const { updateAccountFlags } = useSecureActions()
+  const { processAdditionalEvidence } = useEvidenceUpload()
   const { t } = useTranslation()
   const loadingScreen = useLoadingScreen()
   const { fileUploadErrorAlert } = useAlerts(navigation)
@@ -61,44 +62,6 @@ const useEvidenceUploadModel = (
     },
     [logger]
   )
-
-  const processAdditionalEvidence = useCallback(async () => {
-    // Process additional evidence data
-    // TODO (bm): store properly typed additional evidence in state
-    const additionalEvidence = store.bcscSecure.additionalEvidenceData
-    const evidenceUploads: { uploadUri: string; imageBytes: Buffer }[] = []
-
-    // Process each piece of additional evidence
-    for (const evidenceItem of additionalEvidence) {
-      // Upload metadata for each evidence type to get upload URIs
-      const metadataPayload = {
-        type: evidenceItem.evidenceType.evidence_type,
-        number: evidenceItem.documentNumber,
-        images: evidenceItem.metadata.map((data) => {
-          return { ...data, file_path: undefined }
-        }),
-      }
-
-      const evidenceMetadataResponse = await evidence.sendEvidenceMetadata(metadataPayload)
-      logger.debug(`Evidence metadata for ${metadataPayload.type}`)
-      // For each metadata item, find matching upload URI and read binary
-      for (const metadataItem of evidenceItem.metadata) {
-        const matchingResponse = evidenceMetadataResponse.find(
-          (response: UploadEvidenceResponseData) => response.label === metadataItem.label
-        )
-
-        if (matchingResponse) {
-          // Read the image file
-          const imageBytes = await readFileInChunks(metadataItem.file_path, logger)
-          logger.debug(`Evidence metadata ${metadataItem.label}: ${imageBytes.length}`)
-
-          evidenceUploads.push({ uploadUri: matchingResponse.upload_uri, imageBytes })
-        }
-      }
-    }
-
-    return evidenceUploads
-  }, [evidence, logger, store.bcscSecure.additionalEvidenceData])
 
   const uploadEvidenceMetadata = useCallback(
     async (photoMetadata: VerificationPhotoUploadPayload, videoMetadata: VerificationVideoUploadPayload) => {

--- a/app/src/bcsc-theme/hooks/useEvidenceUpload.tsx
+++ b/app/src/bcsc-theme/hooks/useEvidenceUpload.tsx
@@ -1,0 +1,106 @@
+import useApi from '@/bcsc-theme/api/hooks/useApi'
+import { UploadEvidenceResponseData } from '@/bcsc-theme/api/hooks/useEvidenceApi'
+import { BCState } from '@/store'
+import readFileInChunks from '@/utils/read-file'
+import { TOKENS, useServices, useStore } from '@bifold/core'
+import { useCallback } from 'react'
+
+export interface EvidenceUploadItem {
+  uploadUri: string
+  imageBytes: Buffer
+}
+
+const useEvidenceUpload = () => {
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const [store] = useStore<BCState>()
+  const { evidence } = useApi()
+
+  /**
+   * Uploads the selfie photo (metadata + binary) that was captured during the
+   * pre-verification photo step. No-ops if no photo is available in the store.
+   */
+  const uploadSelfiePhoto = useCallback(async () => {
+    const { photoPath, photoMetadata } = store.bcsc
+    if (!photoPath || !photoMetadata) {
+      logger.debug('No selfie photo to upload')
+      return
+    }
+
+    logger.info('Uploading selfie photo...')
+    const metadataResponse = await evidence.uploadPhotoEvidenceMetadata(photoMetadata)
+    const photoBytes = await readFileInChunks(photoPath, logger)
+    await evidence.uploadPhotoEvidenceBinary(metadataResponse.upload_uri, photoBytes)
+    logger.info(`Selfie photo uploaded: ${photoBytes.length} bytes`)
+  }, [evidence, logger, store.bcsc])
+
+  /**
+   * Processes additional evidence documents (secondary ID for NonPhoto BCSC).
+   * Sends metadata to the evidence API and reads image files from disk.
+   * Returns an array of { uploadUri, imageBytes } items ready for binary upload.
+   *
+   * Used by both the live-call flow (uploads immediately) and the send-video
+   * flow (batches with photo + video in a single Promise.all).
+   */
+  const processAdditionalEvidence = useCallback(async (): Promise<EvidenceUploadItem[]> => {
+    const additionalEvidence = store.bcscSecure.additionalEvidenceData
+    const evidenceUploads: EvidenceUploadItem[] = []
+
+    if (!additionalEvidence || additionalEvidence.length === 0) {
+      logger.debug('No additional evidence to process')
+      return evidenceUploads
+    }
+
+    logger.info(`Processing ${additionalEvidence.length} additional evidence item(s)...`)
+
+    for (const evidenceItem of additionalEvidence) {
+      const metadataPayload = {
+        type: evidenceItem.evidenceType.evidence_type,
+        number: evidenceItem.documentNumber,
+        images: evidenceItem.metadata.map((data) => {
+          return { ...data, file_path: undefined }
+        }),
+      }
+
+      const evidenceMetadataResponse = await evidence.sendEvidenceMetadata(metadataPayload)
+      logger.debug(`Evidence metadata sent for ${metadataPayload.type}`)
+
+      for (const metadataItem of evidenceItem.metadata) {
+        const matchingResponse = evidenceMetadataResponse.find(
+          (response: UploadEvidenceResponseData) => response.label === metadataItem.label
+        )
+
+        if (matchingResponse) {
+          const imageBytes = await readFileInChunks(metadataItem.file_path, logger)
+          logger.debug(`Evidence file read for ${metadataItem.label}: ${imageBytes.length} bytes`)
+          evidenceUploads.push({ uploadUri: matchingResponse.upload_uri, imageBytes })
+        }
+      }
+    }
+
+    return evidenceUploads
+  }, [evidence, logger, store.bcscSecure.additionalEvidenceData])
+
+  /**
+   * Uploads binary data for a list of evidence items that were previously
+   * processed by processAdditionalEvidence.
+   */
+  const uploadEvidenceBinaries = useCallback(
+    async (items: EvidenceUploadItem[]) => {
+      for (const { uploadUri, imageBytes } of items) {
+        await evidence.uploadPhotoEvidenceBinary(uploadUri, imageBytes)
+      }
+      if (items.length > 0) {
+        logger.info(`All additional evidence uploaded (${items.length} file(s))`)
+      }
+    },
+    [evidence, logger]
+  )
+
+  return {
+    uploadSelfiePhoto,
+    processAdditionalEvidence,
+    uploadEvidenceBinaries,
+  }
+}
+
+export default useEvidenceUpload

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -897,6 +897,7 @@ const translation = {
       "StartVideoCall": "Start video call",
       "CallStates": {
         "CreatingSession": "Creating video session...",
+        "UploadingDocuments": "Uploading your photo...",
         "ConnectingWebRTC": "Connecting to video service...",
         "WaitingForAgent": "Waiting for an agent to join...",
         "Initializing": "Initializing...",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -897,6 +897,7 @@ const translation = {
       "StartVideoCall": "Start video call (FR)",
       "CallStates": {
         "CreatingSession": "Creating video session... (FR)",
+        "UploadingDocuments": "Uploading your photo... (FR)",
         "ConnectingWebRTC": "Connecting to video service... (FR)",
         "WaitingForAgent": "Waiting for an agent to join... (FR)",
         "Initializing": "Initializing... (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -897,6 +897,7 @@ const translation = {
       "StartVideoCall": "Start video call (PT-BR)",
       "CallStates": {
         "CreatingSession": "Creating video session... (PT-BR)",
+        "UploadingDocuments": "Uploading your photo... (PT-BR)",
         "ConnectingWebRTC": "Connecting to video service... (PT-BR)",
         "WaitingForAgent": "Waiting for an agent to join... (PT-BR)",
         "Initializing": "Initializing... (PT-BR)",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9425,6 +9425,7 @@ __metadata:
     react-native-screenguard: "npm:~1.1.0"
     react-native-screens: "npm:~4.16.0"
     react-native-splash-screen: "npm:~3.3.0"
+    react-native-sse: "npm:~1.2.1"
     react-native-svg: "npm:~15.12.1"
     react-native-svg-transformer: "npm:~1.5.0"
     react-native-tcp-socket: "npm:~6.0.6"
@@ -19622,6 +19623,13 @@ __metadata:
   peerDependencies:
     react-native: ">=0.57.0"
   checksum: 10c0/0979585b4087dba0825c94393477fc0301210cfa09eae4a98336e91865765f3c774cf8b20c525b3cea74c588e1e4ff0aa9d7500292ad52979670aa59ab83f0a4
+  languageName: node
+  linkType: hard
+
+"react-native-sse@npm:~1.2.1":
+  version: 1.2.1
+  resolution: "react-native-sse@npm:1.2.1"
+  checksum: 10c0/68b95601da2a0d37b2cd7ee4af16169a4650ec615b656cb064aba537f3f516b2242b0533c90b63fc0950ef39e25f5a62d8bc53c70ac892c460d24dc3efe3d844
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary of Changes

- Adds react-native-sse dependency and implements SSE for real-time call disconnect detection
- Uploads selfie photo and additional evidence before WebRTC connection to ensure data is available in IDCheck
- Adds new error type DOCUMENT_UPLOAD_FAILED with improved error messages including optional title field
- Requests Bluetooth permission on Android 12+ and fixes InCallManager speaker/Bluetooth routing
- Adds videoSessionErrorPolicy to suppress global alerts for video call errors (user facing errors are properly descriptive and visible)
- Removes unused iOS permissions (Bluetooth usage descriptions, location, voip) and Android foreground service permissions
- Hooked up v3-equivalent Snowplow error events

# Testing Instructions

On both iOS and Android, go through live call flow, including non-photo

# Acceptance Criteria
- backgrounding and foreground works
- killing the app or backing out of live call stops the call
- bluetooth headsets work
- agent-side disconnect is detected almost instantaneously
- evidence is uploaded successfully and can be seen in IDCheck when verifying. Verification can be done successfully
- going through live call with non-photo card, IDCheck can be completed with all necessary info and photos uploaded

# Screenshots, videos, or gifs

Instant disconnect:
https://github.com/user-attachments/assets/10ec6566-2850-4cd9-bb52-5ca53aa50d28

Service unavailable:
![service_unavailable](https://github.com/user-attachments/assets/1d240ccc-1a02-4863-bab5-dad503df3d40)

# Related Issues

#3204 
#3208 
#3033
#3093
#2723 
#3296 