### PR TITLE
feat(service): implement ERR_112 JWS verification failed error handling

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -86,7 +86,13 @@ const App = () => {
     // adding a dependency to this init-only effect. The callback runs asynchronously
     // on FCM error, so i18next.t() resolves the current language at call time.
     fcmViewModel.setErrorHandler((error) => {
-      if (isAppError(error, AppEventCode.ERR_112_JWS_VERIFICATION_FAILED)) {
+      if (isAppError(error, AppEventCode.ERR_111_UNABLE_TO_VERIFY_MISSING_JWK)) {
+        Alert.alert(
+          i18next.t('Alerts.ProblemWithApp.Title', { errorCode: '111' }),
+          i18next.t('Alerts.ProblemWithApp.Description', { errorCode: '111' }),
+          [{ text: i18next.t('Global.OK') }]
+        )
+      } else if (isAppError(error, AppEventCode.ERR_112_JWS_VERIFICATION_FAILED)) {
         Alert.alert(
           i18next.t('Alerts.ProblemWithApp.Title', { errorCode: '112' }),
           i18next.t('Alerts.ProblemWithApp.Description', { errorCode: '112' }),

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -32,7 +32,10 @@ import {
   TourProvider,
 } from '@bifold/core'
 import WebDisplay from '@screens/WebDisplay'
+import { isAppError } from '@/errors/appError'
+import { AppEventCode } from '@/events/appEventCode'
 import React, { useEffect, useMemo, useState } from 'react'
+import { Alert } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import Config from 'react-native-config'
 import { isTablet } from 'react-native-device-info'
@@ -78,6 +81,15 @@ const App = () => {
 
   useEffect(() => {
     deepLinkViewModel.initialize()
+    fcmViewModel.setErrorHandler((error) => {
+      if (isAppError(error, AppEventCode.ERR_112_JWS_VERIFICATION_FAILED)) {
+        Alert.alert(
+          t('Alerts.ProblemWithApp.Title', { errorCode: '112' }),
+          t('Alerts.ProblemWithApp.Description', { errorCode: '112' }),
+          [{ text: t('Global.OK') }]
+        )
+      }
+    })
     fcmViewModel.initialize()
   }, [])
 

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -9,7 +9,9 @@ import {
 import { BCThemeNames, surveyMonkeyExitUrl, surveyMonkeyUrl } from '@/constants'
 import { ErrorAlertProvider } from '@/contexts/ErrorAlertContext'
 import { NavigationContainerProvider, navigationRef } from '@/contexts/NavigationContainerContext'
+import { isAppError } from '@/errors/appError'
 import { ErrorBoundaryWrapper } from '@/errors/components/ErrorBoundary'
+import { AppEventCode } from '@/events/appEventCode'
 import { localization } from '@/localization'
 import { initialState, Mode, reducer } from '@/store'
 import { themes } from '@/theme'
@@ -32,11 +34,10 @@ import {
   TourProvider,
 } from '@bifold/core'
 import WebDisplay from '@screens/WebDisplay'
-import { isAppError } from '@/errors/appError'
-import { AppEventCode } from '@/events/appEventCode'
+import i18next from 'i18next'
 import React, { useEffect, useMemo, useState } from 'react'
-import { Alert } from 'react-native'
 import { useTranslation } from 'react-i18next'
+import { Alert } from 'react-native'
 import Config from 'react-native-config'
 import { isTablet } from 'react-native-device-info'
 import { KeyboardProvider } from 'react-native-keyboard-controller'
@@ -81,12 +82,15 @@ const App = () => {
 
   useEffect(() => {
     deepLinkViewModel.initialize()
+    // Uses i18next.t() directly instead of the useTranslation hook's t() to avoid
+    // adding a dependency to this init-only effect. The callback runs asynchronously
+    // on FCM error, so i18next.t() resolves the current language at call time.
     fcmViewModel.setErrorHandler((error) => {
       if (isAppError(error, AppEventCode.ERR_112_JWS_VERIFICATION_FAILED)) {
         Alert.alert(
-          t('Alerts.ProblemWithApp.Title', { errorCode: '112' }),
-          t('Alerts.ProblemWithApp.Description', { errorCode: '112' }),
-          [{ text: t('Global.OK') }]
+          i18next.t('Alerts.ProblemWithApp.Title', { errorCode: '112' }),
+          i18next.t('Alerts.ProblemWithApp.Description', { errorCode: '112' }),
+          [{ text: i18next.t('Global.OK') }]
         )
       }
     })

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.test.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.test.ts
@@ -278,6 +278,57 @@ describe('FcmViewModel', () => {
       expect(mockPairingService.handlePairing).not.toHaveBeenCalled()
     })
 
+    it('emits ERR_111 when verified is false and server JWK is unavailable', async () => {
+      // Create a fresh viewModel where JWK fetch returns null
+      mockFetchJwk.mockResolvedValue(null)
+      // eslint-disable-next-line prefer-const
+      let localHandler: ((message: FcmMessage) => void) | undefined
+      const localFcmService = {
+        init: jest.fn(),
+        destroy: jest.fn(),
+        subscribe: jest.fn((h: (message: FcmMessage) => void) => {
+          localHandler = h
+          return jest.fn()
+        }),
+      } as unknown as jest.Mocked<FcmService>
+
+      const noJwkViewModel = new FcmViewModel(
+        localFcmService,
+        mockLogger as any,
+        mockPairingService,
+        mockVerificationResponseService,
+        Mode.BCSC
+      )
+
+      const mockErrorHandler = jest.fn()
+      noJwkViewModel.setErrorHandler(mockErrorHandler)
+      noJwkViewModel.initialize()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      const mockResult = {
+        verified: false,
+        claims: {
+          bcsc_client_name: 'My Service',
+          bcsc_challenge: 'code456',
+        },
+      }
+      ;(decodeLoginChallenge as jest.Mock).mockResolvedValue(mockResult)
+
+      const message = {
+        type: 'challenge',
+        data: { jwt: 'unverified-jwt' },
+      } as FcmMessage
+
+      await localHandler?.(message)
+
+      expect(mockErrorHandler).toHaveBeenCalledTimes(1)
+      const error = mockErrorHandler.mock.calls[0][0]
+      expect(error).toBeInstanceOf(AppError)
+      expect(error.appEvent).toBe(AppEventCode.ERR_111_UNABLE_TO_VERIFY_MISSING_JWK)
+      expect(mockPairingService.handlePairing).not.toHaveBeenCalled()
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('JWK unavailable'))
+    })
+
     it('calls error handler and does not process pairing when verified is false', async () => {
       const mockErrorHandler = jest.fn()
       viewModel.setErrorHandler(mockErrorHandler)

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.test.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.test.ts
@@ -1,3 +1,5 @@
+import { AppError } from '@/errors/appError'
+import { AppEventCode } from '@/events/appEventCode'
 import { DeviceEventEmitter } from 'react-native'
 import { decodeLoginChallenge, showLocalNotification } from 'react-native-bcsc-core'
 import { BCSCEventTypes } from '../../../events/eventTypes'
@@ -8,6 +10,12 @@ import { PairingService } from '../pairing'
 import { VerificationResponseService } from '../verification-response'
 import { FcmViewModel } from './FcmViewModel'
 import { FcmMessage, FcmService } from './services/fcm-service'
+
+jest.mock('@/utils/analytics/analytics-singleton', () => ({
+  Analytics: {
+    trackErrorEvent: jest.fn(),
+  },
+}))
 
 // Mock dependencies
 jest.mock('react-native-bcsc-core', () => ({
@@ -268,6 +276,62 @@ describe('FcmViewModel', () => {
 
       expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to decode challenge'))
       expect(mockPairingService.handlePairing).not.toHaveBeenCalled()
+    })
+
+    it('calls error handler and does not process pairing when verified is false', async () => {
+      const mockErrorHandler = jest.fn()
+      viewModel.setErrorHandler(mockErrorHandler)
+
+      const mockResult = {
+        verified: false,
+        claims: {
+          bcsc_client_name: 'My Service',
+          bcsc_challenge: 'code456',
+        },
+      }
+      ;(decodeLoginChallenge as jest.Mock).mockResolvedValue(mockResult)
+
+      const message = {
+        type: 'challenge',
+        data: { jwt: 'unverified-jwt' },
+      } as FcmMessage
+
+      await capturedMessageHandler?.(message)
+
+      expect(mockErrorHandler).toHaveBeenCalledTimes(1)
+      const error = mockErrorHandler.mock.calls[0][0]
+      expect(error).toBeInstanceOf(AppError)
+      expect(error.appEvent).toBe(AppEventCode.ERR_112_JWS_VERIFICATION_FAILED)
+      expect(mockPairingService.handlePairing).not.toHaveBeenCalled()
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('JWS verification failed'))
+    })
+
+    it('processes pairing normally when verified is true', async () => {
+      const mockErrorHandler = jest.fn()
+      viewModel.setErrorHandler(mockErrorHandler)
+
+      const mockResult = {
+        verified: true,
+        claims: {
+          bcsc_client_name: 'My Service',
+          bcsc_challenge: 'code456',
+        },
+      }
+      ;(decodeLoginChallenge as jest.Mock).mockResolvedValue(mockResult)
+
+      const message = {
+        type: 'challenge',
+        data: { jwt: 'verified-jwt' },
+      } as FcmMessage
+
+      await capturedMessageHandler?.(message)
+
+      expect(mockErrorHandler).not.toHaveBeenCalled()
+      expect(mockPairingService.handlePairing).toHaveBeenCalledWith({
+        serviceTitle: 'My Service',
+        pairingCode: 'code456',
+        source: 'fcm',
+      })
     })
   })
 

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
@@ -133,7 +133,6 @@ export class FcmViewModel {
 
       if (!result.verified) {
         const appError = AppError.fromErrorDefinition(ErrorRegistry.JWS_VERIFICATION_FAILED)
-        appError.handled = true
         this.logger.warn(`[FcmViewModel] [${appError.appEvent}] JWS verification failed`)
         this.onError?.(appError)
         return

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
@@ -27,6 +27,7 @@ export class FcmViewModel {
   private serverJwk: JWK | null = null
   private lastJwkBaseUrl: string | null = null
   private initialized = false
+  private onError?: (error: AppError) => void
 
   /**
    * @param fcmService - Firebase Cloud Messaging service
@@ -42,6 +43,14 @@ export class FcmViewModel {
     private readonly verificationResponseService: VerificationResponseService,
     private readonly mode: Mode = Mode.BCSC
   ) {}
+
+  /**
+   * Sets a callback for handling errors that need to be surfaced to the user.
+   * This bridges the non-React ViewModel to the React alert system.
+   */
+  public setErrorHandler(handler: (error: AppError) => void) {
+    this.onError = handler
+  }
 
   public initialize() {
     if (this.initialized) {
@@ -121,6 +130,14 @@ export class FcmViewModel {
       this.logger.info(
         `[FcmViewModel] Challenge decoded: verified=${result.verified}, client=${result.claims.bcsc_client_name}`
       )
+
+      if (!result.verified) {
+        const appError = AppError.fromErrorDefinition(ErrorRegistry.JWS_VERIFICATION_FAILED)
+        appError.handled = true
+        this.logger.warn(`[FcmViewModel] [${appError.appEvent}] JWS verification failed`)
+        this.onError?.(appError)
+        return
+      }
 
       // Extract pairing data and inject into deep link flow
       const serviceTitle = result.claims.bcsc_client_name

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
@@ -132,6 +132,12 @@ export class FcmViewModel {
       )
 
       if (!result.verified) {
+        if (!this.serverJwk) {
+          const appError = AppError.fromErrorDefinition(ErrorRegistry.MISSING_JWK_ERROR)
+          this.logger.warn(`[FcmViewModel] [${appError.appEvent}] JWK unavailable, cannot verify JWS`)
+          this.onError?.(appError)
+          return
+        }
         const appError = AppError.fromErrorDefinition(ErrorRegistry.JWS_VERIFICATION_FAILED)
         this.logger.warn(`[FcmViewModel] [${appError.appEvent}] JWS verification failed`)
         this.onError?.(appError)

--- a/app/src/hooks/useAlerts.test.tsx
+++ b/app/src/hooks/useAlerts.test.tsx
@@ -291,6 +291,27 @@ describe('useAlerts', () => {
     })
   })
 
+  describe('jwsVerificationFailedAlert', () => {
+    it('should show an alert with the correct title and message', () => {
+      const mockNavigation = { navigate: jest.fn() }
+      const mockEmitAlert = jest.fn()
+      jest.spyOn(ErrorAlertContext, 'useErrorAlert').mockReturnValue({ emitAlert: mockEmitAlert } as any)
+
+      const { result } = renderHook(() => useAlerts(mockNavigation as any))
+
+      result.current.jwsVerificationFailedAlert()
+
+      expect(mockEmitAlert).toHaveBeenCalledWith('Alerts.ProblemWithApp.Title', 'Alerts.ProblemWithApp.Description', {
+        event: AppEventCode.ERR_112_JWS_VERIFICATION_FAILED,
+        actions: [
+          {
+            text: 'Global.OK',
+          },
+        ],
+      })
+    })
+  })
+
   describe('loginServerErrorAlert', () => {
     it('should show an alert with the correct title and message', () => {
       const mockNavigation = { navigate: jest.fn() }

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -274,6 +274,7 @@ export const useAlerts = (navigation: NavigationProp<ParamListBase>) => {
       failedToDeserializeJsonAlert: _createBasicAlert(AppEventCode.ERR_109_FAILED_TO_DESERIALIZE_JSON, 'ProblemWithApp', { errorCode: '109' }),
       unableToDecryptJweAlert: _createBasicAlert(AppEventCode.ERR_110_UNABLE_TO_DECRYPT_JWE, 'ProblemWithApp', { errorCode: '110' }),
       missingJwkAlert: _createBasicAlert(AppEventCode.ERR_111_UNABLE_TO_VERIFY_MISSING_JWK, 'ProblemWithApp', { errorCode: '111' }),
+      jwsVerificationFailedAlert: _createBasicAlert(AppEventCode.ERR_112_JWS_VERIFICATION_FAILED, 'ProblemWithApp', { errorCode: '112' }),
       loginServerErrorAlert: _createBasicAlert(AppEventCode.LOGIN_SERVER_ERROR, 'ProblemWithLogin', { errorCode: '303' }),
       problemWithLoginAlert: _createBasicAlert(AppEventCode.LOGIN_PARSE_URI, 'ProblemWithLogin', { errorCode: '304' }),
       loginRejected401Alert: _createProblemWithAccountAlert(AppEventCode.LOGIN_REJECTED_401, '401'),


### PR DESCRIPTION
## Summary

- `FcmViewModel` now checks the `verified` field from `decodeLoginChallenge` — when JWS signature verification fails (`verified: false`), it creates an `AppError` for analytics tracking, calls an error callback, and stops processing the challenge
- Added `setErrorHandler()` method to `FcmViewModel` for bridging the non-React ViewModel to the React alert system
- `App.tsx` wires up the error handler to show a native `Alert` with "Problem with App (error 112)"
- Added `jwsVerificationFailedAlert` to `useAlerts.tsx` for future use when FCM handling is refactored to hook-based pattern
- No native code changes — both iOS and Android already return `verified: false` consistently

**Follow-up:** #3355 tracks refactoring FCM challenge decoding from the ViewModel to a hook-based service pattern for proper alignment with the established error handling architecture.

## Test plan

- [ ] 2 new `FcmViewModel` tests: `verified: false` triggers error handler, `verified: true` processes normally
- [ ] 1 new `useAlerts` test: `jwsVerificationFailedAlert` emits correct alert payload
- [ ] Verify "Problem with App (error 112)" alert appears when a push notification with an invalid JWS signature is received on device

### Manual testing

To force ERR_112 for testing, add this line in `FcmViewModel.ts` after `decodeLoginChallenge` returns:

```typescript
const result = await decodeLoginChallenge(jwt, this.serverJwk ?? undefined)
result.verified = false // TEMP: force ERR_112 for testing
```

Then trigger any FCM challenge push notification:

1. Logon to BC Parks via the Web Demo site.
2. Use the app to Logon from Computer
3. On the demo site, make sure you remember the device.
4. Repeat 1-2, it will have remembered the device and send a push notification to auth. If the debug code is in place a verification error will be triggered. 

