### PR TITLE
fix: ignore metro log on init

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -27,6 +27,8 @@ import { name as appName } from './app.json'
 LogBox.ignoreLogs([
   // For Credo deps that are still very new
   /module is experimental and could have unexpected/,
+  // Ignore metro open debugger log
+  'Open debugger to view warnings.',
 ])
 
 AppRegistry.registerComponent(appName, () => App)


### PR DESCRIPTION
# Summary of Changes

Ignores the "Open debugger to view warnings." info log on app init.

# Testing Instructions

Replace this text with detailed instructions on how to test the changes included in this PR.

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

<img width="393" height="852" alt="IMG_0847" src="https://github.com/user-attachments/assets/e617fcbf-1727-46da-9271-41891bcc1194" />


# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
