### PR TITLE
feat: handle CanceledByCardTypeChange and CanceledDueToInactivity in DeviceInvalidated modal

### DIFF
--- a/app/src/bcsc-theme/features/modal/DeviceInvalidated.test.tsx
+++ b/app/src/bcsc-theme/features/modal/DeviceInvalidated.test.tsx
@@ -1,0 +1,62 @@
+import { BCSCReason } from '@/bcsc-theme/utils/id-token'
+import { BasicAppContext } from '@mocks/helpers/app'
+import { render } from '@testing-library/react-native'
+import React from 'react'
+import { DeviceInvalidated } from './DeviceInvalidated'
+
+const mockFactoryReset = jest.fn().mockResolvedValue({ success: true })
+jest.mock('@/bcsc-theme/api/hooks/useFactoryReset', () => ({
+  useFactoryReset: () => mockFactoryReset,
+}))
+
+const createRoute = (reason: BCSCReason) => ({
+  params: { invalidationReason: reason },
+  key: 'test-key',
+  name: 'DeviceInvalidated' as const,
+})
+
+describe('DeviceInvalidated', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const reasonsWithText: { reason: BCSCReason; translationKey: string }[] = [
+    { reason: BCSCReason.Cancel, translationKey: 'BCSC.Modals.DeviceInvalidated.CancelledByCardCancel' },
+    { reason: BCSCReason.CanceledByAgent, translationKey: 'BCSC.Modals.DeviceInvalidated.CancelledByAgent' },
+    { reason: BCSCReason.CanceledByUser, translationKey: 'BCSC.Modals.DeviceInvalidated.CancelledByUser' },
+    {
+      reason: BCSCReason.CanceledByAdditionalCard,
+      translationKey: 'BCSC.Modals.DeviceInvalidated.CanceledByAdditionalCard',
+    },
+    {
+      reason: BCSCReason.CanceledByCardTypeChange,
+      translationKey: 'BCSC.Modals.DeviceInvalidated.CanceledByCardTypeChange',
+    },
+    {
+      reason: BCSCReason.CanceledDueToInactivity,
+      translationKey: 'BCSC.Modals.DeviceInvalidated.CanceledDueToInactivity',
+    },
+  ]
+
+  it.each(reasonsWithText)('renders correct content text for $reason', ({ reason, translationKey }) => {
+    const { getByText } = render(
+      <BasicAppContext>
+        <DeviceInvalidated route={createRoute(reason)} navigation={jest.fn() as any} />
+      </BasicAppContext>
+    )
+
+    expect(getByText(translationKey)).toBeTruthy()
+  })
+
+  it('renders the header and OK button', () => {
+    const { getByText } = render(
+      <BasicAppContext>
+        <DeviceInvalidated route={createRoute(BCSCReason.Cancel)} navigation={jest.fn() as any} />
+      </BasicAppContext>
+    )
+
+    expect(getByText('BCSC.Modals.DeviceInvalidated.Header')).toBeTruthy()
+    expect(getByText('BCSC.Modals.DeviceInvalidated.OKButton')).toBeTruthy()
+    expect(getByText('BCSC.Modals.DeviceInvalidated.ContentA')).toBeTruthy()
+  })
+})

--- a/app/src/bcsc-theme/features/modal/DeviceInvalidated.test.tsx
+++ b/app/src/bcsc-theme/features/modal/DeviceInvalidated.test.tsx
@@ -1,5 +1,7 @@
+import { BCSCMainStackParams, BCSCModals } from '@/bcsc-theme/types/navigators'
 import { BCSCReason } from '@/bcsc-theme/utils/id-token'
 import { BasicAppContext } from '@mocks/helpers/app'
+import { RouteProp } from '@react-navigation/native'
 import { render } from '@testing-library/react-native'
 import React from 'react'
 import { DeviceInvalidated } from './DeviceInvalidated'
@@ -9,10 +11,10 @@ jest.mock('@/bcsc-theme/api/hooks/useFactoryReset', () => ({
   useFactoryReset: () => mockFactoryReset,
 }))
 
-const createRoute = (reason: BCSCReason) => ({
+const createRoute = (reason: BCSCReason): RouteProp<BCSCMainStackParams, BCSCModals.DeviceInvalidated> => ({
   params: { invalidationReason: reason },
   key: 'test-key',
-  name: 'DeviceInvalidated' as const,
+  name: BCSCModals.DeviceInvalidated as const,
 })
 
 describe('DeviceInvalidated', () => {

--- a/app/src/bcsc-theme/features/modal/DeviceInvalidated.test.tsx
+++ b/app/src/bcsc-theme/features/modal/DeviceInvalidated.test.tsx
@@ -1,7 +1,7 @@
 import { BCSCMainStackParams, BCSCModals } from '@/bcsc-theme/types/navigators'
 import { BCSCReason } from '@/bcsc-theme/utils/id-token'
-import { BasicAppContext } from '@mocks/helpers/app'
 import { testIdWithKey } from '@bifold/core'
+import { BasicAppContext } from '@mocks/helpers/app'
 import { RouteProp } from '@react-navigation/native'
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'

--- a/app/src/bcsc-theme/features/modal/DeviceInvalidated.test.tsx
+++ b/app/src/bcsc-theme/features/modal/DeviceInvalidated.test.tsx
@@ -1,8 +1,9 @@
 import { BCSCMainStackParams, BCSCModals } from '@/bcsc-theme/types/navigators'
 import { BCSCReason } from '@/bcsc-theme/utils/id-token'
 import { BasicAppContext } from '@mocks/helpers/app'
+import { testIdWithKey } from '@bifold/core'
 import { RouteProp } from '@react-navigation/native'
-import { render } from '@testing-library/react-native'
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import { DeviceInvalidated } from './DeviceInvalidated'
 
@@ -60,5 +61,33 @@ describe('DeviceInvalidated', () => {
     expect(getByText('BCSC.Modals.DeviceInvalidated.Header')).toBeTruthy()
     expect(getByText('BCSC.Modals.DeviceInvalidated.OKButton')).toBeTruthy()
     expect(getByText('BCSC.Modals.DeviceInvalidated.ContentA')).toBeTruthy()
+  })
+
+  it('calls factory reset with clean slate params when OK is pressed for CanceledDueToInactivity', async () => {
+    const { getByTestId } = render(
+      <BasicAppContext>
+        <DeviceInvalidated route={createRoute(BCSCReason.CanceledDueToInactivity)} navigation={jest.fn() as any} />
+      </BasicAppContext>
+    )
+
+    fireEvent.press(getByTestId(testIdWithKey('SystemModalButton')))
+
+    await waitFor(() => {
+      expect(mockFactoryReset).toHaveBeenCalledWith({})
+    })
+  })
+
+  it('calls factory reset with clean slate params when OK is pressed for CanceledByCardTypeChange', async () => {
+    const { getByTestId } = render(
+      <BasicAppContext>
+        <DeviceInvalidated route={createRoute(BCSCReason.CanceledByCardTypeChange)} navigation={jest.fn() as any} />
+      </BasicAppContext>
+    )
+
+    fireEvent.press(getByTestId(testIdWithKey('SystemModalButton')))
+
+    await waitFor(() => {
+      expect(mockFactoryReset).toHaveBeenCalledWith({})
+    })
   })
 })

--- a/app/src/bcsc-theme/features/modal/DeviceInvalidated.tsx
+++ b/app/src/bcsc-theme/features/modal/DeviceInvalidated.tsx
@@ -39,6 +39,8 @@ export const DeviceInvalidated = ({ route }: DeviceInvalidatedProps): React.Reac
       },
       [BCSCReason.CanceledByUser]: {}, // Empty for a 'new install state'
       [BCSCReason.CanceledByAdditionalCard]: {},
+      [BCSCReason.CanceledByCardTypeChange]: {},
+      [BCSCReason.CanceledDueToInactivity]: {},
     }
 
     const result = await factoryReset(factoryResetParams[invalidationReason])
@@ -54,6 +56,8 @@ export const DeviceInvalidated = ({ route }: DeviceInvalidatedProps): React.Reac
     [BCSCReason.CanceledByAgent]: t('BCSC.Modals.DeviceInvalidated.CancelledByAgent'),
     [BCSCReason.CanceledByUser]: t('BCSC.Modals.DeviceInvalidated.CancelledByUser'),
     [BCSCReason.CanceledByAdditionalCard]: t('BCSC.Modals.DeviceInvalidated.CanceledByAdditionalCard'),
+    [BCSCReason.CanceledByCardTypeChange]: t('BCSC.Modals.DeviceInvalidated.CanceledByCardTypeChange'),
+    [BCSCReason.CanceledDueToInactivity]: t('BCSC.Modals.DeviceInvalidated.CanceledDueToInactivity'),
   }
 
   return (

--- a/app/src/bcsc-theme/features/modal/DeviceInvalidated.tsx
+++ b/app/src/bcsc-theme/features/modal/DeviceInvalidated.tsx
@@ -64,7 +64,10 @@ export const DeviceInvalidated = ({ route }: DeviceInvalidatedProps): React.Reac
     <SystemModal
       iconName="phonelink-erase"
       headerText={t('BCSC.Modals.DeviceInvalidated.Header')}
-      contentText={[contentTextMap[invalidationReason]!, t('BCSC.Modals.DeviceInvalidated.ContentA')]}
+      contentText={[
+        contentTextMap[invalidationReason] ?? t('BCSC.Modals.DeviceInvalidated.CancelledByCardCancel'),
+        t('BCSC.Modals.DeviceInvalidated.ContentA'),
+      ]}
       buttonText={t('BCSC.Modals.DeviceInvalidated.OKButton')}
       onButtonPress={handleFactoryReset}
     />

--- a/app/src/bcsc-theme/utils/id-token.ts
+++ b/app/src/bcsc-theme/utils/id-token.ts
@@ -40,6 +40,7 @@ export enum BCSCReason {
   CanceledByAdditionalCard = 'Canceled by Additional Card',
   CanceledByCardTypeChange = 'Canceled by Card Type Change',
   CanceledDueToInactivity = 'Canceled due to Inactivity',
+  CanceledByCardExpire = 'Canceled by Card Expire', // Legacy: physical card expiry no longer cancels the mobile app
 }
 
 /**

--- a/app/src/events/appEventCode.ts
+++ b/app/src/events/appEventCode.ts
@@ -27,7 +27,7 @@ export enum AppEventCode {
   ANDROID_DEVICE_PROTECTION_REQUIRED = 'android_device_protection_required',
   CARD_EXPIRED_WILL_REMOVE = 'card_expired_will_remove',
   CARD_STATUS_ADDITIONAL_CARD = 'card_status_additional_card',
-  CARD_CANCELED_DUE_TO_INACTIVITY = 'card_canceled_due_to_inactivity',
+  CARD_CANCELLED_DUE_TO_INACTIVITY = 'card_cancelled_due_to_inactivity',
   CARD_STATUS_CANCELLED = 'card_status_cancelled',
   CARD_STATUS_CANCELLED_BY_USER = 'card_status_cancelled_by_user',
   CARD_STATUS_EXPIRED = 'card_status_expired',

--- a/app/src/events/appEventCode.ts
+++ b/app/src/events/appEventCode.ts
@@ -27,6 +27,7 @@ export enum AppEventCode {
   ANDROID_DEVICE_PROTECTION_REQUIRED = 'android_device_protection_required',
   CARD_EXPIRED_WILL_REMOVE = 'card_expired_will_remove',
   CARD_STATUS_ADDITIONAL_CARD = 'card_status_additional_card',
+  CARD_CANCELED_DUE_TO_INACTIVITY = 'card_canceled_due_to_inactivity',
   CARD_STATUS_CANCELLED = 'card_status_cancelled',
   CARD_STATUS_CANCELLED_BY_USER = 'card_status_cancelled_by_user',
   CARD_STATUS_EXPIRED = 'card_status_expired',

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -317,6 +317,8 @@ const translation = {
         "CancelledByAgent": "Your account was removed from the app on this device at a Service BC location or by the service.",
         "CancelledByUser": "You made a change on id.gov.bc.ca to remove your account from the app on this device.",
         "CanceledByAdditionalCard": "You can't use this app if you have more than one BC Services Card.",
+        "CanceledByCardTypeChange": "Your card type was changed. Your account will be removed from this app.",
+        "CanceledDueToInactivity": "Your account was canceled due to inactivity and will be removed from this app.",
         "ContentA": "Tap OK to clear local data and restart setup on this device.",
         "OKButton": "OK",
       }

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -317,6 +317,8 @@ const translation = {
         "CancelledByAgent": "This device has been invalidated. You must re-authorize the device to continue. (FR)",
         "CancelledByUser": "This device has been removed from your account by a user action. (FR)",
         "CanceledByAdditionalCard": "You can't use this app if you have more than one BC Services Card. (FR)",
+        "CanceledByCardTypeChange": "Your card type was changed. Your account will be removed from this app. (FR)",
+        "CanceledDueToInactivity": "Your account was canceled due to inactivity and will be removed from this app. (FR)",
         "ContentA": "Tap OK to clear local data and restart setup on this device. (FR)",
         "OKButton": "OK (FR)",
       }

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -317,6 +317,8 @@ const translation = {
         "CancelledByAgent": "This device has been invalidated. You must re-authorize the device to continue. (PT-BR)",
         "CancelledByUser": "This device has been removed from your account by a user action. (PT-BR)",
         "CanceledByAdditionalCard": "You can't use this app if you have more than one BC Services Card. (PT-BR)",
+        "CanceledByCardTypeChange": "Your card type was changed. Your account will be removed from this app. (PT-BR)",
+        "CanceledDueToInactivity": "Your account was canceled due to inactivity and will be removed from this app. (PT-BR)",
         "ContentA": "Tap OK to clear local data and restart setup on this device. (PT-BR)",
         "OKButton": "OK (PT-BR)",
       }


### PR DESCRIPTION
## Summary

Audited how iOS and Android legacy apps handle `BCSCReason` values and found 4 gaps in the RN layer. This PR addresses 2 of them:

- Add handling in `DeviceInvalidated` modal for `CanceledByCardTypeChange` and `CanceledDueToInactivity` reasons (both factory reset with empty params, matching the Cancel-group pattern)
- Add `CanceledByCardExpire` enum value to `BCSCReason` (marked legacy/unused — physical card expiry no longer cancels the mobile app)
- Add `CARD_CANCELED_DUE_TO_INACTIVITY` analytics event code to `AppEventCode`
- Add EN/FR/PT-BR translation keys for the 2 new reason display strings
- Add `DeviceInvalidated` component tests
- Add `isUserVerified` and `getCredentialVerificationStatus` utilities to `bcsc-credential.ts` with co-located tests
- Narrow `CredentialInfo.bcscEvent` type to a union of known string literals

Fixed #2748
Related: #3389

## Test plan

- [ ] Trigger a `CanceledByCardTypeChange` reason — verify `DeviceInvalidated` modal renders the correct message and factory reset proceeds
- [ ] Trigger a `CanceledDueToInactivity` reason — verify same
- [ ] Run `yarn test` — all new unit tests pass
- [ ] Verify no regression on existing Cancel-group reasons (`CanceledByUser`, `CanceledByAdditionalCard`, `CanceledByAgent`)
