### PR TITLE
feat: contact card autofill

### DIFF
--- a/app/src/bcsc-theme/features/verify/ResidentialAddressScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/ResidentialAddressScreen.tsx
@@ -43,7 +43,7 @@ export const ResidentialAddressScreen = ({ navigation }: ResidentialAddressScree
         onChange={(value) => handleChange('streetAddress', value)}
         error={formErrors.streetAddress}
         subtext={t('BCSC.Address.StreetAddressSubtext')}
-        textInputProps={{ autoCorrect: false }}
+        textInputProps={{ autoCorrect: false, autoComplete: 'address-line1', textContentType: 'streetAddressLine1' }}
       />
 
       <InputWithValidation
@@ -53,7 +53,7 @@ export const ResidentialAddressScreen = ({ navigation }: ResidentialAddressScree
         onChange={(value) => handleChange('streetAddress2', value)}
         error={formErrors.streetAddress2}
         subtext={t('BCSC.Address.StreetAddress2Subtext')}
-        textInputProps={{ autoCorrect: false }}
+        textInputProps={{ autoCorrect: false, autoComplete: 'address-line2', textContentType: 'streetAddressLine2' }}
       />
 
       <InputWithValidation
@@ -63,7 +63,7 @@ export const ResidentialAddressScreen = ({ navigation }: ResidentialAddressScree
         onChange={(value) => handleChange('city', value)}
         error={formErrors.city}
         subtext={t('BCSC.Address.CitySubtext')}
-        textInputProps={{ autoCorrect: false }}
+        textInputProps={{ autoCorrect: false, autoComplete: 'postal-address-locality', textContentType: 'addressCity' }}
       />
 
       <DropdownWithValidation
@@ -84,7 +84,12 @@ export const ResidentialAddressScreen = ({ navigation }: ResidentialAddressScree
         onChange={(value) => handleChange('postalCode', value)}
         error={formErrors.postalCode}
         subtext={t('BCSC.Address.PostalCodeSubtext')}
-        textInputProps={{ autoCorrect: false, autoCapitalize: 'characters' }}
+        textInputProps={{
+          autoCorrect: false,
+          autoCapitalize: 'characters',
+          autoComplete: 'postal-code',
+          textContentType: 'postalCode',
+        }}
       />
 
       <View style={{ marginTop: 48, width: '100%' }}>

--- a/app/src/bcsc-theme/features/verify/__snapshots__/ResidentialAddressScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/__snapshots__/ResidentialAddressScreen.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`ResidentialAddress renders correctly 1`] = `
             </Text>
             <TextInput
               accessibilityLabel="BCSC.Address.StreetAddressLabel"
+              autoComplete="address-line1"
               autoCorrect={false}
               onChange={[Function]}
               style={
@@ -133,6 +134,7 @@ exports[`ResidentialAddress renders correctly 1`] = `
                 ]
               }
               testID="com.ariesbifold:id/streetAddress1-input"
+              textContentType="streetAddressLine1"
               value=""
             />
             <Text
@@ -183,6 +185,7 @@ exports[`ResidentialAddress renders correctly 1`] = `
             </Text>
             <TextInput
               accessibilityLabel="BCSC.Address.StreetAddress2Label"
+              autoComplete="address-line2"
               autoCorrect={false}
               onChange={[Function]}
               style={
@@ -201,6 +204,7 @@ exports[`ResidentialAddress renders correctly 1`] = `
                 ]
               }
               testID="com.ariesbifold:id/streetAddress2-input"
+              textContentType="streetAddressLine2"
               value=""
             />
             <Text
@@ -251,6 +255,7 @@ exports[`ResidentialAddress renders correctly 1`] = `
             </Text>
             <TextInput
               accessibilityLabel="BCSC.Address.CityLabel"
+              autoComplete="postal-address-locality"
               autoCorrect={false}
               onChange={[Function]}
               style={
@@ -269,6 +274,7 @@ exports[`ResidentialAddress renders correctly 1`] = `
                 ]
               }
               testID="com.ariesbifold:id/city-input"
+              textContentType="addressCity"
               value=""
             />
             <Text
@@ -462,6 +468,7 @@ exports[`ResidentialAddress renders correctly 1`] = `
             <TextInput
               accessibilityLabel="BCSC.Address.PostalCodeLabel"
               autoCapitalize="characters"
+              autoComplete="postal-code"
               autoCorrect={false}
               onChange={[Function]}
               style={
@@ -480,6 +487,7 @@ exports[`ResidentialAddress renders correctly 1`] = `
                 ]
               }
               testID="com.ariesbifold:id/postalCode-input"
+              textContentType="postalCode"
               value=""
             />
             <Text

--- a/app/src/bcsc-theme/features/verify/email/EmailTextInput.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EmailTextInput.tsx
@@ -36,6 +36,8 @@ const EmailTextInput: React.FC<Props> = ({ handleChangeEmail, ...textInputProps 
         value={value}
         onChangeText={onChangeText}
         keyboardType="email-address"
+        autoComplete={'email'}
+        textContentType={'emailAddress'}
         {...textInputProps}
       />
     </View>

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
@@ -328,7 +328,7 @@ const EvidenceIDCollectionScreen = ({ navigation, route }: EvidenceIDCollectionS
               onChange={(value) => handleChange('lastName', value)}
               error={formErrors.lastName}
               subtext={t('BCSC.EvidenceIDCollection.LastNameSubtext')}
-              textInputProps={{ autoCorrect: false }}
+              textInputProps={{ autoCorrect: false, autoComplete: 'name-family', textContentType: 'familyName' }}
             />
 
             <InputWithValidation
@@ -338,7 +338,7 @@ const EvidenceIDCollectionScreen = ({ navigation, route }: EvidenceIDCollectionS
               onChange={(value) => handleChange('firstName', value)}
               error={formErrors.firstName}
               subtext={t('BCSC.EvidenceIDCollection.FirstNameSubtext')}
-              textInputProps={{ autoCorrect: false }}
+              textInputProps={{ autoCorrect: false, autoComplete: 'name-given', textContentType: 'givenName' }}
             />
 
             <InputWithValidation
@@ -348,7 +348,7 @@ const EvidenceIDCollectionScreen = ({ navigation, route }: EvidenceIDCollectionS
               onChange={(value) => handleChange('middleNames', value)}
               error={formErrors.middleNames}
               subtext={t('BCSC.EvidenceIDCollection.MiddleNamesSubtext')}
-              textInputProps={{ autoCorrect: false }}
+              textInputProps={{ autoCorrect: false, autoComplete: 'name-middle', textContentType: 'middleName' }}
             />
 
             <DatePicker

--- a/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/EvidenceIDCollectionScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/EvidenceIDCollectionScreen.test.tsx.snap
@@ -209,6 +209,7 @@ exports[`EvidenceIDCollection renders correctly 1`] = `
               </Text>
               <TextInput
                 accessibilityLabel="BCSC.EvidenceIDCollection.LastNameLabel"
+                autoComplete="name-family"
                 autoCorrect={false}
                 onChange={[Function]}
                 style={
@@ -227,6 +228,7 @@ exports[`EvidenceIDCollection renders correctly 1`] = `
                   ]
                 }
                 testID="com.ariesbifold:id/lastName-input"
+                textContentType="familyName"
                 value=""
               />
               <Text
@@ -277,6 +279,7 @@ exports[`EvidenceIDCollection renders correctly 1`] = `
               </Text>
               <TextInput
                 accessibilityLabel="BCSC.EvidenceIDCollection.FirstNameLabel"
+                autoComplete="name-given"
                 autoCorrect={false}
                 onChange={[Function]}
                 style={
@@ -295,6 +298,7 @@ exports[`EvidenceIDCollection renders correctly 1`] = `
                   ]
                 }
                 testID="com.ariesbifold:id/firstName-input"
+                textContentType="givenName"
                 value=""
               />
               <Text
@@ -345,6 +349,7 @@ exports[`EvidenceIDCollection renders correctly 1`] = `
               </Text>
               <TextInput
                 accessibilityLabel="BCSC.EvidenceIDCollection.MiddleNamesLabel"
+                autoComplete="name-middle"
                 autoCorrect={false}
                 onChange={[Function]}
                 style={
@@ -363,6 +368,7 @@ exports[`EvidenceIDCollection renders correctly 1`] = `
                   ]
                 }
                 testID="com.ariesbifold:id/middleNames-input"
+                textContentType="middleName"
                 value=""
               />
               <Text


### PR DESCRIPTION
# Summary of Changes

This PR enables the use of Contact Card (iOS) or it's Android equivalent (My Card) to autofill fields in the ResidentialAddress, EvidenceIDCollection, and Email screens. 

# Testing Instructions

Create a Contact Card in the Contacts App with names, email, address, and go through the non-BCSC flow, confirming when you use the relevant text input you can autofill from that Contact Card.

# Acceptance Criteria

Contact Card autofill works

# Screenshots, videos, or gifs

<img width="300" height="650" alt="contact_card_autofill" src="https://github.com/user-attachments/assets/96af50ec-9e9c-4d66-aeb0-6342a2ae367e" />

# Related Issues

#3241 