### PR TITLE
fix: suppress expected 404 errors during attestation polling

### DIFF
--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -176,6 +176,17 @@ export const videoSessionErrorPolicy: ErrorHandlingPolicy = {
   },
 }
 
+// Error policy for attestation status polling — 404 is expected while attestation
+// has not yet been consumed by verifyAttestation.
+export const attestationPollingErrorPolicy: ErrorHandlingPolicy = {
+  matches: (_, context) => {
+    return context.statusCode === 404 && context.endpoint.includes(context.apiEndpoints.attestation)
+  },
+  handle: (_error, context) => {
+    context.logger.info('[AttestationPollingErrorPolicy] 404 expected during polling — attestation not yet consumed')
+  },
+}
+
 // Error policy for unexpected server errors (http status: 500, 503)
 export const unexpectedServerErrorPolicy: ErrorHandlingPolicy = {
   matches: (_, context) => {
@@ -329,6 +340,7 @@ export const ClientErrorHandlingPolicies: ErrorHandlingPolicy[] = [
   alreadyVerifiedErrorPolicy,
   invalidTokenReturnedPolicy,
   videoSessionErrorPolicy,
+  attestationPollingErrorPolicy,
   // Specific polices listed above, followed by global policies
   globalAlertErrorPolicy,
   unexpectedServerErrorPolicy,

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -176,8 +176,8 @@ export const videoSessionErrorPolicy: ErrorHandlingPolicy = {
   },
 }
 
-// Error policy for attestation status polling — 404 is expected while attestation
-// has not yet been consumed by verifyAttestation.
+// Error policy for attestation status polling — 404 is expected while the attestation
+// has not yet been created or consumed by another device's verifyAttestation call.
 export const attestationPollingErrorPolicy: ErrorHandlingPolicy = {
   matches: (_, context) => {
     return context.statusCode === 404 && context.endpoint.includes(context.apiEndpoints.attestation)

--- a/app/src/bcsc-theme/api/hooks/useDeviceAttestationApi.test.ts
+++ b/app/src/bcsc-theme/api/hooks/useDeviceAttestationApi.test.ts
@@ -113,7 +113,9 @@ describe('useDeviceAttestationApi', () => {
       const { result } = renderHook(() => useDeviceAttestationApi(mockApiClient))
       const response = await result.current.checkAttestationStatus(mockJwtID)
 
-      expect(mockApiClient.get).toHaveBeenCalledWith('/attestation/mock_jwt_id_123', {})
+      expect(mockApiClient.get).toHaveBeenCalledWith('/attestation/mock_jwt_id_123', {
+        suppressStatusCodeLogs: [404],
+      })
       expect(response).toBe(true)
     })
 

--- a/app/src/bcsc-theme/api/hooks/useDeviceAttestationApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useDeviceAttestationApi.tsx
@@ -73,7 +73,9 @@ const useDeviceAttestationApi = (apiClient: BCSCApiClient | null) => {
         throw new Error('BCSC client not ready for Device Attestation!')
       }
 
-      const response = await apiClient.get(`${apiClient.endpoints.attestation}/${jwtID}`, {})
+      const response = await apiClient.get(`${apiClient.endpoints.attestation}/${jwtID}`, {
+          suppressStatusCodeLogs: [404],
+        })
 
       // 200 response means that the attestation request has been consumed and is valid
       if (response.status == 200) {

--- a/app/src/bcsc-theme/api/hooks/useDeviceAttestationApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useDeviceAttestationApi.tsx
@@ -74,8 +74,8 @@ const useDeviceAttestationApi = (apiClient: BCSCApiClient | null) => {
       }
 
       const response = await apiClient.get(`${apiClient.endpoints.attestation}/${jwtID}`, {
-          suppressStatusCodeLogs: [404],
-        })
+        suppressStatusCodeLogs: [404],
+      })
 
       // 200 response means that the attestation request has been consumed and is valid
       if (response.status == 200) {


### PR DESCRIPTION
## Summary

- Added `suppressStatusCodeLogs: [404]` to the attestation status GET call in `useDeviceAttestationApi` so that 404 responses are not logged as errors during polling.
- Added `attestationPollingErrorPolicy` to `ClientErrorHandlingPolicies` so that 404s on the attestation endpoint are recognized as expected (attestation not yet consumed by `verifyAttestation`) and handled with an info-level log instead of being treated as unhandled errors.

These changes prevent noise in logs and error reporting from 404s that are a normal part of the attestation polling flow. Rather than red error logs / exceptions from Metro, you see the more graceful logging below:

```console
[BCSCApiClient] Applying error handling policy for: {
  "endpoint": "https://idsit.gov.bc.ca/device/attestations/79caeb5e-45db-49cf-bcab-ef1df7125db6",
  "appEvent": "unknown_server_error"
}
[AttestationPollingErrorPolicy] 404 expected during polling — attestation not yet consumed
```

## Test plan

- [ ] On a device with an account setup, transfer to another device from Account tab
- [ ] No error on HTTP 404 — just the logging noted above

