### PR TITLE
fix: ios scaling webview content

### DIFF
--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
@@ -16,7 +16,7 @@ import {
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ActivityIndicator, StyleSheet, View } from 'react-native'
+import { ActivityIndicator, StyleSheet, useWindowDimensions, View } from 'react-native'
 import * as PushNotifications from '../../../utils/PushNotificationsHelper'
 import { WebViewContent } from '../webview/WebViewContent'
 
@@ -38,6 +38,7 @@ export const TermsOfUseScreen = ({ navigation }: TermsOfUseScreenProps): React.R
   const [webViewIsLoaded, setWebViewIsLoaded] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState(false)
+  const { fontScale } = useWindowDimensions()
 
   const fetchTermsOfUse = useCallback(async () => {
     try {
@@ -124,13 +125,16 @@ export const TermsOfUseScreen = ({ navigation }: TermsOfUseScreenProps): React.R
   return (
     <ScreenWrapper scrollable={false} controls={controls} scrollViewContainerStyle={styles.scrollContainer}>
       <WebViewContent
-        html={createTermsOfUseHtml({
-          termsOfUse,
-          colorPalette: ColorPalette,
-          headerText: t('BCSC.Onboarding.TermsOfUseHeader'),
-          subtitlePrefix: t('BCSC.Onboarding.TermsOfUseSubtitle'),
-          versionLabel: t('BCSC.Onboarding.TermsOfUseVersion'),
-        })}
+        html={createTermsOfUseHtml(
+          {
+            termsOfUse,
+            colorPalette: ColorPalette,
+            headerText: t('BCSC.Onboarding.TermsOfUseHeader'),
+            subtitlePrefix: t('BCSC.Onboarding.TermsOfUseSubtitle'),
+            versionLabel: t('BCSC.Onboarding.TermsOfUseVersion'),
+          },
+          fontScale
+        )}
         onLoaded={() => setWebViewIsLoaded(true)}
       />
     </ScreenWrapper>

--- a/app/src/bcsc-theme/features/onboarding/__snapshots__/TermsOfUseScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/onboarding/__snapshots__/TermsOfUseScreen.test.tsx.snap
@@ -43,13 +43,13 @@ exports[`TermsOfUse renders correctly after loading terms 1`] = `
         "html": "<!DOCTYPE html>
 <html>
 <head>
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1">  
 <style>
   body {
     background-color: #F2F2F2;
     color: #FFFFFFFF;
     font-family: -apple-system, system-ui, sans-serif;
-    font-size: 36px;
+    font-size: 32px !important;
     padding: 0 16px 16px 16px;
     line-height: 1.6;
     margin: 0;

--- a/app/src/bcsc-theme/features/webview/WebViewContent.tsx
+++ b/app/src/bcsc-theme/features/webview/WebViewContent.tsx
@@ -114,7 +114,9 @@ const WebViewContent: React.FC<WebViewContentProps> = ({ url, html, onLoaded }) 
       userAgent="Single App"
       // Accessibility: Apply font scaling for dynamic text sizing
       textZoom={Platform.OS === 'android' ? Math.round(fontScale * 100) : undefined}
-      injectedJavaScriptBeforeContentLoaded={html ? undefined : createWebViewJavascriptInjection(ColorPalette)}
+      injectedJavaScriptBeforeContentLoaded={
+        html ? undefined : createWebViewJavascriptInjection(ColorPalette, fontScale)
+      }
       onMessage={() => {}} // Required for injectedJavaScript to work
       onLoad={onLoaded}
     />

--- a/app/src/bcsc-theme/features/webview/__snapshots__/AuthWebViewScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/webview/__snapshots__/AuthWebViewScreen.test.tsx.snap
@@ -8,9 +8,9 @@ exports[`AuthWebView renders correctly 1`] = `
   injectedJavaScriptBeforeContentLoaded="
     document.addEventListener('DOMContentLoaded', function() {
       
-      const fontScale = 2;
-      document.documentElement.style.fontSize = (16 * fontScale) + 'px';
-      document.body.style.fontSize = (16 * fontScale) + 'px';
+      const baseFontSizePx = 32;
+      document.documentElement.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
+      if (document.body) document.body.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
     
       document.querySelectorAll('footer, header, h1, nav[aria-label="breadcrumb"]').forEach(el => el.remove());
       document.body.style.backgroundColor = '#F2F2F2';
@@ -21,11 +21,13 @@ exports[`AuthWebView renders correctly 1`] = `
         body, body * {
           background-color: #F2F2F2 !important;
           color: #FFFFFFFF !important;
+          font-size: 32px !important;
         }
         a, a *, a:visited, a:visited *, a:hover, a:hover *, a:active, a:active * {
           color: #1A5A96 !important;
           text-decoration-color: #1A5A96 !important;
           border-color: #1A5A96 !important;
+          font-size: 32px !important;
         }
       \`;
       document.head.appendChild(style);

--- a/app/src/bcsc-theme/features/webview/__snapshots__/AuthWebViewScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/webview/__snapshots__/AuthWebViewScreen.test.tsx.snap
@@ -18,16 +18,17 @@ exports[`AuthWebView renders correctly 1`] = `
 
       const style = document.createElement('style');
       style.textContent = \`
+        html, body, body * {
+          font-size: 32px !important;
+        }
         body, body * {
           background-color: #F2F2F2 !important;
           color: #FFFFFFFF !important;
-          font-size: 32px !important;
         }
         a, a *, a:visited, a:visited *, a:hover, a:hover *, a:active, a:active * {
           color: #1A5A96 !important;
           text-decoration-color: #1A5A96 !important;
           border-color: #1A5A96 !important;
-          font-size: 32px !important;
         }
       \`;
       document.head.appendChild(style);

--- a/app/src/bcsc-theme/features/webview/__snapshots__/AuthWebViewScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/webview/__snapshots__/AuthWebViewScreen.test.tsx.snap
@@ -11,6 +11,9 @@ exports[`AuthWebView renders correctly 1`] = `
       const baseFontSizePx = 32;
       document.documentElement.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
       if (document.body) document.body.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
+      var fontStyle = document.createElement('style');
+      fontStyle.textContent = 'html, body, body * { font-size: ' + baseFontSizePx + 'px !important; }';
+      document.head.appendChild(fontStyle);
     
       document.querySelectorAll('footer, header, h1, nav[aria-label="breadcrumb"]').forEach(el => el.remove());
       document.body.style.backgroundColor = '#F2F2F2';
@@ -19,9 +22,6 @@ exports[`AuthWebView renders correctly 1`] = `
       const style = document.createElement('style');
       style.textContent = \`
         html, body, body * {
-          font-size: 32px !important;
-        }
-        body, body * {
           background-color: #F2F2F2 !important;
           color: #FFFFFFFF !important;
         }

--- a/app/src/bcsc-theme/features/webview/__snapshots__/MainWebViewScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/webview/__snapshots__/MainWebViewScreen.test.tsx.snap
@@ -8,9 +8,9 @@ exports[`MainWebView renders correctly 1`] = `
   injectedJavaScriptBeforeContentLoaded="
     document.addEventListener('DOMContentLoaded', function() {
       
-      const fontScale = 2;
-      document.documentElement.style.fontSize = (16 * fontScale) + 'px';
-      document.body.style.fontSize = (16 * fontScale) + 'px';
+      const baseFontSizePx = 32;
+      document.documentElement.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
+      if (document.body) document.body.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
     
       document.querySelectorAll('footer, header, h1, nav[aria-label="breadcrumb"]').forEach(el => el.remove());
       document.body.style.backgroundColor = '#F2F2F2';
@@ -21,11 +21,13 @@ exports[`MainWebView renders correctly 1`] = `
         body, body * {
           background-color: #F2F2F2 !important;
           color: #FFFFFFFF !important;
+          font-size: 32px !important;
         }
         a, a *, a:visited, a:visited *, a:hover, a:hover *, a:active, a:active * {
           color: #1A5A96 !important;
           text-decoration-color: #1A5A96 !important;
           border-color: #1A5A96 !important;
+          font-size: 32px !important;
         }
       \`;
       document.head.appendChild(style);

--- a/app/src/bcsc-theme/features/webview/__snapshots__/MainWebViewScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/webview/__snapshots__/MainWebViewScreen.test.tsx.snap
@@ -11,6 +11,9 @@ exports[`MainWebView renders correctly 1`] = `
       const baseFontSizePx = 32;
       document.documentElement.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
       if (document.body) document.body.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
+      var fontStyle = document.createElement('style');
+      fontStyle.textContent = 'html, body, body * { font-size: ' + baseFontSizePx + 'px !important; }';
+      document.head.appendChild(fontStyle);
     
       document.querySelectorAll('footer, header, h1, nav[aria-label="breadcrumb"]').forEach(el => el.remove());
       document.body.style.backgroundColor = '#F2F2F2';
@@ -19,9 +22,6 @@ exports[`MainWebView renders correctly 1`] = `
       const style = document.createElement('style');
       style.textContent = \`
         html, body, body * {
-          font-size: 32px !important;
-        }
-        body, body * {
           background-color: #F2F2F2 !important;
           color: #FFFFFFFF !important;
         }

--- a/app/src/bcsc-theme/features/webview/__snapshots__/MainWebViewScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/webview/__snapshots__/MainWebViewScreen.test.tsx.snap
@@ -18,16 +18,17 @@ exports[`MainWebView renders correctly 1`] = `
 
       const style = document.createElement('style');
       style.textContent = \`
+        html, body, body * {
+          font-size: 32px !important;
+        }
         body, body * {
           background-color: #F2F2F2 !important;
           color: #FFFFFFFF !important;
-          font-size: 32px !important;
         }
         a, a *, a:visited, a:visited *, a:hover, a:hover *, a:active, a:active * {
           color: #1A5A96 !important;
           text-decoration-color: #1A5A96 !important;
           border-color: #1A5A96 !important;
-          font-size: 32px !important;
         }
       \`;
       document.head.appendChild(style);

--- a/app/src/bcsc-theme/features/webview/__snapshots__/OnboardingWebViewScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/webview/__snapshots__/OnboardingWebViewScreen.test.tsx.snap
@@ -8,9 +8,9 @@ exports[`OnboardingWebView renders correctly 1`] = `
   injectedJavaScriptBeforeContentLoaded="
     document.addEventListener('DOMContentLoaded', function() {
       
-      const fontScale = 2;
-      document.documentElement.style.fontSize = (16 * fontScale) + 'px';
-      document.body.style.fontSize = (16 * fontScale) + 'px';
+      const baseFontSizePx = 32;
+      document.documentElement.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
+      if (document.body) document.body.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
     
       document.querySelectorAll('footer, header, h1, nav[aria-label="breadcrumb"]').forEach(el => el.remove());
       document.body.style.backgroundColor = '#F2F2F2';
@@ -21,11 +21,13 @@ exports[`OnboardingWebView renders correctly 1`] = `
         body, body * {
           background-color: #F2F2F2 !important;
           color: #FFFFFFFF !important;
+          font-size: 32px !important;
         }
         a, a *, a:visited, a:visited *, a:hover, a:hover *, a:active, a:active * {
           color: #1A5A96 !important;
           text-decoration-color: #1A5A96 !important;
           border-color: #1A5A96 !important;
+          font-size: 32px !important;
         }
       \`;
       document.head.appendChild(style);

--- a/app/src/bcsc-theme/features/webview/__snapshots__/OnboardingWebViewScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/webview/__snapshots__/OnboardingWebViewScreen.test.tsx.snap
@@ -18,16 +18,17 @@ exports[`OnboardingWebView renders correctly 1`] = `
 
       const style = document.createElement('style');
       style.textContent = \`
+        html, body, body * {
+          font-size: 32px !important;
+        }
         body, body * {
           background-color: #F2F2F2 !important;
           color: #FFFFFFFF !important;
-          font-size: 32px !important;
         }
         a, a *, a:visited, a:visited *, a:hover, a:hover *, a:active, a:active * {
           color: #1A5A96 !important;
           text-decoration-color: #1A5A96 !important;
           border-color: #1A5A96 !important;
-          font-size: 32px !important;
         }
       \`;
       document.head.appendChild(style);

--- a/app/src/bcsc-theme/features/webview/__snapshots__/OnboardingWebViewScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/webview/__snapshots__/OnboardingWebViewScreen.test.tsx.snap
@@ -11,6 +11,9 @@ exports[`OnboardingWebView renders correctly 1`] = `
       const baseFontSizePx = 32;
       document.documentElement.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
       if (document.body) document.body.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
+      var fontStyle = document.createElement('style');
+      fontStyle.textContent = 'html, body, body * { font-size: ' + baseFontSizePx + 'px !important; }';
+      document.head.appendChild(fontStyle);
     
       document.querySelectorAll('footer, header, h1, nav[aria-label="breadcrumb"]').forEach(el => el.remove());
       document.body.style.backgroundColor = '#F2F2F2';
@@ -19,9 +22,6 @@ exports[`OnboardingWebView renders correctly 1`] = `
       const style = document.createElement('style');
       style.textContent = \`
         html, body, body * {
-          font-size: 32px !important;
-        }
-        body, body * {
           background-color: #F2F2F2 !important;
           color: #FFFFFFFF !important;
         }

--- a/app/src/bcsc-theme/features/webview/__snapshots__/VerifyWebViewScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/webview/__snapshots__/VerifyWebViewScreen.test.tsx.snap
@@ -11,6 +11,9 @@ exports[`VerifyWebView renders correctly 1`] = `
       const baseFontSizePx = 32;
       document.documentElement.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
       if (document.body) document.body.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
+      var fontStyle = document.createElement('style');
+      fontStyle.textContent = 'html, body, body * { font-size: ' + baseFontSizePx + 'px !important; }';
+      document.head.appendChild(fontStyle);
     
       document.querySelectorAll('footer, header, h1, nav[aria-label="breadcrumb"]').forEach(el => el.remove());
       document.body.style.backgroundColor = '#F2F2F2';
@@ -19,9 +22,6 @@ exports[`VerifyWebView renders correctly 1`] = `
       const style = document.createElement('style');
       style.textContent = \`
         html, body, body * {
-          font-size: 32px !important;
-        }
-        body, body * {
           background-color: #F2F2F2 !important;
           color: #FFFFFFFF !important;
         }

--- a/app/src/bcsc-theme/features/webview/__snapshots__/VerifyWebViewScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/webview/__snapshots__/VerifyWebViewScreen.test.tsx.snap
@@ -18,16 +18,17 @@ exports[`VerifyWebView renders correctly 1`] = `
 
       const style = document.createElement('style');
       style.textContent = \`
+        html, body, body * {
+          font-size: 32px !important;
+        }
         body, body * {
           background-color: #F2F2F2 !important;
           color: #FFFFFFFF !important;
-          font-size: 32px !important;
         }
         a, a *, a:visited, a:visited *, a:hover, a:hover *, a:active, a:active * {
           color: #1A5A96 !important;
           text-decoration-color: #1A5A96 !important;
           border-color: #1A5A96 !important;
-          font-size: 32px !important;
         }
       \`;
       document.head.appendChild(style);

--- a/app/src/bcsc-theme/features/webview/__snapshots__/VerifyWebViewScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/webview/__snapshots__/VerifyWebViewScreen.test.tsx.snap
@@ -8,9 +8,9 @@ exports[`VerifyWebView renders correctly 1`] = `
   injectedJavaScriptBeforeContentLoaded="
     document.addEventListener('DOMContentLoaded', function() {
       
-      const fontScale = 2;
-      document.documentElement.style.fontSize = (16 * fontScale) + 'px';
-      document.body.style.fontSize = (16 * fontScale) + 'px';
+      const baseFontSizePx = 32;
+      document.documentElement.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
+      if (document.body) document.body.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
     
       document.querySelectorAll('footer, header, h1, nav[aria-label="breadcrumb"]').forEach(el => el.remove());
       document.body.style.backgroundColor = '#F2F2F2';
@@ -21,11 +21,13 @@ exports[`VerifyWebView renders correctly 1`] = `
         body, body * {
           background-color: #F2F2F2 !important;
           color: #FFFFFFFF !important;
+          font-size: 32px !important;
         }
         a, a *, a:visited, a:visited *, a:hover, a:hover *, a:active, a:active * {
           color: #1A5A96 !important;
           text-decoration-color: #1A5A96 !important;
           border-color: #1A5A96 !important;
+          font-size: 32px !important;
         }
       \`;
       document.head.appendChild(style);

--- a/app/src/bcsc-theme/utils/webview-utils.ts
+++ b/app/src/bcsc-theme/utils/webview-utils.ts
@@ -127,16 +127,17 @@ export const createWebViewJavascriptInjection = (colorPalette: IColorPalette, fo
 
       const style = document.createElement('style');
       style.textContent = \`
+        html, body, body * {
+          ${fontSizeCss}
+        }
         body, body * {
           background-color: ${colorPalette.brand.primaryBackground} !important;
           color: ${colorPalette.brand.secondary} !important;
-          ${fontSizeCss}
         }
         a, a *, a:visited, a:visited *, a:hover, a:hover *, a:active, a:active * {
           color: ${colorPalette.brand.link} !important;
           text-decoration-color: ${colorPalette.brand.link} !important;
           border-color: ${colorPalette.brand.link} !important;
-          ${fontSizeCss}
         }
       \`;
       document.head.appendChild(style);

--- a/app/src/bcsc-theme/utils/webview-utils.ts
+++ b/app/src/bcsc-theme/utils/webview-utils.ts
@@ -89,32 +89,38 @@ ${bodyContent}
 </html>`
 }
 
-export const createFontScalingScript = (): string => {
-  const fontScale = Dimensions.get('window').fontScale
-  if (Platform.OS === 'ios') {
-    return `
-      const fontScale = ${fontScale};
-      document.documentElement.style.fontSize = (16 * fontScale) + 'px';
-      document.body.style.fontSize = (16 * fontScale) + 'px';
-    `
+/**
+ * Returns a script fragment that applies iOS font scaling (Dynamic Type) to the document.
+ * Only runs on iOS (Android uses the WebView textZoom prop). Returns empty string if
+ * baseFontSizePx is invalid (<= 0) to avoid injecting a zero or negative font size.
+ */
+export const createFontScalingScript = (baseFontSizePx: number): string => {
+  if (Platform.OS !== 'ios' || baseFontSizePx <= 0) {
+    return ''
   }
-
-  return ''
+  return `
+      const baseFontSizePx = ${baseFontSizePx};
+      document.documentElement.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
+      if (document.body) document.body.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
+    `
 }
 
 /**
  * Creates webview javascript injection to modify the HTML content loaded from a full web page URL.
  *
- * This includes setting the background color, text color, and link colors to match the app theme.
- * It also removes page chrome (header, footer, nav, h1) since the static page includes full navigation.
+ * This includes applying iOS font scaling (Android uses WebView textZoom), setting the background
+ * color, text color, and link colors to match the app theme, and removing page chrome.
  *
- * @param {IColorPalette} colorPalette - The color palette object containing brand colors
- * @returns {*} {string} JavaScript string to be injected into the WebView
+ * @param colorPalette - The color palette object containing brand colors
+ * @param fontScale - Device font scale (e.g. from useWindowDimensions().fontScale)
  */
-export const createWebViewJavascriptInjection = (colorPalette: IColorPalette): string => {
+export const createWebViewJavascriptInjection = (colorPalette: IColorPalette, fontScale: number): string => {
+  const baseFontSizePx = fontScale > 0 ? Math.round(16 * fontScale) : 16
+  const applyFontScaling = Platform.OS === 'ios' && baseFontSizePx > 0
+  const fontSizeCss = applyFontScaling ? `font-size: ${baseFontSizePx}px !important;` : ''
   return `
     document.addEventListener('DOMContentLoaded', function() {
-      ${createFontScalingScript()}
+      ${createFontScalingScript(baseFontSizePx)}
       document.querySelectorAll('footer, header, h1, nav[aria-label="breadcrumb"]').forEach(el => el.remove());
       document.body.style.backgroundColor = '${colorPalette.brand.primaryBackground}';
       document.body.style.color = '${colorPalette.brand.secondary}';
@@ -124,11 +130,13 @@ export const createWebViewJavascriptInjection = (colorPalette: IColorPalette): s
         body, body * {
           background-color: ${colorPalette.brand.primaryBackground} !important;
           color: ${colorPalette.brand.secondary} !important;
+          ${fontSizeCss}
         }
         a, a *, a:visited, a:visited *, a:hover, a:hover *, a:active, a:active * {
           color: ${colorPalette.brand.link} !important;
           text-decoration-color: ${colorPalette.brand.link} !important;
           border-color: ${colorPalette.brand.link} !important;
+          ${fontSizeCss}
         }
       \`;
       document.head.appendChild(style);

--- a/app/src/bcsc-theme/utils/webview-utils.ts
+++ b/app/src/bcsc-theme/utils/webview-utils.ts
@@ -1,5 +1,5 @@
 import { IColorPalette } from '@bifold/core'
-import { Dimensions, Platform } from 'react-native'
+import { Platform } from 'react-native'
 import { TermsOfUseResponseData } from '../api/hooks/useConfigApi'
 
 /**
@@ -25,6 +25,17 @@ const stripOuterDocumentTags = (html: string): string => {
     .trim()
 }
 
+/**
+ * Creates a CSS fragment that applies font scaling to the document.
+ * Only runs on iOS (Android uses the WebView textZoom prop). Returns empty string if
+ * baseFontSizePx is invalid (<= 0) to avoid injecting a zero or negative font size.
+ */
+const createFontScalingCss = (fontScale: number): number => {
+  const baseFontSizePx = fontScale > 0 ? Math.round(16 * fontScale) : 16
+  const applyFontScaling = Platform.OS === 'ios' && baseFontSizePx > 0
+  return applyFontScaling ? baseFontSizePx : 0
+}
+
 export interface TermsOfUseHtmlOptions {
   termsOfUse: TermsOfUseResponseData
   colorPalette: IColorPalette
@@ -43,26 +54,24 @@ export interface TermsOfUseHtmlOptions {
  * - Subtitle with version and formatted date (from i18n)
  *
  * @param {TermsOfUseHtmlOptions} options - The terms data, color palette, and i18n strings
+ * @param {number} fontScale - The device font scale (e.g. from useWindowDimensions().fontScale)
  * @returns {string} A complete HTML document string
  */
-export const createTermsOfUseHtml = (options: TermsOfUseHtmlOptions): string => {
+export const createTermsOfUseHtml = (options: TermsOfUseHtmlOptions, fontScale: number): string => {
   const { termsOfUse, colorPalette, headerText, subtitlePrefix, versionLabel } = options
   const formattedDate = formatLongDate(termsOfUse.date)
   const bodyContent = stripOuterDocumentTags(termsOfUse.html)
-  // iOS doesn't support the textZoom prop, so we scale the base font-size with the device fontScale.
-  // Android handles this via the WebView textZoom prop in WebViewContent.
-  const fontScale = Platform.OS === 'ios' ? Dimensions.get('window').fontScale : 1
-  const baseFontSize = Math.round(18 * fontScale)
+  const fontSizeCss = createFontScalingCss(fontScale)
   return `<!DOCTYPE html>
 <html>
 <head>
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1">  
 <style>
   body {
     background-color: ${colorPalette.brand.primaryBackground};
     color: ${colorPalette.brand.secondary};
     font-family: -apple-system, system-ui, sans-serif;
-    font-size: ${baseFontSize}px;
+    font-size: ${fontSizeCss}px !important;
     padding: 0 16px 16px 16px;
     line-height: 1.6;
     margin: 0;
@@ -93,6 +102,9 @@ ${bodyContent}
  * Returns a script fragment that applies iOS font scaling (Dynamic Type) to the document.
  * Only runs on iOS (Android uses the WebView textZoom prop). Returns empty string if
  * baseFontSizePx is invalid (<= 0) to avoid injecting a zero or negative font size.
+ *
+ * Sets font-size on html, body, and all body descendants so that elements with explicit
+ * font-sizes from the page's own CSS (e.g. intro paragraphs) are overridden.
  */
 export const createFontScalingScript = (baseFontSizePx: number): string => {
   if (Platform.OS !== 'ios' || baseFontSizePx <= 0) {
@@ -102,6 +114,9 @@ export const createFontScalingScript = (baseFontSizePx: number): string => {
       const baseFontSizePx = ${baseFontSizePx};
       document.documentElement.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
       if (document.body) document.body.style.setProperty('font-size', baseFontSizePx + 'px', 'important');
+      var fontStyle = document.createElement('style');
+      fontStyle.textContent = 'html, body, body * { font-size: ' + baseFontSizePx + 'px !important; }';
+      document.head.appendChild(fontStyle);
     `
 }
 
@@ -115,12 +130,10 @@ export const createFontScalingScript = (baseFontSizePx: number): string => {
  * @param fontScale - Device font scale (e.g. from useWindowDimensions().fontScale)
  */
 export const createWebViewJavascriptInjection = (colorPalette: IColorPalette, fontScale: number): string => {
-  const baseFontSizePx = fontScale > 0 ? Math.round(16 * fontScale) : 16
-  const applyFontScaling = Platform.OS === 'ios' && baseFontSizePx > 0
-  const fontSizeCss = applyFontScaling ? `font-size: ${baseFontSizePx}px !important;` : ''
+  const fontSizeCss = createFontScalingCss(fontScale)
   return `
     document.addEventListener('DOMContentLoaded', function() {
-      ${createFontScalingScript(baseFontSizePx)}
+      ${createFontScalingScript(fontSizeCss)}
       document.querySelectorAll('footer, header, h1, nav[aria-label="breadcrumb"]').forEach(el => el.remove());
       document.body.style.backgroundColor = '${colorPalette.brand.primaryBackground}';
       document.body.style.color = '${colorPalette.brand.secondary}';
@@ -128,9 +141,6 @@ export const createWebViewJavascriptInjection = (colorPalette: IColorPalette, fo
       const style = document.createElement('style');
       style.textContent = \`
         html, body, body * {
-          ${fontSizeCss}
-        }
-        body, body * {
           background-color: ${colorPalette.brand.primaryBackground} !important;
           color: ${colorPalette.brand.secondary} !important;
         }


### PR DESCRIPTION
# Summary of Changes

Adjusts in-app webview scaling on iOS so content fits better on screen and remains readable without extra zooming.

# Testing Instructions

- On an iOS device or simulator, open screens that use the in-app webview and confirm the page scales correctly on first load (no clipped content, no excessive zoom).
- Rotate the device and navigate between a few webview screens to ensure scaling stays consistent and text remains readable.

# Acceptance Criteria

- iOS webview content fits within the visible area on initial load without requiring manual zooming.
- Scaling remains stable across navigation and orientation changes.

# Screenshots, videos, or gifs

<img width="250" height="500" alt="image" src="https://github.com/user-attachments/assets/c0f724ac-3b99-4720-b41a-d1cf83b41fe7" />

# Related Issues

N/A
