### PR TITLE
feat: surface E_FAILED_TO_PARSE_JWS as ERR_117 to the user

### DIFF
--- a/app/__mocks__/react-native-bcsc-core.ts
+++ b/app/__mocks__/react-native-bcsc-core.ts
@@ -58,9 +58,17 @@ export const BcscNativeErrorCodes = {
   JWT_DEVICE_INFO_ERROR: 'E_120_JWT_DEVICE_INFO_ERROR',
   /** JSON serialization failed for a native request or payload */
   JSON_SERIALIZATION_FAILED: 'E_120_JSON_SERIALIZATION_FAILED',
+  /** Secure hardware / keystore could not generate a new keypair */
+  KEYPAIR_GENERATION_FAILED: 'E_KEYPAIR_GENERATION_FAILED',
+  /** Keypair exists but could not be retrieved from secure storage */
+  KEYPAIR_RETRIEVAL_FAILED: 'E_KEYPAIR_RETRIEVAL_FAILED',
+  /** JWS token could not be parsed (malformed or invalid format) */
+  FAILED_TO_PARSE_JWS: 'E_FAILED_TO_PARSE_JWS',
 } as const
 
-export const isBcscNativeError = jest.fn().mockReturnValue(true)
+export const isBcscNativeError = jest.fn((error: unknown): boolean => {
+  return error instanceof Error && 'code' in error
+})
 
 // Issuer Management
 export const setIssuer = jest.fn().mockResolvedValue(true)

--- a/app/src/bcsc-theme/api/hooks/useUserApi.test.ts
+++ b/app/src/bcsc-theme/api/hooks/useUserApi.test.ts
@@ -1,6 +1,6 @@
 import useUserApi from '@/bcsc-theme/api/hooks/useUserApi'
-import { AppEventCode } from '@/events/appEventCode'
 import { AppError, ErrorRegistry } from '@/errors'
+import { AppEventCode } from '@/events/appEventCode'
 import { act, renderHook } from '@testing-library/react-native'
 import * as BcscCore from 'react-native-bcsc-core'
 

--- a/app/src/bcsc-theme/api/hooks/useUserApi.test.ts
+++ b/app/src/bcsc-theme/api/hooks/useUserApi.test.ts
@@ -1,10 +1,36 @@
 import useUserApi from '@/bcsc-theme/api/hooks/useUserApi'
 import { AppEventCode } from '@/events/appEventCode'
+import { AppError, ErrorRegistry } from '@/errors'
 import { act, renderHook } from '@testing-library/react-native'
 import * as BcscCore from 'react-native-bcsc-core'
 
 describe('useUserApi', () => {
   describe('getUserInfo', () => {
+    it('should throw ERR_117 when decodePayload fails with E_FAILED_TO_PARSE_JWS', async () => {
+      const decodePayloadMock = jest.mocked(BcscCore).decodePayload
+      const getAccountMock = jest.mocked(BcscCore).getAccount
+
+      const mockApiClient = {
+        get: jest.fn(),
+        endpoints: {
+          userInfo: '/user/info',
+        },
+      }
+
+      getAccountMock.mockResolvedValue({ clientID: 'test' } as any)
+      mockApiClient.get.mockResolvedValue({ data: 'encoded-data' })
+      const nativeError = Object.assign(new Error('Invalid JWS'), { code: 'E_FAILED_TO_PARSE_JWS' })
+      decodePayloadMock.mockRejectedValue(nativeError)
+
+      const hook = renderHook(() => useUserApi(mockApiClient as any))
+
+      await act(async () => {
+        await expect(hook.result.current.getUserInfo()).rejects.toThrow(
+          AppError.fromErrorDefinition(ErrorRegistry.PARSE_JWS_ERROR, { cause: nativeError })
+        )
+      })
+    })
+
     it('should fetch user info successfully', async () => {
       const decodePayloadMock = jest.mocked(BcscCore).decodePayload
       const getAccountMock = jest.mocked(BcscCore).getAccount

--- a/app/src/bcsc-theme/api/hooks/useUserApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useUserApi.tsx
@@ -1,6 +1,6 @@
 import { AppError, ErrorRegistry } from '@/errors'
 import { useCallback, useMemo } from 'react'
-import { decodePayload } from 'react-native-bcsc-core'
+import { BcscNativeErrorCodes, decodePayload, isBcscNativeError } from 'react-native-bcsc-core'
 import BCSCApiClient from '../client'
 import { withAccount } from './withAccountGuard'
 
@@ -43,6 +43,10 @@ const useUserApi = (apiClient: BCSCApiClient) => {
       try {
         userInfoString = await decodePayload(data)
       } catch (error) {
+        if (isBcscNativeError(error) && error.code === BcscNativeErrorCodes.FAILED_TO_PARSE_JWS) {
+          throw AppError.fromErrorDefinition(ErrorRegistry.PARSE_JWS_ERROR, { cause: error })
+        }
+
         throw AppError.fromErrorDefinition(ErrorRegistry.DECRYPT_JWE_ERROR, { cause: error })
       }
 

--- a/app/src/bcsc-theme/contexts/BCSCIdTokenContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCIdTokenContext.tsx
@@ -109,13 +109,5 @@ export const useIdToken = () => {
     throw new Error('useIdToken must be used within a BCSCIdTokenProvider')
   }
 
-  if (context.isLoading) {
-    throw new Error('useIdToken: ID token is still loading')
-  }
-
-  if (!context.data) {
-    throw new Error('useIdToken: ID token is null')
-  }
-
   return { idToken: context.data, isLoading: context.isLoading, refreshIdToken: context.refreshData }
 }

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.test.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.test.ts
@@ -21,6 +21,12 @@ jest.mock('@/utils/analytics/analytics-singleton', () => ({
 jest.mock('react-native-bcsc-core', () => ({
   decodeLoginChallenge: jest.fn(),
   showLocalNotification: jest.fn(),
+  isBcscNativeError: (error: unknown): boolean => {
+    return error instanceof Error && 'code' in error
+  },
+  BcscNativeErrorCodes: {
+    FAILED_TO_PARSE_JWS: 'E_FAILED_TO_PARSE_JWS',
+  },
 }))
 
 // Mock the API client getter
@@ -386,6 +392,23 @@ describe('FcmViewModel', () => {
         pairingCode: 'code456',
         source: 'fcm',
       })
+    })
+
+    it('logs ERR_117 and returns early when decodeLoginChallenge throws E_FAILED_TO_PARSE_JWS', async () => {
+      const nativeError = Object.assign(new Error('Invalid JWS format'), { code: 'E_FAILED_TO_PARSE_JWS' })
+      ;(decodeLoginChallenge as jest.Mock).mockRejectedValue(nativeError)
+
+      const message = {
+        type: 'challenge',
+        data: { jwt: 'malformed-jwt' },
+      } as FcmMessage
+
+      await capturedMessageHandler?.(message)
+
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('err_117_failed_to_parse_jws'))
+      expect(mockPairingService.handlePairing).not.toHaveBeenCalled()
+      // Should NOT fall through to the generic error log
+      expect(mockLogger.error).not.toHaveBeenCalledWith(expect.stringContaining('Failed to decode challenge'))
     })
   })
 

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
@@ -166,17 +166,16 @@ export class FcmViewModel {
         source: 'fcm',
       })
     } catch (error) {
-      const appError = AppError.fromErrorDefinition(ErrorRegistry.CLAIMS_SET_ERROR, { cause: error })
-      appError.handled = true
-      const causeMessage = error instanceof Error ? error.message : String(error)
-      this.logger.error(`[FcmViewModel] [${appError.appEvent}] Failed to decode challenge: ${causeMessage}`, appError)
       if (isBcscNativeError(error) && error.code === BcscNativeErrorCodes.FAILED_TO_PARSE_JWS) {
         const appError = AppError.fromErrorDefinition(ErrorRegistry.PARSE_JWS_ERROR, { cause: error })
         this.logger.error(`[FcmViewModel] [${appError.appEvent}] Failed to parse JWS in challenge request`)
         return
       }
 
-      this.logger.error(`[FcmViewModel] Failed to decode challenge: ${error}`)
+      const appError = AppError.fromErrorDefinition(ErrorRegistry.CLAIMS_SET_ERROR, { cause: error })
+      appError.handled = true
+      const causeMessage = error instanceof Error ? error.message : String(error)
+      this.logger.error(`[FcmViewModel] [${appError.appEvent}] Failed to decode challenge: ${causeMessage}`, appError)
     }
   }
 

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
@@ -4,7 +4,13 @@ import { AbstractBifoldLogger } from '@bifold/core'
 import { getApp } from '@react-native-firebase/app'
 import { getMessaging, getToken } from '@react-native-firebase/messaging'
 import { Platform } from 'react-native'
-import { BcscNativeErrorCodes, decodeLoginChallenge, isBcscNativeError, JWK, showLocalNotification } from 'react-native-bcsc-core'
+import {
+  BcscNativeErrorCodes,
+  decodeLoginChallenge,
+  isBcscNativeError,
+  JWK,
+  showLocalNotification,
+} from 'react-native-bcsc-core'
 import { Mode } from '../../../store'
 import { getBCSCApiClient } from '../../contexts/BCSCApiClientContext'
 import { isVerificationRequestReviewed } from '../../utils/id-token'

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
@@ -4,7 +4,7 @@ import { AbstractBifoldLogger } from '@bifold/core'
 import { getApp } from '@react-native-firebase/app'
 import { getMessaging, getToken } from '@react-native-firebase/messaging'
 import { Platform } from 'react-native'
-import { decodeLoginChallenge, JWK, showLocalNotification } from 'react-native-bcsc-core'
+import { BcscNativeErrorCodes, decodeLoginChallenge, isBcscNativeError, JWK, showLocalNotification } from 'react-native-bcsc-core'
 import { Mode } from '../../../store'
 import { getBCSCApiClient } from '../../contexts/BCSCApiClientContext'
 import { isVerificationRequestReviewed } from '../../utils/id-token'
@@ -164,6 +164,13 @@ export class FcmViewModel {
       appError.handled = true
       const causeMessage = error instanceof Error ? error.message : String(error)
       this.logger.error(`[FcmViewModel] [${appError.appEvent}] Failed to decode challenge: ${causeMessage}`, appError)
+      if (isBcscNativeError(error) && error.code === BcscNativeErrorCodes.FAILED_TO_PARSE_JWS) {
+        const appError = AppError.fromErrorDefinition(ErrorRegistry.PARSE_JWS_ERROR, { cause: error })
+        this.logger.error(`[FcmViewModel] [${appError.appEvent}] Failed to parse JWS in challenge request`)
+        return
+      }
+
+      this.logger.error(`[FcmViewModel] Failed to decode challenge: ${error}`)
     }
   }
 

--- a/app/src/bcsc-theme/services/hooks/useTokenService.test.tsx
+++ b/app/src/bcsc-theme/services/hooks/useTokenService.test.tsx
@@ -47,6 +47,17 @@ describe('useTokenService', () => {
         getCachedIdTokenMetadata: jest.fn().mockRejectedValue(mockError),
       } as any
       const mockAlerts = { failedToGetClaimsSetAlert: jest.fn() }
+
+      jest.spyOn(useTokenApiModule, 'default').mockReturnValue(tokenApi)
+      jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue(mockAlerts as any)
+
+      const { result } = renderHook(() => useTokenService())
+
+      await expect(result.current.getCachedIdTokenMetadata({ refreshCache: false })).rejects.toThrow(mockError)
+      expect(tokenApi.getCachedIdTokenMetadata).toHaveBeenCalledWith({ refreshCache: false })
+      expect(mockAlerts.failedToGetClaimsSetAlert).toHaveBeenCalled()
+    })
+
     it('should show alert on JWS parse error and rethrow error', async () => {
       const mockError = mockAppError(AppEventCode.ERR_117_FAILED_TO_PARSE_JWS)
       const tokenApi = {
@@ -61,7 +72,6 @@ describe('useTokenService', () => {
 
       await expect(result.current.getCachedIdTokenMetadata({ refreshCache: false })).rejects.toThrow(mockError)
       expect(tokenApi.getCachedIdTokenMetadata).toHaveBeenCalledWith({ refreshCache: false })
-      expect(mockAlerts.failedToGetClaimsSetAlert).toHaveBeenCalled()
       expect(mockAlerts.failedToParseJwsAlert).toHaveBeenCalled()
     })
 

--- a/app/src/bcsc-theme/services/hooks/useTokenService.test.tsx
+++ b/app/src/bcsc-theme/services/hooks/useTokenService.test.tsx
@@ -47,6 +47,12 @@ describe('useTokenService', () => {
         getCachedIdTokenMetadata: jest.fn().mockRejectedValue(mockError),
       } as any
       const mockAlerts = { failedToGetClaimsSetAlert: jest.fn() }
+    it('should show alert on JWS parse error and rethrow error', async () => {
+      const mockError = mockAppError(AppEventCode.ERR_117_FAILED_TO_PARSE_JWS)
+      const tokenApi = {
+        getCachedIdTokenMetadata: jest.fn().mockRejectedValue(mockError),
+      } as any
+      const mockAlerts = { failedToParseJwsAlert: jest.fn() }
 
       jest.spyOn(useTokenApiModule, 'default').mockReturnValue(tokenApi)
       jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue(mockAlerts as any)
@@ -56,6 +62,7 @@ describe('useTokenService', () => {
       await expect(result.current.getCachedIdTokenMetadata({ refreshCache: false })).rejects.toThrow(mockError)
       expect(tokenApi.getCachedIdTokenMetadata).toHaveBeenCalledWith({ refreshCache: false })
       expect(mockAlerts.failedToGetClaimsSetAlert).toHaveBeenCalled()
+      expect(mockAlerts.failedToParseJwsAlert).toHaveBeenCalled()
     })
 
     it('should rethrow error without showing alert if error is not decryption error', async () => {

--- a/app/src/bcsc-theme/services/hooks/useTokenService.tsx
+++ b/app/src/bcsc-theme/services/hooks/useTokenService.tsx
@@ -40,6 +40,8 @@ export const useTokenService = () => {
 
         if (isAppError(error, AppEventCode.ERR_114_FAILED_TO_GET_CLAIMS_SET_AFTER_DECRYPT_AND_VERIFY)) {
           alerts.failedToGetClaimsSetAlert()
+        if (isAppError(error, AppEventCode.ERR_117_FAILED_TO_PARSE_JWS)) {
+          alerts.failedToParseJwsAlert()
         }
 
         throw error

--- a/app/src/bcsc-theme/services/hooks/useTokenService.tsx
+++ b/app/src/bcsc-theme/services/hooks/useTokenService.tsx
@@ -40,6 +40,8 @@ export const useTokenService = () => {
 
         if (isAppError(error, AppEventCode.ERR_114_FAILED_TO_GET_CLAIMS_SET_AFTER_DECRYPT_AND_VERIFY)) {
           alerts.failedToGetClaimsSetAlert()
+        }
+
         if (isAppError(error, AppEventCode.ERR_117_FAILED_TO_PARSE_JWS)) {
           alerts.failedToParseJwsAlert()
         }

--- a/app/src/bcsc-theme/services/hooks/useUserService.test.tsx
+++ b/app/src/bcsc-theme/services/hooks/useUserService.test.tsx
@@ -64,6 +64,12 @@ describe('useUserService', () => {
         getUserInfo: jest.fn().mockRejectedValue(mockError),
       } as any
       const mockAlerts = { failedToGetClaimsSetAlert: jest.fn() }
+    it('should show alert on JWS parse error and rethrow error', async () => {
+      const mockError = mockAppError(AppEventCode.ERR_117_FAILED_TO_PARSE_JWS)
+      const userApi = {
+        getUserInfo: jest.fn().mockRejectedValue(mockError),
+      } as any
+      const mockAlerts = { failedToParseJwsAlert: jest.fn() }
 
       jest.spyOn(useUserApiModule, 'default').mockReturnValue(userApi)
       jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue(mockAlerts as any)
@@ -73,6 +79,7 @@ describe('useUserService', () => {
       await expect(result.current.getUserInfo()).rejects.toThrow(mockError)
       expect(userApi.getUserInfo).toHaveBeenCalled()
       expect(mockAlerts.failedToGetClaimsSetAlert).toHaveBeenCalled()
+      expect(mockAlerts.failedToParseJwsAlert).toHaveBeenCalled()
     })
   })
 
@@ -154,6 +161,12 @@ describe('useUserService', () => {
         getUserInfo: jest.fn().mockRejectedValue(mockError),
       } as any
       const mockAlerts = { failedToGetClaimsSetAlert: jest.fn() }
+    it('should show alert on JWS parse error and rethrow error', async () => {
+      const mockError = mockAppError(AppEventCode.ERR_117_FAILED_TO_PARSE_JWS)
+      const userApi = {
+        getUserInfo: jest.fn().mockRejectedValue(mockError),
+      } as any
+      const mockAlerts = { failedToParseJwsAlert: jest.fn() }
 
       jest.spyOn(useUserApiModule, 'default').mockReturnValue(userApi)
       jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue(mockAlerts as any)
@@ -163,6 +176,7 @@ describe('useUserService', () => {
       await expect(result.current.getUserMetadata()).rejects.toThrow(mockError)
       expect(userApi.getUserInfo).toHaveBeenCalled()
       expect(mockAlerts.failedToGetClaimsSetAlert).toHaveBeenCalled()
+      expect(mockAlerts.failedToParseJwsAlert).toHaveBeenCalled()
     })
   })
 

--- a/app/src/bcsc-theme/services/hooks/useUserService.test.tsx
+++ b/app/src/bcsc-theme/services/hooks/useUserService.test.tsx
@@ -64,6 +64,17 @@ describe('useUserService', () => {
         getUserInfo: jest.fn().mockRejectedValue(mockError),
       } as any
       const mockAlerts = { failedToGetClaimsSetAlert: jest.fn() }
+
+      jest.spyOn(useUserApiModule, 'default').mockReturnValue(userApi)
+      jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue(mockAlerts as any)
+
+      const { result } = renderHook(() => useUserService())
+
+      await expect(result.current.getUserInfo()).rejects.toThrow(mockError)
+      expect(userApi.getUserInfo).toHaveBeenCalled()
+      expect(mockAlerts.failedToGetClaimsSetAlert).toHaveBeenCalled()
+    })
+
     it('should show alert on JWS parse error and rethrow error', async () => {
       const mockError = mockAppError(AppEventCode.ERR_117_FAILED_TO_PARSE_JWS)
       const userApi = {
@@ -78,7 +89,6 @@ describe('useUserService', () => {
 
       await expect(result.current.getUserInfo()).rejects.toThrow(mockError)
       expect(userApi.getUserInfo).toHaveBeenCalled()
-      expect(mockAlerts.failedToGetClaimsSetAlert).toHaveBeenCalled()
       expect(mockAlerts.failedToParseJwsAlert).toHaveBeenCalled()
     })
   })
@@ -161,6 +171,17 @@ describe('useUserService', () => {
         getUserInfo: jest.fn().mockRejectedValue(mockError),
       } as any
       const mockAlerts = { failedToGetClaimsSetAlert: jest.fn() }
+
+      jest.spyOn(useUserApiModule, 'default').mockReturnValue(userApi)
+      jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue(mockAlerts as any)
+
+      const { result } = renderHook(() => useUserService())
+
+      await expect(result.current.getUserMetadata()).rejects.toThrow(mockError)
+      expect(userApi.getUserInfo).toHaveBeenCalled()
+      expect(mockAlerts.failedToGetClaimsSetAlert).toHaveBeenCalled()
+    })
+
     it('should show alert on JWS parse error and rethrow error', async () => {
       const mockError = mockAppError(AppEventCode.ERR_117_FAILED_TO_PARSE_JWS)
       const userApi = {
@@ -175,7 +196,6 @@ describe('useUserService', () => {
 
       await expect(result.current.getUserMetadata()).rejects.toThrow(mockError)
       expect(userApi.getUserInfo).toHaveBeenCalled()
-      expect(mockAlerts.failedToGetClaimsSetAlert).toHaveBeenCalled()
       expect(mockAlerts.failedToParseJwsAlert).toHaveBeenCalled()
     })
   })

--- a/app/src/bcsc-theme/services/hooks/useUserService.tsx
+++ b/app/src/bcsc-theme/services/hooks/useUserService.tsx
@@ -38,6 +38,8 @@ export const useUserService = () => {
 
       if (isAppError(error, AppEventCode.ERR_114_FAILED_TO_GET_CLAIMS_SET_AFTER_DECRYPT_AND_VERIFY)) {
         alerts.failedToGetClaimsSetAlert()
+      }
+
       if (isAppError(error, AppEventCode.ERR_117_FAILED_TO_PARSE_JWS)) {
         alerts.failedToParseJwsAlert()
       }
@@ -73,6 +75,8 @@ export const useUserService = () => {
 
       if (isAppError(error, AppEventCode.ERR_114_FAILED_TO_GET_CLAIMS_SET_AFTER_DECRYPT_AND_VERIFY)) {
         alerts.failedToGetClaimsSetAlert()
+      }
+
       if (isAppError(error, AppEventCode.ERR_117_FAILED_TO_PARSE_JWS)) {
         alerts.failedToParseJwsAlert()
       }

--- a/app/src/bcsc-theme/services/hooks/useUserService.tsx
+++ b/app/src/bcsc-theme/services/hooks/useUserService.tsx
@@ -38,6 +38,8 @@ export const useUserService = () => {
 
       if (isAppError(error, AppEventCode.ERR_114_FAILED_TO_GET_CLAIMS_SET_AFTER_DECRYPT_AND_VERIFY)) {
         alerts.failedToGetClaimsSetAlert()
+      if (isAppError(error, AppEventCode.ERR_117_FAILED_TO_PARSE_JWS)) {
+        alerts.failedToParseJwsAlert()
       }
 
       throw error
@@ -71,6 +73,8 @@ export const useUserService = () => {
 
       if (isAppError(error, AppEventCode.ERR_114_FAILED_TO_GET_CLAIMS_SET_AFTER_DECRYPT_AND_VERIFY)) {
         alerts.failedToGetClaimsSetAlert()
+      if (isAppError(error, AppEventCode.ERR_117_FAILED_TO_PARSE_JWS)) {
+        alerts.failedToParseJwsAlert()
       }
 
       throw error

--- a/app/src/bcsc-theme/utils/id-token.test.ts
+++ b/app/src/bcsc-theme/utils/id-token.test.ts
@@ -24,6 +24,22 @@ describe('ID Token Utils', () => {
       expect(mockLogger.error).not.toHaveBeenCalled()
     })
 
+    it('should throw ERR_117 when native error is E_FAILED_TO_PARSE_JWS', async () => {
+      const bcscCoreMock = jest.mocked(BcscCore)
+
+      const mockLogger = new MockLogger()
+      const nativeError = Object.assign(new Error('Invalid JWS format'), { code: 'E_FAILED_TO_PARSE_JWS' })
+
+      bcscCoreMock.decodePayload = jest.fn().mockRejectedValue(nativeError)
+
+      await expect(getIdTokenMetadata('token', mockLogger)).rejects.toThrow(
+        AppError.fromErrorDefinition(ErrorRegistry.PARSE_JWS_ERROR, { cause: nativeError })
+      )
+
+      expect(bcscCoreMock.decodePayload).toHaveBeenCalledWith('token')
+      expect(mockLogger.error).toHaveBeenCalledWith('[getIdTokenMetadata] Failed to decode ID token payload', nativeError)
+    })
+
     it('should throw an error when unable to decode the ID token', async () => {
       const bcscCoreMock = jest.mocked(BcscCore)
 

--- a/app/src/bcsc-theme/utils/id-token.test.ts
+++ b/app/src/bcsc-theme/utils/id-token.test.ts
@@ -37,7 +37,10 @@ describe('ID Token Utils', () => {
       )
 
       expect(bcscCoreMock.decodePayload).toHaveBeenCalledWith('token')
-      expect(mockLogger.error).toHaveBeenCalledWith('[getIdTokenMetadata] Failed to decode ID token payload', nativeError)
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        '[getIdTokenMetadata] Failed to decode ID token payload',
+        nativeError
+      )
     })
 
     it('should throw an error when unable to decode the ID token', async () => {

--- a/app/src/bcsc-theme/utils/id-token.ts
+++ b/app/src/bcsc-theme/utils/id-token.ts
@@ -1,6 +1,12 @@
 import { AppError, ErrorRegistry } from '@/errors'
 import { BifoldLogger } from '@bifold/core'
-import { BCSCAccountType, BCSCCardType, BcscNativeErrorCodes, decodePayload, isBcscNativeError } from 'react-native-bcsc-core'
+import {
+  BCSCAccountType,
+  BCSCCardType,
+  BcscNativeErrorCodes,
+  decodePayload,
+  isBcscNativeError,
+} from 'react-native-bcsc-core'
 import { StatusNotification } from '../features/fcm/services/fcm-service'
 
 /**

--- a/app/src/bcsc-theme/utils/id-token.ts
+++ b/app/src/bcsc-theme/utils/id-token.ts
@@ -1,6 +1,6 @@
 import { AppError, ErrorRegistry } from '@/errors'
 import { BifoldLogger } from '@bifold/core'
-import { BCSCAccountType, BCSCCardType, decodePayload } from 'react-native-bcsc-core'
+import { BCSCAccountType, BCSCCardType, BcscNativeErrorCodes, decodePayload, isBcscNativeError } from 'react-native-bcsc-core'
 import { StatusNotification } from '../features/fcm/services/fcm-service'
 
 /**
@@ -89,6 +89,7 @@ export interface IdToken {
 /**
  * Decode and parse the BCSC ID token to extract metadata.
  *
+ * @throws AppError with code `ERR_117_FAILED_TO_PARSE_JWS` when the JWS token format is invalid
  * @throws AppError with code `ERR_105_UNABLE_TO_DECRYPT_AND_VERIFY_ID_TOKEN` when payload decoding fails
  * @throws AppError with code `ERR_109_FAILED_TO_DESERIALIZE_JSON` if JSON parsing of the payload fails.
  *
@@ -102,6 +103,11 @@ export async function getIdTokenMetadata(idToken: string, logger: BifoldLogger):
     payloadString = await decodePayload(idToken)
   } catch (error) {
     logger.error('[getIdTokenMetadata] Failed to decode ID token payload', error as Error)
+
+    if (isBcscNativeError(error) && error.code === BcscNativeErrorCodes.FAILED_TO_PARSE_JWS) {
+      throw AppError.fromErrorDefinition(ErrorRegistry.PARSE_JWS_ERROR, { cause: error })
+    }
+
     throw AppError.fromErrorDefinition(ErrorRegistry.DECRYPT_VERIFY_ID_TOKEN_ERROR, { cause: error })
   }
 

--- a/app/src/hooks/useAlerts.test.tsx
+++ b/app/src/hooks/useAlerts.test.tsx
@@ -860,6 +860,23 @@ describe('useAlerts', () => {
     })
   })
 
+  describe('failedToParseJwsAlert', () => {
+    it('should show an alert with the correct title and message', () => {
+      const mockNavigation = { navigate: jest.fn() }
+      const mockEmitAlert = jest.fn()
+      jest.spyOn(ErrorAlertContext, 'useErrorAlert').mockReturnValue({ emitAlert: mockEmitAlert } as any)
+
+      const { result } = renderHook(() => useAlerts(mockNavigation as any))
+
+      result.current.failedToParseJwsAlert()
+
+      expect(mockEmitAlert).toHaveBeenCalledWith('Alerts.ProblemWithApp.Title', 'Alerts.ProblemWithApp.Description', {
+        event: AppEventCode.ERR_117_FAILED_TO_PARSE_JWS,
+        actions: [{ text: 'Global.OK' }],
+      })
+    })
+  })
+
   describe('clientRegistrationNullAlert', () => {
     it('should show an alert with the correct title and message', () => {
       const mockNavigation = { navigate: jest.fn() }

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -283,6 +283,7 @@ export const useAlerts = (navigation: NavigationProp<ParamListBase>) => {
       jwsVerificationFailedAlert: _createBasicAlert(AppEventCode.ERR_112_JWS_VERIFICATION_FAILED, 'ProblemWithApp', { errorCode: '112' }),
       failedToGetClaimsSetAlert: _createBasicAlert(AppEventCode.ERR_114_FAILED_TO_GET_CLAIMS_SET_AFTER_DECRYPT_AND_VERIFY, 'ProblemWithApp', { errorCode: '114' }),
       failedToSerializeJsonAlert: _createBasicAlert(AppEventCode.ERR_115_FAILED_TO_SERIALIZE_JSON, 'ProblemWithApp', { errorCode: '115' }),
+      failedToParseJwsAlert: _createBasicAlert(AppEventCode.ERR_117_FAILED_TO_PARSE_JWS, 'ProblemWithApp', { errorCode: '117' }),
       loginServerErrorAlert: _createBasicAlert(AppEventCode.LOGIN_SERVER_ERROR, 'ProblemWithLogin', { errorCode: '303' }),
       problemWithLoginAlert: _createBasicAlert(AppEventCode.LOGIN_PARSE_URI, 'ProblemWithLogin', { errorCode: '304' }),
       loginRejected401Alert: _createProblemWithAccountAlert(AppEventCode.LOGIN_REJECTED_401, '401'),

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -1555,7 +1555,7 @@ class BcscCoreModule(
             val jwtPayload = jweObject.payload.toString()
 
             // Parse the JWT to extract and decode the payload (claims)
-            val jwtSegments = jwtPayload.split(".")
+            val jwtSegments = jwtPayload.split(".", limit = 3)
             if (jwtSegments.size < 3) {
                 promise.reject("E_FAILED_TO_PARSE_JWS", "Invalid JWS format in decrypted payload")
                 return

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -143,6 +143,9 @@ class BcscCoreModule(
         // JWT expiration in seconds
         private const val JWT_EXPIRATION_SECONDS = 3600 // 1 hour
 
+        // JWS compact serialization: header.payload.signature
+        private const val JWS_COMPACT_SEGMENT_COUNT = 3
+
         // Notification channel constants
         private const val NOTIFICATION_CHANNEL_ID = "bcsc_foreground_notifications"
         private const val NOTIFICATION_CHANNEL_NAME = "BCSC Notifications"
@@ -1555,8 +1558,8 @@ class BcscCoreModule(
             val jwtPayload = jweObject.payload.toString()
 
             // Parse the JWT to extract and decode the payload (claims)
-            val jwtSegments = jwtPayload.split(".", limit = 3)
-            if (jwtSegments.size < 3) {
+            val jwtSegments = jwtPayload.split(".")
+            if (jwtSegments.size != JWS_COMPACT_SEGMENT_COUNT) {
                 promise.reject("E_FAILED_TO_PARSE_JWS", "Invalid JWS format in decrypted payload")
                 return
             }
@@ -1591,7 +1594,7 @@ class BcscCoreModule(
             promise.reject("E_JWE_DECRYPT_ERROR", "Failed to decrypt JWE", e)
         } catch (e: IllegalArgumentException) {
             Log.e(NAME, "decodePayload: Base64 decode error: ${e.message}", e)
-            promise.reject("E_BASE64_DECODE_ERROR", "Failed to decode base64 payload", e)
+            promise.reject("E_FAILED_TO_PARSE_JWS", "Failed to decode JWS payload segment", e)
         } catch (e: Exception) {
             Log.e(NAME, "decodePayload: Unexpected error: ${e.message}", e)
             promise.reject("E_PAYLOAD_DECODE_ERROR", "Unable to decode payload", e)

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -1556,8 +1556,8 @@ class BcscCoreModule(
 
             // Parse the JWT to extract and decode the payload (claims)
             val jwtSegments = jwtPayload.split(".")
-            if (jwtSegments.size < 2) {
-                promise.reject("E_INVALID_JWT", "Invalid JWT format in decrypted payload")
+            if (jwtSegments.size < 3) {
+                promise.reject("E_FAILED_TO_PARSE_JWS", "Invalid JWS format in decrypted payload")
                 return
             }
 
@@ -4088,6 +4088,9 @@ class BcscCoreModule(
                 }
 
             promise.resolve(result)
+        } catch (e: java.text.ParseException) {
+            Log.e(NAME, "decodeLoginChallenge: JWS parse error: ${e.message}", e)
+            promise.reject("E_FAILED_TO_PARSE_JWS", "Failed to parse JWS: ${e.message}", e)
         } catch (e: Exception) {
             Log.e(NAME, "decodeLoginChallenge: Unexpected error: ${e.message}", e)
             promise.reject("E_DECODE_LOGIN_CHALLENGE_ERROR", "Unable to decode login challenge", e)

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -1101,7 +1101,7 @@ class BcscCore: NSObject {
       base64String = base64String.replacingOccurrences(of: "-", with: "+")
       base64String = base64String.replacingOccurrences(of: "_", with: "/")
       guard let decodedData = Data(base64Encoded: base64String),
-        let base64Decoded = String(data: decodedData, encoding: .utf8)
+            let base64Decoded = String(data: decodedData, encoding: .utf8)
       else {
         reject("E_FAILED_TO_PARSE_JWS", "Failed to decode JWS payload segment", nil)
         return

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -41,6 +41,8 @@ class BcscCore: NSObject {
   static let generalizedOsName = "iOS"
   static let provider = "https://idsit.gov.bc.ca/device/"
   static let clientName = "BC Services Wallet"
+  /// JWS compact serialization: header.payload.signature
+  static let jwsCompactSegmentCount = 3
 
   static func requiresMainQueueSetup() -> Bool {
     return false
@@ -1085,7 +1087,7 @@ class BcscCore: NSObject {
 
       // Break down and decode JWT
       let segments = payload.components(separatedBy: ".")
-      guard segments.count >= 3 else {
+      guard segments.count == BcscCore.jwsCompactSegmentCount else {
         reject("E_FAILED_TO_PARSE_JWS", "Invalid JWS format in decrypted payload", nil)
         return
       }
@@ -1098,14 +1100,12 @@ class BcscCore: NSObject {
       }
       base64String = base64String.replacingOccurrences(of: "-", with: "+")
       base64String = base64String.replacingOccurrences(of: "_", with: "/")
-      let decodedData = Data(
-        base64Encoded: base64String, options: Data.Base64DecodingOptions(rawValue: UInt(0))
-      )
-
-      let base64Decoded = String(
-        data: decodedData! as Data,
-        encoding: String.Encoding(rawValue: String.Encoding.utf8.rawValue)
-      )!
+      guard let decodedData = Data(base64Encoded: base64String),
+        let base64Decoded = String(data: decodedData, encoding: .utf8)
+      else {
+        reject("E_FAILED_TO_PARSE_JWS", "Failed to decode JWS payload segment", nil)
+        return
+      }
       resolve(base64Decoded)
     } catch {
       reject("E_PAYLOAD_DECODE_ERROR", "Unable to decode payload", nil)

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -1085,6 +1085,10 @@ class BcscCore: NSObject {
 
       // Break down and decode JWT
       let segments = payload.components(separatedBy: ".")
+      guard segments.count >= 3 else {
+        reject("E_FAILED_TO_PARSE_JWS", "Invalid JWS format in decrypted payload", nil)
+        return
+      }
       var base64String = segments[1]
       let requiredLength = Int(4 * ceil(Float(base64String.count) / 4.0))
       let nbrPaddings = requiredLength - base64String.count
@@ -1129,10 +1133,19 @@ class BcscCore: NSObject {
       return
     }
 
+    // 1. Parse the JWT
+    let jws: JWS
     do {
-      // 1. Parse the JWT
-      let jws = try JWS.parse(s: jwt)
+      jws = try JWS.parse(s: jwt)
+    } catch {
+      reject(
+        "E_FAILED_TO_PARSE_JWS",
+        "Failed to parse JWS: \(error.localizedDescription)", error
+      )
+      return
+    }
 
+    do {
       // 2. Extract claims
       guard let claimsSet = try jws.getJwtClaimsSet() else {
         reject("E_INVALID_JWT", "Unable to parse JWT claims", nil)

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -38,6 +38,8 @@ export const BcscNativeErrorCodes = {
   JWT_DEVICE_INFO_ERROR: 'E_120_JWT_DEVICE_INFO_ERROR',
   /** JSON serialization failed in the native module */
   JSON_SERIALIZATION_FAILED: 'E_JSON_SERIALIZATION_FAILED',
+  /** JWS token could not be parsed (malformed or invalid format) */
+  FAILED_TO_PARSE_JWS: 'E_FAILED_TO_PARSE_JWS',
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

- Add `E_FAILED_TO_PARSE_JWS` native rejection in iOS/Android for malformed JWS tokens in `decodePayload()` and `decodeLoginChallenge()`
- Wire the native error through the error handling layers so users see a **"Problem with App (error 117)"** alert
- Add `FAILED_TO_PARSE_JWS` to `BcscNativeErrorCodes`, check for it before generic fallbacks in `id-token.ts` and `useUserApi.tsx`, catch in service hooks, and handle in `FcmViewModel` (analytics + log only)

## Test plan

- [x] `yarn typecheck` passes
- [x] All new and existing tests pass (`yarn test`)
- [x] Tests cover: API layer throw, service hook catch/alert/rethrow, useAlerts definition, FcmViewModel analytics logging
- [x] Verified `isBcscNativeError` mock fix doesn't break existing tests (`SecureAppScreen`, `PINEntryForm`, `useVerificationResponseViewModel`)

## Manual Tesitng

  // Replace:
  payloadString = await decodePayload(idToken)

  // With:
  payloadString = await decodePayload('not.a.valid-jws')

