### PR TITLE
fix: live call cleanup and activity monitor pause

### DIFF
--- a/app/src/bcsc-theme/contexts/BCSCActivityContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCActivityContext.tsx
@@ -82,7 +82,6 @@ export const BCSCActivityProvider: React.FC<PropsWithChildren> = ({ children }) 
     [clearInactivityTimeoutIfExists, handleInactivityTimeout]
   )
 
-  // TODO (bm): use these in live call
   const pauseActivityTracking = useCallback(() => {
     logger.info('BCSC Activity: Pausing activity tracking')
     isPausedRef.current = true

--- a/app/src/bcsc-theme/features/onboarding/IntroCarousel.tsx
+++ b/app/src/bcsc-theme/features/onboarding/IntroCarousel.tsx
@@ -134,7 +134,7 @@ export const IntroCarouselScreen = ({ navigation }: IntroCarouselScreenProps): R
       <ThemedText>{t(pageData.bodyContentA)}</ThemedText>
       {pageData.bodyContentB ? <ThemedText>{t(pageData.bodyContentB)}</ThemedText> : null}
       {pageData.key === 'access' ? (
-        <View style={{ marginTop: Spacing.xxl }}>
+        <View style={{ marginTop: Spacing.md }}>
           <CardButton
             title={t('BCSC.Home.WhereToUseTitle')}
             onPress={() =>

--- a/app/src/bcsc-theme/features/onboarding/__snapshots__/IntroCarousel.test.tsx.snap
+++ b/app/src/bcsc-theme/features/onboarding/__snapshots__/IntroCarousel.test.tsx.snap
@@ -128,7 +128,7 @@ exports[`IntroCarouselScreen Rendering should render correctly 1`] = `
               <View
                 style={
                   {
-                    "marginTop": 40,
+                    "marginTop": 16,
                   }
                 }
               >

--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.test.tsx
@@ -1,3 +1,4 @@
+import { BCSCActivityProvider } from '@/bcsc-theme/contexts/BCSCActivityContext'
 import { FcmService, FcmServiceProvider } from '@/bcsc-theme/features/fcm'
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
@@ -22,9 +23,11 @@ describe('LiveCall', () => {
     const fcmService = new FcmService()
     const tree = render(
       <BasicAppContext>
-        <FcmServiceProvider service={fcmService}>
-          <LiveCallScreen navigation={mockNavigation as never} />
-        </FcmServiceProvider>
+        <BCSCActivityProvider>
+          <FcmServiceProvider service={fcmService}>
+            <LiveCallScreen navigation={mockNavigation as never} />
+          </FcmServiceProvider>
+        </BCSCActivityProvider>
       </BasicAppContext>
     )
 
@@ -39,9 +42,11 @@ describe('LiveCall', () => {
 
     const tree = render(
       <BasicAppContext>
-        <FcmServiceProvider service={fcmService}>
-          <LiveCallScreen navigation={mockNavigation as never} />
-        </FcmServiceProvider>
+        <BCSCActivityProvider>
+          <FcmServiceProvider service={fcmService}>
+            <LiveCallScreen navigation={mockNavigation as never} />
+          </FcmServiceProvider>
+        </BCSCActivityProvider>
       </BasicAppContext>
     )
 

--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
@@ -1,5 +1,6 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { AppBannerSection as BannerSection, BCSCBanner } from '@/bcsc-theme/components/AppBanner'
+import { useBCSCActivity } from '@/bcsc-theme/contexts/BCSCActivityContext'
 import { useFcmService } from '@/bcsc-theme/features/fcm'
 import useVideoCallFlow from '@/bcsc-theme/features/verify/live-call/hooks/useVideoCallFlow'
 import { VideoCallFlowState } from '@/bcsc-theme/features/verify/live-call/types/live-call'
@@ -45,6 +46,7 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
   const { token } = useApi()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const { liveCallHavingTroubleAlert } = useAlerts(navigation)
+  const { pauseActivityTracking, resumeActivityTracking } = useBCSCActivity()
 
   // check if verified, save token if so, and then navigate accordingly
   const leaveCall = useCallback(async () => {
@@ -228,6 +230,13 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
       InCallManager.stop()
     }
   }, [])
+
+  useEffect(() => {
+    pauseActivityTracking()
+    return () => {
+      resumeActivityTracking()
+    }
+  }, [pauseActivityTracking, resumeActivityTracking])
 
   // loading / error user-facing state message
   const stateMessage = useMemo(() => {

--- a/app/src/bcsc-theme/features/verify/live-call/__snapshots__/LiveCallScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/live-call/__snapshots__/LiveCallScreen.test.tsx.snap
@@ -1,178 +1,90 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LiveCall renders correctly 1`] = `
-<RNCSafeAreaView
-  edges={
-    {
-      "bottom": "additive",
-      "left": "additive",
-      "right": "additive",
-      "top": "additive",
-    }
-  }
+<View
+  onMoveShouldSetResponder={[Function]}
+  onMoveShouldSetResponderCapture={[Function]}
+  onResponderEnd={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderReject={[Function]}
+  onResponderRelease={[Function]}
+  onResponderStart={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  onStartShouldSetResponderCapture={[Function]}
   style={
     {
-      "backgroundColor": "#F2F2F2",
       "flex": 1,
-      "justifyContent": "space-between",
     }
   }
 >
-  <View
+  <RNCSafeAreaView
+    edges={
+      {
+        "bottom": "additive",
+        "left": "additive",
+        "right": "additive",
+        "top": "additive",
+      }
+    }
     style={
       {
+        "backgroundColor": "#F2F2F2",
         "flex": 1,
+        "justifyContent": "space-between",
       }
     }
   >
-    <View
-      style={
-        {
-          "backgroundColor": "#001e3d",
-          "height": 11,
-          "width": "100%",
-        }
-      }
-    >
-      <View
-        collapsable={false}
-        style={
-          {
-            "backgroundColor": "#FCBA19",
-            "bottom": 0,
-            "height": "100%",
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-            "transform": [
-              {
-                "translateX": -375,
-              },
-              {
-                "scaleX": 0,
-              },
-              {
-                "translateX": 375,
-              },
-            ],
-            "width": "100%",
-          }
-        }
-      />
-    </View>
     <View
       style={
         {
           "flex": 1,
-          "padding": 16,
         }
       }
-    >
-      <Text
-        maxFontSizeMultiplier={2}
-        style={
-          [
-            {
-              "color": "#313132",
-              "fontFamily": "BCSans-Regular",
-              "fontSize": 32,
-              "fontWeight": "bold",
-            },
-            {
-              "marginTop": 80,
-              "textAlign": "center",
-            },
-          ]
-        }
-      >
-        BCSC.VideoCall.Loading.OneMomentPlease
-      </Text>
-      <Text
-        maxFontSizeMultiplier={2}
-        style={
-          [
-            {
-              "color": "#313132",
-              "fontFamily": "BCSans-Regular",
-              "fontSize": 18,
-              "fontWeight": "normal",
-            },
-            {
-              "marginTop": 80,
-              "textAlign": "center",
-            },
-          ]
-        }
-      >
-        BCSC.VideoCall.CallStates.UploadingDocuments
-      </Text>
-      <
-        height={200}
-        style={
-          {
-            "alignSelf": "center",
-            "marginVertical": 16,
-          }
-        }
-        width={200}
-      />
-    </View>
-  </View>
-  <View
-    style={
-      {
-        "marginTop": "auto",
-        "padding": 16,
-      }
-    }
-  >
-    <View
-      accessibilityLabel="Global.Cancel"
-      accessibilityRole="button"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        {
-          "backgroundColor": "#003366",
-          "borderRadius": 4,
-          "opacity": 1,
-          "padding": 16,
-        }
-      }
-      testID="com.ariesbifold:id/Cancel"
     >
       <View
         style={
           {
-            "alignItems": "center",
-            "flexDirection": "row",
-            "justifyContent": "center",
+            "backgroundColor": "#001e3d",
+            "height": 11,
+            "width": "100%",
+          }
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            {
+              "backgroundColor": "#FCBA19",
+              "bottom": 0,
+              "height": "100%",
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "transform": [
+                {
+                  "translateX": -375,
+                },
+                {
+                  "scaleX": 0,
+                },
+                {
+                  "translateX": 375,
+                },
+              ],
+              "width": "100%",
+            }
+          }
+        />
+      </View>
+      <View
+        style={
+          {
+            "flex": 1,
+            "padding": 16,
           }
         }
       >
@@ -183,28 +95,136 @@ exports[`LiveCall renders correctly 1`] = `
               {
                 "color": "#313132",
                 "fontFamily": "BCSans-Regular",
-                "fontSize": 18,
-                "fontWeight": "normal",
+                "fontSize": 32,
+                "fontWeight": "bold",
               },
-              [
-                {
-                  "color": "#FFFFFF",
-                  "fontFamily": "BCSans-Regular",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
-                  "textAlign": "center",
-                },
-                false,
-                false,
-                false,
-              ],
+              {
+                "marginTop": 80,
+                "textAlign": "center",
+              },
             ]
           }
         >
-          Global.Cancel
+          BCSC.VideoCall.Loading.OneMomentPlease
         </Text>
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              {
+                "marginTop": 80,
+                "textAlign": "center",
+              },
+            ]
+          }
+        >
+          BCSC.VideoCall.CallStates.UploadingDocuments
+        </Text>
+        <
+          height={200}
+          style={
+            {
+              "alignSelf": "center",
+              "marginVertical": 16,
+            }
+          }
+          width={200}
+        />
       </View>
     </View>
-  </View>
-</RNCSafeAreaView>
+    <View
+      style={
+        {
+          "marginTop": "auto",
+          "padding": 16,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Global.Cancel"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "backgroundColor": "#003366",
+            "borderRadius": 4,
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/Cancel"
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            maxFontSizeMultiplier={2}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                },
+                [
+                  {
+                    "color": "#FFFFFF",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                    "textAlign": "center",
+                  },
+                  false,
+                  false,
+                  false,
+                ],
+              ]
+            }
+          >
+            Global.Cancel
+          </Text>
+        </View>
+      </View>
+    </View>
+  </RNCSafeAreaView>
+</View>
 `;

--- a/app/src/bcsc-theme/features/verify/live-call/hooks/useVideoCallFlow.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/hooks/useVideoCallFlow.tsx
@@ -54,11 +54,13 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
   const [localStream, setLocalStream] = useState<MediaStream | null>(null)
   const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null)
   const [isInBackground, setIsInBackground] = useState(false)
-  const [connection, setConnection] = useState<ConnectResult | null>(null)
   const backendKeepAliveTimerRef = useRef<NodeJS.Timeout | null>(null)
   const prevIsInBackgroundRef = useRef(false)
-  const cleanupCompletedRef = useRef(false)
   const handleRemoteDisconnectRef = useRef<(() => Promise<void>) | null>(null)
+  const abortedRef = useRef(false)
+  const connectionRef = useRef<ConnectResult | null>(null)
+  const sessionRef = useRef<VideoSession | null>(null)
+  const clientCallIdRef = useRef<string | null>(null)
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const { video } = useApi()
   const { uploadSelfiePhoto, processAdditionalEvidence, uploadEvidenceBinaries } = useEvidenceUpload()
@@ -92,34 +94,45 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
   // disconnects from pexip conference
   // updates call and session via API
   // clears state
+  //
+  // This function is idempotent: refs are captured and cleared synchronously
+  // at the top so concurrent or repeated calls are safe no-ops.
   const cleanup = useCallback(async () => {
-    if (cleanupCompletedRef.current) {
-      logger.info('Cleanup already completed, skipping...')
-      return
-    }
-    cleanupCompletedRef.current = true
-    connection?.setAppInitiatedDisconnect(true)
-    connection?.stopPexipKeepAlive()
-    connection?.closePexipEventSource()
+    abortedRef.current = true
+
+    // Capture and clear refs synchronously to prevent concurrent cleanup
+    // calls from double-releasing resources
+    const conn = connectionRef.current
+    connectionRef.current = null
+    const sid = sessionRef.current?.session_id ?? null
+    sessionRef.current = null
+    const cid = clientCallIdRef.current
+    clientCallIdRef.current = null
+
+    conn?.setAppInitiatedDisconnect(true)
+    conn?.stopPexipKeepAlive()
+    conn?.closePexipEventSource()
     clearIntervalIfExists(backendKeepAliveTimerRef)
 
-    try {
-      logger.info('Disconnecting from Pexip...')
-      await connection?.disconnectPexip()
-    } catch (error) {
-      logger.error('Error disconnecting from Pexip:', error as Error)
-    }
+    if (conn) {
+      try {
+        logger.info('Disconnecting from Pexip...')
+        await conn.disconnectPexip()
+      } catch (error) {
+        logger.error('Error disconnecting from Pexip:', error as Error)
+      }
 
-    try {
-      connection?.releaseLocalStream()
-    } catch (error) {
-      logger.error('Error releasing local stream:', error as Error)
-    }
+      try {
+        conn.releaseLocalStream()
+      } catch (error) {
+        logger.error('Error releasing local stream:', error as Error)
+      }
 
-    try {
-      connection?.closePeerConnection()
-    } catch (error) {
-      logger.error('Error closing peer connection:', error as Error)
+      try {
+        conn.closePeerConnection()
+      } catch (error) {
+        logger.error('Error closing peer connection:', error as Error)
+      }
     }
 
     // Clear stream state after releasing local streams and closing peer connections
@@ -127,30 +140,25 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
     setLocalStream(null)
     setRemoteStream(null)
 
-    try {
-      if (!session || !clientCallId) {
-        throw new Error('Missing required parameters to end call')
+    if (sid && cid) {
+      try {
+        await video.updateVideoCallStatus(sid, cid, 'call_ended')
+      } catch (error) {
+        logger.error('Failed to update video call status:', error as Error)
       }
-
-      await video.updateVideoCallStatus(session.session_id, clientCallId, 'call_ended')
-    } catch (error) {
-      logger.error('Failed to update video call status:', error as Error)
     }
 
-    try {
-      if (!session) {
-        throw new Error(t('BCSC.VideoCall.MissingSession'))
+    if (sid) {
+      try {
+        await video.endVideoSession(sid)
+      } catch (error) {
+        logger.error('Failed to end video session:', error as Error)
       }
-
-      await video.endVideoSession(session.session_id)
-    } catch (error) {
-      logger.error('Failed to end video session:', error as Error)
     }
 
     setSession(null)
     setClientCallId(null)
-    setConnection(null)
-  }, [video, clientCallId, session, connection, logger, t])
+  }, [video, logger])
 
   const startBackendKeepAlive = useCallback(() => {
     clearIntervalIfExists(backendKeepAliveTimerRef)
@@ -224,6 +232,7 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
   const createSession = useCallback(async (): Promise<VideoSession | null> => {
     try {
       const newSession = await video.createVideoSession()
+      sessionRef.current = newSession
       setSession(newSession)
       return newSession
     } catch (error) {
@@ -255,7 +264,7 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
 
         const conn = await connect(connectionRequest, logger)
         conn.setAppInitiatedDisconnect(false)
-        setConnection(conn)
+        connectionRef.current = conn
         setLocalStream(conn.localStream)
 
         setFlowState(VideoCallFlowState.WAITING_FOR_AGENT)
@@ -274,6 +283,7 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
     async (sessionId: string): Promise<VideoCall | null> => {
       try {
         const id = uuid.v4().toString()
+        clientCallIdRef.current = id
         setClientCallId(id)
         const call = await video.createVideoCall(sessionId, id, 'call_ringing')
         return call
@@ -288,30 +298,37 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
   // three step process with the steps above
   // all of the functions within catch their own errors
   const startVideoCall = useCallback(async () => {
-    cleanupCompletedRef.current = false
+    abortedRef.current = false
     setFlowState(VideoCallFlowState.UPLOADING_DOCUMENTS)
     const uploaded = await uploadPreCallEvidence()
-    if (!uploaded) {
+    if (!uploaded || abortedRef.current) {
       return
     }
 
     setFlowState(VideoCallFlowState.CREATING_SESSION)
     const newSession = await createSession()
-    if (!newSession) {
+    if (!newSession || abortedRef.current) {
       return
     }
 
     setFlowState(VideoCallFlowState.CONNECTING_WEBRTC)
     const connected = await establishWebRTCConnection(newSession)
-    if (!connected) {
+    if (!connected || abortedRef.current) {
+      // If aborted after WebRTC resources were allocated, clean them up
+      if (abortedRef.current) {
+        await cleanup()
+      }
       return
     }
 
     const newCall = await createCall(newSession.session_id)
-    if (!newCall) {
+    if (!newCall || abortedRef.current) {
+      if (abortedRef.current) {
+        await cleanup()
+      }
       return
     }
-  }, [createSession, uploadPreCallEvidence, establishWebRTCConnection, createCall])
+  }, [createSession, uploadPreCallEvidence, establishWebRTCConnection, createCall, cleanup])
 
   // if the user encounters a retryable error, they can start the process again
   const retryConnection = useCallback(async () => {


### PR DESCRIPTION
# Summary of Changes

This PR does two things for live call:
- pauses activity monitoring during live call so users don't get kicked out of a call due to not touching the screen for a given time
- fixes cleanup logic so there isn't a race condition, allowing all calls to be cancelled properly

There's also a three character change to a button position to get closer to wireframe

# Testing Instructions

See the reproduction steps in the ticket linked below

# Acceptance Criteria

All calls that should be ended, are fully ended

# Screenshots, videos, or gifs

N/A

# Related Issues

#3208 