### PR TITLE
fix(verify): show BCSC serial number in Step 2 during NPC flow

### DIFF
--- a/app/src/hooks/useSetupSteps.test.tsx
+++ b/app/src/hooks/useSetupSteps.test.tsx
@@ -583,6 +583,26 @@ describe('useSetupSteps Hook', () => {
       expect(hook.result.current.id.subtext[0]).toContain('123456789')
     })
 
+    it('should return serial number in subtext for NPC when serial is present but step 2 is not complete', () => {
+      const store = structuredClone(initialState)
+      store.bcsc.selectedNickname = 'test'
+      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCNonPhoto
+      store.bcscSecure.serial = 'G00001234'
+      // No additional evidence yet — step 2 is NOT complete for NPC
+      const hook = renderHook(() => useSetupSteps(store))
+      expect(hook.result.current.id.completed).toBe(false)
+      expect(hook.result.current.id.subtext[0]).toContain('G00001234')
+    })
+
+    it('should return default subtext when no serial and no evidence is present', () => {
+      const store = structuredClone(initialState)
+      store.bcsc.selectedNickname = 'test'
+      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCNonPhoto
+      // No serial, no evidence
+      const hook = renderHook(() => useSetupSteps(store))
+      expect(hook.result.current.id.subtext).toEqual(['BCSC.Steps.ScanOrTakePhotos'])
+    })
+
     it('should have empty subtext for email step (custom children rendering)', () => {
       const store = structuredClone(initialState)
       const hook = renderHook(() => useSetupSteps(store))

--- a/app/src/hooks/useSetupSteps.ts
+++ b/app/src/hooks/useSetupSteps.ts
@@ -119,19 +119,12 @@ export const useSetupSteps = (store: BCState): SetupStepsResult => {
     }
 
     const getStep2Subtext = (): string[] => {
-      // Only show document info if step 2 is explicitly completed
-      if (!step2Completed) {
-        return [t('BCSC.Steps.ScanOrTakePhotos')]
-      }
-
       const cards: string[] = []
 
-      // If the BCSC card is registered, show the BCSC serial number
       if (store.bcscSecure.serial) {
         cards.push(t('BCSC.Steps.GetVerificationStep2Subtext1', { serial: store.bcscSecure.serial }))
       }
 
-      // If the user has added additional evidence, add each to the list
       for (const evidence of store.bcscSecure.additionalEvidenceData.filter(isEvidenceComplete)) {
         cards.push(
           t('BCSC.Steps.GetVerificationStep2Subtext2', {


### PR DESCRIPTION
## Summary

- Fixes regression where Step 2 of the setup flow no longer displayed the BCSC serial number after scanning in the NPC (Non-Photo Card) workflow
- Removed the `!step2Completed` early return in `getStep2Subtext()` so the serial is shown as soon as it's collected, rather than waiting for the 2nd photo ID to also be provided. In a Photo-Card step 2 is done with 1 ID; For a Non-Photo Card there is the 2nd step of entering a 2nd ID.
- Restores v3 behaviour

<img width="256" alt="Screenshot_20260312-140138" src="https://github.com/user-attachments/assets/bdee9ec8-35ae-4883-b9c1-e86f8718f3be" />

## Manual Testing

- [ ] Input a Photo Card, you will see step 2 completed (and others) and the ID Number;
- [ ] Input a NPC, you will see the card number and the app will be waiting for the 2nd ID.

