### PR TITLE
fix: update tests to expect fallback error codes

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useUserApi.test.ts
+++ b/app/src/bcsc-theme/api/hooks/useUserApi.test.ts
@@ -6,7 +6,7 @@ import * as BcscCore from 'react-native-bcsc-core'
 
 describe('useUserApi', () => {
   describe('getUserInfo', () => {
-    it('should throw ERR_117 when decodePayload fails with E_FAILED_TO_PARSE_JWS', async () => {
+    it('should wrap native E_FAILED_TO_PARSE_JWS as DECRYPT_JWE_ERROR', async () => {
       const decodePayloadMock = jest.mocked(BcscCore).decodePayload
       const getAccountMock = jest.mocked(BcscCore).getAccount
 
@@ -26,7 +26,7 @@ describe('useUserApi', () => {
 
       await act(async () => {
         await expect(hook.result.current.getUserInfo()).rejects.toThrow(
-          AppError.fromErrorDefinition(ErrorRegistry.PARSE_JWS_ERROR, { cause: nativeError })
+          AppError.fromErrorDefinition(ErrorRegistry.DECRYPT_JWE_ERROR, { cause: nativeError })
         )
       })
     })

--- a/app/src/bcsc-theme/utils/id-token.test.ts
+++ b/app/src/bcsc-theme/utils/id-token.test.ts
@@ -24,7 +24,7 @@ describe('ID Token Utils', () => {
       expect(mockLogger.error).not.toHaveBeenCalled()
     })
 
-    it('should throw ERR_117 when native error is E_FAILED_TO_PARSE_JWS', async () => {
+    it('should wrap native E_FAILED_TO_PARSE_JWS as DECRYPT_VERIFY_ID_TOKEN_ERROR', async () => {
       const bcscCoreMock = jest.mocked(BcscCore)
 
       const mockLogger = new MockLogger()
@@ -33,7 +33,7 @@ describe('ID Token Utils', () => {
       bcscCoreMock.decodePayload = jest.fn().mockRejectedValue(nativeError)
 
       await expect(getIdTokenMetadata('token', mockLogger)).rejects.toThrow(
-        AppError.fromErrorDefinition(ErrorRegistry.PARSE_JWS_ERROR, { cause: nativeError })
+        AppError.fromErrorDefinition(ErrorRegistry.DECRYPT_VERIFY_ID_TOKEN_ERROR, { cause: nativeError })
       )
 
       expect(bcscCoreMock.decodePayload).toHaveBeenCalledWith('token')


### PR DESCRIPTION
## Summary

- Update 2 tests that were asserting ERR_117 (PARSE_JWS_ERROR) for `E_FAILED_TO_PARSE_JWS` errors
- PR #3445 simplified error handling to use call-site fallbacks instead of native-code-specific mappings, but these tests weren't updated in that PR

### Changes
- `id-token.test.ts`: expects `DECRYPT_VERIFY_ID_TOKEN_ERROR` instead of `PARSE_JWS_ERROR`
- `useUserApi.test.ts`: expects `DECRYPT_JWE_ERROR` instead of `PARSE_JWS_ERROR`

## Test plan

- [x] Both tests pass locally