### PR TITLE
fix: refresh token issues

### DIFF
--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -15,9 +15,9 @@ import { JWK, JWKResponseData } from './hooks/useJwksApi'
 import { TokenResponse } from './hooks/useTokens'
 import { withAccount } from './hooks/withAccountGuard'
 
-// Refresh tokens 60 seconds before they actually expire to avoid
+// Refresh tokens 30 seconds before they actually expire to avoid
 // expiry-on-the-wire races when multiple requests fire near the boundary.
-const TOKEN_EXPIRY_BUFFER_MS = 60 * 1000
+const TOKEN_EXPIRY_BUFFER_MS = 30 * 1000
 
 // Extend AxiosRequestConfig to include skipBearerAuth
 declare module 'axios' {

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -15,6 +15,10 @@ import { JWK, JWKResponseData } from './hooks/useJwksApi'
 import { TokenResponse } from './hooks/useTokens'
 import { withAccount } from './hooks/withAccountGuard'
 
+// Refresh tokens 60 seconds before they actually expire to avoid
+// expiry-on-the-wire races when multiple requests fire near the boundary.
+const TOKEN_EXPIRY_BUFFER_MS = 60 * 1000
+
 // Extend AxiosRequestConfig to include skipBearerAuth
 declare module 'axios' {
   export interface AxiosRequestConfig {
@@ -233,18 +237,25 @@ class BCSCApiClient {
         return this.tokens
       }
 
-      // access token is expired, fetch new tokens using refresh token
-      return this.getTokensForRefreshToken(this.tokens.refresh_token)
+      // access token is expired or about to expire, fetch new tokens using refresh token
+      // Set tokensPromise immediately to prevent concurrent callers from starting duplicate refreshes
+      this.tokensPromise = this.fetchTokens(this.tokens.refresh_token)
+      try {
+        this.tokens = await this.tokensPromise
+      } finally {
+        this.tokensPromise = null
+      }
+      return this.tokens
     })
   }
 
   private isTokenExpired(token?: string): boolean {
     let isExpired = true
-    // if no token is present, return that token is "expired" and fetch a new one
+    // if no token is present, or within the buffer limit of expiring, return that token is "expired" and fetch a new one
     if (token) {
       const decodedToken = jwtDecode(token)
       const exp = decodedToken.exp ?? 0
-      isExpired = Date.now() >= exp * 1000
+      isExpired = Date.now() >= exp * 1000 - TOKEN_EXPIRY_BUFFER_MS
     }
     return isExpired
   }

--- a/app/src/bcsc-theme/api/hooks/useTokens.tsx
+++ b/app/src/bcsc-theme/api/hooks/useTokens.tsx
@@ -62,9 +62,12 @@ const useTokenApi = (apiClient: BCSCApiClient) => {
         })
 
         try {
-          // Pass both refreshToken and accessToken to avoid duplicate API call in updateTokens
-          await updateTokens({ refreshToken: data.refresh_token, accessToken: data.access_token })
+          // Set apiClient.tokens BEFORE updateTokens so it can see that tokens are already
+          // fresh. Without this ordering, updateTokens calls getTokensForRefreshToken which
+          // posts to /device/token again — the new access token from that second call
+          // invalidates this one server-side, causing 500s on concurrent requests.
           apiClient.tokens = data
+          await updateTokens({ refreshToken: data.refresh_token, accessToken: data.access_token })
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error)
           apiClient.logger.error(`[checkDeviceCodeStatus] Failed to update tokens: ${message}`)

--- a/app/src/bcsc-theme/api/hooks/useTokens.tsx
+++ b/app/src/bcsc-theme/api/hooks/useTokens.tsx
@@ -62,10 +62,6 @@ const useTokenApi = (apiClient: BCSCApiClient) => {
         })
 
         try {
-          // Set apiClient.tokens BEFORE updateTokens so it can see that tokens are already
-          // fresh. Without this ordering, updateTokens calls getTokensForRefreshToken which
-          // posts to /device/token again — the new access token from that second call
-          // invalidates this one server-side, causing 500s on concurrent requests.
           apiClient.tokens = data
           await updateTokens({ refreshToken: data.refresh_token, accessToken: data.access_token })
         } catch (error) {

--- a/app/src/bcsc-theme/contexts/BCSCIdTokenContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCIdTokenContext.tsx
@@ -1,6 +1,6 @@
 import { CredentialMetadata } from '@/store'
 import { TOKENS, useServices } from '@bifold/core'
-import { createContext, PropsWithChildren, useContext, useEffect, useMemo } from 'react'
+import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useRef } from 'react'
 import useApi from '../api/hooks/useApi'
 import useDataLoader from '../hooks/useDataLoader'
 import { IdToken } from '../utils/id-token'
@@ -67,8 +67,16 @@ export const BCSCIdTokenProvider = ({ children }: PropsWithChildren) => {
   const api = useApi()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
 
+  // On initial mount, use the cached tokens from hydrateSecureState or brand new verification
+  // Subsequent refreshes (e.g. refreshIdToken) fetch fresh tokens from the server
+  const isInitialLoad = useRef(true)
+
   const { data, load, isLoading, refresh } = useDataLoader(
-    () => api.token.getCachedIdTokenMetadata({ refreshCache: true }),
+    async () => {
+      const shouldRefresh = !isInitialLoad.current
+      isInitialLoad.current = false
+      return api.token.getCachedIdTokenMetadata({ refreshCache: shouldRefresh })
+    },
     {
       onError: (error) => logger.error('BCSCIdTokenProvider: Failed to load ID Token metadata', error as Error),
     }

--- a/app/src/bcsc-theme/contexts/BCSCIdTokenContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCIdTokenContext.tsx
@@ -2,6 +2,7 @@ import { CredentialMetadata } from '@/store'
 import { TOKENS, useServices } from '@bifold/core'
 import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useRef } from 'react'
 import useApi from '../api/hooks/useApi'
+import { useBCSCApiClient } from '../hooks/useBCSCApiClient'
 import useDataLoader from '../hooks/useDataLoader'
 import { IdToken } from '../utils/id-token'
 
@@ -65,6 +66,7 @@ export const BCSCIdTokenContext = createContext<BCSCIdTokenContextType<IdToken> 
  */
 export const BCSCIdTokenProvider = ({ children }: PropsWithChildren) => {
   const api = useApi()
+  const apiClient = useBCSCApiClient()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
 
   // On initial mount, use the cached tokens from hydrateSecureState or brand new verification
@@ -73,7 +75,10 @@ export const BCSCIdTokenProvider = ({ children }: PropsWithChildren) => {
 
   const { data, load, isLoading, refresh } = useDataLoader(
     async () => {
-      const shouldRefresh = !isInitialLoad.current
+      // On initial mount, skip the server refresh if apiClient already has tokens
+      // (populated by hydrateSecureState). If tokens are missing, force a refresh
+      // so we don't throw TOKEN_NULL in some weird scenario
+      const shouldRefresh = !isInitialLoad.current || !apiClient.tokens
       isInitialLoad.current = false
       return api.token.getCachedIdTokenMetadata({ refreshCache: shouldRefresh })
     },

--- a/app/src/bcsc-theme/features/account-transfer/transferee/TransferQRScannerScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/TransferQRScannerScreen.tsx
@@ -1,6 +1,7 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { PermissionDisabled } from '@/bcsc-theme/components/PermissionDisabled'
 import { LoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
+import { useBCSCApiClient } from '@/bcsc-theme/hooks/useBCSCApiClient'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { BCSC_EMAIL_NOT_PROVIDED } from '@/constants'
@@ -44,6 +45,7 @@ import { useCameraPermission } from 'react-native-vision-camera'
  */
 const TransferQRScannerScreen: React.FC = () => {
   const { deviceAttestation, authorization, token } = useApi()
+  const apiClient = useBCSCApiClient()
   const { updateTokens } = useSecureActions()
   const navigator = useNavigation<StackNavigationProp<BCSCVerifyStackParams>>()
   const [store] = useStore<BCState>()
@@ -161,6 +163,7 @@ const TransferQRScannerScreen: React.FC = () => {
             client_assertion: newDeviceJWT,
           })
 
+          apiClient.tokens = deviceToken
           await updateTokens({ refreshToken: deviceToken.refresh_token, accessToken: deviceToken.access_token })
 
           navigator.navigate(BCSCScreens.VerificationSuccess)
@@ -173,7 +176,7 @@ const TransferQRScannerScreen: React.FC = () => {
         setIsLoading(false)
       }
     },
-    [store, deviceAttestation, t, token, isLoading, scanError, navigator, updateTokens]
+    [store, deviceAttestation, t, token, isLoading, scanError, navigator, updateTokens, apiClient]
   )
 
   if (isPermissionLoading) {

--- a/app/src/bcsc-theme/hooks/useSecureActions.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.tsx
@@ -683,16 +683,21 @@ export const useSecureActions = () => {
         logger.warn('[IsVerified] No credential found but refresh token exists — treating as not verified.')
       }
 
+      let freshTokens: TokenResponse | null = null
       if (refreshToken && apiClient && isClientReady) {
         try {
-          await apiClient.getTokensForRefreshToken(refreshToken)
+          freshTokens = await apiClient.getTokensForRefreshToken(refreshToken)
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error)
           logger.error(`[hydrateSecureState] Failed to refresh tokens with stored refresh token: ${message}`)
         }
       }
 
-      await updateTokens({ refreshToken, registrationAccessToken, accessToken })
+      await updateTokens({
+        refreshToken: freshTokens?.refresh_token ?? refreshToken,
+        registrationAccessToken,
+        accessToken: freshTokens?.access_token ?? accessToken,
+      })
 
       // Reconstruct userMetadata from authorizationRequest (matches IAS apps)
       let userMetadata: NonBCSCUserMetadata | undefined = undefined

--- a/app/src/bcsc-theme/hooks/useSecureActions.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.tsx
@@ -180,18 +180,11 @@ export const useSecureActions = () => {
    */
   const updateTokens = useCallback(
     async (tokens: { refreshToken?: string; registrationAccessToken?: string; accessToken?: string }) => {
-      const promises = []
-
       if (tokens.refreshToken !== undefined) {
         dispatch({
           type: BCDispatchAction.UPDATE_SECURE_REFRESH_TOKEN,
           payload: [tokens.refreshToken],
         })
-
-        // Only sync to apiClient if client is ready AND we have a valid refresh token
-        if (isClientReady && apiClient && tokens.refreshToken) {
-          promises.push(apiClient.getTokensForRefreshToken(tokens.refreshToken))
-        }
       }
 
       if (tokens.registrationAccessToken !== undefined) {
@@ -208,10 +201,9 @@ export const useSecureActions = () => {
         })
       }
 
-      promises.push(persistTokens(tokens.refreshToken, tokens.registrationAccessToken, tokens.accessToken))
-      await Promise.all(promises)
+      await persistTokens(tokens.refreshToken, tokens.registrationAccessToken, tokens.accessToken)
     },
-    [dispatch, persistTokens, apiClient, isClientReady]
+    [dispatch, persistTokens]
   )
 
   /**
@@ -691,6 +683,15 @@ export const useSecureActions = () => {
         logger.warn('[IsVerified] No credential found but refresh token exists — treating as not verified.')
       }
 
+      if (refreshToken && apiClient && isClientReady) {
+        try {
+          await apiClient.getTokensForRefreshToken(refreshToken)
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          logger.error(`[hydrateSecureState] Failed to refresh tokens with stored refresh token: ${message}`)
+        }
+      }
+
       await updateTokens({ refreshToken, registrationAccessToken, accessToken })
 
       // Reconstruct userMetadata from authorizationRequest (matches IAS apps)
@@ -768,7 +769,7 @@ export const useSecureActions = () => {
       logger.error('Failed to hydrate secure state:', error as Error)
       throw error
     }
-  }, [logger, updateTokens, dispatch])
+  }, [logger, updateTokens, dispatch, apiClient, isClientReady])
 
   /**
    * Clears secure state from store (does not delete from native storage).


### PR DESCRIPTION
# Summary of Changes

This PR addresses two issues:
- Prevents unnecessary double-fetch of refresh tokens
- Ensures tokens are refreshed a minute before they expire rather than the moment they expire

# Testing Instructions

Go through verification, log in and out, kill the app and restart. Nothing breaks. Feel free to `console.warn('blah')` in the fetchTokens call to confirm it is only called once as-needed

# Acceptance Criteria

Refresh token calls are only made as needed

# Screenshots, videos, or gifs

N/A

# Related Issues

#3388 
#3232 (potentially)
#3382 (potentially)