### PR TITLE
fix: use shared hitSlop constant in ServiceLoginScreen

### DIFF
--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
@@ -1,7 +1,7 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { useQuickLoginURL } from '@/bcsc-theme/hooks/useQuickLoginUrl'
 import { BCSCMainStackParams, BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
-import { HelpCentreUrl, REPORT_SUSPICIOUS_URL } from '@/constants'
+import { HelpCentreUrl, hitSlop, REPORT_SUSPICIOUS_URL } from '@/constants'
 import { BCState, Mode } from '@/store'
 import {
   Button,
@@ -157,7 +157,7 @@ const ServiceLoginDefaultView = ({
                 testID={testIdWithKey('HelpButton')}
                 accessibilityLabel={t('BCSC.Screens.HelpCentre')}
                 accessibilityRole="button"
-                hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                hitSlop={hitSlop}
                 onPress={onOpenInfoShared}
               >
                 <Icon name="help-outline" size={24} color={ColorPalette.brand.primary} />


### PR DESCRIPTION
## Summary

- Replaces hardcoded inline `hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}` on the help button in `ServiceLoginScreen.tsx` with the shared `hitSlop` constant imported from `@/constants` (44px on all sides)
- Ensures touch target sizing is consistent with the rest of the codebase

## Test plan

- [ ] Verify the help button in `ServiceLoginScreen` is tappable and responds correctly on both iOS and Android
- [ ] Confirm no visual regressions on the `ServiceLoginScreen`
