### PR TITLE
feat: add error codes 400 - 501

### DIFF
--- a/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
@@ -11,7 +11,10 @@ import {
   birthdateLockoutErrorPolicy,
   cardExpiredErrorPolicy,
   ClientErrorHandlingPolicies,
+  failedToRetrieveStringResourceErrorPolicy,
   globalAlertErrorPolicy,
+  invalidRegistrationRequestErrorPolicy,
+  invalidUrlErrorPolicy,
   noTokensReturnedErrorPolicy,
   unexpectedServerErrorPolicy,
   updateRequiredErrorPolicy,
@@ -512,6 +515,81 @@ describe('clientErrorPolicies', () => {
     })
   })
 
+  describe('failedToRetrieveStringResourceErrorPolicy', () => {
+    describe('matches', () => {
+      it('should match ERR_400_FAILED_TO_RETRIEVE_STRING_RESOURCE', () => {
+        const error = newError('err_400_failed_to_retrieve_string_resource')
+        expect(failedToRetrieveStringResourceErrorPolicy.matches(error, {} as any)).toBeTruthy()
+      })
+
+      it('should NOT match other errors', () => {
+        const error = newError('server_error')
+        expect(failedToRetrieveStringResourceErrorPolicy.matches(error, {} as any)).toBeFalsy()
+      })
+    })
+
+    describe('handle', () => {
+      it('should call failedToRetrieveStringResourceAlert and mark error as handled', () => {
+        const error = newError('err_400_failed_to_retrieve_string_resource')
+        const mockAlert = jest.fn()
+        const context = { alerts: { failedToRetrieveStringResourceAlert: mockAlert } }
+        failedToRetrieveStringResourceErrorPolicy.handle(error, context as any)
+        expect(mockAlert).toHaveBeenCalled()
+        expect(error.handled).toBe(true)
+      })
+    })
+  })
+
+  describe('invalidUrlErrorPolicy', () => {
+    describe('matches', () => {
+      it('should match ERR_500_INVALID_URL', () => {
+        const error = newError('err_500_invalid_url')
+        expect(invalidUrlErrorPolicy.matches(error, {} as any)).toBeTruthy()
+      })
+
+      it('should NOT match other errors', () => {
+        const error = newError('server_error')
+        expect(invalidUrlErrorPolicy.matches(error, {} as any)).toBeFalsy()
+      })
+    })
+
+    describe('handle', () => {
+      it('should call invalidUrlAlert and mark error as handled', () => {
+        const error = newError('err_500_invalid_url')
+        const mockAlert = jest.fn()
+        const context = { alerts: { invalidUrlAlert: mockAlert } }
+        invalidUrlErrorPolicy.handle(error, context as any)
+        expect(mockAlert).toHaveBeenCalled()
+        expect(error.handled).toBe(true)
+      })
+    })
+  })
+
+  describe('invalidRegistrationRequestErrorPolicy', () => {
+    describe('matches', () => {
+      it('should match ERR_501_INVALID_REGISTRATION_REQUEST', () => {
+        const error = newError('err_501_invalid_registration_request')
+        expect(invalidRegistrationRequestErrorPolicy.matches(error, {} as any)).toBeTruthy()
+      })
+
+      it('should NOT match other errors', () => {
+        const error = newError('server_error')
+        expect(invalidRegistrationRequestErrorPolicy.matches(error, {} as any)).toBeFalsy()
+      })
+    })
+
+    describe('handle', () => {
+      it('should call invalidRegistrationRequestAlert and mark error as handled', () => {
+        const error = newError('err_501_invalid_registration_request')
+        const mockAlert = jest.fn()
+        const context = { alerts: { invalidRegistrationRequestAlert: mockAlert } }
+        invalidRegistrationRequestErrorPolicy.handle(error, context as any)
+        expect(mockAlert).toHaveBeenCalled()
+        expect(error.handled).toBe(true)
+      })
+    })
+  })
+
   describe('ClientErrorHandlingPolicies', () => {
     describe('policy order', () => {
       it('should respect policy order when multiple policies match', () => {
@@ -556,6 +634,52 @@ describe('clientErrorPolicies', () => {
 
         // alreadyRegisteredErrorPolicy should come before globalAlertErrorPolicy
         expect(indexOfAlreadyRegistered).toBeLessThan(indexOfGlobalAlert)
+      })
+
+      it('should have alreadyRegisteredErrorPolicy before invalidRegistrationRequestErrorPolicy', () => {
+        const indexOfAlreadyRegistered = ClientErrorHandlingPolicies.indexOf(alreadyRegisteredErrorPolicy)
+        const indexOfInvalidRegistration = ClientErrorHandlingPolicies.indexOf(invalidRegistrationRequestErrorPolicy)
+
+        expect(indexOfAlreadyRegistered).toBeLessThan(indexOfInvalidRegistration)
+      })
+
+      it('should have new IAS error policies before globalAlertErrorPolicy', () => {
+        const indexOfStringResource = ClientErrorHandlingPolicies.indexOf(failedToRetrieveStringResourceErrorPolicy)
+        const indexOfInvalidUrl = ClientErrorHandlingPolicies.indexOf(invalidUrlErrorPolicy)
+        const indexOfInvalidRegistration = ClientErrorHandlingPolicies.indexOf(invalidRegistrationRequestErrorPolicy)
+        const indexOfGlobalAlert = ClientErrorHandlingPolicies.indexOf(globalAlertErrorPolicy)
+
+        expect(indexOfStringResource).toBeLessThan(indexOfGlobalAlert)
+        expect(indexOfInvalidUrl).toBeLessThan(indexOfGlobalAlert)
+        expect(indexOfInvalidRegistration).toBeLessThan(indexOfGlobalAlert)
+      })
+
+      it('should prefer alreadyRegisteredErrorPolicy for ERR_501 with "client is in invalid" on deviceAuthorization', () => {
+        const error = newError('err_501_invalid_registration_request')
+        error.cause = new AxiosError('client is in invalid state')
+        const context = {
+          endpoint: '/api/devicecode',
+          apiEndpoints: {
+            deviceAuthorization: '/api/devicecode',
+          },
+        }
+
+        const matchedPolicy = ClientErrorHandlingPolicies.find((policy) => policy.matches(error, context as any))
+        expect(matchedPolicy).toBe(alreadyRegisteredErrorPolicy)
+      })
+
+      it('should fall through to invalidRegistrationRequestErrorPolicy for ERR_501 without "client is in invalid"', () => {
+        const error = newError('err_501_invalid_registration_request')
+        error.cause = new AxiosError('some other reason')
+        const context = {
+          endpoint: '/api/other',
+          apiEndpoints: {
+            deviceAuthorization: '/api/devicecode',
+          },
+        }
+
+        const matchedPolicy = ClientErrorHandlingPolicies.find((policy) => policy.matches(error, context as any))
+        expect(matchedPolicy).toBe(invalidRegistrationRequestErrorPolicy)
       })
     })
   })

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -321,6 +321,39 @@ export const cardExpiredErrorPolicy: ErrorHandlingPolicy = {
   },
 }
 
+// Error policy for ERR_400_FAILED_TO_RETRIEVE_STRING_RESOURCE — bad request due to malformed or misconfigured client
+export const failedToRetrieveStringResourceErrorPolicy: ErrorHandlingPolicy = {
+  matches: (error) => {
+    return error.appEvent === AppEventCode.ERR_400_FAILED_TO_RETRIEVE_STRING_RESOURCE
+  },
+  handle: (error, context) => {
+    context.alerts.failedToRetrieveStringResourceAlert()
+    error.handled = true
+  },
+}
+
+// Error policy for ERR_500_INVALID_URL — server-side URL validation failure
+export const invalidUrlErrorPolicy: ErrorHandlingPolicy = {
+  matches: (error) => {
+    return error.appEvent === AppEventCode.ERR_500_INVALID_URL
+  },
+  handle: (error, context) => {
+    context.alerts.invalidUrlAlert()
+    error.handled = true
+  },
+}
+
+// Fallback error policy for ERR_501_INVALID_REGISTRATION_REQUEST cases not handled by alreadyRegisteredErrorPolicy
+export const invalidRegistrationRequestErrorPolicy: ErrorHandlingPolicy = {
+  matches: (error) => {
+    return error.appEvent === AppEventCode.ERR_501_INVALID_REGISTRATION_REQUEST
+  },
+  handle: (error, context) => {
+    context.alerts.invalidRegistrationRequestAlert()
+    error.handled = true
+  },
+}
+
 // ----------------------------------------
 // Error Handling Policy Factories
 // ----------------------------------------
@@ -339,6 +372,9 @@ export const ClientErrorHandlingPolicies: ErrorHandlingPolicy[] = [
   loginRejectedOnDeviceAuthorizationErrorPolicy,
   alreadyVerifiedErrorPolicy,
   invalidTokenReturnedPolicy,
+  failedToRetrieveStringResourceErrorPolicy,
+  invalidUrlErrorPolicy,
+  invalidRegistrationRequestErrorPolicy,
   videoSessionErrorPolicy,
   attestationPollingErrorPolicy,
   // Specific polices listed above, followed by global policies

--- a/app/src/bcsc-theme/services/hooks/useRegistrationService.test.tsx
+++ b/app/src/bcsc-theme/services/hooks/useRegistrationService.test.tsx
@@ -244,6 +244,66 @@ describe('useRegistrationService', () => {
       })
     })
 
+    describe('App error ERR_400_FAILED_TO_RETRIEVE_STRING_RESOURCE', () => {
+      it('should show failedToRetrieveStringResourceAlert on string resource error', async () => {
+        const mockError = mockAppError(AppEventCode.ERR_400_FAILED_TO_RETRIEVE_STRING_RESOURCE)
+        const registrationApi = {
+          register: jest.fn().mockRejectedValue(mockError),
+        } as any
+        const failedToRetrieveStringResourceAlert = jest.fn()
+        const mockAlerts = { failedToRetrieveStringResourceAlert }
+
+        jest.spyOn(useRegistrationApiModule, 'default').mockReturnValue(registrationApi)
+        jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue(mockAlerts as any)
+
+        const { result } = renderHook(() => useRegistrationService())
+
+        await expect(result.current.register('deviceAuth' as any)).rejects.toThrow(mockError)
+        expect(registrationApi.register).toHaveBeenCalledWith('deviceAuth')
+        expect(failedToRetrieveStringResourceAlert).toHaveBeenCalled()
+      })
+    })
+
+    describe('App error ERR_500_INVALID_URL', () => {
+      it('should show invalidUrlAlert on invalid URL error', async () => {
+        const mockError = mockAppError(AppEventCode.ERR_500_INVALID_URL)
+        const registrationApi = {
+          register: jest.fn().mockRejectedValue(mockError),
+        } as any
+        const invalidUrlAlert = jest.fn()
+        const mockAlerts = { invalidUrlAlert }
+
+        jest.spyOn(useRegistrationApiModule, 'default').mockReturnValue(registrationApi)
+        jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue(mockAlerts as any)
+
+        const { result } = renderHook(() => useRegistrationService())
+
+        await expect(result.current.register('deviceAuth' as any)).rejects.toThrow(mockError)
+        expect(registrationApi.register).toHaveBeenCalledWith('deviceAuth')
+        expect(invalidUrlAlert).toHaveBeenCalled()
+      })
+    })
+
+    describe('App error ERR_501_INVALID_REGISTRATION_REQUEST', () => {
+      it('should show invalidRegistrationRequestAlert on invalid registration request error', async () => {
+        const mockError = mockAppError(AppEventCode.ERR_501_INVALID_REGISTRATION_REQUEST)
+        const registrationApi = {
+          register: jest.fn().mockRejectedValue(mockError),
+        } as any
+        const invalidRegistrationRequestAlert = jest.fn()
+        const mockAlerts = { invalidRegistrationRequestAlert }
+
+        jest.spyOn(useRegistrationApiModule, 'default').mockReturnValue(registrationApi)
+        jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue(mockAlerts as any)
+
+        const { result } = renderHook(() => useRegistrationService())
+
+        await expect(result.current.register('deviceAuth' as any)).rejects.toThrow(mockError)
+        expect(registrationApi.register).toHaveBeenCalledWith('deviceAuth')
+        expect(invalidRegistrationRequestAlert).toHaveBeenCalled()
+      })
+    })
+
     it('should rethrow error without showing alert if error is not bcsc native error or client registration null app error', async () => {
       const mockError = mockAppError('ERR_SOME_OTHER_ERROR')
       const registrationApi = {
@@ -258,6 +318,9 @@ describe('useRegistrationService', () => {
       const problemWithAppAlert = jest.fn()
       const clientRegistrationNullAlert = jest.fn()
       const failedToSerializeJsonAlert = jest.fn()
+      const failedToRetrieveStringResourceAlert = jest.fn()
+      const invalidUrlAlert = jest.fn()
+      const invalidRegistrationRequestAlert = jest.fn()
 
       const mockAlerts = {
         toJsonMethodFailureAlert,
@@ -269,6 +332,9 @@ describe('useRegistrationService', () => {
         problemWithAppAlert,
         clientRegistrationNullAlert,
         failedToSerializeJsonAlert,
+        failedToRetrieveStringResourceAlert,
+        invalidUrlAlert,
+        invalidRegistrationRequestAlert,
       }
 
       jest.spyOn(useRegistrationApiModule, 'default').mockReturnValue(registrationApi)
@@ -287,6 +353,9 @@ describe('useRegistrationService', () => {
       expect(problemWithAppAlert).not.toHaveBeenCalled()
       expect(clientRegistrationNullAlert).not.toHaveBeenCalled()
       expect(failedToSerializeJsonAlert).not.toHaveBeenCalled()
+      expect(failedToRetrieveStringResourceAlert).not.toHaveBeenCalled()
+      expect(invalidUrlAlert).not.toHaveBeenCalled()
+      expect(invalidRegistrationRequestAlert).not.toHaveBeenCalled()
     })
   })
 
@@ -461,6 +530,9 @@ describe('useRegistrationService', () => {
       const jwtDeviceInfoAlert = jest.fn()
       const problemWithAppAlert = jest.fn()
       const clientRegistrationNullAlert = jest.fn()
+      const failedToRetrieveStringResourceAlert = jest.fn()
+      const invalidUrlAlert = jest.fn()
+      const invalidRegistrationRequestAlert = jest.fn()
       const mockAlerts = {
         toJsonMethodFailureAlert,
         toJsonStringMethodFailureAlert,
@@ -470,6 +542,9 @@ describe('useRegistrationService', () => {
         jwtDeviceInfoAlert,
         problemWithAppAlert,
         clientRegistrationNullAlert,
+        failedToRetrieveStringResourceAlert,
+        invalidUrlAlert,
+        invalidRegistrationRequestAlert,
       }
 
       jest.spyOn(useRegistrationApiModule, 'default').mockReturnValue(registrationApi)
@@ -487,6 +562,9 @@ describe('useRegistrationService', () => {
       expect(jwtDeviceInfoAlert).not.toHaveBeenCalled()
       expect(problemWithAppAlert).not.toHaveBeenCalled()
       expect(clientRegistrationNullAlert).not.toHaveBeenCalled()
+      expect(failedToRetrieveStringResourceAlert).not.toHaveBeenCalled()
+      expect(invalidUrlAlert).not.toHaveBeenCalled()
+      expect(invalidRegistrationRequestAlert).not.toHaveBeenCalled()
     })
   })
 

--- a/app/src/bcsc-theme/services/hooks/useRegistrationService.tsx
+++ b/app/src/bcsc-theme/services/hooks/useRegistrationService.tsx
@@ -22,6 +22,9 @@ const getRegistrationAlertMap = (alerts: AppAlerts): Partial<Record<AppEventCode
   [AppEventCode.ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL]: alerts.clientRegistrationNullAlert,
   [AppEventCode.ERR_109_FAILED_TO_DESERIALIZE_JSON]: alerts.failedToDeserializeJsonAlert,
   [AppEventCode.ERR_115_FAILED_TO_SERIALIZE_JSON]: alerts.failedToSerializeJsonAlert,
+  [AppEventCode.ERR_400_FAILED_TO_RETRIEVE_STRING_RESOURCE]: alerts.failedToRetrieveStringResourceAlert,
+  [AppEventCode.ERR_500_INVALID_URL]: alerts.invalidUrlAlert,
+  [AppEventCode.ERR_501_INVALID_REGISTRATION_REQUEST]: alerts.invalidRegistrationRequestAlert,
 })
 
 /**

--- a/app/src/hooks/useAlerts.test.tsx
+++ b/app/src/hooks/useAlerts.test.tsx
@@ -1145,6 +1145,57 @@ describe('useAlerts', () => {
     })
   })
 
+  describe('failedToRetrieveStringResourceAlert', () => {
+    it('should show an alert with the correct title and message', () => {
+      const mockNavigation = { navigate: jest.fn() }
+      const mockEmitAlert = jest.fn()
+      jest.spyOn(ErrorAlertContext, 'useErrorAlert').mockReturnValue({ emitAlert: mockEmitAlert } as any)
+
+      const { result } = renderHook(() => useAlerts(mockNavigation as any))
+
+      result.current.failedToRetrieveStringResourceAlert()
+
+      expect(mockEmitAlert).toHaveBeenCalledWith('Alerts.ProblemWithApp.Title', 'Alerts.ProblemWithApp.Description', {
+        event: AppEventCode.ERR_400_FAILED_TO_RETRIEVE_STRING_RESOURCE,
+        actions: [{ text: 'Global.OK' }],
+      })
+    })
+  })
+
+  describe('invalidUrlAlert', () => {
+    it('should show an alert with the correct title and message', () => {
+      const mockNavigation = { navigate: jest.fn() }
+      const mockEmitAlert = jest.fn()
+      jest.spyOn(ErrorAlertContext, 'useErrorAlert').mockReturnValue({ emitAlert: mockEmitAlert } as any)
+
+      const { result } = renderHook(() => useAlerts(mockNavigation as any))
+
+      result.current.invalidUrlAlert()
+
+      expect(mockEmitAlert).toHaveBeenCalledWith('Alerts.ProblemWithApp.Title', 'Alerts.ProblemWithApp.Description', {
+        event: AppEventCode.ERR_500_INVALID_URL,
+        actions: [{ text: 'Global.OK' }],
+      })
+    })
+  })
+
+  describe('invalidRegistrationRequestAlert', () => {
+    it('should show an alert with the correct title and message', () => {
+      const mockNavigation = { navigate: jest.fn() }
+      const mockEmitAlert = jest.fn()
+      jest.spyOn(ErrorAlertContext, 'useErrorAlert').mockReturnValue({ emitAlert: mockEmitAlert } as any)
+
+      const { result } = renderHook(() => useAlerts(mockNavigation as any))
+
+      result.current.invalidRegistrationRequestAlert()
+
+      expect(mockEmitAlert).toHaveBeenCalledWith('Alerts.ProblemWithApp.Title', 'Alerts.ProblemWithApp.Description', {
+        event: AppEventCode.ERR_501_INVALID_REGISTRATION_REQUEST,
+        actions: [{ text: 'Global.OK' }],
+      })
+    })
+  })
+
   describe('factoryResetAlert', () => {
     it('should show an alert with the correct title and message', () => {
       const mockNavigation = { navigate: jest.fn() }

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -291,6 +291,9 @@ export const useAlerts = (navigation: NavigationProp<ParamListBase>) => {
       loginRejected400Alert: _createProblemWithAccountAlert(AppEventCode.LOGIN_REJECTED_400, '400-1'),
       noTokensReturnedAlert: _createProblemWithAccountAlert(AppEventCode.NO_TOKENS_RETURNED, '214'),
       invalidTokenAlert: _createProblemWithAccountAlert(AppEventCode.INVALID_TOKEN, '215'),
+      failedToRetrieveStringResourceAlert: _createBasicAlert(AppEventCode.ERR_400_FAILED_TO_RETRIEVE_STRING_RESOURCE, 'ProblemWithApp', { errorCode: '400' }),
+      invalidUrlAlert: _createBasicAlert(AppEventCode.ERR_500_INVALID_URL, 'ProblemWithApp', { errorCode: '500' }),
+      invalidRegistrationRequestAlert: _createBasicAlert(AppEventCode.ERR_501_INVALID_REGISTRATION_REQUEST, 'ProblemWithApp', { errorCode: '501' }),
     }),
     [
       appUpdateRequiredAlert,

--- a/app/src/screens/ErrorAlertTest.tsx
+++ b/app/src/screens/ErrorAlertTest.tsx
@@ -188,6 +188,11 @@ const ErrorAlertTest: React.FC<ErrorAlertTestProps> = ({ onBack }) => {
       onBack() // close modal first
       injectErrorCodeIntoAxiosResponse(client, 'invalid_token', `${client.endpoints.token}`)
     },
+    err_400_failed_to_retrieve_string_resource: () =>
+      injectErrorCodeIntoAxiosResponse(client, 'err_400_failed_to_retrieve_string_resource'),
+    err_500_invalid_url: () => injectErrorCodeIntoAxiosResponse(client, 'err_500_invalid_url'),
+    err_501_invalid_registration_request: () =>
+      injectErrorCodeIntoAxiosResponse(client, 'err_501_invalid_registration_request'),
   }
 
   const getCategoryIcon = (category: ErrorCategory): string => {


### PR DESCRIPTION
# Summary of Changes

- Added dedicated alerts, client error policies, and registration service handling for IAS error codes 400, 500, and 501.
- Extended the Developer Error & Alert Testing screen to manually trigger these IAS error responses end-to-end.

# Testing Instructions

1. Automated: yarn test --testPathPattern="clientErrorPolicies|useRegistrationService|useAlerts"
2. Manual: On a device/simulator, open the Developer → Error & Alert Testing screen.

# Acceptance Criteria

- IAS error codes 400, 500, and 501 surface user-facing alerts via `useAlerts` instead of falling through to generic handling.
- New client error policies are invoked for 400/500/501, and `alreadyRegisteredErrorPolicy` still takes precedence for the \"client is in invalid\" 501 case.
- Registration service shows the correct alerts when these errors are thrown directly from registration APIs.
- The Developer Error & Alert Testing screen can reliably trigger all three IAS error codes end-to-end.
- All updated Jest suites pass without regression.

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A
