### PR TITLE
fix(bcsc): implement ERR_115 failed to serialize JSON error handling

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
@@ -8,10 +8,12 @@ import { useCallback, useMemo } from 'react'
 import { Platform } from 'react-native'
 import {
   AccountSecurityMethod,
+  BcscNativeErrorCodes,
   getAccount,
   getAccountSecurityMethod,
   getDeviceId,
   getDynamicClientRegistrationBody,
+  isBcscNativeError,
   setAccount,
 } from 'react-native-bcsc-core'
 import BCSCApiClient from '../client'
@@ -123,6 +125,7 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
    *
    * @throws Error if BCSC client is not ready or registration fails
    * @throws AppError with code `ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL` if registration response is null
+   * @throws AppError with code `ERR_115_FAILED_TO_SERIALIZE_JSON` if native JSON serialization fails
    *
    * @returns Promise resolving to registration response data or void if account exists
    */
@@ -137,7 +140,15 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
         getNotificationTokens(logger),
       ])
 
-      const body = await getDynamicClientRegistrationBody(fcmDeviceToken, deviceToken, attestation)
+      let body: string | null
+      try {
+        body = await getDynamicClientRegistrationBody(fcmDeviceToken, deviceToken, attestation)
+      } catch (error) {
+        if (isBcscNativeError(error) && error.code === BcscNativeErrorCodes.JSON_SERIALIZATION_FAILED) {
+          throw AppError.fromErrorDefinition(ErrorRegistry.SERIALIZE_JSON_ERROR, { cause: error })
+        }
+        throw error
+      }
 
       if (!body) {
         throw AppError.fromErrorDefinition(ErrorRegistry.CLIENT_REGISTRATION_NULL)
@@ -203,6 +214,7 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
    * @throws Error if client not ready, missing parameters, or update fails
    * @throws AppError with code `ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL` if registration response is null
    * @throws AppError with code `ERR_109_FAILED_TO_DESERIALIZE_JSON` if response body cannot be parsed as JSON
+   * @throws AppError with code `ERR_115_FAILED_TO_SERIALIZE_JSON` if native JSON serialization fails
    *
    * @param registrationAccessToken - Bearer token for registration endpoint access
    * @param selectedNickname - New client name/nickname to set
@@ -228,7 +240,15 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
           getNotificationTokens(logger),
         ])
 
-        const body = await getDynamicClientRegistrationBody(fcmDeviceToken, deviceToken, attestation, selectedNickname)
+        let body: string | null
+        try {
+          body = await getDynamicClientRegistrationBody(fcmDeviceToken, deviceToken, attestation, selectedNickname)
+        } catch (error) {
+          if (isBcscNativeError(error) && error.code === BcscNativeErrorCodes.JSON_SERIALIZATION_FAILED) {
+            throw AppError.fromErrorDefinition(ErrorRegistry.SERIALIZE_JSON_ERROR, { cause: error })
+          }
+          throw error
+        }
 
         if (!body) {
           throw AppError.fromErrorDefinition(ErrorRegistry.CLIENT_REGISTRATION_NULL)

--- a/app/src/bcsc-theme/services/hooks/useRegistrationService.test.tsx
+++ b/app/src/bcsc-theme/services/hooks/useRegistrationService.test.tsx
@@ -107,6 +107,44 @@ describe('useRegistrationService', () => {
       })
     })
 
+    describe('App error ERR_115_FAILED_TO_SERIALIZE_JSON', () => {
+      it('should show the alert for the app error', async () => {
+        const mockError = mockAppError(AppEventCode.ERR_115_FAILED_TO_SERIALIZE_JSON)
+        const registrationApi = {
+          register: jest.fn().mockRejectedValue(mockError),
+        } as any
+        const failedToSerializeJsonAlert = jest.fn()
+        const mockAlerts = { failedToSerializeJsonAlert }
+
+        jest.spyOn(useRegistrationApiModule, 'default').mockReturnValue(registrationApi)
+        jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue(mockAlerts as any)
+
+        const { result } = renderHook(() => useRegistrationService())
+
+        await expect(result.current.register('deviceAuth' as any)).rejects.toThrow(mockError)
+        expect(registrationApi.register).toHaveBeenCalledWith('deviceAuth')
+        expect(failedToSerializeJsonAlert).toHaveBeenCalled()
+      })
+
+      it('should rethrow error without showing alert if error is not serialize json error', async () => {
+        const mockError = mockAppError('ERR_SOME_OTHER_ERROR')
+        const registrationApi = {
+          register: jest.fn().mockRejectedValue(mockError),
+        } as any
+        const failedToSerializeJsonAlert = jest.fn()
+        const mockAlerts = { failedToSerializeJsonAlert }
+
+        jest.spyOn(useRegistrationApiModule, 'default').mockReturnValue(registrationApi)
+        jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue(mockAlerts as any)
+
+        const { result } = renderHook(() => useRegistrationService())
+
+        await expect(result.current.register('deviceAuth' as any)).rejects.toThrow(mockError)
+        expect(registrationApi.register).toHaveBeenCalledWith('deviceAuth')
+        expect(failedToSerializeJsonAlert).not.toHaveBeenCalled()
+      })
+    })
+
     it('should rethrow error without showing alert if error is not bcsc native error or client registration null app error', async () => {
       const mockError = mockAppError('ERR_SOME_OTHER_ERROR')
       const registrationApi = {
@@ -114,7 +152,8 @@ describe('useRegistrationService', () => {
       } as any
       const problemWithAppAlert = jest.fn()
       const clientRegistrationNullAlert = jest.fn()
-      const mockAlerts = { problemWithAppAlert, clientRegistrationNullAlert }
+      const failedToSerializeJsonAlert = jest.fn()
+      const mockAlerts = { problemWithAppAlert, clientRegistrationNullAlert, failedToSerializeJsonAlert }
 
       jest.spyOn(useRegistrationApiModule, 'default').mockReturnValue(registrationApi)
       jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue(mockAlerts as any)
@@ -125,6 +164,7 @@ describe('useRegistrationService', () => {
       expect(registrationApi.register).toHaveBeenCalledWith('deviceAuth')
       expect(problemWithAppAlert).not.toHaveBeenCalled()
       expect(clientRegistrationNullAlert).not.toHaveBeenCalled()
+      expect(failedToSerializeJsonAlert).not.toHaveBeenCalled()
     })
   })
 
@@ -204,6 +244,26 @@ describe('useRegistrationService', () => {
       expect(registrationApi.updateRegistration).toHaveBeenCalledWith('someToken', 'someNickname')
       expect(problemWithAppAlert).not.toHaveBeenCalled()
       expect(clientRegistrationNullAlert).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('App error ERR_115_FAILED_TO_SERIALIZE_JSON (updateRegistration)', () => {
+    it('should show the alert for the app error', async () => {
+      const mockError = mockAppError(AppEventCode.ERR_115_FAILED_TO_SERIALIZE_JSON)
+      const registrationApi = {
+        updateRegistration: jest.fn().mockRejectedValue(mockError),
+      } as any
+      const failedToSerializeJsonAlert = jest.fn()
+      const mockAlerts = { failedToSerializeJsonAlert }
+
+      jest.spyOn(useRegistrationApiModule, 'default').mockReturnValue(registrationApi)
+      jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue(mockAlerts as any)
+
+      const { result } = renderHook(() => useRegistrationService())
+
+      await expect(result.current.updateRegistration('someToken', 'someNickname')).rejects.toThrow(mockError)
+      expect(registrationApi.updateRegistration).toHaveBeenCalledWith('someToken', 'someNickname')
+      expect(failedToSerializeJsonAlert).toHaveBeenCalled()
     })
   })
 

--- a/app/src/bcsc-theme/services/hooks/useRegistrationService.tsx
+++ b/app/src/bcsc-theme/services/hooks/useRegistrationService.tsx
@@ -38,6 +38,10 @@ export const useRegistrationService = () => {
           alerts.clientRegistrationNullAlert()
         }
 
+        if (isAppError(error, AppEventCode.ERR_115_FAILED_TO_SERIALIZE_JSON)) {
+          alerts.failedToSerializeJsonAlert()
+        }
+
         throw error
       }
     },
@@ -66,6 +70,10 @@ export const useRegistrationService = () => {
 
         if (isAppError(error, AppEventCode.ERR_109_FAILED_TO_DESERIALIZE_JSON)) {
           alerts.failedToDeserializeJsonAlert()
+        }
+
+        if (isAppError(error, AppEventCode.ERR_115_FAILED_TO_SERIALIZE_JSON)) {
+          alerts.failedToSerializeJsonAlert()
         }
 
         throw error

--- a/app/src/hooks/useAlerts.test.tsx
+++ b/app/src/hooks/useAlerts.test.tsx
@@ -765,6 +765,27 @@ describe('useAlerts', () => {
     })
   })
 
+  describe('failedToSerializeJsonAlert', () => {
+    it('should show an alert with the correct title and message', () => {
+      const mockNavigation = { navigate: jest.fn() }
+      const mockEmitAlert = jest.fn()
+      jest.spyOn(ErrorAlertContext, 'useErrorAlert').mockReturnValue({ emitAlert: mockEmitAlert } as any)
+
+      const { result } = renderHook(() => useAlerts(mockNavigation as any))
+
+      result.current.failedToSerializeJsonAlert()
+
+      expect(mockEmitAlert).toHaveBeenCalledWith('Alerts.ProblemWithApp.Title', 'Alerts.ProblemWithApp.Description', {
+        event: AppEventCode.ERR_115_FAILED_TO_SERIALIZE_JSON,
+        actions: [
+          {
+            text: 'Global.OK',
+          },
+        ],
+      })
+    })
+  })
+
   describe('factoryResetAlert', () => {
     it('should show an alert with the correct title and message', () => {
       const mockNavigation = { navigate: jest.fn() }

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -275,6 +275,7 @@ export const useAlerts = (navigation: NavigationProp<ParamListBase>) => {
       unableToDecryptJweAlert: _createBasicAlert(AppEventCode.ERR_110_UNABLE_TO_DECRYPT_JWE, 'ProblemWithApp', { errorCode: '110' }),
       missingJwkAlert: _createBasicAlert(AppEventCode.ERR_111_UNABLE_TO_VERIFY_MISSING_JWK, 'ProblemWithApp', { errorCode: '111' }),
       jwsVerificationFailedAlert: _createBasicAlert(AppEventCode.ERR_112_JWS_VERIFICATION_FAILED, 'ProblemWithApp', { errorCode: '112' }),
+      failedToSerializeJsonAlert: _createBasicAlert(AppEventCode.ERR_115_FAILED_TO_SERIALIZE_JSON, 'ProblemWithApp', { errorCode: '115' }),
       loginServerErrorAlert: _createBasicAlert(AppEventCode.LOGIN_SERVER_ERROR, 'ProblemWithLogin', { errorCode: '303' }),
       problemWithLoginAlert: _createBasicAlert(AppEventCode.LOGIN_PARSE_URI, 'ProblemWithLogin', { errorCode: '304' }),
       loginRejected401Alert: _createProblemWithAccountAlert(AppEventCode.LOGIN_REJECTED_401, '401'),

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -1249,6 +1249,13 @@ class BcscCoreModule(
                 "Error creating dynamic client registration with bcsc-keypair-port: ${e.devMessage}",
                 e,
             )
+        } catch (e: org.json.JSONException) {
+            Log.e(NAME, "getDynamicClientRegistrationBody: JSON serialization error: ${e.message}", e)
+            promise.reject(
+                "E_JSON_SERIALIZATION_FAILED",
+                "Failed to serialize client registration data: ${e.message}",
+                e,
+            )
         } catch (e: Exception) {
             Log.e(NAME, "getDynamicClientRegistrationBody: Unexpected error: ${e.message}", e)
             promise.reject("E_DCR_ERROR", "Unexpected error creating dynamic client registration: ${e.message}", e)

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -26,6 +26,8 @@ export const BcscNativeErrorCodes = {
   KEYPAIR_GENERATION_FAILED: 'E_KEYPAIR_GENERATION_FAILED',
   /** Keypair exists but could not be retrieved from secure storage */
   KEYPAIR_RETRIEVAL_FAILED: 'E_KEYPAIR_RETRIEVAL_FAILED',
+  /** JSON serialization failed in the native module */
+  JSON_SERIALIZATION_FAILED: 'E_JSON_SERIALIZATION_FAILED',
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Implements ERR_115 (`FAILED_TO_SERIALIZE_JSON`) error handling as part of the ERR_1xx error code series. Closes #3095 (partial — one error code in the series).

- Added `JSON_SERIALIZATION_FAILED` (`E_JSON_SERIALIZATION_FAILED`) to `BcscNativeErrorCodes` in `packages/bcsc-core/src/index.ts`
- Added Android catch block for `org.json.JSONException` in `BcscCoreModule.kt`, rejecting with `E_JSON_SERIALIZATION_FAILED` to align with iOS
- Wrapped `getDynamicClientRegistrationBody` calls in `useRegistrationApi.tsx` to catch native `E_JSON_SERIALIZATION_FAILED` and rethrow as `AppError(SERIALIZE_JSON_ERROR)`
- Added `failedToSerializeJsonAlert` in `useAlerts.tsx` surfacing ERR_115 to the user
- Surfaced ERR_115 alert in `useRegistrationService.tsx` for both `register` and `updateRegistration` flows
- Added tests for all layers: `useAlerts.test.tsx`, `useRegistrationService.test.tsx`

## Test plan

- [ ] `yarn test` passes with no regressions
- [ ] `yarn typecheck` passes
- [ ] `yarn lint` passes
- [ ] Manually trigger a JSON serialization failure on Android and verify ERR_115 alert is shown
- [ ] Manually trigger a JSON serialization failure on iOS and verify ERR_115 alert is shown
- [ ] Verify unrelated errors are rethrown without showing the ERR_115 alert

## Manual Testing: Triggering ERR_115 on Android

To visually verify the alert, temporarily force `getDynamicClientRegistrationBody` to reject in Kotlin:

**`packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt`** — at the top of `getDynamicClientRegistrationBody()` (~line 1149), add:

```kotlin
promise.reject(
    "E_JSON_SERIALIZATION_FAILED",
    "DEBUG: Simulated JSON serialization failure for ERR_115 testing",
)
return
```

**Rebuild Android** (`cd app && yarn android`), then trigger any registration flow. The "Problem with App (error 115)" alert should appear.



https://github.com/user-attachments/assets/89f3dfe5-1bf3-4ac6-98e0-2da7bc59f554



