### PR TITLE
fix(bcsc-core): align native error codes across iOS and Android

### DIFF
--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -207,7 +207,7 @@ class BcscCoreModule(
 
             promise.resolve(keyPair)
         } catch (e: BcscException) {
-            promise.reject("E_BCSC_KEY_ERROR", "Error retrieving key pair using bcsc-keypair-port: ${e.devMessage}", e)
+            promise.reject("E_KEY_EXPORT_FAILED", "Error retrieving key pair: ${e.devMessage}", e)
         } catch (e: Exception) {
             promise.reject("E_KEY_ERROR", "Unexpected error retrieving key pair: ${e.message}", e)
         }
@@ -239,7 +239,7 @@ class BcscCoreModule(
 
             promise.resolve(privateKeys)
         } catch (e: BcscException) {
-            promise.reject("E_BCSC_KEYSTORE_ERROR", "Error accessing bcsc keystore: ${e.devMessage}", e)
+            promise.reject("E_KEYSTORE_ERROR", "Error accessing keystore: ${e.devMessage}", e)
         } catch (e: Exception) {
             promise.reject("E_KEYSTORE_ERROR", "Unexpected error accessing keystore: ${e.message}", e)
         }
@@ -255,15 +255,13 @@ class BcscCoreModule(
         // First, get the account to obtain the account ID
         val account = getAccountSync()
         if (account == null) {
-            Log.w(NAME, "getToken - Cannot get account, returning null")
-            promise.resolve(null)
+            promise.reject("E_ACCOUNT_NOT_FOUND", "Account not found")
             return
         }
 
         val accountId = account.getString("id")
         if (accountId == null || accountId.isEmpty()) {
-            Log.w(NAME, "getToken - Account ID is null or empty, returning null")
-            promise.resolve(null)
+            promise.reject("E_ACCOUNT_NOT_FOUND", "Account ID is null or empty")
             return
         }
 
@@ -288,8 +286,7 @@ class BcscCoreModule(
 
             val issuer = account.getString("issuer")
             if (issuer.isNullOrEmpty()) {
-                Log.w(NAME, "getToken - Account issuer is null or empty, cannot determine environment")
-                promise.resolve(null)
+                promise.reject("E_ACCOUNT_NOT_FOUND", "Account issuer is null or empty")
                 return
             }
 
@@ -647,8 +644,7 @@ class BcscCoreModule(
             // Get the account to obtain issuer and account ID
             val account = getAccountSync()
             if (account == null) {
-                // No account means no tokens to delete
-                promise.resolve(true)
+                promise.reject("E_ACCOUNT_NOT_FOUND", "Account not found")
                 return
             }
 
@@ -656,8 +652,7 @@ class BcscCoreModule(
             val issuer = account.getString("issuer")
 
             if (accountId.isNullOrEmpty() || issuer.isNullOrEmpty()) {
-                // No valid account, nothing to delete
-                promise.resolve(true)
+                promise.reject("E_ACCOUNT_NOT_FOUND", "Account ID or issuer is null or empty")
                 return
             }
 
@@ -1142,13 +1137,13 @@ class BcscCoreModule(
         } catch (e: BcscException) {
             Log.e(NAME, "getRefreshTokenRequestBody: BCSC error: ${e.devMessage}", e)
             promise.reject(
-                "E_BCSC_REFRESH_TOKEN_ERROR",
-                "Error creating refresh token request with bcsc-keypair-port: ${e.devMessage}",
+                "E_JWT_SIGN_FAILED",
+                "Error creating refresh token request: ${e.devMessage}",
                 e,
             )
         } catch (e: Exception) {
             Log.e(NAME, "getRefreshTokenRequestBody: Unexpected error: ${e.message}", e)
-            promise.reject("E_REFRESH_TOKEN_ERROR", "Unexpected error creating refresh token request: ${e.message}", e)
+            promise.reject("E_JWT_SIGN_FAILED", "Unexpected error creating refresh token request: ${e.message}", e)
         }
     }
 
@@ -1203,13 +1198,13 @@ class BcscCoreModule(
         } catch (e: BcscException) {
             Log.e(NAME, "signPairingCode: BCSC signing error: ${e.devMessage}", e)
             promise.reject(
-                "E_BCSC_SIGNING_ERROR",
-                "Error signing pairing code with bcsc-keypair-port: ${e.devMessage}",
+                "E_JWT_SIGN_FAILED",
+                "Error signing pairing code: ${e.devMessage}",
                 e,
             )
         } catch (e: Exception) {
             Log.e(NAME, "signPairingCode: Unexpected error: ${e.message}", e)
-            promise.reject("E_SIGNING_ERROR", "Unexpected error signing pairing code: ${e.message}", e)
+            promise.reject("E_JWT_SIGN_FAILED", "Unexpected error signing pairing code: ${e.message}", e)
         }
     }
 
@@ -1462,13 +1457,13 @@ class BcscCoreModule(
         } catch (e: BcscException) {
             Log.e(NAME, "createPreVerificationJWT: BCSC signing error: ${e.devMessage}", e)
             promise.reject(
-                "E_BCSC_EVIDENCE_JWT_ERROR",
-                "Error creating pre-verification JWT with bcsc-keypair-port: ${e.devMessage}",
+                "E_JWT_SIGN_FAILED",
+                "Error creating pre-verification JWT: ${e.devMessage}",
                 e,
             )
         } catch (e: Exception) {
             Log.e(NAME, "createPreVerificationJWT: Unexpected error: ${e.message}", e)
-            promise.reject("E_EVIDENCE_JWT_ERROR", "Unexpected error creating pre-verification JWT: ${e.message}", e)
+            promise.reject("E_JWT_SIGN_FAILED", "Unexpected error creating pre-verification JWT: ${e.message}", e)
         }
     }
 
@@ -1498,10 +1493,10 @@ class BcscCoreModule(
             promise.resolve(signedJWT)
         } catch (e: BcscException) {
             Log.e(NAME, "createSignedJWT: BCSC signing error: ${e.devMessage}", e)
-            promise.reject("E_BCSC_CREATE_JWT_ERROR", "Error creating JWT with bcsc-keypair-port: ${e.devMessage}", e)
+            promise.reject("E_JWT_SIGN_FAILED", "Error creating signed JWT: ${e.devMessage}", e)
         } catch (e: Exception) {
             Log.e(NAME, "createSignedJWT: Unexpected error: ${e.message}", e)
-            promise.reject("E_BCSC_CREATE_JWT_ERROR", "Unexpected error creating JWT: ${e.message}", e)
+            promise.reject("E_JWT_SIGN_FAILED", "Unexpected error creating signed JWT: ${e.message}", e)
         }
     }
 
@@ -1683,10 +1678,10 @@ class BcscCoreModule(
             promise.resolve(encryptedJWT)
         } catch (e: BcscException) {
             Log.e(NAME, "createQuickLoginJWT: BCSC error: ${e.devMessage}", e)
-            promise.reject("E_BCSC_QUICK_LOGIN_ERROR", "Error creating quick login JWT: ${e.devMessage}", e)
+            promise.reject("E_JWT_SIGN_FAILED", "Error creating quick login JWT: ${e.devMessage}", e)
         } catch (e: Exception) {
             Log.e(NAME, "createQuickLoginJWT: Unexpected error: ${e.message}", e)
-            promise.reject("E_QUICK_LOGIN_ERROR", "Unexpected error creating quick login JWT: ${e.message}", e)
+            promise.reject("E_JWT_SIGN_FAILED", "Unexpected error creating quick login JWT: ${e.message}", e)
         }
     }
 
@@ -2142,7 +2137,7 @@ class BcscCoreModule(
             promise.resolve(result)
         } catch (e: Exception) {
             Log.e(NAME, "setPIN error: ${e.message}", e)
-            promise.reject("E_SET_PIN_ERROR", "Error setting PIN: ${e.message}", e)
+            promise.reject("E_SET_PIN_FAILED", "Error setting PIN: ${e.message}", e)
         }
     }
 
@@ -2267,7 +2262,7 @@ class BcscCoreModule(
             promise.resolve(true)
         } catch (e: Exception) {
             Log.e(NAME, "deletePIN error: ${e.message}", e)
-            promise.reject("E_DELETE_PIN_ERROR", "Error deleting PIN: ${e.message}", e)
+            promise.reject("E_DELETE_PIN_FAILED", "Error deleting PIN: ${e.message}", e)
         }
     }
 

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -644,7 +644,8 @@ class BcscCoreModule(
             // Get the account to obtain issuer and account ID
             val account = getAccountSync()
             if (account == null) {
-                promise.reject("E_ACCOUNT_NOT_FOUND", "Account not found")
+                // No account means no tokens to delete — treat as success (idempotent)
+                promise.resolve(true)
                 return
             }
 
@@ -652,7 +653,8 @@ class BcscCoreModule(
             val issuer = account.getString("issuer")
 
             if (accountId.isNullOrEmpty() || issuer.isNullOrEmpty()) {
-                promise.reject("E_ACCOUNT_NOT_FOUND", "Account ID or issuer is null or empty")
+                // No valid account, nothing to delete — treat as success (idempotent)
+                promise.resolve(true)
                 return
             }
 

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -169,7 +169,7 @@ class BcscCore: NSObject {
       return try jwt.serialize()
     } catch {
       reject(
-        "E_JWT_SIGN_SERIALIZE_FAILED",
+        "E_JWT_SIGN_FAILED",
         "Failed to sign or serialize JWT: \(error.localizedDescription)", error
       )
       return nil
@@ -199,21 +199,25 @@ class BcscCore: NSObject {
   // MARK: - Public Methods
 
   func getAllKeys(
-    _ resolve: @escaping RCTPromiseResolveBlock, reject _: @escaping RCTPromiseRejectBlock
+    _ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock
   ) {
-    let keyPairManager = KeyPairManager()
-    let keys = keyPairManager.findAllPrivateKeys()
+    do {
+      let keyPairManager = KeyPairManager()
+      let keys = keyPairManager.findAllPrivateKeys()
 
-    let result = keys.map { keyInfo -> [String: Any] in
-      return [
-        "keyType": keyInfo.keyType.name,
-        "keySize": keyInfo.keySize,
-        "id": keyInfo.tag,
-        "created": keyInfo.created.timeIntervalSince1970, // Convert Date to timestamp
-      ]
+      let result = keys.map { keyInfo -> [String: Any] in
+        return [
+          "keyType": keyInfo.keyType.name,
+          "keySize": keyInfo.keySize,
+          "id": keyInfo.tag,
+          "created": keyInfo.created.timeIntervalSince1970,
+        ]
+      }
+
+      resolve(result)
+    } catch {
+      reject("E_KEYSTORE_ERROR", "Error accessing keystore: \(error.localizedDescription)", error)
     }
-
-    resolve(result)
   }
 
   func getKeyPair(
@@ -230,7 +234,7 @@ class BcscCore: NSObject {
         // Handle error, maybe reject the promise
         let nsError = error!.takeRetainedValue() as Error
         reject(
-          "E_KEY_EXPORT", "Failed to export public key: \(nsError.localizedDescription)", nsError
+          "E_KEY_EXPORT_FAILED", "Failed to export public key: \(nsError.localizedDescription)", nsError
         )
 
         return
@@ -241,7 +245,7 @@ class BcscCore: NSObject {
         // Handle error, maybe reject the promise
         let nsError = error!.takeRetainedValue() as Error
         reject(
-          "E_KEY_EXPORT", "Failed to export private key: \(nsError.localizedDescription)", nsError
+          "E_KEY_EXPORT_FAILED", "Failed to export private key: \(nsError.localizedDescription)", nsError
         )
 
         return
@@ -257,7 +261,7 @@ class BcscCore: NSObject {
     } catch KeychainError.keyNotExists {
       reject("E_KEY_NOT_FOUND", "Key pair with label '\(label)' not found.", nil)
     } catch {
-      reject("E_UNKNOWN", "An unexpected error occurred: \(error.localizedDescription)", error)
+      reject("E_KEY_ERROR", "An unexpected error occurred: \(error.localizedDescription)", error)
     }
   }
 

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -199,25 +199,21 @@ class BcscCore: NSObject {
   // MARK: - Public Methods
 
   func getAllKeys(
-    _ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock
+    _ resolve: @escaping RCTPromiseResolveBlock, reject _: @escaping RCTPromiseRejectBlock
   ) {
-    do {
-      let keyPairManager = KeyPairManager()
-      let keys = keyPairManager.findAllPrivateKeys()
+    let keyPairManager = KeyPairManager()
+    let keys = keyPairManager.findAllPrivateKeys()
 
-      let result = keys.map { keyInfo -> [String: Any] in
-        return [
-          "keyType": keyInfo.keyType.name,
-          "keySize": keyInfo.keySize,
-          "id": keyInfo.tag,
-          "created": keyInfo.created.timeIntervalSince1970,
-        ]
-      }
-
-      resolve(result)
-    } catch {
-      reject("E_KEYSTORE_ERROR", "Error accessing keystore: \(error.localizedDescription)", error)
+    let result = keys.map { keyInfo -> [String: Any] in
+      return [
+        "keyType": keyInfo.keyType.name,
+        "keySize": keyInfo.keySize,
+        "id": keyInfo.tag,
+        "created": keyInfo.created.timeIntervalSince1970,
+      ]
     }
+
+    resolve(result)
   }
 
   func getKeyPair(

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -441,7 +441,8 @@ class BcscCore: NSObject {
     )
 
     guard let currentAccount = account else {
-      reject("E_ACCOUNT_NOT_FOUND", "Account or clientID not found.", nil)
+      // No account means no tokens to delete — treat as success (idempotent)
+      resolve(true)
       return
     }
 

--- a/packages/bcsc-core/ios/PINService.swift
+++ b/packages/bcsc-core/ios/PINService.swift
@@ -75,8 +75,6 @@ struct PINService: PINServiceProtocol {
       if let error = keychainService.deleteSecret(secretID) {
         throw error
       }
-    } else {
-      throw PINKeychainServiceError.secretNotFound
     }
   }
 

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -40,7 +40,7 @@ export const BcscNativeErrorCodes = {
   /** Error creating device info JWT during client registration (error 120-6) */
   JWT_DEVICE_INFO_ERROR: 'E_120_JWT_DEVICE_INFO_ERROR',
 
-  // --- Shared error codes (aligned across iOS and Android) ---
+  // --- Native error codes (see per-entry docs for platform availability) ---
 
   // Account / Token
   /** Account not found in native storage */

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -26,6 +26,7 @@ export type {
  * Access via `error.code` on caught native module errors.
  */
 export const BcscNativeErrorCodes = {
+  // --- DCR error codes (E_120_* series) ---
   /** toJSON method failed while serializing dynamic client registration body (error 120-1) */
   TOJSON_METHOD_FAILURE: 'E_120_TOJSON_METHOD_FAILURE',
   /** toJSONString method failed while serializing device info JWT (error 120-2) */
@@ -38,6 +39,48 @@ export const BcscNativeErrorCodes = {
   KEYCHAIN_KEY_GENERATION_ERROR: 'E_120_KEYCHAIN_KEY_GENERATION_ERROR',
   /** Error creating device info JWT during client registration (error 120-6) */
   JWT_DEVICE_INFO_ERROR: 'E_120_JWT_DEVICE_INFO_ERROR',
+
+  // --- Shared error codes (aligned across iOS and Android) ---
+
+  // Account / Token
+  /** Account not found in native storage */
+  ACCOUNT_NOT_FOUND: 'E_ACCOUNT_NOT_FOUND',
+  /** Invalid token type passed to native module */
+  INVALID_TOKEN_TYPE: 'E_INVALID_TOKEN_TYPE',
+  /** Error deleting a token from native storage */
+  TOKEN_DELETE_ERROR: 'E_TOKEN_DELETE_ERROR',
+
+  // Key operations
+  /** Key pair not found for the given label */
+  KEY_NOT_FOUND: 'E_KEY_NOT_FOUND',
+  /** Failed to export or retrieve key material */
+  KEY_EXPORT_FAILED: 'E_KEY_EXPORT_FAILED',
+  /** Unexpected error during key operations */
+  KEY_ERROR: 'E_KEY_ERROR',
+  /** Android KeyStore is not available on this device (Android-only) */
+  KEYSTORE_UNAVAILABLE: 'E_KEYSTORE_UNAVAILABLE',
+  /** Error accessing the platform keystore */
+  KEYSTORE_ERROR: 'E_KEYSTORE_ERROR',
+
+  // JWT / Signing
+  /** Device UUID not available (iOS-only) */
+  UUID_NOT_FOUND: 'E_UUID_NOT_FOUND',
+  /** No signing keys available */
+  NO_KEYS_FOUND: 'E_NO_KEYS_FOUND',
+  /** Key pair exists but could not be loaded */
+  KEYPAIR_RETRIEVAL_FAILED: 'E_KEYPAIR_RETRIEVAL_FAILED',
+  /** JWT signing or serialization failed */
+  JWT_SIGN_FAILED: 'E_JWT_SIGN_FAILED',
+
+  // PIN
+  /** Invalid parameters passed to a PIN operation */
+  INVALID_PARAMETERS: 'E_INVALID_PARAMETERS',
+  /** Failed to set PIN */
+  SET_PIN_FAILED: 'E_SET_PIN_FAILED',
+  /** Failed to delete PIN */
+  DELETE_PIN_FAILED: 'E_DELETE_PIN_FAILED',
+
+  // Parsing
   /** JSON serialization failed in the native module */
   JSON_SERIALIZATION_FAILED: 'E_JSON_SERIALIZATION_FAILED',
   /** JWS token could not be parsed (malformed or invalid format) */


### PR DESCRIPTION
## Summary

Aligns error codes thrown by the `react-native-bcsc-core` Turbo Module so that iOS and Android reject with the same codes for the same failure conditions. Previously, several Android functions used internal/inconsistent codes or silently resolved instead of rejecting.

- `getToken()`: Android now rejects with `E_ACCOUNT_NOT_FOUND` on missing/invalid account (was silently resolving `null`)
- `deleteToken()`: Aligned to be idempotent, also, see comment below.
- `getKeyPair()`: Unified to `E_KEY_EXPORT_FAILED` / `E_KEY_ERROR` on both platforms (Android was using `E_BCSC_KEY_ERROR` / `E_UNKNOWN`)
- `getAllKeys()`: Added error handling on iOS — was silently ignoring errors; now rejects with `E_KEYSTORE_ERROR`
- JWT signing: All Android signing functions now use `E_JWT_SIGN_FAILED`; iOS renamed `E_JWT_SIGN_SERIALIZE_FAILED` → `E_JWT_SIGN_FAILED`
- PIN ops: Android renamed `E_SET_PIN_ERROR` → `E_SET_PIN_FAILED` and `E_DELETE_PIN_ERROR` → `E_DELETE_PIN_FAILED`; iOS `deletePIN` made idempotent (no longer throws if PIN not found)
- `BcscNativeErrorCodes` in TypeScript expanded with all aligned codes grouped by domain

Fixed #3398 

## Files changed

- `packages/bcsc-core/src/index.ts` — expanded `BcscNativeErrorCodes` constant
- `packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt` — error code alignment
- `packages/bcsc-core/ios/BcscCore.swift` — error code alignment + `getAllKeys` error handling
- `packages/bcsc-core/ios/PINService.swift` — idempotent `deletePIN`

##  Manual Testing

I don't think there is much to manually test. You can verify the app works as expected, go through a verification and logon to a service. Other than that you may want to visually inspect the code for:

