### PR TITLE
fix: map E_FAILED_TO_PARSE_JWS to PARSE_JWS_ERROR in decodePayload call sites

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useUserApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useUserApi.tsx
@@ -1,7 +1,7 @@
 import { AppError, ErrorRegistry } from '@/errors'
 import { throwAppError } from '@bcsc-theme/utils/native-error-map'
 import { useCallback, useMemo } from 'react'
-import { decodePayload } from 'react-native-bcsc-core'
+import { BcscNativeErrorCodes, decodePayload, isBcscNativeError } from 'react-native-bcsc-core'
 import BCSCApiClient from '../client'
 import { withAccount } from './withAccountGuard'
 
@@ -44,6 +44,9 @@ const useUserApi = (apiClient: BCSCApiClient) => {
       try {
         userInfoString = await decodePayload(data)
       } catch (error) {
+        if (isBcscNativeError(error) && error.code === BcscNativeErrorCodes.FAILED_TO_PARSE_JWS) {
+          return throwAppError(error, ErrorRegistry.PARSE_JWS_ERROR)
+        }
         return throwAppError(error, ErrorRegistry.DECRYPT_JWE_ERROR)
       }
 

--- a/app/src/bcsc-theme/utils/id-token.ts
+++ b/app/src/bcsc-theme/utils/id-token.ts
@@ -1,6 +1,12 @@
 import { AppError, ErrorRegistry } from '@/errors'
 import { BifoldLogger } from '@bifold/core'
-import { BCSCAccountType, BcscNativeErrorCodes, BCSCCardType, decodePayload, isBcscNativeError } from 'react-native-bcsc-core'
+import {
+  BCSCAccountType,
+  BCSCCardType,
+  BcscNativeErrorCodes,
+  decodePayload,
+  isBcscNativeError,
+} from 'react-native-bcsc-core'
 
 import { StatusNotification } from '../features/fcm/services/fcm-service'
 import { throwAppError } from './native-error-map'

--- a/app/src/bcsc-theme/utils/id-token.ts
+++ b/app/src/bcsc-theme/utils/id-token.ts
@@ -1,6 +1,6 @@
 import { AppError, ErrorRegistry } from '@/errors'
 import { BifoldLogger } from '@bifold/core'
-import { BCSCAccountType, BCSCCardType, decodePayload } from 'react-native-bcsc-core'
+import { BCSCAccountType, BcscNativeErrorCodes, BCSCCardType, decodePayload, isBcscNativeError } from 'react-native-bcsc-core'
 
 import { StatusNotification } from '../features/fcm/services/fcm-service'
 import { throwAppError } from './native-error-map'
@@ -105,6 +105,9 @@ export async function getIdTokenMetadata(idToken: string, logger: BifoldLogger):
     payloadString = await decodePayload(idToken)
   } catch (error) {
     logger.error('[getIdTokenMetadata] Failed to decode ID token payload', error as Error)
+    if (isBcscNativeError(error) && error.code === BcscNativeErrorCodes.FAILED_TO_PARSE_JWS) {
+      return throwAppError(error, ErrorRegistry.PARSE_JWS_ERROR)
+    }
     return throwAppError(error, ErrorRegistry.DECRYPT_VERIFY_ID_TOKEN_ERROR)
   }
 


### PR DESCRIPTION
## Summary
- Added specific handling for `E_FAILED_TO_PARSE_JWS` native error code in `decodePayload` catch blocks
- `id-token.ts` and `useUserApi.tsx` now map this error to `ErrorRegistry.PARSE_JWS_ERROR` (ERR_117) instead of falling through to generic error definitions
- Fixes 2 failing tests that expected the specific error mapping

## Test plan
- [x] `yarn test` — all 187 suites pass (previously 2 failing)