### PR TITLE
fix: hide brief extra selfie in live call video feed

### DIFF
--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.test.tsx
@@ -1,10 +1,10 @@
 import { BCSCActivityProvider } from '@/bcsc-theme/contexts/BCSCActivityContext'
+import { FcmService, FcmServiceProvider } from '@/bcsc-theme/features/fcm'
 import { VideoCallFlowState } from '@/bcsc-theme/features/verify/live-call/types/live-call'
 import { CROP_DELAY_MS } from '@/constants'
-import { FcmService, FcmServiceProvider } from '@/bcsc-theme/features/fcm'
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { render, act } from '@testing-library/react-native'
+import { act, render } from '@testing-library/react-native'
 import React from 'react'
 import LiveCallScreen from './LiveCallScreen'
 

--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.test.tsx
@@ -1,10 +1,30 @@
 import { BCSCActivityProvider } from '@/bcsc-theme/contexts/BCSCActivityContext'
+import { VideoCallFlowState } from '@/bcsc-theme/features/verify/live-call/types/live-call'
+import { CROP_DELAY_MS } from '@/constants'
 import { FcmService, FcmServiceProvider } from '@/bcsc-theme/features/fcm'
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { render } from '@testing-library/react-native'
+import { render, act } from '@testing-library/react-native'
 import React from 'react'
 import LiveCallScreen from './LiveCallScreen'
+
+const mockUseVideoCallFlow = jest.fn()
+jest.mock('./hooks/useVideoCallFlow', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockUseVideoCallFlow(...args),
+}))
+
+const defaultVideoCallFlowReturn = {
+  flowState: VideoCallFlowState.IDLE,
+  videoCallError: null,
+  localStream: null,
+  remoteStream: null,
+  isInBackground: false,
+  startVideoCall: jest.fn(),
+  cleanup: jest.fn().mockResolvedValue(undefined),
+  retryConnection: jest.fn().mockResolvedValue(undefined),
+  setCallEnded: jest.fn(),
+}
 
 describe('LiveCall', () => {
   let mockNavigation: any
@@ -13,6 +33,7 @@ describe('LiveCall', () => {
     mockNavigation = useNavigation()
     jest.clearAllMocks()
     jest.useFakeTimers()
+    mockUseVideoCallFlow.mockReturnValue(defaultVideoCallFlowReturn)
   })
 
   afterEach(() => {
@@ -55,5 +76,60 @@ describe('LiveCall', () => {
 
     tree.unmount()
     expect(spy).toHaveBeenCalledWith(false)
+  })
+
+  describe('crop delay overlay', () => {
+    it('shows the calling agent overlay during the crop delay period', () => {
+      mockUseVideoCallFlow.mockReturnValue({
+        ...defaultVideoCallFlowReturn,
+        flowState: VideoCallFlowState.IN_CALL,
+      })
+
+      const fcmService = new FcmService()
+      const tree = render(
+        <BasicAppContext>
+          <BCSCActivityProvider>
+            <FcmServiceProvider service={fcmService}>
+              <LiveCallScreen navigation={mockNavigation as never} />
+            </FcmServiceProvider>
+          </BCSCActivityProvider>
+        </BasicAppContext>
+      )
+
+      expect(tree.getByText('BCSC.VideoCall.CallingAgent')).toBeTruthy()
+
+      tree.unmount()
+    })
+
+    it('hides the calling agent overlay after CROP_DELAY_MS elapses', () => {
+      mockUseVideoCallFlow.mockReturnValue({
+        ...defaultVideoCallFlowReturn,
+        flowState: VideoCallFlowState.IN_CALL,
+      })
+
+      const fcmService = new FcmService()
+      const tree = render(
+        <BasicAppContext>
+          <BCSCActivityProvider>
+            <FcmServiceProvider service={fcmService}>
+              <LiveCallScreen navigation={mockNavigation as never} />
+            </FcmServiceProvider>
+          </BCSCActivityProvider>
+        </BasicAppContext>
+      )
+
+      // Overlay should be visible before the delay
+      expect(tree.getByText('BCSC.VideoCall.CallingAgent')).toBeTruthy()
+
+      // Advance timers past the crop delay
+      act(() => {
+        jest.advanceTimersByTime(CROP_DELAY_MS)
+      })
+
+      // Overlay should no longer be rendered
+      expect(tree.queryByText('BCSC.VideoCall.CallingAgent')).toBeNull()
+
+      tree.unmount()
+    })
   })
 })

--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
@@ -312,6 +312,7 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
         },
         hasTroubleContainer: {
           marginLeft: 'auto',
+          marginRight: Spacing.xs,
         },
         selfieVideoContainer: {
           width: width / 4,

--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
@@ -321,6 +321,21 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
         selfieVideo: {
           flex: 1,
         },
+        cropOverlay: {
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: '15%',
+          backgroundColor: 'black',
+          justifyContent: 'center',
+          alignItems: 'center',
+          paddingHorizontal: Spacing.xl,
+        },
+        cropOverlayText: {
+          color: ColorPalette.grayscale.white,
+          textAlign: 'center',
+        },
       }),
     [width, Spacing, ColorPalette]
   )
@@ -347,6 +362,12 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
   return (
     <View style={styles.container}>
       {remoteStream && <RTCView style={styles.agentVideo} objectFit={'contain'} streamURL={remoteStream.toURL()} />}
+
+      {!callStartTime && (
+        <View style={styles.cropOverlay}>
+          <ThemedText style={styles.cropOverlayText}>{t('BCSC.VideoCall.CallingAgent')}</ThemedText>
+        </View>
+      )}
 
       <SafeAreaView edges={['top']} style={{ flex: 0, backgroundColor: NavigationTheme.colors.primary }} />
       <SafeAreaView edges={['left', 'right']} style={{ flex: 1, justifyContent: 'space-between' }}>

--- a/app/src/bcsc-theme/features/verify/live-call/__snapshots__/LiveCallScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/live-call/__snapshots__/LiveCallScreen.test.tsx.snap
@@ -124,7 +124,7 @@ exports[`LiveCall renders correctly 1`] = `
             ]
           }
         >
-          BCSC.VideoCall.CallStates.UploadingDocuments
+          BCSC.VideoCall.CallStates.Initializing
         </Text>
         <
           height={200}

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -895,6 +895,7 @@ const translation = {
       "MissingSessionOrCallId": "Missing session or call ID for keep-alive update",
       "DeviceCodeError": "Missing device or user code",
       "ServiceBC": "Service BC",
+      "CallingAgent": "Calling agent to verify your identity...",
       "BeforeYouCallTitle": "Before you call",
       "WiFiRecommended": "Wi-Fi Recommended",
       "StandardDataCharges": "Standard data charges may apply for calls over a cellular network.",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -895,6 +895,7 @@ const translation = {
       "MissingSessionOrCallId": "Missing session or call ID for keep-alive update (FR)",
       "DeviceCodeError": "Missing device or user code (FR)",
       "ServiceBC": "Service BC (FR)",
+      "CallingAgent": "Calling agent to verify your identity... (FR)",
       "BeforeYouCallTitle": "Before you call (FR)",
       "WiFiRecommended": "Wi-Fi Recommended (FR)",
       "StandardDataCharges": "Standard data charges may apply for calls over a cellular network. (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -895,6 +895,7 @@ const translation = {
       "MissingSessionOrCallId": "Missing session or call ID for keep-alive update (PT-BR)",
       "DeviceCodeError": "Missing device or user code (PT-BR)",
       "ServiceBC": "Service BC (PT-BR)",
+      "CallingAgent": "Calling agent to verify your identity... (PT-BR)",
       "BeforeYouCallTitle": "Before you call (PT-BR)",
       "WiFiRecommended": "Wi-Fi Recommended (PT-BR)",
       "StandardDataCharges": "Standard data charges may apply for calls over a cellular network. (PT-BR)",


### PR DESCRIPTION
# Summary of Changes

Hides the extra selfie feed that shows up during the first few seconds of video call

# Testing Instructions

Try a live call

# Acceptance Criteria

Doesn't show extra selfie feed

# Screenshots, videos, or gifs

Before:
<img width="250" height="580" alt="image" src="https://github.com/user-attachments/assets/36bab461-d755-4cbf-882d-602dedaf997a" />

After:
<img width="284" height="614" alt="hide_ugly" src="https://github.com/user-attachments/assets/3771b6ca-724b-4a07-9fbc-99f9d1e552ff" />

# Related Issues

#3326 