### PR TITLE
feat(evidence): other options

### DIFF
--- a/app/__mocks__/custom/@react-navigation/core.ts
+++ b/app/__mocks__/custom/@react-navigation/core.ts
@@ -11,6 +11,7 @@ const navigation = {
   })),
   goBack: jest.fn(),
   pop: jest.fn(),
+  replace: jest.fn(),
   reset: jest.fn(),
   dispatch: jest.fn(),
   addListener: jest.fn(),

--- a/app/src/bcsc-theme/features/verify/non-photo/AdditionalIdentificationRequiredScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/AdditionalIdentificationRequiredScreen.tsx
@@ -70,6 +70,8 @@ const AdditionalIdentificationRequiredScreen: React.FC<AdditionalIdentificationR
                * @see EnterBirthdateViewModel.authorizeDevice()
                */
               cardProcess: store.bcscSecure.cardProcess ?? BCSCCardProcess.None,
+              // Non-photo BCSC users see photo IDs first, with an "Other Options" escape hatch
+              photoFilter: 'photo',
             })
           }}
           buttonType={ButtonType.Primary}

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
@@ -15,13 +15,13 @@ import {
   useServices,
   useStore,
 } from '@bifold/core'
-import { CommonActions } from '@react-navigation/native'
+import { CommonActions, RouteProp } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import moment from 'moment'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Keyboard, View } from 'react-native'
-import { BCSCCardProcess, EvidenceType } from 'react-native-bcsc-core'
+import { BCSCCardProcess } from 'react-native-bcsc-core'
 import DatePicker from 'react-native-date-picker'
 
 type EvidenceCollectionFormState = {
@@ -36,7 +36,7 @@ type EvidenceCollectionFormErrors = Partial<EvidenceCollectionFormState>
 
 type EvidenceIDCollectionScreenProps = {
   navigation: StackNavigationProp<BCSCVerifyStackParams, BCSCScreens.EvidenceIDCollection>
-  route: { params: { cardType: EvidenceType; documentNumber?: string } }
+  route: RouteProp<BCSCVerifyStackParams, BCSCScreens.EvidenceIDCollection>
 }
 
 /**
@@ -258,6 +258,8 @@ const EvidenceIDCollectionScreen = ({ navigation, route }: EvidenceIDCollectionS
             name: BCSCScreens.EvidenceTypeList,
             params: {
               cardProcess: BCSCCardProcess.BCSCNonPhoto,
+              // Second time around: must select a photo ID, no "Other Options" escape hatch
+              photoFilter: 'photo',
             },
           },
         ],
@@ -272,6 +274,13 @@ const EvidenceIDCollectionScreen = ({ navigation, route }: EvidenceIDCollectionS
       logger.error('Error removing evidence on cancel', error as Error)
     }
 
+    const navParams: BCSCVerifyStackParams[BCSCScreens.EvidenceTypeList] = {
+      cardProcess: store.bcscSecure.cardProcess ?? BCSCCardProcess.BCSCNonPhoto,
+    }
+    if (store.bcscSecure.cardProcess === BCSCCardProcess.BCSCNonPhoto) {
+      navParams.photoFilter = 'photo'
+    }
+
     navigation.dispatch(
       CommonActions.reset({
         index: 1,
@@ -279,7 +288,7 @@ const EvidenceIDCollectionScreen = ({ navigation, route }: EvidenceIDCollectionS
           { name: BCSCScreens.SetupSteps },
           {
             name: BCSCScreens.EvidenceTypeList,
-            params: { cardProcess: store.bcscSecure.cardProcess ?? BCSCCardProcess.BCSCNonPhoto },
+            params: navParams,
           },
         ],
       })

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.test.tsx
@@ -1,9 +1,13 @@
+import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { render } from '@testing-library/react-native'
+import { RouteProp } from '@react-navigation/native'
+import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 import { BCSCCardProcess } from 'react-native-bcsc-core'
 import EvidenceTypeListScreen from './EvidenceTypeListScreen'
+
+type EvidenceTypeListRoute = RouteProp<BCSCVerifyStackParams, BCSCScreens.EvidenceTypeList>
 
 describe('EvidenceTypeList', () => {
   let mockNavigation: any
@@ -23,11 +27,63 @@ describe('EvidenceTypeList', () => {
       <BasicAppContext>
         <EvidenceTypeListScreen
           navigation={mockNavigation as never}
-          route={{ params: { cardProcess: BCSCCardProcess.None } }}
+          route={{ params: { cardProcess: BCSCCardProcess.None } } as EvidenceTypeListRoute}
         />
       </BasicAppContext>
     )
 
     expect(tree).toMatchSnapshot()
+  })
+
+  it('renders "Other Options" footer when photoFilter is photo and no evidence selected', () => {
+    const { getByText, getByTestId } = render(
+      <BasicAppContext>
+        <EvidenceTypeListScreen
+          navigation={mockNavigation as never}
+          route={
+            { params: { cardProcess: BCSCCardProcess.BCSCNonPhoto, photoFilter: 'photo' } } as EvidenceTypeListRoute
+          }
+        />
+      </BasicAppContext>
+    )
+
+    expect(getByText('BCSC.EvidenceTypeList.OtherOptions')).toBeTruthy()
+    expect(getByText('BCSC.EvidenceTypeList.IDontHaveAnyOfThese')).toBeTruthy()
+    expect(getByTestId('com.ariesbifold:id/EvidenceTypeListOtherOptions')).toBeTruthy()
+  })
+
+  it('navigates to nonPhoto filter when "Other Options" is pressed', () => {
+    const { getByTestId } = render(
+      <BasicAppContext>
+        <EvidenceTypeListScreen
+          navigation={mockNavigation as never}
+          route={
+            { params: { cardProcess: BCSCCardProcess.BCSCNonPhoto, photoFilter: 'photo' } } as EvidenceTypeListRoute
+          }
+        />
+      </BasicAppContext>
+    )
+
+    fireEvent.press(getByTestId('com.ariesbifold:id/EvidenceTypeListOtherOptions'))
+    expect(mockNavigation.replace).toHaveBeenCalledWith('BCSCEvidenceTypeList', {
+      cardProcess: BCSCCardProcess.BCSCNonPhoto,
+      photoFilter: 'nonPhoto',
+    })
+  })
+
+  it('does not render "Other Options" footer when photoFilter is nonPhoto', () => {
+    const { queryByText } = render(
+      <BasicAppContext>
+        <EvidenceTypeListScreen
+          navigation={mockNavigation as never}
+          route={
+            { params: { cardProcess: BCSCCardProcess.BCSCNonPhoto, photoFilter: 'nonPhoto' } } as EvidenceTypeListRoute
+          }
+        />
+      </BasicAppContext>
+    )
+
+    expect(queryByText('BCSC.EvidenceTypeList.OtherOptions')).toBeNull()
+    expect(queryByText('BCSC.EvidenceTypeList.IDontHaveAnyOfThese')).toBeNull()
   })
 })

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.test.tsx
@@ -47,8 +47,7 @@ describe('EvidenceTypeList', () => {
       </BasicAppContext>
     )
 
-    expect(getByText('BCSC.EvidenceTypeList.OtherOptions')).toBeTruthy()
-    expect(getByText('BCSC.EvidenceTypeList.IDontHaveAnyOfThese')).toBeTruthy()
+    expect(getByText('BCSC.EvidenceTypeList.ShowMoreOptions')).toBeTruthy()
     expect(getByTestId('com.ariesbifold:id/EvidenceTypeListOtherOptions')).toBeTruthy()
   })
 
@@ -83,7 +82,6 @@ describe('EvidenceTypeList', () => {
       </BasicAppContext>
     )
 
-    expect(queryByText('BCSC.EvidenceTypeList.OtherOptions')).toBeNull()
-    expect(queryByText('BCSC.EvidenceTypeList.IDontHaveAnyOfThese')).toBeNull()
+    expect(queryByText('BCSC.EvidenceTypeList.ShowMoreOptions')).toBeNull()
   })
 })

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.tsx
@@ -5,7 +5,7 @@ import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { BCState } from '@/store'
 import { ScreenWrapper, testIdWithKey, ThemedText, TOKENS, useServices, useStore, useTheme } from '@bifold/core'
-import { useFocusEffect } from '@react-navigation/native'
+import { RouteProp, useFocusEffect } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -14,11 +14,7 @@ import { BCSCCardProcess, EvidenceType } from 'react-native-bcsc-core'
 
 type EvidenceTypeListScreenProps = {
   navigation: StackNavigationProp<BCSCVerifyStackParams, BCSCScreens.EvidenceTypeList>
-  route: {
-    params: {
-      cardProcess: BCSCCardProcess
-    }
-  }
+  route: RouteProp<BCSCVerifyStackParams, BCSCScreens.EvidenceTypeList>
 }
 
 interface SectionData {
@@ -45,7 +41,7 @@ const ItemSeparator = () => {
 }
 
 const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenProps) => {
-  const { cardProcess } = route.params
+  const { cardProcess, photoFilter } = route.params
   const { ColorPalette, Spacing } = useTheme()
   const { t } = useTranslation()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
@@ -120,6 +116,14 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
         // list is filtered differently based on when the user seeing this screen
         // first and second runs will show slightly different cards
         p.evidence_types.forEach((e) => {
+          // Apply photo filter if specified (used by non-photo BCSC flow)
+          if (photoFilter === 'photo' && !e.has_photo) {
+            return
+          }
+          if (photoFilter === 'nonPhoto' && e.has_photo) {
+            return
+          }
+
           if (shouldAddEvidence(e)) {
             cards = addToEvidenceDictionary(cards, e)
           }
@@ -128,7 +132,7 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
     })
     const mappedData = mapEvidenceToSections(cards)
     setEvidenceSections(mappedData)
-  }, [data, cardProcess, shouldAddEvidence])
+  }, [data, cardProcess, photoFilter, shouldAddEvidence])
 
   const mapEvidenceToSections = (cards: Record<string, EvidenceType[]>): SectionData[] => {
     const mappedData: { title: string; data: EvidenceType[] }[] = []
@@ -169,9 +173,29 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
       return [t('BCSC.EvidenceTypeList.Heading'), t('BCSC.EvidenceTypeList.Description')]
     }
 
+    if (photoFilter === 'photo') {
+      // Non-photo BCSC first visit — showing photo IDs
+      return [t('BCSC.EvidenceTypeList.Heading'), t('BCSC.EvidenceTypeList.Description')]
+    }
+
+    if (photoFilter === 'nonPhoto') {
+      // Non-photo BCSC "Other Options" — showing non-photo IDs
+      return [t('BCSC.EvidenceTypeList.FirstID'), '']
+    }
+
     // Choose your first ID
     return [t('BCSC.EvidenceTypeList.FirstID'), '']
-  }, [store.bcscSecure.additionalEvidenceData.length, cardProcess, t])
+  }, [store.bcscSecure.additionalEvidenceData.length, cardProcess, photoFilter, t])
+
+  /**
+   * Whether the "Other Options" escape hatch should be shown.
+   * Only shown when:
+   * - Filtering for photo IDs (photoFilter === 'photo')
+   * - First evidence selection (no evidence selected yet)
+   * This matches v3 behavior: non-photo BCSC users who don't have a photo ID
+   * can choose a non-photo ID instead (but will still need a photo ID afterward).
+   */
+  const showOtherOptions = photoFilter === 'photo' && store.bcscSecure.additionalEvidenceData.length === 0
 
   if (isLoading) {
     return <ActivityIndicator size={'large'} style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }} />
@@ -216,6 +240,31 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
             </View>
           </Pressable>
         )}
+        ListFooterComponent={
+          showOtherOptions ? (
+            <>
+              <SectionSeparator />
+              <ThemedText style={[styles.cardSection, { color: ColorPalette.brand.primary }]} variant={'headingFour'}>
+                {t('BCSC.EvidenceTypeList.OtherOptions')}
+              </ThemedText>
+              <Pressable
+                onPress={() => {
+                  navigation.replace(BCSCScreens.EvidenceTypeList, {
+                    cardProcess,
+                    photoFilter: 'nonPhoto',
+                  })
+                }}
+                testID={testIdWithKey('EvidenceTypeListOtherOptions')}
+                style={({ pressed }) => [
+                  styles.cardSection,
+                  pressed && { backgroundColor: ColorPalette.brand.primaryLight, opacity: 0.8 },
+                ]}
+              >
+                <ThemedText>{t('BCSC.EvidenceTypeList.IDontHaveAnyOfThese')}</ThemedText>
+              </Pressable>
+            </>
+          ) : null
+        }
       />
     </ScreenWrapper>
   )

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.tsx
@@ -180,7 +180,7 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
 
     if (photoFilter === 'nonPhoto') {
       // Non-photo BCSC "Other Options" — showing non-photo IDs
-      return [t('BCSC.EvidenceTypeList.FirstID'), '']
+      return [t('BCSC.EvidenceTypeList.OtherIDOptionsHeading'), t('BCSC.EvidenceTypeList.OtherIDOptionsDescription')]
     }
 
     // Choose your first ID
@@ -260,7 +260,7 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
                   pressed && { backgroundColor: ColorPalette.brand.primaryLight, opacity: 0.8 },
                 ]}
               >
-                <ThemedText>{t('BCSC.EvidenceTypeList.IDontHaveAnyOfThese')}</ThemedText>
+                <ThemedText>{t('BCSC.EvidenceTypeList.ShowMoreOptions')}</ThemedText>
               </Pressable>
             </>
           ) : null

--- a/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/EvidenceTypeListScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/EvidenceTypeListScreen.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`EvidenceTypeList renders correctly 1`] = `
     </Text>
   </View>
   <RCTScrollView
+    ListFooterComponent={null}
     data={[]}
     getItem={[Function]}
     getItemCount={[Function]}

--- a/app/src/bcsc-theme/types/navigators.ts
+++ b/app/src/bcsc-theme/types/navigators.ts
@@ -169,7 +169,7 @@ export type BCSCVerifyStackParams = {
   [BCSCScreens.AdditionalIdentificationRequired]: undefined
   [BCSCScreens.DualIdentificationRequired]: undefined
   [BCSCScreens.IDPhotoInformation]: { cardType: EvidenceType }
-  [BCSCScreens.EvidenceTypeList]: { cardProcess: BCSCCardProcess }
+  [BCSCScreens.EvidenceTypeList]: { cardProcess: BCSCCardProcess; photoFilter?: 'photo' | 'nonPhoto' }
   [BCSCScreens.EvidenceCapture]: { cardType: EvidenceType }
   [BCSCScreens.EvidenceIDCollection]: { cardType: EvidenceType; documentNumber?: string }
   [BCSCScreens.BeforeYouCall]: { formattedHours?: string }

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -960,7 +960,9 @@ const translation = {
       "Description": "Use an ID that has the same name as on your BC Services Card.",
       "NonBCSCDescription": "Use an ID that has the same name as your first ID.",
       "FirstID": "Choose your first ID",
-      "SecondID": "Choose your second ID"
+      "SecondID": "Choose your second ID",
+      "OtherOptions": "Other Options",
+      "IDontHaveAnyOfThese": "I don't have any of these"
     },
     "EvidenceIDCollection": {
       "Heading1": "Enter the information",

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -962,7 +962,9 @@ const translation = {
       "FirstID": "Choose your first ID",
       "SecondID": "Choose your second ID",
       "OtherOptions": "Other Options",
-      "IDontHaveAnyOfThese": "I don't have any of these"
+      "ShowMoreOptions": "Show more options",
+      "OtherIDOptionsHeading": "Other ID options",
+      "OtherIDOptionsDescription": "You can use one of the following IDs, but will also need to provide photo ID."
     },
     "EvidenceIDCollection": {
       "Heading1": "Enter the information",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -961,8 +961,10 @@ const translation = {
       "NonBCSCDescription": "Use an ID that has the same name as your first ID. (FR)",
       "FirstID": "Choose your first ID (FR)",
       "SecondID": "Choose your second ID (FR)",
-      "OtherOptions": "Other Options (FR)",
-      "IDontHaveAnyOfThese": "I don't have any of these (FR)"
+      "OtherOptions": "Other options (FR)",
+      "ShowMoreOptions": "Show more options (FR)",
+      "OtherIDOptionsHeading": "Other ID options (FR)",
+      "OtherIDOptionsDescription": "You can use one of the following IDs, but will also need to provide photo ID. (FR)"
     },
     "EvidenceIDCollection": {
       "Heading1": "Enter the information (FR)",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -960,7 +960,9 @@ const translation = {
       "Description": "Use an ID that has the same name as on your BC Services Card. (FR)",
       "NonBCSCDescription": "Use an ID that has the same name as your first ID. (FR)",
       "FirstID": "Choose your first ID (FR)",
-      "SecondID": "Choose your second ID (FR)"
+      "SecondID": "Choose your second ID (FR)",
+      "OtherOptions": "Other Options (FR)",
+      "IDontHaveAnyOfThese": "I don't have any of these (FR)"
     },
     "EvidenceIDCollection": {
       "Heading1": "Enter the information (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -961,8 +961,10 @@ const translation = {
       "NonBCSCDescription": "Use an ID that has the same name as your first ID. (PT-BR)",
       "FirstID": "Choose your first ID (PT-BR)",
       "SecondID": "Choose your second ID (PT-BR)",
-      "OtherOptions": "Other Options (PT-BR)",
-      "IDontHaveAnyOfThese": "I don't have any of these (PT-BR)"
+      "OtherOptions": "Other options (PT-BR)",
+      "ShowMoreOptions": "Show more options (PT-BR)",
+      "OtherIDOptionsHeading": "Other ID options (PT-BR)",
+      "OtherIDOptionsDescription": "You can use one of the following IDs, but will also need to provide photo ID. (PT-BR)"
     },
     "EvidenceIDCollection": {
       "Heading1": "Enter the information (PT-BR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -960,7 +960,9 @@ const translation = {
       "Description": "Use an ID that has the same name as on your BC Services Card. (PT-BR)",
       "NonBCSCDescription": "Use an ID that has the same name as your first ID. (PT-BR)",
       "FirstID": "Choose your first ID (PT-BR)",
-      "SecondID": "Choose your second ID (PT-BR)"
+      "SecondID": "Choose your second ID (PT-BR)",
+      "OtherOptions": "Other Options (PT-BR)",
+      "IDontHaveAnyOfThese": "I don't have any of these (PT-BR)"
     },
     "EvidenceIDCollection": {
       "Heading1": "Enter the information (PT-BR)",


### PR DESCRIPTION
# Summary of Changes

This PR adds the "Other options" section to evidence upload, following the same logic as v3.

# Testing Instructions

Use a non-photo BCSC, and verify you see the Other options section as the bottom of the evidence type selection screen. The "Other" options should all be non-photo options. Non-BCSC should not show this section

# Acceptance Criteria

Feature parity with v3 in evidence selection

# Screenshots, videos, or gifs
v3:
<img width="284" height="614" alt="other_options_v3_1" src="https://github.com/user-attachments/assets/ad68c5a5-a383-4e19-9e58-af6ab6772eb7" />
<img width="284" height="614" alt="other_options_v3_2" src="https://github.com/user-attachments/assets/6c63ca1e-0caf-4f27-994a-ac9308c3f940" />

v4 now:
https://github.com/user-attachments/assets/a853dfd2-623d-48e6-8992-2ee7d1e44ecf

# Related Issues

#3338 