### PR TITLE
fix: updated event listener to navigate away from ios guidance screen

### DIFF
--- a/app/src/bcsc-theme/features/pairing/PairingConfirmation.test.tsx
+++ b/app/src/bcsc-theme/features/pairing/PairingConfirmation.test.tsx
@@ -17,6 +17,7 @@ describe('PairingConfirmation', () => {
   beforeEach(() => {
     mockNavigation = useNavigation()
     jest.clearAllMocks()
+    jest.spyOn(AppState, 'addEventListener').mockImplementation(() => ({ remove: jest.fn() }) as any)
   })
 
   describe('when on iOS with fromAppSwitch', () => {

--- a/app/src/bcsc-theme/features/pairing/PairingConfirmation.tsx
+++ b/app/src/bcsc-theme/features/pairing/PairingConfirmation.tsx
@@ -19,13 +19,13 @@ const PairingConfirmation: React.FC<PairingConfirmationProps> = ({ navigation, r
   const showIOSAppSwitchGuide = Platform.OS === 'ios' && fromAppSwitch
 
   useEffect(() => {
-    if (Platform.OS !== 'ios') {
+    if (!showIOSAppSwitchGuide) {
       return
     }
 
     // On iOS, if the user backgrounds the app while on this screen -> navigate back to home screen
     const subscription = AppState.addEventListener('change', (nextAppState) => {
-      if (nextAppState === 'background') {
+      if (nextAppState === 'background' && showIOSAppSwitchGuide) {
         navigation.dispatch(
           CommonActions.reset({
             index: 0,
@@ -36,7 +36,7 @@ const PairingConfirmation: React.FC<PairingConfirmationProps> = ({ navigation, r
     })
 
     return subscription.remove
-  }, [navigation])
+  }, [navigation, showIOSAppSwitchGuide])
 
   const onClose = () => {
     if (fromAppSwitch && Platform.OS === 'android') {

--- a/app/src/bcsc-theme/features/pairing/PairingConfirmation.tsx
+++ b/app/src/bcsc-theme/features/pairing/PairingConfirmation.tsx
@@ -3,34 +3,29 @@ import ArrowUp from '@assets/img/arrowup.svg'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { CommonActions } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack'
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AppState, BackHandler, Platform } from 'react-native'
 import ServiceBookmarkButton from './components/ServiceBookmarkButton'
 
 const ARROW_SIZE = 80
 
-type ManualPairingProps = StackScreenProps<BCSCMainStackParams, BCSCScreens.PairingConfirmation>
+type PairingConfirmationProps = StackScreenProps<BCSCMainStackParams, BCSCScreens.PairingConfirmation>
 
-const ManualPairing: React.FC<ManualPairingProps> = ({ navigation, route }) => {
+const PairingConfirmation: React.FC<PairingConfirmationProps> = ({ navigation, route }) => {
   const { ColorPalette, Spacing } = useTheme()
   const { t } = useTranslation()
   const { serviceName, serviceId, fromAppSwitch } = route.params
-  const showAppSwitchGuidance = Platform.OS === 'ios' && fromAppSwitch
-  const appStateRef = useRef(AppState.currentState)
+  const showIOSAppSwitchGuide = Platform.OS === 'ios' && fromAppSwitch
 
   useEffect(() => {
-    if (!showAppSwitchGuidance) {
+    if (Platform.OS !== 'ios') {
       return
     }
 
-    // On iOS, when coming from an app switch, we want to automatically navigate the user back
-    // to the home screen when they return to the app (since they've completed the action in
-    // the other app)
+    // On iOS, if the user backgrounds the app while on this screen -> navigate back to home screen
     const subscription = AppState.addEventListener('change', (nextAppState) => {
-      const prev = appStateRef.current
-      appStateRef.current = nextAppState
-      if (prev === 'background' && nextAppState === 'active') {
+      if (nextAppState === 'background') {
         navigation.dispatch(
           CommonActions.reset({
             index: 0,
@@ -41,7 +36,7 @@ const ManualPairing: React.FC<ManualPairingProps> = ({ navigation, route }) => {
     })
 
     return subscription.remove
-  }, [showAppSwitchGuidance, navigation])
+  }, [navigation])
 
   const onClose = () => {
     if (fromAppSwitch && Platform.OS === 'android') {
@@ -56,7 +51,7 @@ const ManualPairing: React.FC<ManualPairingProps> = ({ navigation, route }) => {
     }
   }
 
-  const controls = !showAppSwitchGuidance ? (
+  const controls = !showIOSAppSwitchGuide ? (
     <Button
       title={t('Global.Close')}
       buttonType={ButtonType.Primary}
@@ -72,7 +67,7 @@ const ManualPairing: React.FC<ManualPairingProps> = ({ navigation, route }) => {
       edges={['bottom', 'left', 'right', 'top']}
       scrollViewContainerStyle={{ gap: Spacing.md }}
     >
-      {showAppSwitchGuidance && (
+      {showIOSAppSwitchGuide && (
         <ArrowUp
           height={ARROW_SIZE}
           width={ARROW_SIZE}
@@ -84,13 +79,13 @@ const ManualPairing: React.FC<ManualPairingProps> = ({ navigation, route }) => {
         />
       )}
       {fromAppSwitch ? (
-        <ThemedText style={{ marginTop: showAppSwitchGuidance ? undefined : Spacing.md }} variant={'headingThree'}>
+        <ThemedText style={{ marginTop: showIOSAppSwitchGuide ? undefined : Spacing.md }} variant={'headingThree'}>
           {t('BCSC.ManualPairing.FromAppSwitchCompletionTitle', { serviceName })}
         </ThemedText>
       ) : (
         <ThemedText variant={'headingThree'}>{t('BCSC.ManualPairing.CompletionTitle')}</ThemedText>
       )}
-      {showAppSwitchGuidance && (
+      {showIOSAppSwitchGuide && (
         <ThemedText style={{ color: ColorPalette.brand.primary }}>
           {t('BCSC.ManualPairing.FromAppSwitchCompletionSubtitle')}
         </ThemedText>
@@ -109,4 +104,4 @@ const ManualPairing: React.FC<ManualPairingProps> = ({ navigation, route }) => {
   )
 }
 
-export default ManualPairing
+export default PairingConfirmation


### PR DESCRIPTION
# Summary of Changes

This PR fixes a bug when navigating away from the manual pairing IOS guidance screen.

# Testing Instructions
Follow issue instructions

Attempt pairing additional time with that guidance screen still opened (app backgrounded)

# Acceptance Criteria

Should never get stuck on that screen (see issue)

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues
https://github.com/orgs/bcgov/projects/108/views/1?pane=issue&itemId=162937952&issue=bcgov%7Cbc-wallet-mobile%7C3381
