### PR TITLE
fix: correct transfer QR code URL and align regeneration with native iOS

### DIFF
--- a/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
@@ -58,7 +58,7 @@ const TransferQRDisplayScreen: React.FC = () => {
       jti: jti,
     })
 
-    const url = `${store.developer.environment.iasApiBaseUrl}/device/static/selfsetup.html?${jwt}`
+    const url = `${store.developer.environment.iasApiBaseUrl}/static/selfsetup.html?${jwt}`
     setQRValue(url)
     setIsLoading(false)
   }, [store.developer.environment.iasApiBaseUrl, jti])

--- a/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
@@ -19,6 +19,10 @@ import { ActivityIndicator, StyleSheet, View } from 'react-native'
 import { createDeviceSignedJWT, getAccount } from 'react-native-bcsc-core'
 import uuid from 'react-native-uuid'
 
+const qrCodeRefreshInterval = 50000 // 50 seconds
+const jwtTimeToLive = 60 // 60 seconds
+const attestationPollInterval = 3000 // 3 seconds
+
 const TransferQRDisplayScreen: React.FC = () => {
   const jtiRef = useRef(uuid.v4().toString())
   const { deviceAttestation } = useApi()
@@ -57,7 +61,7 @@ const TransferQRDisplayScreen: React.FC = () => {
       iss: account.clientID,
       sub: account.clientID,
       iat: timeInSeconds,
-      exp: timeInSeconds + 60, // give this token 1 minute to live
+      exp: timeInSeconds + jwtTimeToLive,
       jti: newJti,
     })
 
@@ -85,7 +89,7 @@ const TransferQRDisplayScreen: React.FC = () => {
     }
     intervalRef.current = setInterval(() => {
       createToken()
-    }, 50000) // 50 seconds
+    }, qrCodeRefreshInterval)
   }, [createToken])
 
   const refreshToken = useCallback(() => {
@@ -110,7 +114,7 @@ const TransferQRDisplayScreen: React.FC = () => {
     checkAttestation(jtiRef.current)
     const interval = setInterval(() => {
       checkAttestation(jtiRef.current)
-    }, 3000)
+    }, attestationPollInterval)
     return () => clearInterval(interval)
   }, [checkAttestation])
 

--- a/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
@@ -54,7 +54,6 @@ const TransferQRDisplayScreen: React.FC = () => {
     }
 
     const newJti = uuid.v4().toString()
-    jtiRef.current = newJti
 
     const jwt = await createDeviceSignedJWT({
       aud: account.issuer,
@@ -65,6 +64,7 @@ const TransferQRDisplayScreen: React.FC = () => {
       jti: newJti,
     })
 
+    jtiRef.current = newJti
     const url = `${store.developer.environment.iasApiBaseUrl}/static/selfsetup.html?${jwt}`
     setQRValue(url)
     setIsLoading(false)
@@ -111,12 +111,15 @@ const TransferQRDisplayScreen: React.FC = () => {
   }, [refreshToken, startInterval])
 
   useEffect(() => {
+    if (!qrValue) {
+      return
+    }
     checkAttestation(jtiRef.current)
     const interval = setInterval(() => {
       checkAttestation(jtiRef.current)
     }, attestationPollInterval)
     return () => clearInterval(interval)
-  }, [checkAttestation])
+  }, [checkAttestation, qrValue])
 
   if (isLoading) {
     return <ActivityIndicator size={'large'} style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }} />


### PR DESCRIPTION
## Summary
- Fixes the account transfer QR code URL by removing the extra `/device` path segment
- The QR URL was `{iasApiBaseUrl}/device/static/selfsetup.html?{jwt}` but should be `{iasApiBaseUrl}/static/selfsetup.html?{jwt}`
- This caused the receiving device to hit the wrong endpoint, resulting in "Invalid QR code" and "Server Error 302" errors during account transfer
- Aligns QR regeneration behavior with native iOS:
  - Generate a new UUID/jti on each QR refresh instead of reusing one for the entire session
  - QR regeneration interval changed from 30s to 50s (10s overlap with 60s JWT expiry, matching native iOS)
  - Attestation poll reads the latest jti via ref on each 3s tick
- Extracts magic numbers into named constants (`qrCodeRefreshInterval`, `jwtTimeToLive`, `attestationPollInterval`)
- Updates jtiRef only after JWT creation succeeds, preventing mismatched state on failure
- Defers attestation polling until the first QR is displayed

## Test plan
- [ ] Initiate account transfer from old device (generate QR code)
- [ ] Scan QR code on new device
- [ ] Verify attestation and token exchange completes successfully
- [ ] Verify old device navigates to transfer success screen
- [ ] Wait 50s+ and confirm QR visually refreshes with a new code
- [ ] Scan the refreshed QR and verify it still works
