### PR TITLE
fix: reset to home screen on ios nav back to pairing conf

### DIFF
--- a/app/src/bcsc-theme/features/pairing/PairingConfirmation.test.tsx
+++ b/app/src/bcsc-theme/features/pairing/PairingConfirmation.test.tsx
@@ -71,6 +71,30 @@ describe('PairingConfirmation', () => {
       expect(mockNavigation.dispatch).toHaveBeenCalled()
       addEventSpy.mockRestore()
     })
+
+    it('does not navigate home on inactive → active (e.g. notification center dismissal)', () => {
+      let appStateCallback: (state: AppStateStatus) => void
+      const removeSpy = jest.fn()
+      const addEventSpy = jest.spyOn(AppState, 'addEventListener').mockImplementation((_, callback) => {
+        appStateCallback = callback as (state: AppStateStatus) => void
+        return { remove: removeSpy } as any
+      })
+
+      const route = { params: { ...defaultRoute.params, fromAppSwitch: true } }
+
+      render(
+        <BasicAppContext>
+          <PairingConfirmation navigation={mockNavigation as never} route={route as never} />
+        </BasicAppContext>
+      )
+
+      // Simulate inactive → active (e.g. pulling down notification center)
+      appStateCallback!('inactive')
+      appStateCallback!('active')
+
+      expect(mockNavigation.dispatch).not.toHaveBeenCalled()
+      addEventSpy.mockRestore()
+    })
   })
 
   describe('when on iOS without fromAppSwitch', () => {

--- a/app/src/bcsc-theme/features/pairing/PairingConfirmation.test.tsx
+++ b/app/src/bcsc-theme/features/pairing/PairingConfirmation.test.tsx
@@ -2,7 +2,7 @@ import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
 import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
-import { BackHandler, Platform } from 'react-native'
+import { AppState, AppStateStatus, BackHandler, Platform } from 'react-native'
 import PairingConfirmation from './PairingConfirmation'
 
 describe('PairingConfirmation', () => {
@@ -46,6 +46,30 @@ describe('PairingConfirmation', () => {
       )
 
       expect(queryByTestId('com.ariesbifold:id/Close')).toBeNull()
+    })
+
+    it('navigates home when the app returns from background', () => {
+      let appStateCallback: (state: AppStateStatus) => void
+      const removeSpy = jest.fn()
+      const addEventSpy = jest.spyOn(AppState, 'addEventListener').mockImplementation((_, callback) => {
+        appStateCallback = callback as (state: AppStateStatus) => void
+        return { remove: removeSpy } as any
+      })
+
+      const route = { params: { ...defaultRoute.params, fromAppSwitch: true } }
+
+      render(
+        <BasicAppContext>
+          <PairingConfirmation navigation={mockNavigation as never} route={route as never} />
+        </BasicAppContext>
+      )
+
+      // Simulate background → foreground transition
+      appStateCallback!('background')
+      appStateCallback!('active')
+
+      expect(mockNavigation.dispatch).toHaveBeenCalled()
+      addEventSpy.mockRestore()
     })
   })
 

--- a/app/src/bcsc-theme/features/pairing/PairingConfirmation.tsx
+++ b/app/src/bcsc-theme/features/pairing/PairingConfirmation.tsx
@@ -3,9 +3,9 @@ import ArrowUp from '@assets/img/arrowup.svg'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { CommonActions } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack'
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { BackHandler, Platform } from 'react-native'
+import { AppState, BackHandler, Platform } from 'react-native'
 import ServiceBookmarkButton from './components/ServiceBookmarkButton'
 
 const ARROW_SIZE = 80
@@ -17,6 +17,31 @@ const ManualPairing: React.FC<ManualPairingProps> = ({ navigation, route }) => {
   const { t } = useTranslation()
   const { serviceName, serviceId, fromAppSwitch } = route.params
   const showAppSwitchGuidance = Platform.OS === 'ios' && fromAppSwitch
+  const appStateRef = useRef(AppState.currentState)
+
+  useEffect(() => {
+    if (!showAppSwitchGuidance) {
+      return
+    }
+
+    // On iOS, when coming from an app switch, we want to automatically navigate the user back
+    // to the home screen when they return to the app (since they've completed the action in
+    // the other app)
+    const subscription = AppState.addEventListener('change', (nextAppState) => {
+      const prev = appStateRef.current
+      appStateRef.current = nextAppState
+      if ((prev === 'inactive' || prev === 'background') && nextAppState === 'active') {
+        navigation.dispatch(
+          CommonActions.reset({
+            index: 0,
+            routes: [{ name: BCSCStacks.Tab }],
+          })
+        )
+      }
+    })
+
+    return subscription.remove
+  }, [showAppSwitchGuidance, navigation])
 
   const onClose = () => {
     if (fromAppSwitch && Platform.OS === 'android') {
@@ -45,7 +70,7 @@ const ManualPairing: React.FC<ManualPairingProps> = ({ navigation, route }) => {
     <ScreenWrapper
       controls={controls}
       edges={['bottom', 'left', 'right', 'top']}
-      scrollViewContainerStyle={{ gap: Spacing.lg }}
+      scrollViewContainerStyle={{ gap: Spacing.md }}
     >
       {showAppSwitchGuidance && (
         <ArrowUp
@@ -59,7 +84,7 @@ const ManualPairing: React.FC<ManualPairingProps> = ({ navigation, route }) => {
         />
       )}
       {fromAppSwitch ? (
-        <ThemedText style={{ marginTop: Spacing.md }} variant={'headingThree'}>
+        <ThemedText style={{ marginTop: showAppSwitchGuidance ? undefined : Spacing.md }} variant={'headingThree'}>
           {t('BCSC.ManualPairing.FromAppSwitchCompletionTitle', { serviceName })}
         </ThemedText>
       ) : (

--- a/app/src/bcsc-theme/features/pairing/PairingConfirmation.tsx
+++ b/app/src/bcsc-theme/features/pairing/PairingConfirmation.tsx
@@ -30,7 +30,7 @@ const ManualPairing: React.FC<ManualPairingProps> = ({ navigation, route }) => {
     const subscription = AppState.addEventListener('change', (nextAppState) => {
       const prev = appStateRef.current
       appStateRef.current = nextAppState
-      if ((prev === 'inactive' || prev === 'background') && nextAppState === 'active') {
+      if (prev === 'background' && nextAppState === 'active') {
         navigation.dispatch(
           CommonActions.reset({
             index: 0,


### PR DESCRIPTION
# Summary of Changes

Prevents a stuck state when navigating back to the pairing confirmation on iOS after a deeplink login, matching ias-ios behaviour

# Testing Instructions

On iOS, log into BC Parks demo via deeplink. Then navigate back to the BCSC app, see that you are redirected to the home screen

# Acceptance Criteria

Testing works

# Screenshots, videos, or gifs

N/A

# Related Issues

#3381 