### PR TITLE
fix(bcsc-core): create error helpers and wire call sites

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useUserApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useUserApi.tsx
@@ -1,6 +1,7 @@
 import { AppError, ErrorRegistry } from '@/errors'
+import { throwAppError } from '@bcsc-theme/utils/native-error-map'
 import { useCallback, useMemo } from 'react'
-import { BcscNativeErrorCodes, decodePayload, isBcscNativeError } from 'react-native-bcsc-core'
+import { decodePayload } from 'react-native-bcsc-core'
 import BCSCApiClient from '../client'
 import { withAccount } from './withAccountGuard'
 
@@ -43,11 +44,7 @@ const useUserApi = (apiClient: BCSCApiClient) => {
       try {
         userInfoString = await decodePayload(data)
       } catch (error) {
-        if (isBcscNativeError(error) && error.code === BcscNativeErrorCodes.FAILED_TO_PARSE_JWS) {
-          throw AppError.fromErrorDefinition(ErrorRegistry.PARSE_JWS_ERROR, { cause: error })
-        }
-
-        throw AppError.fromErrorDefinition(ErrorRegistry.DECRYPT_JWE_ERROR, { cause: error })
+        throwAppError(error, ErrorRegistry.DECRYPT_JWE_ERROR)
       }
 
       let parsed: UserInfoResponseData

--- a/app/src/bcsc-theme/api/hooks/useUserApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useUserApi.tsx
@@ -44,7 +44,7 @@ const useUserApi = (apiClient: BCSCApiClient) => {
       try {
         userInfoString = await decodePayload(data)
       } catch (error) {
-        throwAppError(error, ErrorRegistry.DECRYPT_JWE_ERROR)
+        return throwAppError(error, ErrorRegistry.DECRYPT_JWE_ERROR)
       }
 
       let parsed: UserInfoResponseData

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.test.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.test.ts
@@ -394,7 +394,7 @@ describe('FcmViewModel', () => {
       })
     })
 
-    it('logs ERR_117 and returns early when decodeLoginChallenge throws E_FAILED_TO_PARSE_JWS', async () => {
+    it('wraps decodeLoginChallenge errors as AppError with claims set fallback', async () => {
       const nativeError = Object.assign(new Error('Invalid JWS format'), { code: 'E_FAILED_TO_PARSE_JWS' })
       ;(decodeLoginChallenge as jest.Mock).mockRejectedValue(nativeError)
 
@@ -405,10 +405,11 @@ describe('FcmViewModel', () => {
 
       await capturedMessageHandler?.(message)
 
-      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('err_117_failed_to_parse_jws'))
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('err_114_failed_to_get_claims_set_after_decrypt_and_verify'),
+        expect.anything()
+      )
       expect(mockPairingService.handlePairing).not.toHaveBeenCalled()
-      // Should NOT fall through to the generic error log
-      expect(mockLogger.error).not.toHaveBeenCalledWith(expect.stringContaining('Failed to decode challenge'))
     })
   })
 

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
@@ -1,16 +1,11 @@
 import { AppError } from '@/errors/appError'
 import { ErrorRegistry } from '@/errors/errorRegistry'
+import { toAppError } from '@bcsc-theme/utils/native-error-map'
 import { AbstractBifoldLogger } from '@bifold/core'
 import { getApp } from '@react-native-firebase/app'
 import { getMessaging, getToken } from '@react-native-firebase/messaging'
 import { Platform } from 'react-native'
-import {
-  BcscNativeErrorCodes,
-  decodeLoginChallenge,
-  isBcscNativeError,
-  JWK,
-  showLocalNotification,
-} from 'react-native-bcsc-core'
+import { decodeLoginChallenge, JWK, showLocalNotification } from 'react-native-bcsc-core'
 import { Mode } from '../../../store'
 import { getBCSCApiClient } from '../../contexts/BCSCApiClientContext'
 import { isVerificationRequestReviewed } from '../../utils/id-token'
@@ -166,13 +161,7 @@ export class FcmViewModel {
         source: 'fcm',
       })
     } catch (error) {
-      if (isBcscNativeError(error) && error.code === BcscNativeErrorCodes.FAILED_TO_PARSE_JWS) {
-        const appError = AppError.fromErrorDefinition(ErrorRegistry.PARSE_JWS_ERROR, { cause: error })
-        this.logger.error(`[FcmViewModel] [${appError.appEvent}] Failed to parse JWS in challenge request`)
-        return
-      }
-
-      const appError = AppError.fromErrorDefinition(ErrorRegistry.CLAIMS_SET_ERROR, { cause: error })
+      const appError = toAppError(error, ErrorRegistry.CLAIMS_SET_ERROR)
       appError.handled = true
       const causeMessage = error instanceof Error ? error.message : String(error)
       this.logger.error(`[FcmViewModel] [${appError.appEvent}] Failed to decode challenge: ${causeMessage}`, appError)

--- a/app/src/bcsc-theme/utils/id-token.ts
+++ b/app/src/bcsc-theme/utils/id-token.ts
@@ -105,7 +105,7 @@ export async function getIdTokenMetadata(idToken: string, logger: BifoldLogger):
     payloadString = await decodePayload(idToken)
   } catch (error) {
     logger.error('[getIdTokenMetadata] Failed to decode ID token payload', error as Error)
-    throwAppError(error, ErrorRegistry.DECRYPT_VERIFY_ID_TOKEN_ERROR)
+    return throwAppError(error, ErrorRegistry.DECRYPT_VERIFY_ID_TOKEN_ERROR)
   }
 
   let payload: IdToken

--- a/app/src/bcsc-theme/utils/id-token.ts
+++ b/app/src/bcsc-theme/utils/id-token.ts
@@ -92,8 +92,7 @@ export interface IdToken {
 /**
  * Decode and parse the BCSC ID token to extract metadata.
  *
- * @throws AppError with code `ERR_117_FAILED_TO_PARSE_JWS` when the JWS token format is invalid
- * @throws AppError with code `ERR_105_UNABLE_TO_DECRYPT_AND_VERIFY_ID_TOKEN` when payload decoding fails
+ * @throws AppError with code `ERR_105_UNABLE_TO_DECRYPT_AND_VERIFY_ID_TOKEN` when payload decoding fails.
  * @throws AppError with code `ERR_109_FAILED_TO_DESERIALIZE_JSON` if JSON parsing of the payload fails.
  *
  * @param idToken - The BCSC ID token (JWE).

--- a/app/src/bcsc-theme/utils/id-token.ts
+++ b/app/src/bcsc-theme/utils/id-token.ts
@@ -2,8 +2,8 @@ import { AppError, ErrorRegistry } from '@/errors'
 import { BifoldLogger } from '@bifold/core'
 import { BCSCAccountType, BCSCCardType, decodePayload } from 'react-native-bcsc-core'
 
-import { throwAppError } from './native-error-map'
 import { StatusNotification } from '../features/fcm/services/fcm-service'
+import { throwAppError } from './native-error-map'
 
 /**
  * BCSC event types

--- a/app/src/bcsc-theme/utils/id-token.ts
+++ b/app/src/bcsc-theme/utils/id-token.ts
@@ -1,12 +1,8 @@
 import { AppError, ErrorRegistry } from '@/errors'
 import { BifoldLogger } from '@bifold/core'
-import {
-  BCSCAccountType,
-  BCSCCardType,
-  BcscNativeErrorCodes,
-  decodePayload,
-  isBcscNativeError,
-} from 'react-native-bcsc-core'
+import { BCSCAccountType, BCSCCardType, decodePayload } from 'react-native-bcsc-core'
+
+import { throwAppError } from './native-error-map'
 import { StatusNotification } from '../features/fcm/services/fcm-service'
 
 /**
@@ -110,12 +106,7 @@ export async function getIdTokenMetadata(idToken: string, logger: BifoldLogger):
     payloadString = await decodePayload(idToken)
   } catch (error) {
     logger.error('[getIdTokenMetadata] Failed to decode ID token payload', error as Error)
-
-    if (isBcscNativeError(error) && error.code === BcscNativeErrorCodes.FAILED_TO_PARSE_JWS) {
-      throw AppError.fromErrorDefinition(ErrorRegistry.PARSE_JWS_ERROR, { cause: error })
-    }
-
-    throw AppError.fromErrorDefinition(ErrorRegistry.DECRYPT_VERIFY_ID_TOKEN_ERROR, { cause: error })
+    throwAppError(error, ErrorRegistry.DECRYPT_VERIFY_ID_TOKEN_ERROR)
   }
 
   let payload: IdToken

--- a/app/src/bcsc-theme/utils/native-error-map.test.ts
+++ b/app/src/bcsc-theme/utils/native-error-map.test.ts
@@ -1,0 +1,72 @@
+import { AppError } from '@/errors/appError'
+import { ErrorRegistry } from '@/errors/errorRegistry'
+
+import { toAppError, throwAppError } from './native-error-map'
+
+jest.mock('react-native', () => ({
+  DeviceEventEmitter: { emit: jest.fn() },
+  Platform: { OS: 'ios', select: jest.fn((obj: Record<string, unknown>) => obj.ios ?? obj.default) },
+}))
+
+jest.mock('@bifold/core', () => ({
+  BifoldError: class BifoldError extends Error {},
+}))
+
+jest.mock('@/utils/logger', () => ({
+  appLogger: { error: jest.fn(), warn: jest.fn(), debug: jest.fn(), info: jest.fn() },
+}))
+
+jest.mock('@/utils/analytics/analytics-singleton', () => ({
+  Analytics: { trackErrorEvent: jest.fn() },
+}))
+
+jest.mock('i18next', () => ({
+  t: jest.fn((key: string) => key),
+}))
+
+describe('native-error-map', () => {
+  describe('toAppError', () => {
+    it('wraps an Error as AppError with the given definition', () => {
+      const error = new Error('something broke')
+      const result = toAppError(error, ErrorRegistry.STORAGE_WRITE_ERROR)
+
+      expect(result).toBeInstanceOf(AppError)
+      expect(result.appEvent).toBe(ErrorRegistry.STORAGE_WRITE_ERROR.appEvent)
+      expect(result.cause).toBe(error)
+    })
+
+    it('wraps a non-Error value as AppError', () => {
+      const result = toAppError('string error', ErrorRegistry.CLAIMS_SET_ERROR)
+
+      expect(result).toBeInstanceOf(AppError)
+      expect(result.appEvent).toBe(ErrorRegistry.CLAIMS_SET_ERROR.appEvent)
+    })
+
+    it('preserves the category from the definition', () => {
+      const error = new Error('test')
+      const result = toAppError(error, ErrorRegistry.DEVICE_AUTHORIZATION_ERROR)
+
+      expect(result.code).toContain('device')
+    })
+  })
+
+  describe('throwAppError', () => {
+    it('throws an AppError with the given definition', () => {
+      const error = new Error('native failure')
+
+      expect(() => throwAppError(error, ErrorRegistry.DECRYPT_JWE_ERROR)).toThrow(AppError)
+
+      try {
+        throwAppError(error, ErrorRegistry.DECRYPT_JWE_ERROR)
+      } catch (thrown) {
+        expect(thrown).toBeInstanceOf(AppError)
+        expect((thrown as AppError).appEvent).toBe(ErrorRegistry.DECRYPT_JWE_ERROR.appEvent)
+        expect((thrown as AppError).cause).toBe(error)
+      }
+    })
+
+    it('throws an AppError for a non-Error value', () => {
+      expect(() => throwAppError(42, ErrorRegistry.STORAGE_READ_ERROR)).toThrow(AppError)
+    })
+  })
+})

--- a/app/src/bcsc-theme/utils/native-error-map.test.ts
+++ b/app/src/bcsc-theme/utils/native-error-map.test.ts
@@ -1,7 +1,7 @@
 import { AppError } from '@/errors/appError'
 import { ErrorRegistry } from '@/errors/errorRegistry'
 
-import { toAppError, throwAppError } from './native-error-map'
+import { throwAppError, toAppError } from './native-error-map'
 
 jest.mock('react-native', () => ({
   DeviceEventEmitter: { emit: jest.fn() },

--- a/app/src/bcsc-theme/utils/native-error-map.ts
+++ b/app/src/bcsc-theme/utils/native-error-map.ts
@@ -1,0 +1,16 @@
+import { AppError } from '@/errors'
+import { ErrorDefinition } from '@/errors/errorRegistry'
+
+/**
+ * Wraps any caught error as an AppError using the provided definition.
+ * The original error is preserved in the cause chain for debugging.
+ */
+export const toAppError = (error: unknown, definition: ErrorDefinition): AppError =>
+  AppError.fromErrorDefinition(definition, { cause: error })
+
+/**
+ * Throwing variant of {@link toAppError}.
+ */
+export const throwAppError = (error: unknown, definition: ErrorDefinition): never => {
+  throw toAppError(error, definition)
+}


### PR DESCRIPTION
## Summary

- Add `toAppError`/`throwAppError` utilities that wrap any caught error as `AppError` with a provided `ErrorDefinition`, preserving the original error in the cause chain
- Wire into the 3 call sites that had inline `isBcscNativeError` checks: `id-token.ts`, `useUserApi.tsx`, `FcmViewModel.ts`
- Remove inline `isBcscNativeError`/`BcscNativeErrorCodes` branching — the native error code is still in `cause.code` for debugging

## Test plan

Standard PR review. Mostly visual inspection of app.


Closes #3421
