### PR TITLE
feat(onboarding): add Where to use button to intro carousel

### DIFF
--- a/app/src/bcsc-theme/features/onboarding/IntroCarousel.test.tsx
+++ b/app/src/bcsc-theme/features/onboarding/IntroCarousel.test.tsx
@@ -1,0 +1,125 @@
+import { BCSCScreens } from '@bcsc-theme/types/navigators'
+import { WHERE_TO_USE_URL } from '@/constants'
+import { testIdWithKey } from '@bifold/core'
+import { useNavigation } from '@mocks/custom/@react-navigation/core'
+import { BasicAppContext } from '@mocks/helpers/app'
+import { fireEvent, render } from '@testing-library/react-native'
+import React from 'react'
+import { IntroCarouselScreen } from './IntroCarousel'
+
+describe('IntroCarouselScreen', () => {
+  let mockNavigation: any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockNavigation = useNavigation()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('Rendering', () => {
+    it('should render correctly', () => {
+      const tree = render(
+        <BasicAppContext>
+          <IntroCarouselScreen navigation={mockNavigation as never} />
+        </BasicAppContext>
+      )
+
+      expect(tree).toMatchSnapshot()
+    })
+
+    it('should display the first carousel page content', () => {
+      const { getByText } = render(
+        <BasicAppContext>
+          <IntroCarouselScreen navigation={mockNavigation as never} />
+        </BasicAppContext>
+      )
+
+      expect(getByText('BCSC.Onboarding.CarouselServicesHeader')).toBeTruthy()
+      expect(getByText('BCSC.Onboarding.CarouselServicesContent')).toBeTruthy()
+    })
+
+    it('should display the "Where to use" button on the first carousel page', () => {
+      const { getByText } = render(
+        <BasicAppContext>
+          <IntroCarouselScreen navigation={mockNavigation as never} />
+        </BasicAppContext>
+      )
+
+      expect(getByText('BCSC.Home.WhereToUseTitle')).toBeTruthy()
+    })
+
+    it('should display all three carousel pages', () => {
+      const { getByText } = render(
+        <BasicAppContext>
+          <IntroCarouselScreen navigation={mockNavigation as never} />
+        </BasicAppContext>
+      )
+
+      expect(getByText('BCSC.Onboarding.CarouselServicesHeader')).toBeTruthy()
+      expect(getByText('BCSC.Onboarding.CarouselProveHeader')).toBeTruthy()
+      expect(getByText('BCSC.Onboarding.CarouselCannotUseHeader')).toBeTruthy()
+    })
+  })
+
+  describe('Navigation', () => {
+    it('should navigate to OnboardingWebView when "Where to use" button is pressed', () => {
+      const { getByText } = render(
+        <BasicAppContext>
+          <IntroCarouselScreen navigation={mockNavigation as never} />
+        </BasicAppContext>
+      )
+
+      fireEvent.press(getByText('BCSC.Home.WhereToUseTitle'))
+
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.OnboardingWebView, {
+        title: 'BCSC.Onboarding.CarouselServicesHeader',
+        url: WHERE_TO_USE_URL,
+      })
+    })
+
+    it('should navigate to the next carousel page when Next is pressed', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <IntroCarouselScreen navigation={mockNavigation as never} />
+        </BasicAppContext>
+      )
+
+      fireEvent.press(getByTestId(testIdWithKey('CarouselNext')))
+
+      expect(mockNavigation.navigate).not.toHaveBeenCalled()
+    })
+
+    it('should navigate to OnboardingPrivacyPolicy when Next is pressed on the last page', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <IntroCarouselScreen navigation={mockNavigation as never} />
+        </BasicAppContext>
+      )
+
+      const nextButton = getByTestId(testIdWithKey('CarouselNext'))
+
+      // Navigate through all pages
+      fireEvent.press(nextButton)
+      fireEvent.press(nextButton)
+      fireEvent.press(nextButton)
+
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.OnboardingPrivacyPolicy)
+    })
+
+    it('should not navigate back when Back is pressed on the first page', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <IntroCarouselScreen navigation={mockNavigation as never} />
+        </BasicAppContext>
+      )
+
+      const backButton = getByTestId(testIdWithKey('CarouselBack'))
+
+      expect(backButton.props.accessibilityState.disabled).toBe(true)
+    })
+  })
+})

--- a/app/src/bcsc-theme/features/onboarding/IntroCarousel.test.tsx
+++ b/app/src/bcsc-theme/features/onboarding/IntroCarousel.test.tsx
@@ -42,14 +42,14 @@ describe('IntroCarouselScreen', () => {
       expect(getByText('BCSC.Onboarding.CarouselServicesContent')).toBeTruthy()
     })
 
-    it('should display the "Where to use" button on the first carousel page', () => {
-      const { getByText } = render(
+    it('should display the "Where to use" button only on the first carousel page', () => {
+      const { getAllByTestId } = render(
         <BasicAppContext>
           <IntroCarouselScreen navigation={mockNavigation as never} />
         </BasicAppContext>
       )
 
-      expect(getByText('BCSC.Home.WhereToUseTitle')).toBeTruthy()
+      expect(getAllByTestId(testIdWithKey('CardButton-BCSC.Home.WhereToUseTitle'))).toHaveLength(1)
     })
 
     it('should display all three carousel pages', () => {
@@ -67,13 +67,13 @@ describe('IntroCarouselScreen', () => {
 
   describe('Navigation', () => {
     it('should navigate to OnboardingWebView when "Where to use" button is pressed', () => {
-      const { getByText } = render(
+      const { getByTestId } = render(
         <BasicAppContext>
           <IntroCarouselScreen navigation={mockNavigation as never} />
         </BasicAppContext>
       )
 
-      fireEvent.press(getByText('BCSC.Home.WhereToUseTitle'))
+      fireEvent.press(getByTestId(testIdWithKey('CardButton-BCSC.Home.WhereToUseTitle')))
 
       expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.OnboardingWebView, {
         title: 'BCSC.Onboarding.CarouselServicesHeader',

--- a/app/src/bcsc-theme/features/onboarding/IntroCarousel.test.tsx
+++ b/app/src/bcsc-theme/features/onboarding/IntroCarousel.test.tsx
@@ -1,5 +1,5 @@
-import { BCSCScreens } from '@bcsc-theme/types/navigators'
 import { WHERE_TO_USE_URL } from '@/constants'
+import { BCSCScreens } from '@bcsc-theme/types/navigators'
 import { testIdWithKey } from '@bifold/core'
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'

--- a/app/src/bcsc-theme/features/onboarding/IntroCarousel.tsx
+++ b/app/src/bcsc-theme/features/onboarding/IntroCarousel.tsx
@@ -1,4 +1,6 @@
+import { CardButton } from '@/bcsc-theme/components/CardButton'
 import { BCSCOnboardingStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
+import { WHERE_TO_USE_URL } from '@/constants'
 import FirstTutorial from '@assets/img/FirstTutorial.jpg'
 import SecondTutorial from '@assets/img/SecondTutorial.jpg'
 import ThirdTutorial from '@assets/img/ThirdTutorial.jpg'
@@ -131,6 +133,20 @@ export const IntroCarouselScreen = ({ navigation }: IntroCarouselScreenProps): R
       <ThemedText variant={'headingThree'}>{t(pageData.headerContent)}</ThemedText>
       <ThemedText>{t(pageData.bodyContentA)}</ThemedText>
       {pageData.bodyContentB ? <ThemedText>{t(pageData.bodyContentB)}</ThemedText> : null}
+      {pageData.key === 'access' ? (
+        <View style={{ marginTop: Spacing.xxl }}>
+        <CardButton
+          title={t('BCSC.Home.WhereToUseTitle')}
+          onPress={() =>
+            navigation.navigate(BCSCScreens.OnboardingWebView, {
+              title: t('BCSC.Onboarding.CarouselServicesHeader'),
+              url: WHERE_TO_USE_URL,
+            })
+          }
+          endIcon="open-in-new"
+        />
+        </View>
+      ) : null}
     </View>
   )
 

--- a/app/src/bcsc-theme/features/onboarding/IntroCarousel.tsx
+++ b/app/src/bcsc-theme/features/onboarding/IntroCarousel.tsx
@@ -135,16 +135,16 @@ export const IntroCarouselScreen = ({ navigation }: IntroCarouselScreenProps): R
       {pageData.bodyContentB ? <ThemedText>{t(pageData.bodyContentB)}</ThemedText> : null}
       {pageData.key === 'access' ? (
         <View style={{ marginTop: Spacing.xxl }}>
-        <CardButton
-          title={t('BCSC.Home.WhereToUseTitle')}
-          onPress={() =>
-            navigation.navigate(BCSCScreens.OnboardingWebView, {
-              title: t('BCSC.Onboarding.CarouselServicesHeader'),
-              url: WHERE_TO_USE_URL,
-            })
-          }
-          endIcon="open-in-new"
-        />
+          <CardButton
+            title={t('BCSC.Home.WhereToUseTitle')}
+            onPress={() =>
+              navigation.navigate(BCSCScreens.OnboardingWebView, {
+                title: t('BCSC.Onboarding.CarouselServicesHeader'),
+                url: WHERE_TO_USE_URL,
+              })
+            }
+            endIcon="open-in-new"
+          />
         </View>
       ) : null}
     </View>

--- a/app/src/bcsc-theme/features/onboarding/__snapshots__/IntroCarousel.test.tsx.snap
+++ b/app/src/bcsc-theme/features/onboarding/__snapshots__/IntroCarousel.test.tsx.snap
@@ -1,0 +1,599 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IntroCarouselScreen Rendering should render correctly 1`] = `
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "additive",
+      "right": "additive",
+      "top": "additive",
+    }
+  }
+  style={
+    [
+      {
+        "backgroundColor": "#F2F2F2",
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    handlerTag={-1}
+    handlerType="FlingGestureHandler"
+    onGestureHandlerEvent={[Function]}
+    onGestureHandlerStateChange={[Function]}
+    style={
+      {
+        "flex": 1,
+      }
+    }
+  >
+    <RCTScrollView
+      showsVerticalScrollIndicator={false}
+      style={
+        {
+          "flex": 1,
+        }
+      }
+    >
+      <View>
+        <View
+          collapsable={false}
+          style={
+            {
+              "flexDirection": "row",
+              "transform": [
+                {
+                  "translateX": 0,
+                },
+              ],
+              "width": 2250,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "width": 750,
+              }
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "gap": 16,
+                    "padding": 16,
+                  },
+                  {
+                    "width": 750,
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  {
+                    "alignItems": "center",
+                  }
+                }
+              >
+                <Image
+                  source=""
+                  style={
+                    {
+                      "height": 300,
+                      "resizeMode": "contain",
+                      "width": 750,
+                    }
+                  }
+                />
+              </View>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 26,
+                      "fontWeight": "bold",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                BCSC.Onboarding.CarouselServicesHeader
+              </Text>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "normal",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                BCSC.Onboarding.CarouselServicesContent
+              </Text>
+              <View
+                style={
+                  {
+                    "marginTop": 40,
+                  }
+                }
+              >
+                <View
+                  accessibilityLabel="BCSC.Home.WhereToUseTitle"
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": "#FFFFFF",
+                      "borderColor": "#D9EAF7",
+                      "borderRadius": 4,
+                      "borderWidth": 1,
+                      "opacity": 1,
+                      "padding": 16,
+                    }
+                  }
+                  testID="com.ariesbifold:id/CardButton-BCSC.Home.WhereToUseTitle"
+                >
+                  <View
+                    style={
+                      {
+                        "gap": 8,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "justifyContent": "space-between",
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#003366",
+                              "fontSize": 20,
+                              "fontWeight": "bold",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Home.WhereToUseTitle
+                      </Text>
+                      <Text
+                        allowFontScaling={false}
+                        selectable={false}
+                        style={
+                          [
+                            {
+                              "color": undefined,
+                              "fontSize": 32,
+                            },
+                            {
+                              "color": "#003366",
+                            },
+                            {
+                              "fontFamily": "Material Icons",
+                              "fontStyle": "normal",
+                              "fontWeight": "normal",
+                            },
+                            {},
+                          ]
+                        }
+                      >
+                        
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              {
+                "width": 750,
+              }
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "gap": 16,
+                    "padding": 16,
+                  },
+                  {
+                    "width": 750,
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  {
+                    "alignItems": "center",
+                  }
+                }
+              >
+                <Image
+                  source=""
+                  style={
+                    {
+                      "height": 300,
+                      "resizeMode": "contain",
+                      "width": 750,
+                    }
+                  }
+                />
+              </View>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 26,
+                      "fontWeight": "bold",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                BCSC.Onboarding.CarouselProveHeader
+              </Text>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "normal",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                BCSC.Onboarding.CarouselProveBodyContentA
+              </Text>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "normal",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                BCSC.Onboarding.CarouselProveBodyContentB
+              </Text>
+            </View>
+          </View>
+          <View
+            style={
+              {
+                "width": 750,
+              }
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "gap": 16,
+                    "padding": 16,
+                  },
+                  {
+                    "width": 750,
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  {
+                    "alignItems": "center",
+                  }
+                }
+              >
+                <Image
+                  source=""
+                  style={
+                    {
+                      "height": 300,
+                      "resizeMode": "contain",
+                      "width": 750,
+                    }
+                  }
+                />
+              </View>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 26,
+                      "fontWeight": "bold",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                BCSC.Onboarding.CarouselCannotUseHeader
+              </Text>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "normal",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                BCSC.Onboarding.CarouselCannotUseBodyContentA
+              </Text>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "normal",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                BCSC.Onboarding.CarouselCannotUseBodyContentB
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+        }
+      }
+    >
+      <View
+        accessibilityLabel="BCSC.Onboarding.CarouselBack"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": true,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={false}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "opacity": 0.5,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/CarouselBack"
+      >
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              {
+                "color": "#FFFFFF",
+                "fontWeight": "bold",
+              },
+            ]
+          }
+        >
+          BCSC.Onboarding.CarouselBack
+        </Text>
+      </View>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 24,
+          }
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "backgroundColor": "#FFFFFFFF",
+                "borderRadius": 6,
+                "height": 12,
+                "width": 12,
+              },
+              {
+                "backgroundColor": "#003366",
+              },
+            ]
+          }
+        />
+        <View
+          style={
+            [
+              {
+                "backgroundColor": "#FFFFFFFF",
+                "borderRadius": 6,
+                "height": 12,
+                "width": 12,
+              },
+              false,
+            ]
+          }
+        />
+        <View
+          style={
+            [
+              {
+                "backgroundColor": "#FFFFFFFF",
+                "borderRadius": 6,
+                "height": 12,
+                "width": 12,
+              },
+              false,
+            ]
+          }
+        />
+      </View>
+      <View
+        accessibilityLabel="BCSC.Onboarding.CarouselNext"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/CarouselNext"
+      >
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              {
+                "color": "#FFFFFF",
+                "fontWeight": "bold",
+              },
+            ]
+          }
+        >
+          BCSC.Onboarding.CarouselNext
+        </Text>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaView>
+`;

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -48,7 +48,7 @@ export const ACCESSIBILITY_URL =
 // appending param fromapp=1 to certain id.gov urls automatically removes header and footer and such
 export const HELP_URL = 'https://id.gov.bc.ca/static/help/topics.html?fromapp=1'
 export const SECURE_APP_LEARN_MORE_URL = 'https://id.gov.bc.ca/static/help/secure_app.html'
-export const WHERE_TO_USE_URL = 'https://id.gov.bc.ca/account/services'
+export const WHERE_TO_USE_URL = ACCOUNT_SERVICES_URL
 export const CONTACT_US_GOVERNMENT_WEBSITE_URL =
   'https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/contact-us'
 export const GET_BCSC_CARD_URL =

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -48,6 +48,7 @@ export const ACCESSIBILITY_URL =
 // appending param fromapp=1 to certain id.gov urls automatically removes header and footer and such
 export const HELP_URL = 'https://id.gov.bc.ca/static/help/topics.html?fromapp=1'
 export const SECURE_APP_LEARN_MORE_URL = 'https://id.gov.bc.ca/static/help/secure_app.html'
+export const WHERE_TO_USE_URL = 'https://id.gov.bc.ca/account/services'
 export const CONTACT_US_GOVERNMENT_WEBSITE_URL =
   'https://www2.gov.bc.ca/gov/content/governments/government-id/bc-services-card/contact-us'
 export const GET_BCSC_CARD_URL =


### PR DESCRIPTION
## Summary
- Adds a "Where to use" `CardButton` to the first onboarding carousel page ("Access services online")
- Button opens `https://id.gov.bc.ca/account/services` in an in-app WebView
- Adds `WHERE_TO_USE_URL` constant to `app/src/constants.ts`

Fixes #3291

<img width="256" alt="Screenshot_20260225-163132" src="https://github.com/user-attachments/assets/a699ee37-95a5-44a1-a160-430d47f87532" />

## Test plan
- [x] Unit tests added for `IntroCarouselScreen` (8 tests, all passing)
- [ ] Verify button renders on the first carousel slide with correct spacing
- [ ] Verify tapping the button opens the services page in the in-app WebView
- [ ] Verify button does not appear on the second or third carousel slides

