### PR TITLE
chore: run quality checks on merge queue

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, labeled]
+  merge_group:
 
 jobs:
   quality:


### PR DESCRIPTION
## Summary
- Add `merge_group` trigger to the Code Quality workflow so the "Lint, Format, Typecheck, Test, and Coverage" job runs in the merge queue

## Test plan
- [ ] Verify the quality check appears as a required status on PRs entering the merge queue

