### PR TITLE
fix: invalid setup steps state after exiting send video verification

### DIFF
--- a/app/src/bcsc-theme/features/verify/SetupStepsScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/SetupStepsScreen.tsx
@@ -32,7 +32,6 @@ const SetupStepsScreen: React.FC<SetupStepsScreenProps> = ({ navigation }) => {
   const { t } = useTranslation()
   const { Spacing, ColorPalette, TextTheme } = useTheme()
   const [store] = useStore<BCState>()
-
   const { steps, stepActions, isCheckingStatus, handleCheckStatus, handleCancelVerification } =
     useSetupStepsModel(navigation)
 
@@ -210,7 +209,7 @@ const SetupStepsScreen: React.FC<SetupStepsScreenProps> = ({ navigation }) => {
     <ScreenWrapper padded={false} edges={['bottom', 'left', 'right']}>
       {accountType === AccountSetupType.AddAccount ? renderAddAccountSteps() : renderTransferAccountSteps()}
 
-      {store.bcscSecure.userSubmittedVerificationVideo || store.bcscSecure.verificationRequestId ? (
+      {store.bcscSecure.userSubmittedVerificationVideo ? (
         <>
           <View style={styles.itemSeparator} />
           <TouchableOpacity
@@ -230,7 +229,7 @@ const SetupStepsScreen: React.FC<SetupStepsScreenProps> = ({ navigation }) => {
               {t('BCSC.Steps.CheckStatus')}
             </ThemedText>
             {isCheckingStatus ? (
-              <ActivityIndicator color={ColorPalette.brand.text} />
+              <ActivityIndicator color={ColorPalette.brand.text} size={32} />
             ) : (
               <Icon name={'chevron-right'} color={ColorPalette.brand.text} size={32} />
             )}

--- a/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx
@@ -5,7 +5,7 @@ import { useRegistrationService } from '@/bcsc-theme/services/hooks/useRegistrat
 import { isUserVerified } from '@/bcsc-theme/utils/bcsc-credential'
 import { useAlerts } from '@/hooks/useAlerts'
 import { useSetupSteps } from '@/hooks/useSetupSteps'
-import { BCState } from '@/store'
+import { BCDispatchAction, BCState } from '@/store'
 import { BCSCScreens, BCSCVerifyStackParams } from '@bcsc-theme/types/navigators'
 import { TOKENS, useServices, useStore } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -22,7 +22,7 @@ import { BCSCCardProcess } from 'react-native-bcsc-core'
  */
 const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParams>) => {
   const { t } = useTranslation()
-  const [store] = useStore<BCState>()
+  const [store, dispatch] = useStore<BCState>()
   const { updateVerificationRequest, updateAccountFlags, deleteVerificationData, clearSecureState } = useSecureActions()
   const { evidence, token } = useApi()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
@@ -141,6 +141,8 @@ const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParam
       } finally {
         // Clear verification request from secure state
         updateVerificationRequest(null, null)
+        dispatch({ type: BCDispatchAction.RESET_SEND_VIDEO })
+        dispatch({ type: BCDispatchAction.UPDATE_VIDEO_PROMPTS, payload: [undefined] })
         await updateAccountFlags({
           userSubmittedVerificationVideo: false,
         })
@@ -153,6 +155,7 @@ const useSetupStepsModel = (navigation: StackNavigationProp<BCSCVerifyStackParam
     evidence,
     logger,
     updateVerificationRequest,
+    dispatch,
     updateAccountFlags,
     navigation,
   ])

--- a/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.tsx
@@ -25,7 +25,21 @@ const useVerificationMethodModel = ({ navigation }: useVerificationMethodModelPr
     try {
       setSendVideoLoading(true)
 
-      const { sha256, id, prompts } = await evidence.createVerificationRequest()
+      let verificationRequest
+      if (!store.bcscSecure.verificationRequestId) {
+        // NOTE: Making this request too many times will be rate limited by the server.
+        verificationRequest = await evidence.createVerificationRequest()
+      }
+
+      if (store.bcscSecure.verificationRequestId && !store.bcsc.prompts) {
+        // NOTE: Making this request too many times will be rate limited by the server.
+        verificationRequest = await evidence.getVerificationRequestPrompts(store.bcscSecure.verificationRequestId)
+      }
+
+      if (verificationRequest) {
+        updateVerificationRequest(verificationRequest.id, verificationRequest.sha256)
+        dispatch({ type: BCDispatchAction.UPDATE_VIDEO_PROMPTS, payload: [verificationRequest.prompts] })
+      }
 
       await Promise.allSettled([
         removeFileSafely(store.bcsc.videoPath, logger),
@@ -36,8 +50,6 @@ const useVerificationMethodModel = ({ navigation }: useVerificationMethodModelPr
       VerificationVideoCache.clearCache()
 
       dispatch({ type: BCDispatchAction.RESET_SEND_VIDEO })
-      updateVerificationRequest(id, sha256)
-      dispatch({ type: BCDispatchAction.UPDATE_VIDEO_PROMPTS, payload: [prompts] })
 
       navigation.navigate(BCSCScreens.InformationRequired)
     } catch (error) {
@@ -47,14 +59,16 @@ const useVerificationMethodModel = ({ navigation }: useVerificationMethodModelPr
       setSendVideoLoading(false)
     }
   }, [
-    updateVerificationRequest,
-    dispatch,
-    evidence,
-    logger,
-    navigation,
-    store.bcsc.photoPath,
+    store.bcscSecure.verificationRequestId,
+    store.bcsc.prompts,
     store.bcsc.videoPath,
+    store.bcsc.photoPath,
     store.bcsc.videoThumbnailPath,
+    logger,
+    dispatch,
+    navigation,
+    evidence,
+    updateVerificationRequest,
   ])
 
   const handlePressLiveCall = useCallback(async () => {

--- a/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.test.tsx
@@ -15,6 +15,15 @@ jest.mock('react-native-vision-camera', () => ({
   CameraRuntimeError: class extends Error {},
 }))
 
+const storeWithPrompts = {
+  bcsc: {
+    prompts: [
+      { id: 1, prompt: 'Say your name' },
+      { id: 2, prompt: 'Show your face' },
+    ],
+  },
+} as any
+
 describe('TakeVideoScreen', () => {
   beforeEach(() => {
     jest.useFakeTimers()
@@ -28,7 +37,7 @@ describe('TakeVideoScreen', () => {
   test('renders correctly', () => {
     const navigation = useNavigation()
     const tree = render(
-      <BasicAppContext>
+      <BasicAppContext initialStateOverride={storeWithPrompts}>
         <TakeVideoScreen navigation={navigation as never} />
       </BasicAppContext>
     )
@@ -42,7 +51,7 @@ describe('TakeVideoScreen', () => {
 
     const navigation = useNavigation()
     const { getByText } = render(
-      <BasicAppContext>
+      <BasicAppContext initialStateOverride={storeWithPrompts}>
         <TakeVideoScreen navigation={navigation as never} />
       </BasicAppContext>
     )
@@ -61,7 +70,7 @@ describe('TakeVideoScreen', () => {
 
     const navigation = useNavigation()
     const { getByText } = render(
-      <BasicAppContext>
+      <BasicAppContext initialStateOverride={storeWithPrompts}>
         <BCSCLoadingProvider>
           <TakeVideoScreen navigation={navigation as never} />
         </BCSCLoadingProvider>

--- a/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.tsx
@@ -72,6 +72,11 @@ const TakeVideoScreen = ({ navigation }: TakeVideoScreenProps) => {
     return currentIndex >= prompts.length - 1
   }, [prompts, prompt])
 
+  if (!prompts.length) {
+    // Developer error - prompts must be persisted before reaching this screen.
+    throw new Error('[TakeVideoScreen] No prompts found in store')
+  }
+
   const styles = useMemo(
     () =>
       StyleSheet.create({

--- a/app/src/store.tsx
+++ b/app/src/store.tsx
@@ -516,7 +516,7 @@ const bcReducer = (state: BCState, action: ReducerAction<BCDispatchAction>): BCS
       return newState
     }
     case BCSCDispatchAction.UPDATE_VIDEO_PROMPTS: {
-      const prompts: VerificationPrompt[] = (action?.payload || []).pop()
+      const prompts: VerificationPrompt[] = (action?.payload || []).pop() ?? []
       const bcsc = { ...state.bcsc, prompts }
       const newState = { ...state, bcsc }
       return newState
@@ -547,7 +547,6 @@ const bcReducer = (state: BCState, action: ReducerAction<BCDispatchAction>): BCS
         videoPath: undefined,
         videoDuration: undefined,
         videoThumbnailPath: undefined,
-        prompts: undefined,
       }
       const newState = { ...state, bcsc }
       return newState


### PR DESCRIPTION
# Summary of Changes

Fixes invalid state on the setup steps screen after a user exits the send-video verification flow. The "Check status" / "Choose another way" buttons were appearing incorrectly because state wasn't properly cleaned up.

Impacts — Behavioral change: verification requests are no longer re-created when re-entering the send-video flow, reducing rate-limit risk. Prompts survive RESET_SEND_VIDEO and are only cleared on explicit cancel.
  
# Testing Instructions

Replace this text with detailed instructions on how to test the changes included in this PR.

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
