### PR TITLE
feat: reset id collection setup step 2

### DIFF
--- a/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.test.ts
@@ -1,14 +1,17 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import useSetupStepsModel from '@/bcsc-theme/features/verify/_models/useSetupStepsModel'
+import * as useRegistrationServiceModule from '@/bcsc-theme/services/hooks/useRegistrationService'
 import { BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { useSetupSteps } from '@/hooks/useSetupSteps'
 import { BCState } from '@/store'
 import * as Bifold from '@bifold/core'
 import { BasicAppContext } from '@mocks/helpers/app'
+import { getAccount, getAccountSecurityMethod } from '@mocks/react-native-bcsc-core'
 import { act, renderHook } from '@testing-library/react-native'
 import { Alert } from 'react-native'
 import { BCSCCardProcess, BCSCCardType } from 'react-native-bcsc-core'
 
+jest.mock('react-native-bcsc-core')
 jest.mock('@/bcsc-theme/api/hooks/useApi')
 jest.mock('@/hooks/useSetupSteps')
 jest.mock('@bifold/core', () => {
@@ -23,12 +26,16 @@ jest.mock('@bifold/core', () => {
 const mockUpdateTokens = jest.fn().mockResolvedValue(undefined)
 const mockUpdateVerificationRequest = jest.fn()
 const mockUpdateAccountFlags = jest.fn().mockResolvedValue(undefined)
+const mockClearSecureState = jest.fn()
+const mockDeleteVerificationData = jest.fn()
 jest.mock('@/bcsc-theme/hooks/useSecureActions', () => ({
   __esModule: true,
   default: jest.fn(() => ({
     updateTokens: mockUpdateTokens,
     updateVerificationRequest: mockUpdateVerificationRequest,
     updateAccountFlags: mockUpdateAccountFlags,
+    clearSecureState: mockClearSecureState,
+    deleteVerificationData: mockDeleteVerificationData,
   })),
 }))
 
@@ -59,6 +66,7 @@ describe('useSetupStepsModel', () => {
       verificationRequestId: 'test-verification-id',
       additionalEvidenceData: [],
       cardProcess: 'combined',
+      walletKey: 'wallet-key',
     },
   }
 
@@ -456,6 +464,41 @@ describe('useSetupStepsModel', () => {
       expect(mockUpdateVerificationRequest).not.toHaveBeenCalled()
       expect(mockUpdateAccountFlags).not.toHaveBeenCalled()
       expect(mockNavigation.navigate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleResetCardRegistration', () => {
+    it('should throw error if no account', async () => {
+      getAccount.mockResolvedValue(null)
+
+      const { result } = renderHook(() => useSetupStepsModel(mockNavigation), { wrapper: BasicAppContext })
+
+      await result.current.handleResetCardRegistration()
+
+      expect(mockLogger.error).toHaveBeenCalled()
+    })
+
+    it('should delete and clear all registration and verification data', async () => {
+      const mockDeleteRegistration = jest.fn()
+      const mockRegister = jest.fn()
+      getAccount.mockResolvedValue({ clientID: 'test-client-id' } as any)
+      getAccountSecurityMethod.mockResolvedValue('DeviceAuth')
+      jest.spyOn(useRegistrationServiceModule, 'useRegistrationService').mockReturnValue({
+        deleteRegistration: mockDeleteRegistration,
+        register: mockRegister,
+      } as any)
+
+      const { result } = renderHook(() => useSetupStepsModel(mockNavigation), { wrapper: BasicAppContext })
+
+      await result.current.handleResetCardRegistration()
+
+      expect(mockDeleteRegistration).toHaveBeenCalledWith('test-client-id')
+      expect(mockClearSecureState).toHaveBeenCalledWith({
+        hasAccount: true,
+        isHydrated: true,
+        walletKey: 'wallet-key',
+      })
+      expect(mockDeleteVerificationData).toHaveBeenCalledWith()
     })
   })
 })

--- a/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.test.ts
@@ -68,6 +68,7 @@ describe('useSetupStepsModel', () => {
       additionalEvidenceData: [],
       cardProcess: 'combined',
       walletKey: 'wallet-key',
+      registrationAccessToken: 'registration-access-token',
     },
   }
 
@@ -469,7 +470,7 @@ describe('useSetupStepsModel', () => {
   })
 
   describe('handleResetCardRegistration', () => {
-    it('should throw error if no account', async () => {
+    it('logs error if no account', async () => {
       getAccount.mockResolvedValue(null)
 
       const { result } = renderHook(() => useSetupStepsModel(mockNavigation), { wrapper: BasicAppContext })
@@ -480,9 +481,8 @@ describe('useSetupStepsModel', () => {
     })
 
     it('should display factory reset alert if error', async () => {
-      const factoryResetAlertSpy = jest
-        .spyOn(useAlertsModule, 'useAlerts')
-        .mockReturnValue({ factoryResetAlert: jest.fn() } as any)
+      const mockFactoryResetAlert = jest.fn()
+      jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue({ factoryResetAlert: mockFactoryResetAlert } as any)
       getAccount.mockResolvedValue(null)
 
       const { result } = renderHook(() => useSetupStepsModel(mockNavigation), { wrapper: BasicAppContext })
@@ -490,7 +490,7 @@ describe('useSetupStepsModel', () => {
       await result.current.handleResetCardRegistration()
 
       expect(mockLogger.error).toHaveBeenCalled()
-      expect(factoryResetAlertSpy).toHaveBeenCalled()
+      expect(mockFactoryResetAlert).toHaveBeenCalled()
     })
 
     it('should delete and clear all registration and verification data', async () => {
@@ -512,6 +512,7 @@ describe('useSetupStepsModel', () => {
         hasAccount: true,
         isHydrated: true,
         walletKey: 'wallet-key',
+        registrationAccessToken: 'registration-access-token',
       })
       expect(mockDeleteVerificationData).toHaveBeenCalledWith()
     })

--- a/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.test.ts
@@ -2,6 +2,7 @@ import useApi from '@/bcsc-theme/api/hooks/useApi'
 import useSetupStepsModel from '@/bcsc-theme/features/verify/_models/useSetupStepsModel'
 import * as useRegistrationServiceModule from '@/bcsc-theme/services/hooks/useRegistrationService'
 import { BCSCScreens } from '@/bcsc-theme/types/navigators'
+import * as useAlertsModule from '@/hooks/useAlerts'
 import { useSetupSteps } from '@/hooks/useSetupSteps'
 import { BCState } from '@/store'
 import * as Bifold from '@bifold/core'
@@ -476,6 +477,20 @@ describe('useSetupStepsModel', () => {
       await result.current.handleResetCardRegistration()
 
       expect(mockLogger.error).toHaveBeenCalled()
+    })
+
+    it('should display factory reset alert if error', async () => {
+      const factoryResetAlertSpy = jest
+        .spyOn(useAlertsModule, 'useAlerts')
+        .mockReturnValue({ factoryResetAlert: jest.fn() } as any)
+      getAccount.mockResolvedValue(null)
+
+      const { result } = renderHook(() => useSetupStepsModel(mockNavigation), { wrapper: BasicAppContext })
+
+      await result.current.handleResetCardRegistration()
+
+      expect(mockLogger.error).toHaveBeenCalled()
+      expect(factoryResetAlertSpy).toHaveBeenCalled()
     })
 
     it('should delete and clear all registration and verification data', async () => {

--- a/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
@@ -1,13 +1,17 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
+import { withAccount } from '@/bcsc-theme/api/hooks/withAccountGuard'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
+import { useRegistrationService } from '@/bcsc-theme/services/hooks/useRegistrationService'
 import { useAlerts } from '@/hooks/useAlerts'
 import { useSetupSteps } from '@/hooks/useSetupSteps'
 import { BCState } from '@/store'
 import { BCSCScreens, BCSCVerifyStackParams } from '@bcsc-theme/types/navigators'
 import { TOKENS, useServices, useStore } from '@bifold/core'
+import { useFocusEffect } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import * as BcscCore from 'react-native-bcsc-core'
 import { BCSCCardProcess } from 'react-native-bcsc-core'
 
 /**
@@ -19,14 +23,67 @@ import { BCSCCardProcess } from 'react-native-bcsc-core'
 const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParams, BCSCScreens.SetupSteps>) => {
   const { t } = useTranslation()
   const [store] = useStore<BCState>()
-  const { updateVerificationRequest, updateAccountFlags } = useSecureActions()
+  const { updateVerificationRequest, updateAccountFlags, deleteVerificationData, clearSecureState } = useSecureActions()
   const { evidence, token } = useApi()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const [isCheckingStatus, setIsCheckingStatus] = useState(false)
   const { cancelVerificationRequestAlert } = useAlerts(navigation)
+  const registrationService = useRegistrationService()
 
   // Get unified step state (completed, focused, subtext for each step)
   const steps = useSetupSteps(store)
+
+  /**
+   * Handle resetting the card registration process.
+   *
+   * Note: This will reset the completion of all setup steps excluding step 1 (account nickname).
+   * Why? Account nickname is excluded as it is independent to the card registration process (setup step 2).
+   *
+   * @returns Promise that resolves when the reset process is complete
+   */
+  const handleResetCardRegistration = useCallback(async () => {
+    try {
+      withAccount(async (account) => {
+        // 1. Clear the secure state and trigger a setup steps re-render
+        clearSecureState({
+          hasAccount: true,
+          isHydrated: true,
+          walletKey: store.bcscSecure.walletKey, // used for authentication
+        })
+
+        // 2. Get the previous device auth for re-registering the account
+        const securityMethod = await BcscCore.getAccountSecurityMethod()
+
+        await Promise.all([
+          // 3. Clean up registration on the backend
+          registrationService.deleteRegistration(account.clientID),
+          // 4. Re-register the device and generate a new account (prevents "client is in invalid state/statue" errors)
+          registrationService.register(securityMethod),
+          // 4. Delete any persisted verification data in device file system
+          deleteVerificationData(),
+        ])
+      })
+    } catch (error) {
+      logger.error('[handleResetCardRegistration] Error resetting card registration', error as Error)
+    }
+  }, [clearSecureState, deleteVerificationData, logger, registrationService, store.bcscSecure.walletKey])
+
+  useFocusEffect(
+    useCallback(() => {
+      if (steps.id.completed || (!steps.address.completed && !steps.email.completed)) {
+        // If ID step completed or address and email are both incomplete, we can assume workflow is normal
+        return
+      }
+
+      // This can be triggered by users backing out when they have partially completed step 2 (id collection)
+      logger.debug('[useSetupStepsModel] Invalid steps detected, cancelling registration and resetting state.', {
+        idStepCompleted: steps.id.completed,
+        addressStepCompleted: steps.address.completed,
+        emailStepCompleted: steps.email.completed,
+      })
+      handleResetCardRegistration()
+    }, [handleResetCardRegistration, logger, steps.address.completed, steps.email.completed, steps.id.completed])
+  )
 
   /**
    * Check the status of a pending verification request
@@ -170,6 +227,7 @@ const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParam
     isCheckingStatus,
     handleCheckStatus,
     handleCancelVerification,
+    handleResetCardRegistration,
   }
 }
 

--- a/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
@@ -27,9 +27,8 @@ const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParam
   const { evidence, token } = useApi()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const [isCheckingStatus, setIsCheckingStatus] = useState(false)
-  const { cancelVerificationRequestAlert } = useAlerts(navigation)
+  const { cancelVerificationRequestAlert, factoryResetAlert } = useAlerts(navigation)
   const registrationService = useRegistrationService()
-  const { factoryResetAlert } = useAlerts(navigation)
 
   // Get unified step state (completed, focused, subtext for each step)
   const steps = useSetupSteps(store)
@@ -63,7 +62,7 @@ const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParam
         // 4. Delete any persisted verification data in device file system
         await deleteVerificationData()
         // 5. Re-register the device and generate a new account (prevents "client is in invalid state/statue" errors)
-        await registrationService.register(securityMethod)
+        await registrationService.createRegistration(securityMethod)
       })
     } catch (error) {
       logger.error('[handleResetCardRegistration] Error resetting card registration', error as Error)

--- a/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
@@ -43,7 +43,7 @@ const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParam
    */
   const handleResetCardRegistration = useCallback(async () => {
     try {
-      withAccount(async (account) => {
+      await withAccount(async (account) => {
         // 1. Clear the secure state and trigger a setup steps re-render
         clearSecureState({
           hasAccount: true,

--- a/app/src/bcsc-theme/hooks/useSecureActions.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.tsx
@@ -746,12 +746,16 @@ export const useSecureActions = () => {
    * Clears secure state from store (does not delete from native storage).
    * Call this on logout or app lock.
    */
-  const clearSecureState = useCallback(() => {
-    logger.info('Clearing secure state from memory')
-    dispatch({
-      type: BCDispatchAction.CLEAR_SECURE_STATE,
-    })
-  }, [logger, dispatch])
+  const clearSecureState = useCallback(
+    (secureState?: Partial<BCSCSecureState>) => {
+      logger.info('Clearing secure state from memory')
+      dispatch({
+        type: BCDispatchAction.CLEAR_SECURE_STATE,
+        payload: [secureState],
+      })
+    },
+    [logger, dispatch]
+  )
 
   /**
    * Logs out the user by clearing secure state from memory and marking as not authenticated.

--- a/app/src/events/appEventCode.ts
+++ b/app/src/events/appEventCode.ts
@@ -142,7 +142,7 @@ export enum AppEventCode {
   NON_BCSC_WAS_DISABLED = 'non_bcsc_was_disabled',
   TOO_MANY_ACTIVE_ACCOUNTS = 'too_many_active_accounts',
   DEVICE_AUTHORIZATION_ERROR = 'device_authorization_error',
-  FACTORY_RESET = 'factory_reset', // Non-IAS error code
+  FATAL_UNRECOVERABLE_ERROR = 'fatal_unrecoverable_error', // Non-IAS error code
   // Wallet/Agent Errors
   STATE_LOAD_ERROR = 'state_load_error', // Non-IAS error code
   AGENT_INITIALIZATION_ERROR = 'agent_initialization_error', // Non-IAS error code

--- a/app/src/events/appEventCode.ts
+++ b/app/src/events/appEventCode.ts
@@ -142,6 +142,7 @@ export enum AppEventCode {
   NON_BCSC_WAS_DISABLED = 'non_bcsc_was_disabled',
   TOO_MANY_ACTIVE_ACCOUNTS = 'too_many_active_accounts',
   DEVICE_AUTHORIZATION_ERROR = 'device_authorization_error',
+  FACTORY_RESET = 'factory_reset', // Non-IAS error code
   // Wallet/Agent Errors
   STATE_LOAD_ERROR = 'state_load_error', // Non-IAS error code
   AGENT_INITIALIZATION_ERROR = 'agent_initialization_error', // Non-IAS error code

--- a/app/src/hooks/useAlerts.test.tsx
+++ b/app/src/hooks/useAlerts.test.tsx
@@ -1,3 +1,4 @@
+import * as useFactoryResetModule from '@/bcsc-theme/api/hooks/useFactoryReset'
 import { mockUseServices, mockUseStore } from '@/bcsc-theme/hooks/useCreateSystemChecks.test'
 import * as ErrorAlertContext from '@/contexts/ErrorAlertContext'
 import { AppEventCode } from '@/events/appEventCode'
@@ -719,6 +720,49 @@ describe('useAlerts', () => {
       action.onPress()
 
       expect(mockAction).toHaveBeenCalled()
+    })
+  })
+
+  describe('factoryResetAlert', () => {
+    it('should show an alert with the correct title and message', () => {
+      const mockNavigation = { navigate: jest.fn() }
+      const mockEmitAlert = jest.fn()
+      jest.spyOn(ErrorAlertContext, 'useErrorAlert').mockReturnValue({ emitAlert: mockEmitAlert } as any)
+
+      const { result } = renderHook(() => useAlerts(mockNavigation as any))
+
+      result.current.factoryResetAlert()
+
+      expect(mockEmitAlert).toHaveBeenCalledWith('Alerts.FactoryReset.Title', 'Alerts.FactoryReset.Description', {
+        event: AppEventCode.FATAL_UNRECOVERABLE_ERROR,
+        actions: [
+          {
+            text: 'Alerts.FactoryReset.Action1',
+            style: 'destructive',
+            onPress: expect.any(Function),
+          },
+        ],
+      })
+    })
+
+    it('onPress should factory reset the app', () => {
+      const mockNavigation = { navigate: jest.fn() }
+      const mockEmitAlert = jest.fn()
+      const mockFactoryReset = jest.fn()
+      jest.spyOn(ErrorAlertContext, 'useErrorAlert').mockReturnValue({ emitAlert: mockEmitAlert } as any)
+      jest.spyOn(useFactoryResetModule, 'useFactoryReset').mockReturnValue(mockFactoryReset as any)
+
+      const { result } = renderHook(() => useAlerts(mockNavigation as any))
+
+      result.current.factoryResetAlert()
+
+      const alertOptions = mockEmitAlert.mock.calls[0][2]
+      const action = alertOptions.actions.find((a: any) => a.text === 'Alerts.FactoryReset.Action1')
+      expect(action).toBeDefined()
+
+      action.onPress()
+
+      expect(mockFactoryReset).toHaveBeenCalled()
     })
   })
 })

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -114,6 +114,30 @@ export const useAlerts = (navigation: NavigationProp<ParamListBase>) => {
     })
   }, [emitAlert, logger, t])
 
+  // Used when the app encounters a fatal error or invalid state where the only recovery option is to reset the app.
+  const factoryResetAlert = useCallback(() => {
+    emitAlert(t('Alerts.FactoryReset.Title'), t('Alerts.FactoryReset.Description'), {
+      event: AppEventCode.FACTORY_RESET,
+      actions: [
+        {
+          text: t('Alerts.FactoryReset.Action1'),
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              const result = await factoryReset()
+
+              if (!result.success) {
+                throw result.error
+              }
+            } catch (error) {
+              logger.error('[FactoryResetAlert] Error factory resetting app', error as Error)
+            }
+          },
+        },
+      ],
+    })
+  }, [emitAlert, logger, t, factoryReset])
+
   const setupExpiredAlert = useCallback(() => {
     emitAlert(t('Alerts.SetupExpired.Title'), t('Alerts.SetupExpired.Description'), {
       event: AppEventCode.USER_INPUT_EXPIRED_VERIFY_REQUEST,
@@ -231,6 +255,7 @@ export const useAlerts = (navigation: NavigationProp<ParamListBase>) => {
       dataUseWarningAlert,
       liveCallHavingTroubleAlert,
       cancelVerificationRequestAlert,
+      factoryResetAlert,
       problemWithAppAlert: _createBasicAlert(AppEventCode.GENERAL, 'ProblemWithApp', { errorCode: '000' }),
       unsecuredNetworkAlert: _createBasicAlert(AppEventCode.UNSECURED_NETWORK, 'UnsecuredNetwork'),
       serverTimeoutAlert: _createBasicAlert(AppEventCode.SERVER_TIMEOUT, 'ServerTimeout'),
@@ -255,14 +280,15 @@ export const useAlerts = (navigation: NavigationProp<ParamListBase>) => {
       invalidTokenAlert: _createProblemWithAccountAlert(AppEventCode.INVALID_TOKEN, '215'),
     }),
     [
-      _createBasicAlert,
-      _createProblemWithAccountAlert,
       appUpdateRequiredAlert,
       setupExpiredAlert,
       liveCallFileUploadAlert,
       dataUseWarningAlert,
       liveCallHavingTroubleAlert,
       cancelVerificationRequestAlert,
+      factoryResetAlert,
+      _createBasicAlert,
+      _createProblemWithAccountAlert,
     ]
   )
 }

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -117,7 +117,7 @@ export const useAlerts = (navigation: NavigationProp<ParamListBase>) => {
   // Used when the app encounters a fatal error or invalid state where the only recovery option is to reset the app.
   const factoryResetAlert = useCallback(() => {
     emitAlert(t('Alerts.FactoryReset.Title'), t('Alerts.FactoryReset.Description'), {
-      event: AppEventCode.FACTORY_RESET,
+      event: AppEventCode.FATAL_UNRECOVERABLE_ERROR,
       actions: [
         {
           text: t('Alerts.FactoryReset.Action1'),

--- a/app/src/hooks/useSetupSteps.ts
+++ b/app/src/hooks/useSetupSteps.ts
@@ -242,5 +242,19 @@ export const useSetupSteps = (store: BCState): SetupStepsResult => {
       currentStep: getCurrentStep(),
       allCompleted: step1Completed && step2Completed && step3Completed && step4Completed && step5Completed,
     }
-  }, [store, t])
+  }, [
+    store.bcsc.accountSetupType,
+    store.bcsc.selectedNickname,
+    store.bcscSecure.additionalEvidenceData,
+    store.bcscSecure.cardProcess,
+    store.bcscSecure.deviceCode,
+    store.bcscSecure.deviceCodeExpiresAt,
+    store.bcscSecure.email,
+    store.bcscSecure.isEmailVerified,
+    store.bcscSecure.serial,
+    store.bcscSecure.userMetadata?.address,
+    store.bcscSecure.userSubmittedVerificationVideo,
+    store.bcscSecure.verified,
+    t,
+  ])
 }

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -1147,6 +1147,11 @@ const translation = {
       "Title": "Problem with Connection",
       "Description": "Please try again."
     },
+    "FactoryReset": {
+      "Title": "Problem with App",
+      "Description": "The app needs to be reset to factory settings to continue. This will delete all information in the app and you will have to set it up again.",
+      "Action1": "Reset App"
+    }
   },
   "BCWalletError": {
     "Camera": {

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -1147,6 +1147,11 @@ const translation = {
       "Title": "Problem with Connection (FR)",
       "Description": "Please try again. (FR)"
     },
+    "FactoryReset": {
+      "Title": "Problem with App (FR)",
+      "Description": "The app needs to be reset to factory settings to continue. This will delete all information in the app and you will have to set it up again. (FR)",
+      "Action1": "Reset App (FR)"
+    }
 	},
   "BCWalletError": {
     // TODO (MD): Fill in translations once all english errors are completed

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -1147,6 +1147,11 @@ const translation = {
       "Title": "Problem with Connection (PT-BR)",
       "Description": "Please try again. (PT-BR)"
     },
+    "FactoryReset": {
+      "Title": "Problem with App (PT-BR)",
+      "Description": "The app needs to be reset to factory settings to continue. This will delete all information in the app and you will have to set it up again. (PT-BR)",
+      "Action1": "Reset App (PT-BR)"
+    }
 	},
   "BCWalletError": {
     // TODO (MD): Fill in translations once all english errors are completed


### PR DESCRIPTION
# Summary of Changes

This PR fixes an invalid state bug during setup steps if a user navigates back out of the ID collection (step 2).

# Testing Instructions

1. Setup app and create nickname
2. Add non photo ID
3. Enter CSN + birthdate
4. Navigate backwards to setup steps
5. Repeat steps (ensuring all state is cleaned up and reset)

# Acceptance Criteria
Setup steps should never be rendering step 3 or 4 complete without step 2 complete.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

#3278 
