### PR TITLE
fix: third party keyboard detection

### DIFF
--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -4442,16 +4442,27 @@ class BcscCoreModule(
     @ReactMethod
     override fun isThirdPartyKeyboardActive(promise: Promise) {
         try {
-            val currentInputMethod =
-                android.provider.Settings.Secure.getString(
-                    reactApplicationContext.contentResolver,
-                    android.provider.Settings.Secure.DEFAULT_INPUT_METHOD,
-                )
-            val isSystemKeyboard =
-                currentInputMethod?.contains("com.android") == true ||
-                    currentInputMethod?.contains("com.google") == true
+            val imm = reactApplicationContext.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+            if (imm == null) {
+                promise.resolve(false)
+                return
+            }
 
-            promise.resolve(!isSystemKeyboard)
+            val defaultInputMethod = android.provider.Settings.Secure.getString(
+                reactApplicationContext.contentResolver,
+                android.provider.Settings.Secure.DEFAULT_INPUT_METHOD,
+            )
+
+            for (imi in imm.enabledInputMethodList) {
+                if (imi.id == defaultInputMethod) {
+                    val appFlags = imi.serviceInfo.applicationInfo.flags
+                    val isThirdParty = (appFlags and android.content.pm.ApplicationInfo.FLAG_SYSTEM) == 0
+                    promise.resolve(isThirdParty)
+                    return
+                }
+            }
+
+            promise.resolve(false)
         } catch (e: Exception) {
             Log.e(NAME, "3rdPartyKeyboardCheck: ${e.message}", e)
             promise.resolve(false) // Default to false if any error occurs, to avoid blocking user input

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -4448,10 +4448,11 @@ class BcscCoreModule(
                 return
             }
 
-            val defaultInputMethod = android.provider.Settings.Secure.getString(
-                reactApplicationContext.contentResolver,
-                android.provider.Settings.Secure.DEFAULT_INPUT_METHOD,
-            )
+            val defaultInputMethod =
+                android.provider.Settings.Secure.getString(
+                    reactApplicationContext.contentResolver,
+                    android.provider.Settings.Secure.DEFAULT_INPUT_METHOD,
+                )
 
             for (imi in imm.enabledInputMethodList) {
                 if (imi.id == defaultInputMethod) {

--- a/packages/bcsc-core/android/src/test/java/com/bcsccore/BcscCoreModuleKeyboardTest.kt
+++ b/packages/bcsc-core/android/src/test/java/com/bcsccore/BcscCoreModuleKeyboardTest.kt
@@ -20,7 +20,6 @@ import org.junit.Before
 import org.junit.Test
 
 class BcscCoreModuleKeyboardTest {
-
     private lateinit var mockReactContext: ReactApplicationContext
     private lateinit var mockContentResolver: ContentResolver
     private lateinit var mockImm: InputMethodManager
@@ -54,12 +53,14 @@ class BcscCoreModuleKeyboardTest {
         id: String,
         isSystemApp: Boolean,
     ): InputMethodInfo {
-        val appInfo = ApplicationInfo().apply {
-            flags = if (isSystemApp) ApplicationInfo.FLAG_SYSTEM else 0
-        }
-        val serviceInfo = ServiceInfo().apply {
-            applicationInfo = appInfo
-        }
+        val appInfo =
+            ApplicationInfo().apply {
+                flags = if (isSystemApp) ApplicationInfo.FLAG_SYSTEM else 0
+            }
+        val serviceInfo =
+            ServiceInfo().apply {
+                applicationInfo = appInfo
+            }
         val imi = mockk<InputMethodInfo>()
         every { imi.id } returns id
         every { imi.serviceInfo } returns serviceInfo

--- a/packages/bcsc-core/android/src/test/java/com/bcsccore/BcscCoreModuleKeyboardTest.kt
+++ b/packages/bcsc-core/android/src/test/java/com/bcsccore/BcscCoreModuleKeyboardTest.kt
@@ -1,0 +1,200 @@
+package com.bcsccore
+
+import android.content.ContentResolver
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.ServiceInfo
+import android.provider.Settings
+import android.util.Log
+import android.view.inputmethod.InputMethodInfo
+import android.view.inputmethod.InputMethodManager
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class BcscCoreModuleKeyboardTest {
+
+    private lateinit var mockReactContext: ReactApplicationContext
+    private lateinit var mockContentResolver: ContentResolver
+    private lateinit var mockImm: InputMethodManager
+    private lateinit var mockPromise: Promise
+    private lateinit var module: BcscCoreModule
+
+    @Before
+    fun setUp() {
+        mockReactContext = mockk(relaxed = true)
+        mockContentResolver = mockk(relaxed = true)
+        mockImm = mockk(relaxed = true)
+        mockPromise = mockk(relaxed = true)
+
+        every { mockReactContext.contentResolver } returns mockContentResolver
+        every { mockReactContext.getSystemService(Context.INPUT_METHOD_SERVICE) } returns mockImm
+
+        mockkStatic(Settings.Secure::class)
+        mockkStatic(Log::class)
+        every { Log.e(any(), any(), any()) } returns 0
+
+        module = BcscCoreModule(mockReactContext)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Settings.Secure::class)
+        unmockkStatic(Log::class)
+    }
+
+    private fun createInputMethodInfo(
+        id: String,
+        isSystemApp: Boolean,
+    ): InputMethodInfo {
+        val appInfo = ApplicationInfo().apply {
+            flags = if (isSystemApp) ApplicationInfo.FLAG_SYSTEM else 0
+        }
+        val serviceInfo = ServiceInfo().apply {
+            applicationInfo = appInfo
+        }
+        val imi = mockk<InputMethodInfo>()
+        every { imi.id } returns id
+        every { imi.serviceInfo } returns serviceInfo
+        return imi
+    }
+
+    // MARK: - System keyboard detection
+
+    @Test
+    fun `resolves false for stock Android keyboard`() {
+        val gboard = createInputMethodInfo("com.google.android.inputmethod.latin/.LatinIME", isSystemApp = true)
+        every { mockImm.enabledInputMethodList } returns listOf(gboard)
+        every {
+            Settings.Secure.getString(mockContentResolver, Settings.Secure.DEFAULT_INPUT_METHOD)
+        } returns "com.google.android.inputmethod.latin/.LatinIME"
+
+        module.isThirdPartyKeyboardActive(mockPromise)
+
+        verify { mockPromise.resolve(false) }
+    }
+
+    @Test
+    fun `resolves false for Samsung keyboard`() {
+        val samsung = createInputMethodInfo("com.samsung.android.honeyboard/.HoneyBoardService", isSystemApp = true)
+        every { mockImm.enabledInputMethodList } returns listOf(samsung)
+        every {
+            Settings.Secure.getString(mockContentResolver, Settings.Secure.DEFAULT_INPUT_METHOD)
+        } returns "com.samsung.android.honeyboard/.HoneyBoardService"
+
+        module.isThirdPartyKeyboardActive(mockPromise)
+
+        verify { mockPromise.resolve(false) }
+    }
+
+    @Test
+    fun `resolves false for older Samsung keyboard`() {
+        val samsung = createInputMethodInfo("com.sec.android.inputmethod/.SamsungIME", isSystemApp = true)
+        every { mockImm.enabledInputMethodList } returns listOf(samsung)
+        every {
+            Settings.Secure.getString(mockContentResolver, Settings.Secure.DEFAULT_INPUT_METHOD)
+        } returns "com.sec.android.inputmethod/.SamsungIME"
+
+        module.isThirdPartyKeyboardActive(mockPromise)
+
+        verify { mockPromise.resolve(false) }
+    }
+
+    // MARK: - Third-party keyboard detection
+
+    @Test
+    fun `resolves true for user-installed third-party keyboard`() {
+        val swiftkey = createInputMethodInfo("com.touchtype.swiftkey/.SwiftkeyIME", isSystemApp = false)
+        every { mockImm.enabledInputMethodList } returns listOf(swiftkey)
+        every {
+            Settings.Secure.getString(mockContentResolver, Settings.Secure.DEFAULT_INPUT_METHOD)
+        } returns "com.touchtype.swiftkey/.SwiftkeyIME"
+
+        module.isThirdPartyKeyboardActive(mockPromise)
+
+        verify { mockPromise.resolve(true) }
+    }
+
+    @Test
+    fun `resolves true when third-party keyboard is active among multiple enabled`() {
+        val gboard = createInputMethodInfo("com.google.android.inputmethod.latin/.LatinIME", isSystemApp = true)
+        val swiftkey = createInputMethodInfo("com.touchtype.swiftkey/.SwiftkeyIME", isSystemApp = false)
+        every { mockImm.enabledInputMethodList } returns listOf(gboard, swiftkey)
+        every {
+            Settings.Secure.getString(mockContentResolver, Settings.Secure.DEFAULT_INPUT_METHOD)
+        } returns "com.touchtype.swiftkey/.SwiftkeyIME"
+
+        module.isThirdPartyKeyboardActive(mockPromise)
+
+        verify { mockPromise.resolve(true) }
+    }
+
+    @Test
+    fun `resolves false when system keyboard is active among multiple enabled`() {
+        val gboard = createInputMethodInfo("com.google.android.inputmethod.latin/.LatinIME", isSystemApp = true)
+        val swiftkey = createInputMethodInfo("com.touchtype.swiftkey/.SwiftkeyIME", isSystemApp = false)
+        every { mockImm.enabledInputMethodList } returns listOf(gboard, swiftkey)
+        every {
+            Settings.Secure.getString(mockContentResolver, Settings.Secure.DEFAULT_INPUT_METHOD)
+        } returns "com.google.android.inputmethod.latin/.LatinIME"
+
+        module.isThirdPartyKeyboardActive(mockPromise)
+
+        verify { mockPromise.resolve(false) }
+    }
+
+    // MARK: - Edge cases
+
+    @Test
+    fun `resolves false when InputMethodManager is null`() {
+        every { mockReactContext.getSystemService(Context.INPUT_METHOD_SERVICE) } returns null
+
+        module.isThirdPartyKeyboardActive(mockPromise)
+
+        verify { mockPromise.resolve(false) }
+    }
+
+    @Test
+    fun `resolves false when no enabled input methods match the default`() {
+        val gboard = createInputMethodInfo("com.google.android.inputmethod.latin/.LatinIME", isSystemApp = true)
+        every { mockImm.enabledInputMethodList } returns listOf(gboard)
+        every {
+            Settings.Secure.getString(mockContentResolver, Settings.Secure.DEFAULT_INPUT_METHOD)
+        } returns "com.unknown.keyboard/.UnknownIME"
+
+        module.isThirdPartyKeyboardActive(mockPromise)
+
+        verify { mockPromise.resolve(false) }
+    }
+
+    @Test
+    fun `resolves false when enabled input method list is empty`() {
+        every { mockImm.enabledInputMethodList } returns emptyList()
+        every {
+            Settings.Secure.getString(mockContentResolver, Settings.Secure.DEFAULT_INPUT_METHOD)
+        } returns "com.google.android.inputmethod.latin/.LatinIME"
+
+        module.isThirdPartyKeyboardActive(mockPromise)
+
+        verify { mockPromise.resolve(false) }
+    }
+
+    @Test
+    fun `resolves false when an exception is thrown`() {
+        every { mockImm.enabledInputMethodList } throws RuntimeException("service unavailable")
+        every {
+            Settings.Secure.getString(mockContentResolver, Settings.Secure.DEFAULT_INPUT_METHOD)
+        } returns "com.google.android.inputmethod.latin/.LatinIME"
+
+        module.isThirdPartyKeyboardActive(mockPromise)
+
+        verify { mockPromise.resolve(false) }
+    }
+}


### PR DESCRIPTION
# Summary of Changes

This PR changes the third party keyboard detection logic from an allowlist approach to a flag approach that matches the existing v3 ias-android app logic. It also includes a new native unit test suite for the method. If an error is thrown during the method, it falls back to false.

# Testing Instructions

Using a Samsung device with default keyboard, enter a text input field and notice there is no more warning about third party keyboards.

# Acceptance Criteria

Samsung (and other standard Android distributors) don't trigger the third party keyboard warning unless using a third party keyboard.

# Screenshots, videos, or gifs

N/A

# Related Issues

#3384 