### PR TITLE
feat: add SauceLabs build pruner script

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -47,7 +47,8 @@ jobs:
   prune-saucelabs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
-    permissions: {}
+    permissions:
+      contents: read
     name: SauceLabs Storage
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,4 +1,4 @@
-name: Backlog Maintenance
+name: Maintenance
 
 on:
   workflow_dispatch:
@@ -43,3 +43,19 @@ jobs:
             This pull request has been automatically closed due
             to inactivity. If it's still relevant, please
             feel free to reopen it.
+
+  prune-saucelabs:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-22.04
+    name: SauceLabs Storage
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup NodeJS
+        uses: ./.github/workflows/actions/setup-node
+
+      - name: Prune old PR builds from SauceLabs
+        env:
+          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+        run: node scripts/saucelabs-prune-builds.mjs --delete

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -47,6 +47,7 @@ jobs:
   prune-saucelabs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
+    permissions: {}
     name: SauceLabs Storage
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -49,6 +49,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
+      pull-requests: read
     name: SauceLabs Storage
     steps:
       - uses: actions/checkout@v6
@@ -60,4 +61,6 @@ jobs:
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: node scripts/saucelabs-prune-builds.mjs --delete

--- a/scripts/saucelabs-app-launch-test.mjs
+++ b/scripts/saucelabs-app-launch-test.mjs
@@ -38,7 +38,6 @@
 
 import './saucelabs-env.mjs'
 import { writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 
 // ── Constants ──────────────────────────────────────────────────────────
 

--- a/scripts/saucelabs-app-launch-test.mjs
+++ b/scripts/saucelabs-app-launch-test.mjs
@@ -36,35 +36,9 @@
  *   node scripts/saucelabs-app-launch-test.mjs
  */
 
-import { readFileSync, writeFileSync, existsSync } from 'node:fs'
-import { resolve, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
-
-// ── Load local .env file if present ────────────────────────────────────
-
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const LOCAL_ENV_PATH = resolve(__dirname, '.env.saucelabs')
-
-if (existsSync(LOCAL_ENV_PATH)) {
-  console.log(`Loading local env from ${LOCAL_ENV_PATH}`)
-  const lines = readFileSync(LOCAL_ENV_PATH, 'utf-8').split('\n')
-  for (const raw of lines) {
-    const line = raw.trim()
-    if (!line || line.startsWith('#')) continue
-    const eq = line.indexOf('=')
-    if (eq === -1) continue
-    const key = line.slice(0, eq).trim()
-    let val = line.slice(eq + 1).trim()
-    // Strip surrounding quotes (single or double)
-    if ((val.startsWith("'") && val.endsWith("'")) || (val.startsWith('"') && val.endsWith('"'))) {
-      val = val.slice(1, -1)
-    }
-    if (!process.env[key]) {
-      process.env[key] = val
-    }
-  }
-  console.log('')
-}
+import './saucelabs-env.mjs'
+import { writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 
 // ── Constants ──────────────────────────────────────────────────────────
 

--- a/scripts/saucelabs-env.mjs
+++ b/scripts/saucelabs-env.mjs
@@ -1,0 +1,33 @@
+/**
+ * Shared .env.saucelabs loader for SauceLabs scripts.
+ *
+ * Reads scripts/.env.saucelabs if present, populating process.env
+ * without overwriting existing values. Supports # comments, blank
+ * lines, and single/double-quoted values.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const LOCAL_ENV_PATH = resolve(__dirname, '.env.saucelabs')
+
+if (existsSync(LOCAL_ENV_PATH)) {
+  console.log(`Loading local env from ${LOCAL_ENV_PATH}\n`)
+  const lines = readFileSync(LOCAL_ENV_PATH, 'utf-8').split('\n')
+  for (const raw of lines) {
+    const line = raw.trim()
+    if (!line || line.startsWith('#')) continue
+    const eq = line.indexOf('=')
+    if (eq === -1) continue
+    const key = line.slice(0, eq).trim()
+    let val = line.slice(eq + 1).trim()
+    if ((val.startsWith("'") && val.endsWith("'")) || (val.startsWith('"') && val.endsWith('"'))) {
+      val = val.slice(1, -1)
+    }
+    if (!process.env[key]) {
+      process.env[key] = val
+    }
+  }
+}

--- a/scripts/saucelabs-env.mjs
+++ b/scripts/saucelabs-env.mjs
@@ -26,7 +26,7 @@ if (existsSync(LOCAL_ENV_PATH)) {
     if ((val.startsWith("'") && val.endsWith("'")) || (val.startsWith('"') && val.endsWith('"'))) {
       val = val.slice(1, -1)
     }
-    if (!process.env[key]) {
+    if (process.env[key] === undefined) {
       process.env[key] = val
     }
   }

--- a/scripts/saucelabs-prune-builds.mjs
+++ b/scripts/saucelabs-prune-builds.mjs
@@ -259,6 +259,7 @@ const main = async () => {
 
 try {
   await main()
+  process.exit(0)
 } catch (err) {
   console.error('\nFatal error:', err.message)
   process.exit(1)

--- a/scripts/saucelabs-prune-builds.mjs
+++ b/scripts/saucelabs-prune-builds.mjs
@@ -99,7 +99,7 @@ const fetchAllFiles = async (queryParams) => {
 const parseFilename = (filename) => {
   const match = filename.match(/^(.+)-(\d+)\.[a-z]+$/i)
   if (!match) return null
-  return { prefix: match[1], buildNumber: parseInt(match[2], 10) }
+  return { prefix: match[1], buildNumber: Number.parseInt(match[2], 10) }
 }
 
 /** Delete a single file from SauceLabs storage. Returns 'deleted' or 'not_found'. */
@@ -245,7 +245,9 @@ const main = async () => {
   }
 }
 
-main().catch((err) => {
+try {
+  await main()
+} catch (err) {
   console.error('\nFatal error:', err.message)
   process.exit(1)
-})
+}

--- a/scripts/saucelabs-prune-builds.mjs
+++ b/scripts/saucelabs-prune-builds.mjs
@@ -67,7 +67,7 @@ const DEBUG = process.argv.includes('--debug')
 
 console.log(`SauceLabs Build Pruner`)
 console.log(`  Region:   ${SAUCE_REGION}`)
-console.log(`  User:     ${SAUCE_USERNAME.slice(0, 3)}${'*'.repeat(SAUCE_USERNAME.length - 3)}`)
+console.log(`  User:     [hidden - from SAUCE_USERNAME env var]`)
 console.log(`  API base: ${API_BASE}`)
 console.log(`  Mode:     ${DRY_RUN ? 'DRY RUN' : 'DELETE'}\n`)
 

--- a/scripts/saucelabs-prune-builds.mjs
+++ b/scripts/saucelabs-prune-builds.mjs
@@ -141,7 +141,12 @@ const main = async () => {
   // 1. Fetch all rc-tagged builds and discover prefixes automatically
   console.log('Fetching rc-tagged builds...')
   const rcFiles = await fetchAllFiles({ tags: 'rc' })
-  const rcParsed = rcFiles.map((f) => ({ ...f, ...parseFilename(f.name) })).filter((f) => f.prefix != null)
+  const rcParsed = rcFiles
+    .map((f) => {
+      const parsed = parseFilename(f.name)
+      return parsed ? { ...f, ...parsed } : null
+    })
+    .filter((f) => f !== null)
 
   // Group rc builds by prefix, keep the highest build number per prefix
   const latestRcByPrefix = new Map()
@@ -163,7 +168,12 @@ const main = async () => {
   // 2. Fetch all pr-tagged builds
   console.log('Fetching pr-tagged builds...')
   const prFiles = await fetchAllFiles({ tags: 'pr' })
-  const prParsed = prFiles.map((f) => ({ ...f, ...parseFilename(f.name) })).filter((f) => f.prefix != null)
+  const prParsed = prFiles
+    .map((f) => {
+      const parsed = parseFilename(f.name)
+      return parsed ? { ...f, ...parsed } : null
+    })
+    .filter((f) => f !== null)
 
   // Group pr builds by prefix
   const prByPrefix = new Map()
@@ -206,7 +216,9 @@ const main = async () => {
         try {
           const result = await deleteFile(file.id)
           console.log(result === 'not_found' ? ' already gone' : ' done')
-          deleted++
+          if (result !== 'not_found') {
+            deleted++
+          }
         } catch (err) {
           console.log(` FAILED: ${err.message}`)
           failed++

--- a/scripts/saucelabs-prune-builds.mjs
+++ b/scripts/saucelabs-prune-builds.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+/**
+ * SauceLabs Build Pruner
+ *
+ * Discovers all apps in SauceLabs storage automatically. For each app it
+ * finds the latest `rc`-tagged build, then deletes all `pr`-tagged builds
+ * with a lower build number. No hardcoded app names or bundle IDs — the
+ * script works entirely from SauceLabs storage metadata.
+ *
+ * Required environment variables:
+ *   SAUCE_USERNAME    – SauceLabs username
+ *   SAUCE_ACCESS_KEY  – SauceLabs access key
+ *
+ * Usage:
+ *   node scripts/saucelabs-prune-builds.mjs              # dry-run (default)
+ *   node scripts/saucelabs-prune-builds.mjs --delete      # actually delete
+ *
+ * ── Local development ──────────────────────────────────────────────────
+ * Reads scripts/.env.saucelabs if present (same as saucelabs-app-launch-test).
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// ── Load local .env file if present ────────────────────────────────────
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const LOCAL_ENV_PATH = resolve(__dirname, '.env.saucelabs')
+
+if (existsSync(LOCAL_ENV_PATH)) {
+  console.log(`Loading local env from ${LOCAL_ENV_PATH}\n`)
+  const lines = readFileSync(LOCAL_ENV_PATH, 'utf-8').split('\n')
+  for (const raw of lines) {
+    const line = raw.trim()
+    if (!line || line.startsWith('#')) continue
+    const eq = line.indexOf('=')
+    if (eq === -1) continue
+    const key = line.slice(0, eq).trim()
+    let val = line.slice(eq + 1).trim()
+    if ((val.startsWith("'") && val.endsWith("'")) || (val.startsWith('"') && val.endsWith('"'))) {
+      val = val.slice(1, -1)
+    }
+    if (!process.env[key]) {
+      process.env[key] = val
+    }
+  }
+}
+
+// ── Config ─────────────────────────────────────────────────────────────
+
+const SAUCE_REGION = 'us-west-1'
+const API_BASE = `https://api.${SAUCE_REGION}.saucelabs.com/v1/storage`
+
+const SAUCE_USERNAME = process.env.SAUCE_USERNAME
+const SAUCE_ACCESS_KEY = process.env.SAUCE_ACCESS_KEY
+
+if (!SAUCE_USERNAME || !SAUCE_ACCESS_KEY) {
+  console.error('Error: SAUCE_USERNAME and SAUCE_ACCESS_KEY must be set.')
+  process.exit(1)
+}
+
+const AUTH = Buffer.from(`${SAUCE_USERNAME}:${SAUCE_ACCESS_KEY}`).toString('base64')
+const HEADERS = { Authorization: `Basic ${AUTH}`, 'Content-Type': 'application/json' }
+const DRY_RUN = !process.argv.includes('--delete')
+const DEBUG = process.argv.includes('--debug')
+
+console.log(`SauceLabs Build Pruner`)
+console.log(`  Region:   ${SAUCE_REGION}`)
+console.log(`  User:     ${SAUCE_USERNAME}`)
+console.log(`  API base: ${API_BASE}`)
+console.log(`  Mode:     ${DRY_RUN ? 'DRY RUN' : 'DELETE'}\n`)
+
+// ── SauceLabs API helpers ──────────────────────────────────────────────
+
+/**
+ * Fetch all files from SauceLabs storage for a given query,
+ * handling pagination automatically.
+ */
+const fetchAllFiles = async (queryParams) => {
+  const files = []
+  let page = 1
+  const perPage = 100
+  const label = queryParams.tags ?? 'all'
+
+  while (true) {
+    process.stdout.write(`  Fetching ${label}-tagged files (page ${page})...`)
+    const params = new URLSearchParams({ ...queryParams, per_page: String(perPage), page: String(page) })
+    const url = `${API_BASE}/files?${params}`
+    const res = await fetch(url, { headers: HEADERS })
+
+    if (!res.ok) {
+      const body = await res.text()
+      throw new Error(`SauceLabs API error ${res.status}: ${body}`)
+    }
+
+    const data = await res.json()
+    const items = data.items ?? []
+    const total = data.total_items ?? '?'
+    files.push(...items)
+    console.log(` got ${items.length} (${files.length}/${total} total)`)
+
+    if (items.length < perPage || files.length >= (data.total_items ?? Infinity)) {
+      break
+    }
+    page++
+  }
+
+  console.log(`  Done: ${files.length} ${label}-tagged file(s) found.\n`)
+
+  if (DEBUG && files.length > 0) {
+    console.log('  [DEBUG] Sample file object keys:', Object.keys(files[0]).join(', '))
+    console.log('  [DEBUG] Sample file object:', JSON.stringify(files[0], null, 2), '\n')
+  }
+
+  return files
+}
+
+/**
+ * Parse a SauceLabs filename into its prefix and build number.
+ * Expects pattern: PREFIX-NUMBER.ext (e.g. BCSC-Dev-123.ipa, BCWallet-456.aab)
+ * The prefix is everything before the last dash-digits-dot-extension.
+ * Returns { prefix, buildNumber } or null if the name doesn't match.
+ */
+const parseFilename = (filename) => {
+  const match = filename.match(/^(.+)-(\d+)\.[a-z]+$/i)
+  if (!match) return null
+  return { prefix: match[1], buildNumber: parseInt(match[2], 10) }
+}
+
+/** Delete a single file from SauceLabs storage. Returns 'deleted' or 'not_found'. */
+const deleteFile = async (fileId) => {
+  const url = `${API_BASE}/files/${fileId}`
+  if (DEBUG) {
+    console.log(`\n  [DEBUG] DELETE ${url}`)
+  }
+
+  const res = await fetch(url, {
+    method: 'DELETE',
+    headers: HEADERS,
+  })
+
+  if (DEBUG) {
+    const body = await res.clone().text()
+    console.log(`  [DEBUG] Response ${res.status}: ${body}`)
+  }
+
+  if (res.status === 404) return 'not_found'
+
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Failed to delete ${fileId}: ${res.status} ${body}`)
+  }
+
+  return 'deleted'
+}
+
+// ── Main ───────────────────────────────────────────────────────────────
+
+const main = async () => {
+  console.log(
+    DRY_RUN
+      ? '🔍 DRY RUN — no files will be deleted. Pass --delete to actually prune.\n'
+      : '🗑️  DELETE MODE — files will be permanently removed.\n'
+  )
+
+  // 1. Fetch all rc-tagged builds and discover prefixes automatically
+  console.log('Fetching rc-tagged builds...')
+  const rcFiles = await fetchAllFiles({ tags: 'rc' })
+  const rcParsed = rcFiles.map((f) => ({ ...f, ...parseFilename(f.name) })).filter((f) => f.prefix != null)
+
+  // Group rc builds by prefix, keep the highest build number per prefix
+  const latestRcByPrefix = new Map()
+  for (const f of rcParsed) {
+    const existing = latestRcByPrefix.get(f.prefix)
+    if (!existing || f.buildNumber > existing.buildNumber) {
+      latestRcByPrefix.set(f.prefix, f)
+    }
+  }
+
+  const prefixes = [...latestRcByPrefix.keys()].sort()
+  console.log(`Discovered ${prefixes.length} app prefix(es): ${prefixes.join(', ')}\n`)
+
+  if (prefixes.length === 0) {
+    console.log('No rc-tagged builds found in storage. Nothing to prune.')
+    return
+  }
+
+  // 2. Fetch all pr-tagged builds
+  console.log('Fetching pr-tagged builds...')
+  const prFiles = await fetchAllFiles({ tags: 'pr' })
+  const prParsed = prFiles.map((f) => ({ ...f, ...parseFilename(f.name) })).filter((f) => f.prefix != null)
+
+  // Group pr builds by prefix
+  const prByPrefix = new Map()
+  for (const f of prParsed) {
+    if (!prByPrefix.has(f.prefix)) prByPrefix.set(f.prefix, [])
+    prByPrefix.get(f.prefix).push(f)
+  }
+
+  // 3. For each discovered prefix, prune pr builds older than latest rc
+  const results = []
+  for (const prefix of prefixes) {
+    console.log(`\n${'─'.repeat(60)}`)
+    console.log(`Processing: ${prefix}`)
+    console.log('─'.repeat(60))
+
+    const latestRc = latestRcByPrefix.get(prefix)
+    console.log(`  Latest rc build: ${latestRc.name} (build #${latestRc.buildNumber})`)
+
+    const prBuilds = prByPrefix.get(prefix) ?? []
+    const toDelete = prBuilds.filter((f) => f.buildNumber < latestRc.buildNumber)
+    const toKeep = prBuilds.filter((f) => f.buildNumber >= latestRc.buildNumber)
+
+    if (toDelete.length === 0) {
+      console.log(`  No pr builds older than rc build #${latestRc.buildNumber}. Nothing to prune.`)
+      results.push({ deleted: 0, skipped: toKeep.length, prefix })
+      continue
+    }
+
+    console.log(`  Found ${toDelete.length} pr build(s) to prune, ${toKeep.length} to keep.`)
+    toDelete.sort((a, b) => a.buildNumber - b.buildNumber)
+
+    for (const file of toDelete) {
+      if (DRY_RUN) {
+        console.log(`  [DRY RUN] Would delete: ${file.name} (build #${file.buildNumber}, id: ${file.id})`)
+      } else {
+        process.stdout.write(`  Deleting: ${file.name} (build #${file.buildNumber})...`)
+        try {
+          const result = await deleteFile(file.id)
+          console.log(result === 'not_found' ? ' already gone' : ' done')
+        } catch (err) {
+          console.log(` FAILED: ${err.message}`)
+        }
+      }
+    }
+
+    results.push({ deleted: toDelete.length, skipped: toKeep.length, prefix })
+  }
+
+  // Summary
+  console.log(`\n${'═'.repeat(60)}`)
+  console.log('Summary')
+  console.log('═'.repeat(60))
+  for (const r of results) {
+    const action = DRY_RUN ? 'would delete' : 'deleted'
+    console.log(`  ${r.prefix}: ${r.deleted} ${action}, ${r.skipped} kept`)
+  }
+
+  const total = results.reduce((sum, r) => sum + r.deleted, 0)
+  if (DRY_RUN && total > 0) {
+    console.log(`\nRe-run with --delete to remove ${total} file(s).`)
+  }
+}
+
+main().catch((err) => {
+  console.error('\nFatal error:', err.message)
+  process.exit(1)
+})

--- a/scripts/saucelabs-prune-builds.mjs
+++ b/scripts/saucelabs-prune-builds.mjs
@@ -2,14 +2,16 @@
 /**
  * SauceLabs Build Pruner
  *
- * Discovers all apps in SauceLabs storage automatically. For each app it
- * finds the latest `rc`-tagged build, then deletes all `pr`-tagged builds
- * with a lower build number. No hardcoded app names or bundle IDs — the
- * script works entirely from SauceLabs storage metadata.
+ * Deletes SauceLabs storage builds for closed/merged pull requests.
+ * Fetches all open PRs from GitHub, then removes any SauceLabs build
+ * tagged with a PR number that is no longer open. Builds for open PRs
+ * are always kept.
  *
  * Required environment variables:
- *   SAUCE_USERNAME    – SauceLabs username
- *   SAUCE_ACCESS_KEY  – SauceLabs access key
+ *   SAUCE_USERNAME      – SauceLabs username
+ *   SAUCE_ACCESS_KEY    – SauceLabs access key
+ *   GITHUB_TOKEN        – GitHub token with pull-requests:read scope
+ *   GITHUB_REPOSITORY   – owner/repo (e.g. bcgov/bc-wallet-mobile)
  *
  * Usage:
  *   node scripts/saucelabs-prune-builds.mjs              # dry-run (default)
@@ -28,29 +30,65 @@ const API_BASE = `https://api.${SAUCE_REGION}.saucelabs.com/v1/storage`
 
 const SAUCE_USERNAME = process.env.SAUCE_USERNAME
 const SAUCE_ACCESS_KEY = process.env.SAUCE_ACCESS_KEY
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN
+const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY
 
 if (!SAUCE_USERNAME || !SAUCE_ACCESS_KEY) {
   console.error('Error: SAUCE_USERNAME and SAUCE_ACCESS_KEY must be set.')
   process.exit(1)
 }
 
-const AUTH = Buffer.from(`${SAUCE_USERNAME}:${SAUCE_ACCESS_KEY}`).toString('base64')
-const HEADERS = { Authorization: `Basic ${AUTH}`, 'Content-Type': 'application/json' }
+if (!GITHUB_TOKEN || !GITHUB_REPOSITORY) {
+  console.error('Error: GITHUB_TOKEN and GITHUB_REPOSITORY must be set.')
+  process.exit(1)
+}
+
+const SAUCE_AUTH = Buffer.from(`${SAUCE_USERNAME}:${SAUCE_ACCESS_KEY}`).toString('base64')
+const SAUCE_HEADERS = { Authorization: `Basic ${SAUCE_AUTH}`, 'Content-Type': 'application/json' }
+const GITHUB_HEADERS = { Authorization: `Bearer ${GITHUB_TOKEN}`, Accept: 'application/vnd.github+json' }
 const DRY_RUN = !process.argv.includes('--delete')
 const DEBUG = process.argv.includes('--debug')
 
 console.log(`SauceLabs Build Pruner`)
-console.log(`  Region:   ${SAUCE_REGION}`)
-console.log(`  User:     [hidden - from SAUCE_USERNAME env var]`)
-console.log(`  API base: ${API_BASE}`)
-console.log(`  Mode:     ${DRY_RUN ? 'DRY RUN' : 'DELETE'}\n`)
+console.log(`  Region:     ${SAUCE_REGION}`)
+console.log(`  Repository: ${GITHUB_REPOSITORY}`)
+console.log(`  Mode:       ${DRY_RUN ? 'DRY RUN' : 'DELETE'}\n`)
+
+// ── GitHub API helpers ────────────────────────────────────────────────
+
+/** Fetch all open PR numbers from GitHub, handling pagination. */
+const fetchOpenPRNumbers = async () => {
+  const numbers = new Set()
+  let page = 1
+  const perPage = 100
+
+  while (true) {
+    process.stdout.write(`  Fetching open PRs (page ${page})...`)
+    const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls?state=open&per_page=${perPage}&page=${page}`
+    const res = await fetch(url, { headers: GITHUB_HEADERS })
+
+    if (!res.ok) {
+      const body = await res.text()
+      throw new Error(`GitHub API error ${res.status}: ${body}`)
+    }
+
+    const prs = await res.json()
+    for (const pr of prs) {
+      numbers.add(pr.number)
+    }
+    console.log(` got ${prs.length} (${numbers.size} total)`)
+
+    if (prs.length < perPage) break
+    page++
+  }
+
+  console.log(`  Done: ${numbers.size} open PR(s) found.\n`)
+  return numbers
+}
 
 // ── SauceLabs API helpers ──────────────────────────────────────────────
 
-/**
- * Fetch all files from SauceLabs storage for a given query,
- * handling pagination automatically.
- */
+/** Fetch all files from SauceLabs storage for a given query, handling pagination. */
 const fetchAllFiles = async (queryParams) => {
   const files = []
   let page = 1
@@ -61,7 +99,7 @@ const fetchAllFiles = async (queryParams) => {
     process.stdout.write(`  Fetching ${label}-tagged files (page ${page})...`)
     const params = new URLSearchParams({ ...queryParams, per_page: String(perPage), page: String(page) })
     const url = `${API_BASE}/files?${params}`
-    const res = await fetch(url, { headers: HEADERS })
+    const res = await fetch(url, { headers: SAUCE_HEADERS })
 
     if (!res.ok) {
       const body = await res.text()
@@ -90,18 +128,6 @@ const fetchAllFiles = async (queryParams) => {
   return files
 }
 
-/**
- * Parse a SauceLabs filename into its prefix and build number.
- * Expects pattern: PREFIX-NUMBER.ext (e.g. BCSC-Dev-123.ipa, BCWallet-456.aab)
- * The prefix is everything before the last dash-digits-dot-extension.
- * Returns { prefix, buildNumber } or null if the name doesn't match.
- */
-const parseFilename = (filename) => {
-  const match = filename.match(/^(.+)-(\d+)\.[a-z]+$/i)
-  if (!match) return null
-  return { prefix: match[1], buildNumber: Number.parseInt(match[2], 10) }
-}
-
 /** Delete a single file from SauceLabs storage. Returns 'deleted' or 'not_found'. */
 const deleteFile = async (fileId) => {
   const url = `${API_BASE}/files/${fileId}`
@@ -111,7 +137,7 @@ const deleteFile = async (fileId) => {
 
   const res = await fetch(url, {
     method: 'DELETE',
-    headers: HEADERS,
+    headers: SAUCE_HEADERS,
   })
 
   if (DEBUG) {
@@ -129,6 +155,20 @@ const deleteFile = async (fileId) => {
   return 'deleted'
 }
 
+/**
+ * Extract the PR number from a file's tags.
+ * Tags are stored as file.tags (array of strings).
+ * Looks for a tag matching "pr-NNNN" and returns NNNN, or null.
+ */
+const extractPRNumber = (file) => {
+  const tags = file.tags ?? []
+  for (const tag of tags) {
+    const match = tag.match(/^pr-(\d+)$/)
+    if (match) return Number.parseInt(match[1], 10)
+  }
+  return null
+}
+
 // ── Main ───────────────────────────────────────────────────────────────
 
 const main = async () => {
@@ -138,81 +178,59 @@ const main = async () => {
       : '🗑️  DELETE MODE — files will be permanently removed.\n'
   )
 
-  // 1. Fetch all rc-tagged builds and discover prefixes automatically
-  console.log('Fetching rc-tagged builds...')
-  const rcFiles = await fetchAllFiles({ tags: 'rc' })
-  const rcParsed = rcFiles
-    .map((f) => {
-      const parsed = parseFilename(f.name)
-      return parsed ? { ...f, ...parsed } : null
-    })
-    .filter((f) => f !== null)
+  // 1. Fetch all open PR numbers from GitHub
+  console.log('Fetching open PRs from GitHub...')
+  const openPRs = await fetchOpenPRNumbers()
 
-  // Group rc builds by prefix, keep the highest build number per prefix
-  const latestRcByPrefix = new Map()
-  for (const f of rcParsed) {
-    const existing = latestRcByPrefix.get(f.prefix)
-    if (!existing || f.buildNumber > existing.buildNumber) {
-      latestRcByPrefix.set(f.prefix, f)
+  // 2. Fetch all pr-tagged builds from SauceLabs
+  console.log('Fetching pr-tagged builds from SauceLabs...')
+  const prFiles = await fetchAllFiles({ tags: 'pr' })
+
+  // 3. Partition builds into keep (open PR) and delete (closed PR)
+  const toDelete = []
+  const toKeep = []
+  const noTag = []
+
+  for (const file of prFiles) {
+    const prNumber = extractPRNumber(file)
+    if (prNumber === null) {
+      noTag.push(file)
+    } else if (openPRs.has(prNumber)) {
+      toKeep.push(file)
+    } else {
+      toDelete.push({ ...file, prNumber })
     }
   }
 
-  const prefixes = [...latestRcByPrefix.keys()].sort()
-  console.log(`Discovered ${prefixes.length} app prefix(es): ${prefixes.join(', ')}\n`)
+  console.log(`  Keeping:  ${toKeep.length} build(s) for ${openPRs.size} open PR(s)`)
+  console.log(`  Deleting: ${toDelete.length} build(s) for closed PRs`)
+  if (noTag.length > 0) {
+    console.log(`  Skipped:  ${noTag.length} build(s) with no pr-NNNN tag`)
+  }
 
-  if (prefixes.length === 0) {
-    console.log('No rc-tagged builds found in storage. Nothing to prune.')
+  if (toDelete.length === 0) {
+    console.log('\nNothing to prune.')
     return
   }
 
-  // 2. Fetch all pr-tagged builds
-  console.log('Fetching pr-tagged builds...')
-  const prFiles = await fetchAllFiles({ tags: 'pr' })
-  const prParsed = prFiles
-    .map((f) => {
-      const parsed = parseFilename(f.name)
-      return parsed ? { ...f, ...parsed } : null
-    })
-    .filter((f) => f !== null)
-
-  // Group pr builds by prefix
-  const prByPrefix = new Map()
-  for (const f of prParsed) {
-    if (!prByPrefix.has(f.prefix)) prByPrefix.set(f.prefix, [])
-    prByPrefix.get(f.prefix).push(f)
+  // Group by PR number for readable output
+  const byPR = new Map()
+  for (const file of toDelete) {
+    if (!byPR.has(file.prNumber)) byPR.set(file.prNumber, [])
+    byPR.get(file.prNumber).push(file)
   }
 
-  // 3. For each discovered prefix, prune pr builds older than latest rc
-  const results = []
-  for (const prefix of prefixes) {
-    console.log(`\n${'─'.repeat(60)}`)
-    console.log(`Processing: ${prefix}`)
-    console.log('─'.repeat(60))
+  // 4. Delete builds for closed PRs
+  let deleted = 0
+  let failed = 0
 
-    const latestRc = latestRcByPrefix.get(prefix)
-    console.log(`  Latest rc build: ${latestRc.name} (build #${latestRc.buildNumber})`)
-
-    const prBuilds = prByPrefix.get(prefix) ?? []
-    const toDelete = prBuilds.filter((f) => f.buildNumber < latestRc.buildNumber)
-    const toKeep = prBuilds.filter((f) => f.buildNumber >= latestRc.buildNumber)
-
-    if (toDelete.length === 0) {
-      console.log(`  No pr builds older than rc build #${latestRc.buildNumber}. Nothing to prune.`)
-      results.push({ deleted: 0, failed: 0, skipped: toKeep.length, prefix })
-      continue
-    }
-
-    console.log(`  Found ${toDelete.length} pr build(s) to prune, ${toKeep.length} to keep.`)
-    toDelete.sort((a, b) => a.buildNumber - b.buildNumber)
-
-    let deleted = 0
-    let failed = 0
-
-    for (const file of toDelete) {
+  for (const [prNumber, files] of [...byPR.entries()].sort((a, b) => a[0] - b[0])) {
+    console.log(`\n  PR #${prNumber} (closed) — ${files.length} build(s):`)
+    for (const file of files) {
       if (DRY_RUN) {
-        console.log(`  [DRY RUN] Would delete: ${file.name} (build #${file.buildNumber}, id: ${file.id})`)
+        console.log(`    [DRY RUN] Would delete: ${file.name} (id: ${file.id})`)
       } else {
-        process.stdout.write(`  Deleting: ${file.name} (build #${file.buildNumber})...`)
+        process.stdout.write(`    Deleting: ${file.name}...`)
         try {
           const result = await deleteFile(file.id)
           console.log(result === 'not_found' ? ' already gone' : ' done')
@@ -225,34 +243,25 @@ const main = async () => {
         }
       }
     }
-
-    results.push({
-      deleted: DRY_RUN ? toDelete.length : deleted,
-      failed,
-      skipped: toKeep.length,
-      prefix,
-    })
   }
 
   // Summary
   console.log(`\n${'═'.repeat(60)}`)
   console.log('Summary')
   console.log('═'.repeat(60))
-  for (const r of results) {
-    const action = DRY_RUN ? 'would delete' : 'deleted'
-    const failInfo = r.failed > 0 ? `, ${r.failed} failed` : ''
-    console.log(`  ${r.prefix}: ${r.deleted} ${action}${failInfo}, ${r.skipped} kept`)
+  console.log(`  Open PRs:     ${openPRs.size}`)
+  console.log(`  Builds kept:  ${toKeep.length}`)
+  const action = DRY_RUN ? 'would delete' : 'deleted'
+  const count = DRY_RUN ? toDelete.length : deleted
+  const failInfo = failed > 0 ? `, ${failed} failed` : ''
+  console.log(`  Builds ${action}: ${count}${failInfo}`)
+
+  if (DRY_RUN && toDelete.length > 0) {
+    console.log(`\nRe-run with --delete to remove ${toDelete.length} file(s).`)
   }
 
-  const totalDeleted = results.reduce((sum, r) => sum + r.deleted, 0)
-  const totalFailed = results.reduce((sum, r) => sum + r.failed, 0)
-
-  if (DRY_RUN && totalDeleted > 0) {
-    console.log(`\nRe-run with --delete to remove ${totalDeleted} file(s).`)
-  }
-
-  if (totalFailed > 0) {
-    console.error(`\n${totalFailed} deletion(s) failed.`)
+  if (failed > 0) {
+    console.error(`\n${failed} deletion(s) failed.`)
     process.exit(1)
   }
 }

--- a/scripts/saucelabs-prune-builds.mjs
+++ b/scripts/saucelabs-prune-builds.mjs
@@ -19,6 +19,8 @@
  *
  * ── Local development ──────────────────────────────────────────────────
  * Reads scripts/.env.saucelabs if present (same as saucelabs-app-launch-test).
+ * For GITHUB_TOKEN, use: GITHUB_TOKEN=$(gh auth token)
+ * For GITHUB_REPOSITORY, use: GITHUB_REPOSITORY=bcgov/bc-wallet-mobile
  */
 
 import './saucelabs-env.mjs'
@@ -206,6 +208,11 @@ const main = async () => {
   console.log(`  Deleting: ${toDelete.length} build(s) for closed PRs`)
   if (noTag.length > 0) {
     console.log(`  Skipped:  ${noTag.length} build(s) with no pr-NNNN tag`)
+    if (DEBUG) {
+      for (const file of noTag) {
+        console.log(`    [DEBUG] No pr-NNNN tag: ${file.name} (id: ${file.id}, tags: ${(file.tags ?? []).join(', ')})`)
+      }
+    }
   }
 
   if (toDelete.length === 0) {

--- a/scripts/saucelabs-prune-builds.mjs
+++ b/scripts/saucelabs-prune-builds.mjs
@@ -67,7 +67,7 @@ const DEBUG = process.argv.includes('--debug')
 
 console.log(`SauceLabs Build Pruner`)
 console.log(`  Region:   ${SAUCE_REGION}`)
-console.log(`  User:     ${SAUCE_USERNAME}`)
+console.log(`  User:     ${SAUCE_USERNAME.slice(0, 3)}${'*'.repeat(SAUCE_USERNAME.length - 3)}`)
 console.log(`  API base: ${API_BASE}`)
 console.log(`  Mode:     ${DRY_RUN ? 'DRY RUN' : 'DELETE'}\n`)
 
@@ -214,12 +214,15 @@ const main = async () => {
 
     if (toDelete.length === 0) {
       console.log(`  No pr builds older than rc build #${latestRc.buildNumber}. Nothing to prune.`)
-      results.push({ deleted: 0, skipped: toKeep.length, prefix })
+      results.push({ deleted: 0, failed: 0, skipped: toKeep.length, prefix })
       continue
     }
 
     console.log(`  Found ${toDelete.length} pr build(s) to prune, ${toKeep.length} to keep.`)
     toDelete.sort((a, b) => a.buildNumber - b.buildNumber)
+
+    let deleted = 0
+    let failed = 0
 
     for (const file of toDelete) {
       if (DRY_RUN) {
@@ -229,13 +232,20 @@ const main = async () => {
         try {
           const result = await deleteFile(file.id)
           console.log(result === 'not_found' ? ' already gone' : ' done')
+          deleted++
         } catch (err) {
           console.log(` FAILED: ${err.message}`)
+          failed++
         }
       }
     }
 
-    results.push({ deleted: toDelete.length, skipped: toKeep.length, prefix })
+    results.push({
+      deleted: DRY_RUN ? toDelete.length : deleted,
+      failed,
+      skipped: toKeep.length,
+      prefix,
+    })
   }
 
   // Summary
@@ -244,12 +254,20 @@ const main = async () => {
   console.log('═'.repeat(60))
   for (const r of results) {
     const action = DRY_RUN ? 'would delete' : 'deleted'
-    console.log(`  ${r.prefix}: ${r.deleted} ${action}, ${r.skipped} kept`)
+    const failInfo = r.failed > 0 ? `, ${r.failed} failed` : ''
+    console.log(`  ${r.prefix}: ${r.deleted} ${action}${failInfo}, ${r.skipped} kept`)
   }
 
-  const total = results.reduce((sum, r) => sum + r.deleted, 0)
-  if (DRY_RUN && total > 0) {
-    console.log(`\nRe-run with --delete to remove ${total} file(s).`)
+  const totalDeleted = results.reduce((sum, r) => sum + r.deleted, 0)
+  const totalFailed = results.reduce((sum, r) => sum + r.failed, 0)
+
+  if (DRY_RUN && totalDeleted > 0) {
+    console.log(`\nRe-run with --delete to remove ${totalDeleted} file(s).`)
+  }
+
+  if (totalFailed > 0) {
+    console.error(`\n${totalFailed} deletion(s) failed.`)
+    process.exit(1)
   }
 }
 

--- a/scripts/saucelabs-prune-builds.mjs
+++ b/scripts/saucelabs-prune-builds.mjs
@@ -19,33 +19,7 @@
  * Reads scripts/.env.saucelabs if present (same as saucelabs-app-launch-test).
  */
 
-import { existsSync, readFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
-
-// ── Load local .env file if present ────────────────────────────────────
-
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const LOCAL_ENV_PATH = resolve(__dirname, '.env.saucelabs')
-
-if (existsSync(LOCAL_ENV_PATH)) {
-  console.log(`Loading local env from ${LOCAL_ENV_PATH}\n`)
-  const lines = readFileSync(LOCAL_ENV_PATH, 'utf-8').split('\n')
-  for (const raw of lines) {
-    const line = raw.trim()
-    if (!line || line.startsWith('#')) continue
-    const eq = line.indexOf('=')
-    if (eq === -1) continue
-    const key = line.slice(0, eq).trim()
-    let val = line.slice(eq + 1).trim()
-    if ((val.startsWith("'") && val.endsWith("'")) || (val.startsWith('"') && val.endsWith('"'))) {
-      val = val.slice(1, -1)
-    }
-    if (!process.env[key]) {
-      process.env[key] = val
-    }
-  }
-}
+import './saucelabs-env.mjs'
 
 // ── Config ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds `scripts/saucelabs-prune-builds.mjs` to prune SauceLabs storage builds for closed/merged PRs
- Fetches all open PRs from GitHub, then removes any SauceLabs build tagged with a PR number that is no longer open — builds for open PRs are always kept
- Extracts shared `.env.saucelabs` loader into `scripts/saucelabs-env.mjs` (used by both SauceLabs scripts)
- Adds a `prune-saucelabs` job to the daily maintenance workflow
- Safe by default: dry-run mode is the default; pass `--delete` to actually remove files
- `--debug` flag available for troubleshooting API responses

## Test plan

- [x] Run without `--delete` and verify dry-run output lists expected files without removing anything
- [x] Run with `--delete` and confirm builds for closed PRs are removed from SauceLabs storage
- [x] Run with `--debug` and confirm API response details are printed
- [x] Verify builds for open PRs are kept
- [x] Confirm `SAUCE_USERNAME`, `SAUCE_ACCESS_KEY`, `GITHUB_TOKEN`, and `GITHUB_REPOSITORY` env vars are required and script exits with an error if missing

Fixes #3297

# Manual testing

I ran it, it works as expected. If you want to try, you need a SauceLabs account and a GitHub token:

```
export SAUCE_USERNAME="account_name_here"
export SAUCE_ACCESS_KEY=key-goes-here
GITHUB_TOKEN=$(gh auth token) \
GITHUB_REPOSITORY=bcgov/bc-wallet-mobile \
node scripts/saucelabs-prune-builds.mjs
```

This does a dry run only. Add `--delete` to actually prune.