### PR TITLE
fix: deep link protocols

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -71,10 +71,6 @@
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="didcomm" />
         <data android:scheme="bcwallet" />
-        <data android:scheme="ca.bc.gov.id.servicescard" />
-        <data android:scheme="ca.bc.gov.id.servicescard.dev" />
-        <data android:scheme="ca.bc.gov.id.servicescard.qa" />
-        <data android:scheme="ca.bc.gov.id.servicescard.test" />
       </intent-filter>
     </activity>
   </application>

--- a/scripts/apply-variant.mjs
+++ b/scripts/apply-variant.mjs
@@ -29,9 +29,9 @@
  *   variants/bcsc-dev/delete.txt
  */
 
-import { readFileSync, writeFileSync, existsSync, unlinkSync, readdirSync, statSync, copyFileSync, mkdirSync } from 'fs'
-import { join, dirname, resolve } from 'path'
 import { spawnSync } from 'child_process'
+import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'fs'
+import { dirname, join, resolve } from 'path'
 
 // ─── Constants ──────────────────────────────────────────────────
 
@@ -188,7 +188,8 @@ function copyDirRecursive(src, dest) {
 }
 
 /**
- * Apply URL schemes to Info.plist for BCSC variants.
+ * Replace URL schemes in Info.plist for BCSC variants.
+ * Replaces the entire CFBundleURLTypes array with the variant's schemes.
  */
 function applyUrlSchemes(env) {
   const schemes = env.IOS_URL_SCHEMES
@@ -201,31 +202,93 @@ function applyUrlSchemes(env) {
 
   const schemeList = schemes.split(',').map((s) => s.trim())
 
-  // Build the URL scheme dict XML
-  const schemeEntries = schemeList.map((s) => `\t\t\t\t<string>${s}</string>`).join('\n')
-  const urlSchemeDict = `\t\t<dict>
+  // Build one dict per scheme (matching v3 ias-ios pattern)
+  const schemeDicts = schemeList
+    .map(
+      (s) => `\t\t<dict>
 \t\t\t<key>CFBundleURLSchemes</key>
 \t\t\t<array>
-${schemeEntries}
+\t\t\t\t<string>${s}</string>
 \t\t\t</array>
 \t\t</dict>`
+    )
+    .join('\n')
 
-  // Check if this URL scheme dict already exists
-  if (content.includes(schemeList[0])) {
-    console.log('  URL schemes already present in Info.plist, skipping')
+  const newUrlTypes = `<key>CFBundleURLTypes</key>
+\t<array>
+${schemeDicts}
+\t</array>`
+
+  // Find the CFBundleURLTypes block using nesting-aware parsing
+  const startMarker = '<key>CFBundleURLTypes</key>'
+  const startIdx = content.indexOf(startMarker)
+  if (startIdx === -1) {
+    console.warn('  WARN: Could not find CFBundleURLTypes in Info.plist')
     return
   }
 
-  // Insert before the closing </array> of CFBundleURLTypes
-  // Find the CFBundleURLTypes array and add our dict before its closing </array>
-  const urlTypesPattern = /(<key>CFBundleURLTypes<\/key>\s*<array>)([\s\S]*?)(\s*<\/array>)/
-  const match = content.match(urlTypesPattern)
-  if (match) {
-    content = content.replace(urlTypesPattern, `$1$2\n${urlSchemeDict}$3`)
-    writeFileSync(plistPath, content)
-    console.log(`  Added ${schemeList.length} URL schemes to Info.plist`)
+  // Find the <array> that follows, then track nesting to find matching </array>
+  const arrayStart = content.indexOf('<array>', startIdx)
+  if (arrayStart === -1) {
+    console.warn('  WARN: Could not find <array> after CFBundleURLTypes')
+    return
+  }
+
+  let depth = 0
+  let i = arrayStart
+  let endIdx = -1
+  while (i < content.length) {
+    if (content.startsWith('<array>', i)) {
+      depth++
+      i += '<array>'.length
+    } else if (content.startsWith('</array>', i)) {
+      depth--
+      if (depth === 0) {
+        endIdx = i + '</array>'.length
+        break
+      }
+      i += '</array>'.length
+    } else {
+      i++
+    }
+  }
+
+  if (endIdx === -1) {
+    console.warn('  WARN: Could not find closing </array> for CFBundleURLTypes')
+    return
+  }
+
+  content = content.slice(0, startIdx) + newUrlTypes + content.slice(endIdx)
+  writeFileSync(plistPath, content)
+  console.log(`  Replaced URL schemes in Info.plist: ${schemeList.join(', ')}`)
+}
+
+/**
+ * Replace URL schemes in AndroidManifest.xml for BCSC variants.
+ * Replaces the browsable intent-filter data schemes with the variant's schemes.
+ */
+function applyAndroidUrlSchemes(env) {
+  const schemes = env.ANDROID_URL_SCHEMES
+  if (!schemes) return
+
+  const manifestPath = join(ROOT_DIR, 'app/android/app/src/main/AndroidManifest.xml')
+  if (!existsSync(manifestPath)) return
+
+  let content = readFileSync(manifestPath, 'utf-8')
+
+  const schemeList = schemes.split(',').map((s) => s.trim())
+  const schemeLines = schemeList.map((s) => `        <data android:scheme="${s}" />`).join('\n')
+
+  // Replace the browsable intent-filter's data schemes
+  const intentFilterPattern =
+    /(<intent-filter>\s*<action android:name="android\.intent\.action\.VIEW" \/>\s*<category android:name="android\.intent\.category\.DEFAULT" \/>\s*<category android:name="android\.intent\.category\.BROWSABLE" \/>)\s*(?:<data android:scheme="[^"]+" \/>\s*)+(<\/intent-filter>)/
+
+  if (content.match(intentFilterPattern)) {
+    content = content.replace(intentFilterPattern, `$1\n${schemeLines}\n      $2`)
+    writeFileSync(manifestPath, content)
+    console.log(`  Replaced URL schemes in AndroidManifest.xml: ${schemeList.join(', ')}`)
   } else {
-    console.warn('  WARN: Could not find CFBundleURLTypes in Info.plist')
+    console.warn('  WARN: Could not find browsable intent-filter in AndroidManifest.xml')
   }
 }
 
@@ -252,7 +315,10 @@ function applyPbxprojStructuralFixes(env) {
       'g'
     )
 
-    if (content.match(sectionPattern) && !content.includes(`inputPaths = (\n\t\t\t);\n\t\t\tname = "[CP] ${section}"`)) {
+    if (
+      content.match(sectionPattern) &&
+      !content.includes(`inputPaths = (\n\t\t\t);\n\t\t\tname = "[CP] ${section}"`)
+    ) {
       content = content.replace(sectionPattern, `$1$2inputPaths = (\n\t\t\t);\n\t\t\t$3`)
     }
 
@@ -376,6 +442,12 @@ function applyVariant(variantName) {
   if (env.IOS_URL_SCHEMES) {
     console.log(`\n→ Applying iOS URL schemes...`)
     applyUrlSchemes(env)
+  }
+
+  // 5b. Apply URL schemes (Android)
+  if (env.ANDROID_URL_SCHEMES) {
+    console.log(`\n→ Applying Android URL schemes...`)
+    applyAndroidUrlSchemes(env)
   }
 
   // 6. Apply pbxproj target name change

--- a/variants/bcsc-dev/variant.env
+++ b/variants/bcsc-dev/variant.env
@@ -13,8 +13,8 @@ IOS_PRODUCT_NAME='$(TARGET_NAME)'
 IOS_PBXPROJ_TARGET_NAME='BCWallet'
 
 # URL schemes (comma-separated) — replaces base bcwallet/didcomm schemes
-IOS_URL_SCHEMES='ca.bc.gov.iddev.servicescard,ca.bc.gov.iddev.servicescard.v2'
-ANDROID_URL_SCHEMES='ca.bc.gov.iddev.servicescard.v2,ca.bc.gov.id.servicescard.dev'
+IOS_URL_SCHEMES='ca.bc.gov.iddev.servicescard,ca.bc.gov.idqa.servicescard,ca.bc.gov.idtest.servicescard'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.dev,ca.bc.gov.id.servicescard.qa,ca.bc.gov.id.servicescard.test'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-dev/variant.env
+++ b/variants/bcsc-dev/variant.env
@@ -12,8 +12,9 @@ IOS_BUNDLE_ID='ca.bc.gov.iddev.servicescard'
 IOS_PRODUCT_NAME='$(TARGET_NAME)'
 IOS_PBXPROJ_TARGET_NAME='BCWallet'
 
-# URL schemes to add to Info.plist (comma-separated)
-IOS_URL_SCHEMES='ca.bc.gov.iddev.servicescard,ca.bc.gov.idqa.servicescard,ca.bc.gov.idtest.servicescard,ca.bc.gov.idsit.servicescard'
+# URL schemes (comma-separated) — replaces base bcwallet/didcomm schemes
+IOS_URL_SCHEMES='ca.bc.gov.iddev.servicescard,ca.bc.gov.iddev.servicescard.v2'
+ANDROID_URL_SCHEMES='ca.bc.gov.iddev.servicescard.v2,ca.bc.gov.id.servicescard.dev'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-dev/variant.env
+++ b/variants/bcsc-dev/variant.env
@@ -13,8 +13,8 @@ IOS_PRODUCT_NAME='$(TARGET_NAME)'
 IOS_PBXPROJ_TARGET_NAME='BCWallet'
 
 # URL schemes (comma-separated) — replaces base bcwallet/didcomm schemes
-IOS_URL_SCHEMES='ca.bc.gov.iddev.servicescard,ca.bc.gov.idqa.servicescard,ca.bc.gov.idtest.servicescard'
-ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.dev,ca.bc.gov.id.servicescard.qa,ca.bc.gov.id.servicescard.test'
+IOS_URL_SCHEMES='ca.bc.gov.iddev.servicescard,ca.bc.gov.iddev.servicescard.v2,ca.bc.gov.idqa.servicescard,ca.bc.gov.idqa.servicescard.v2,ca.bc.gov.idtest.servicescard,ca.bc.gov.idtest.servicescard.v2'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.dev,ca.bc.gov.iddev.servicescard.v2,ca.bc.gov.id.servicescard.qa,ca.bc.gov.idqa.servicescard.v2,ca.bc.gov.id.servicescard.test,ca.bc.gov.idtest.servicescard.v2'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-prod/variant.env
+++ b/variants/bcsc-prod/variant.env
@@ -12,8 +12,9 @@ IOS_BUNDLE_ID='ca.bc.gov.id.servicescard'
 IOS_PRODUCT_NAME='$(TARGET_NAME)'
 IOS_PBXPROJ_TARGET_NAME='BCWallet'
 
-# URL schemes to add to Info.plist (comma-separated)
-IOS_URL_SCHEMES='ca.bc.gov.id.servicescard'
+# URL schemes (comma-separated) — replaces base bcwallet/didcomm schemes
+IOS_URL_SCHEMES='ca.bc.gov.id.servicescard,ca.bc.gov.id.servicescard.v2'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.v2,ca.bc.gov.id.servicescard'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-prod/variant.env
+++ b/variants/bcsc-prod/variant.env
@@ -13,8 +13,8 @@ IOS_PRODUCT_NAME='$(TARGET_NAME)'
 IOS_PBXPROJ_TARGET_NAME='BCWallet'
 
 # URL schemes (comma-separated) — replaces base bcwallet/didcomm schemes
-IOS_URL_SCHEMES='ca.bc.gov.id.servicescard,ca.bc.gov.id.servicescard.v2'
-ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.v2,ca.bc.gov.id.servicescard'
+IOS_URL_SCHEMES='ca.bc.gov.id.servicescard'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-prod/variant.env
+++ b/variants/bcsc-prod/variant.env
@@ -13,8 +13,8 @@ IOS_PRODUCT_NAME='$(TARGET_NAME)'
 IOS_PBXPROJ_TARGET_NAME='BCWallet'
 
 # URL schemes (comma-separated) — replaces base bcwallet/didcomm schemes
-IOS_URL_SCHEMES='ca.bc.gov.id.servicescard'
-ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard'
+IOS_URL_SCHEMES='ca.bc.gov.id.servicescard,ca.bc.gov.id.servicescard.v2'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard,ca.bc.gov.id.servicescard.v2'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-qa/variant.env
+++ b/variants/bcsc-qa/variant.env
@@ -13,8 +13,8 @@ IOS_PRODUCT_NAME='$(TARGET_NAME)'
 IOS_PBXPROJ_TARGET_NAME='BCWallet'
 
 # URL schemes (comma-separated) — replaces base bcwallet/didcomm schemes
-IOS_URL_SCHEMES='ca.bc.gov.iddev.servicescard,ca.bc.gov.idqa.servicescard,ca.bc.gov.idtest.servicescard'
-ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.dev,ca.bc.gov.id.servicescard.qa,ca.bc.gov.id.servicescard.test'
+IOS_URL_SCHEMES='ca.bc.gov.iddev.servicescard,ca.bc.gov.iddev.servicescard.v2,ca.bc.gov.idqa.servicescard,ca.bc.gov.idqa.servicescard.v2,ca.bc.gov.idtest.servicescard,ca.bc.gov.idtest.servicescard.v2'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.dev,ca.bc.gov.iddev.servicescard.v2,ca.bc.gov.id.servicescard.qa,ca.bc.gov.idqa.servicescard.v2,ca.bc.gov.id.servicescard.test,ca.bc.gov.idtest.servicescard.v2'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-qa/variant.env
+++ b/variants/bcsc-qa/variant.env
@@ -12,8 +12,9 @@ IOS_BUNDLE_ID='ca.bc.gov.idqa.servicescard'
 IOS_PRODUCT_NAME='$(TARGET_NAME)'
 IOS_PBXPROJ_TARGET_NAME='BCWallet'
 
-# URL schemes to add to Info.plist (comma-separated)
-IOS_URL_SCHEMES='ca.bc.gov.id.servicescard,ca.bc.gov.iddev.servicescard,ca.bc.gov.idqa.servicescard,ca.bc.gov.idtest.servicescard,ca.bc.gov.idsit.servicescard'
+# URL schemes (comma-separated) — replaces base bcwallet/didcomm schemes
+IOS_URL_SCHEMES='ca.bc.gov.idqa.servicescard,ca.bc.gov.idqa.servicescard.v2'
+ANDROID_URL_SCHEMES='ca.bc.gov.idqa.servicescard.v2,ca.bc.gov.id.servicescard.qa'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-qa/variant.env
+++ b/variants/bcsc-qa/variant.env
@@ -13,8 +13,8 @@ IOS_PRODUCT_NAME='$(TARGET_NAME)'
 IOS_PBXPROJ_TARGET_NAME='BCWallet'
 
 # URL schemes (comma-separated) — replaces base bcwallet/didcomm schemes
-IOS_URL_SCHEMES='ca.bc.gov.idqa.servicescard,ca.bc.gov.idqa.servicescard.v2'
-ANDROID_URL_SCHEMES='ca.bc.gov.idqa.servicescard.v2,ca.bc.gov.id.servicescard.qa'
+IOS_URL_SCHEMES='ca.bc.gov.iddev.servicescard,ca.bc.gov.idqa.servicescard,ca.bc.gov.idtest.servicescard'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.dev,ca.bc.gov.id.servicescard.qa,ca.bc.gov.id.servicescard.test'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-test/variant.env
+++ b/variants/bcsc-test/variant.env
@@ -12,8 +12,9 @@ IOS_BUNDLE_ID='ca.bc.gov.idtest.servicescard'
 IOS_PRODUCT_NAME='$(TARGET_NAME)'
 IOS_PBXPROJ_TARGET_NAME='BCWallet'
 
-# URL schemes to add to Info.plist (comma-separated)
-IOS_URL_SCHEMES='ca.bc.gov.id.servicescard,ca.bc.gov.iddev.servicescard,ca.bc.gov.idqa.servicescard,ca.bc.gov.idtest.servicescard,ca.bc.gov.idsit.servicescard'
+# URL schemes (comma-separated) — replaces base bcwallet/didcomm schemes
+IOS_URL_SCHEMES='ca.bc.gov.idtest.servicescard,ca.bc.gov.idtest.servicescard.v2'
+ANDROID_URL_SCHEMES='ca.bc.gov.idtest.servicescard.v2,ca.bc.gov.id.servicescard.test'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-test/variant.env
+++ b/variants/bcsc-test/variant.env
@@ -13,8 +13,8 @@ IOS_PRODUCT_NAME='$(TARGET_NAME)'
 IOS_PBXPROJ_TARGET_NAME='BCWallet'
 
 # URL schemes (comma-separated) — replaces base bcwallet/didcomm schemes
-IOS_URL_SCHEMES='ca.bc.gov.idtest.servicescard,ca.bc.gov.idtest.servicescard.v2'
-ANDROID_URL_SCHEMES='ca.bc.gov.idtest.servicescard.v2,ca.bc.gov.id.servicescard.test'
+IOS_URL_SCHEMES='ca.bc.gov.iddev.servicescard,ca.bc.gov.idqa.servicescard,ca.bc.gov.idtest.servicescard'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.dev,ca.bc.gov.id.servicescard.qa,ca.bc.gov.id.servicescard.test'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-test/variant.env
+++ b/variants/bcsc-test/variant.env
@@ -13,8 +13,8 @@ IOS_PRODUCT_NAME='$(TARGET_NAME)'
 IOS_PBXPROJ_TARGET_NAME='BCWallet'
 
 # URL schemes (comma-separated) — replaces base bcwallet/didcomm schemes
-IOS_URL_SCHEMES='ca.bc.gov.iddev.servicescard,ca.bc.gov.idqa.servicescard,ca.bc.gov.idtest.servicescard'
-ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.dev,ca.bc.gov.id.servicescard.qa,ca.bc.gov.id.servicescard.test'
+IOS_URL_SCHEMES='ca.bc.gov.iddev.servicescard,ca.bc.gov.iddev.servicescard.v2,ca.bc.gov.idqa.servicescard,ca.bc.gov.idqa.servicescard.v2,ca.bc.gov.idtest.servicescard,ca.bc.gov.idtest.servicescard.v2'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.dev,ca.bc.gov.iddev.servicescard.v2,ca.bc.gov.id.servicescard.qa,ca.bc.gov.idqa.servicescard.v2,ca.bc.gov.id.servicescard.test,ca.bc.gov.idtest.servicescard.v2'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'


### PR DESCRIPTION
# Summary of Changes

This PR makes it so only BC Wallet has didcomm and bcwallet inbound deeplinks, and only BCSC variants have the same inbound deeplinks as v3 (ias-ios and ias-android) including some v2 schemes we were missing. Not sure what those are used for but best to keep parity I figure.

The only difference between v3 and v4 now is that our non-prod environments accept all non-prod inbound schemes, not just their own, to account for the environment switching we have enabled. So qa, dev, sit, test, can all be tested with BCSC Dev still. Prod cannot, and prod does not accept non-prod inbound schemes.

# Testing Instructions
Do a BC Wallet build, try a BC Wallet deeplink from the showcase (the functionality doesn't work but just verify BC Wallet is opened)

Do a BCSC bcsc-dev variant build, try a BCSC demo deeplink

# Acceptance Criteria

Deeplinks work as expected and BC Wallet doesn't open BCSC stuff, BCSC doesn't open BC Wallet stuff

# Screenshots, videos, or gifs

N/A

# Related Issues

#3203 