### PR TITLE
feat: implement ERR_120 client registration failure error handling

### DIFF
--- a/app/src/bcsc-theme/services/hooks/useRegistrationService.test.tsx
+++ b/app/src/bcsc-theme/services/hooks/useRegistrationService.test.tsx
@@ -168,6 +168,26 @@ describe('useRegistrationService', () => {
       })
     })
 
+    describe('App error ERR_120_CLIENT_REGISTRATION_FAILURE', () => {
+      it('should show clientRegistrationFailureAlert on client registration failure', async () => {
+        const mockError = mockAppError(AppEventCode.ERR_120_CLIENT_REGISTRATION_FAILURE)
+        const registrationApi = {
+          register: jest.fn().mockRejectedValue(mockError),
+        } as any
+        const clientRegistrationFailureAlert = jest.fn()
+        const mockAlerts = { clientRegistrationFailureAlert }
+
+        jest.spyOn(useRegistrationApiModule, 'default').mockReturnValue(registrationApi)
+        jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue(mockAlerts as any)
+
+        const { result } = renderHook(() => useRegistrationService())
+
+        await expect(result.current.register('deviceAuth' as any)).rejects.toThrow(mockError)
+        expect(registrationApi.register).toHaveBeenCalledWith('deviceAuth')
+        expect(clientRegistrationFailureAlert).toHaveBeenCalled()
+      })
+    })
+
     describe('App error ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL', () => {
       it('should show the alert for the app error', async () => {
         const mockError = mockAppError(AppEventCode.ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL)
@@ -255,7 +275,7 @@ describe('useRegistrationService', () => {
       const keychainKeyDoesntExistAlert = jest.fn()
       const keychainKeyGenerationAlert = jest.fn()
       const jwtDeviceInfoAlert = jest.fn()
-      const problemWithAppAlert = jest.fn()
+      const clientRegistrationFailureAlert = jest.fn()
       const clientRegistrationNullAlert = jest.fn()
       const failedToSerializeJsonAlert = jest.fn()
 
@@ -266,7 +286,7 @@ describe('useRegistrationService', () => {
         keychainKeyDoesntExistAlert,
         keychainKeyGenerationAlert,
         jwtDeviceInfoAlert,
-        problemWithAppAlert,
+        clientRegistrationFailureAlert,
         clientRegistrationNullAlert,
         failedToSerializeJsonAlert,
       }
@@ -284,7 +304,7 @@ describe('useRegistrationService', () => {
       expect(keychainKeyDoesntExistAlert).not.toHaveBeenCalled()
       expect(keychainKeyGenerationAlert).not.toHaveBeenCalled()
       expect(jwtDeviceInfoAlert).not.toHaveBeenCalled()
-      expect(problemWithAppAlert).not.toHaveBeenCalled()
+      expect(clientRegistrationFailureAlert).not.toHaveBeenCalled()
       expect(clientRegistrationNullAlert).not.toHaveBeenCalled()
       expect(failedToSerializeJsonAlert).not.toHaveBeenCalled()
     })
@@ -428,6 +448,26 @@ describe('useRegistrationService', () => {
       })
     })
 
+    describe('App error ERR_120_CLIENT_REGISTRATION_FAILURE', () => {
+      it('should show clientRegistrationFailureAlert on client registration failure', async () => {
+        const mockError = mockAppError(AppEventCode.ERR_120_CLIENT_REGISTRATION_FAILURE)
+        const registrationApi = {
+          updateRegistration: jest.fn().mockRejectedValue(mockError),
+        } as any
+        const clientRegistrationFailureAlert = jest.fn()
+        const mockAlerts = { clientRegistrationFailureAlert }
+
+        jest.spyOn(useRegistrationApiModule, 'default').mockReturnValue(registrationApi)
+        jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue(mockAlerts as any)
+
+        const { result } = renderHook(() => useRegistrationService())
+
+        await expect(result.current.updateRegistration('someToken', 'someNickname')).rejects.toThrow(mockError)
+        expect(registrationApi.updateRegistration).toHaveBeenCalledWith('someToken', 'someNickname')
+        expect(clientRegistrationFailureAlert).toHaveBeenCalled()
+      })
+    })
+
     describe('App error ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL', () => {
       it('should show the alert for the app error', async () => {
         const mockError = mockAppError(AppEventCode.ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL)
@@ -459,7 +499,7 @@ describe('useRegistrationService', () => {
       const keychainKeyDoesntExistAlert = jest.fn()
       const keychainKeyGenerationAlert = jest.fn()
       const jwtDeviceInfoAlert = jest.fn()
-      const problemWithAppAlert = jest.fn()
+      const clientRegistrationFailureAlert = jest.fn()
       const clientRegistrationNullAlert = jest.fn()
       const mockAlerts = {
         toJsonMethodFailureAlert,
@@ -468,7 +508,7 @@ describe('useRegistrationService', () => {
         keychainKeyDoesntExistAlert,
         keychainKeyGenerationAlert,
         jwtDeviceInfoAlert,
-        problemWithAppAlert,
+        clientRegistrationFailureAlert,
         clientRegistrationNullAlert,
       }
 
@@ -485,7 +525,7 @@ describe('useRegistrationService', () => {
       expect(keychainKeyDoesntExistAlert).not.toHaveBeenCalled()
       expect(keychainKeyGenerationAlert).not.toHaveBeenCalled()
       expect(jwtDeviceInfoAlert).not.toHaveBeenCalled()
-      expect(problemWithAppAlert).not.toHaveBeenCalled()
+      expect(clientRegistrationFailureAlert).not.toHaveBeenCalled()
       expect(clientRegistrationNullAlert).not.toHaveBeenCalled()
     })
   })

--- a/app/src/bcsc-theme/services/hooks/useRegistrationService.tsx
+++ b/app/src/bcsc-theme/services/hooks/useRegistrationService.tsx
@@ -18,7 +18,7 @@ const getRegistrationAlertMap = (alerts: AppAlerts): Partial<Record<AppEventCode
   [AppEventCode.ERR_120_KEYCHAIN_KEY_DOESNT_EXIST_ERROR]: alerts.keychainKeyDoesntExistAlert,
   [AppEventCode.ERR_120_KEYCHAIN_KEY_GENERATION_ERROR]: alerts.keychainKeyGenerationAlert,
   [AppEventCode.ERR_120_JWT_DEVICE_INFO_ERROR]: alerts.jwtDeviceInfoAlert,
-  [AppEventCode.ERR_120_CLIENT_REGISTRATION_FAILURE]: alerts.problemWithAppAlert,
+  [AppEventCode.ERR_120_CLIENT_REGISTRATION_FAILURE]: alerts.clientRegistrationFailureAlert,
   [AppEventCode.ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL]: alerts.clientRegistrationNullAlert,
   [AppEventCode.ERR_109_FAILED_TO_DESERIALIZE_JSON]: alerts.failedToDeserializeJsonAlert,
   [AppEventCode.ERR_115_FAILED_TO_SERIALIZE_JSON]: alerts.failedToSerializeJsonAlert,

--- a/app/src/hooks/useAlerts.test.tsx
+++ b/app/src/hooks/useAlerts.test.tsx
@@ -1091,6 +1091,23 @@ describe('useAlerts', () => {
     })
   })
 
+  describe('clientRegistrationFailureAlert', () => {
+    it('should show an alert with the correct title and message', () => {
+      const mockNavigation = { navigate: jest.fn() }
+      const mockEmitAlert = jest.fn()
+      jest.spyOn(ErrorAlertContext, 'useErrorAlert').mockReturnValue({ emitAlert: mockEmitAlert } as any)
+
+      const { result } = renderHook(() => useAlerts(mockNavigation as any))
+
+      result.current.clientRegistrationFailureAlert()
+
+      expect(mockEmitAlert).toHaveBeenCalledWith('Alerts.ProblemWithApp.Title', 'Alerts.ProblemWithApp.Description', {
+        event: AppEventCode.ERR_120_CLIENT_REGISTRATION_FAILURE,
+        actions: [{ text: 'Global.OK' }],
+      })
+    })
+  })
+
   describe('noTokensReturnedAlert', () => {
     it('should show an alert with the correct title and message', () => {
       const mockNavigation = { navigate: jest.fn() }

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -304,6 +304,7 @@ export const useAlerts = (navigation: NavigationProp<ParamListBase>) => {
       keychainKeyDoesntExistAlert: _createBasicAlert(AppEventCode.ERR_120_KEYCHAIN_KEY_DOESNT_EXIST_ERROR, 'ProblemWithApp', { errorCode: '120-4' }),
       keychainKeyGenerationAlert: _createBasicAlert(AppEventCode.ERR_120_KEYCHAIN_KEY_GENERATION_ERROR, 'ProblemWithApp', { errorCode: '120-5' }),
       jwtDeviceInfoAlert: _createBasicAlert(AppEventCode.ERR_120_JWT_DEVICE_INFO_ERROR, 'ProblemWithApp', { errorCode: '120-6' }),
+      clientRegistrationFailureAlert: _createBasicAlert(AppEventCode.ERR_120_CLIENT_REGISTRATION_FAILURE, 'ProblemWithApp', { errorCode: '120' }),
       missingJwkAlert: _createBasicAlert(AppEventCode.ERR_111_UNABLE_TO_VERIFY_MISSING_JWK, 'ProblemWithApp', { errorCode: '111' }),
       jwsVerificationFailedAlert: _createBasicAlert(AppEventCode.ERR_112_JWS_VERIFICATION_FAILED, 'ProblemWithApp', { errorCode: '112' }),
       failedToGetClaimsSetAlert: _createBasicAlert(AppEventCode.ERR_114_FAILED_TO_GET_CLAIMS_SET_AFTER_DECRYPT_AND_VERIFY, 'ProblemWithApp', { errorCode: '114' }),


### PR DESCRIPTION
## Summary

**TL;DR**: ERR_120 fires when the native module fails in a way we didn't explicitly map — an unexpected/unknown native error during client registration. Not much to manually test here.

- Add dedicated `clientRegistrationFailureAlert` with error code `120` in `useAlerts.tsx`, replacing the generic `problemWithAppAlert` fallback for unmapped native errors during DCR
- Update `useRegistrationService.tsx` alert map to route `ERR_120_CLIENT_REGISTRATION_FAILURE` to the new specific alert
- Add test coverage for the new alert and service-layer error handling (both `register` and `updateRegistration`)

Fixes #3095 

## Test plan
- [ ] Verify `useAlerts.test.tsx` — new `clientRegistrationFailureAlert` test passes
- [ ] Verify `useRegistrationService.test.tsx` — ERR_120 tests pass for both `register` and `updateRegistration`
- [ ] Verify catch-all tests updated to reference `clientRegistrationFailureAlert` instead of `problemWithAppAlert`
- [ ] `yarn typecheck` passes
- [ ] `yarn test` passes

## Manual Testing — ERR_120

To visually verify the error 120 alert on Android:

1. In `packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt`, add an unconditional throw at the top of `getDynamicClientRegistrationBody()`:
   ```kotlin
   throw RuntimeException("Debug trigger: simulating unmapped native error for ERR_120")
   ```
2. Rebuild the Android app
3. Trigger registration (e.g., onboarding flow or PIN entry)
4. Expected: native alert appears — **"Problem with App"** / *"The app does not appear to be installed correctly. Please remove the app from your device and add it again. (error 120)"* / **[OK]**


<img width="256" alt="Screenshot_20260306-152509" src="https://github.com/user-attachments/assets/369d3148-949e-40c6-a9f1-2bcc02d96f9e" />



