### PR TITLE
fix: navigate to verification success when refresh token exists

### DIFF
--- a/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.test.ts
@@ -249,6 +249,24 @@ describe('useSetupStepsModel', () => {
 
       expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.VerificationMethodSelection)
     })
+
+    it('should navigate to VerificationSuccess if refreshToken exists', () => {
+      const storeWithRefreshToken = {
+        ...mockStore,
+        bcscSecure: {
+          ...mockStore.bcscSecure,
+          refreshToken: 'existing-refresh-token',
+        },
+      } as any
+      const bifoldMock = jest.mocked(Bifold)
+      bifoldMock.useStore.mockReturnValue([storeWithRefreshToken, mockDispatch])
+
+      const { result } = renderHook(() => useSetupStepsModel(mockNavigation), { wrapper: BasicAppContext })
+
+      result.current.stepActions.verify()
+
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.VerificationSuccess)
+    })
   })
 
   describe('stepActions.transfer', () => {

--- a/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
@@ -201,6 +201,12 @@ const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParam
       },
 
       verify: () => {
+        // Note: This ensures that if the user somehow got to the steps screen with a refresh token (shouldn't be possible but just in case), we navigate them to the success screen
+        if (store.bcscSecure.refreshToken) {
+          navigation.navigate(BCSCScreens.VerificationSuccess)
+          return
+        }
+
         navigation.navigate(BCSCScreens.VerificationMethodSelection)
       },
       transfer: () => {
@@ -213,6 +219,7 @@ const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParam
       steps.id.nonPhotoBcscNeedsAdditionalCard,
       steps.id.completed,
       store.bcscSecure.cardProcess,
+      store.bcscSecure.refreshToken,
     ]
   )
 

--- a/app/src/bcsc-theme/navigators/VerifyStack.tsx
+++ b/app/src/bcsc-theme/navigators/VerifyStack.tsx
@@ -6,7 +6,8 @@ import { useVerificationResponseListener } from '@/bcsc-theme/features/verificat
 import { getDefaultModalOptions } from '@/bcsc-theme/navigators/stack-utils'
 import { BCSCModals, BCSCScreens, BCSCStacks, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { DEFAULT_HEADER_TITLE_CONTAINER_STYLE, HelpCentreUrl } from '@/constants'
-import { testIdWithKey, useDefaultStackOptions, useTheme } from '@bifold/core'
+import { BCState } from '@/store'
+import { testIdWithKey, useDefaultStackOptions, useStore, useTheme } from '@bifold/core'
 import { createStackNavigator } from '@react-navigation/stack'
 import { useTranslation } from 'react-i18next'
 import Developer from '../../screens/Developer'
@@ -67,6 +68,7 @@ const VerifyStack = () => {
   const theme = useTheme()
   const { t } = useTranslation()
   const defaultStackOptions = useDefaultStackOptions(theme)
+  const [store] = useStore<BCState>()
   useBCSCStack(BCSCStacks.Verify)
 
   // Listen for verification approval push notifications and navigate to success screen
@@ -74,7 +76,8 @@ const VerifyStack = () => {
 
   return (
     <Stack.Navigator
-      initialRouteName={BCSCScreens.SetupSteps}
+      // If the user has a refresh token, they have completed setup and should go to success screen. Otherwise, start at setup steps.
+      initialRouteName={store.bcscSecure.refreshToken ? BCSCScreens.VerificationSuccess : BCSCScreens.SetupSteps}
       screenOptions={{
         ...defaultStackOptions,
         headerShown: true,


### PR DESCRIPTION
# Summary of Changes

This PR fixes a bug that prevented the user from completing the verification if they somehow had a refresh token.


# Testing Instructions

1. Verify in person
2. Close app on "You're all set"
3. Proceed to step 5
4. Should see "You're all set" screen and complete verification

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
