### PR TITLE
fix(account-transfer): fix invalid QR code errors during BCSC device transfer

### DIFF
--- a/app/src/bcsc-theme/features/account-transfer/transferee/TransferQRScannerScreen.test.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/TransferQRScannerScreen.test.tsx
@@ -3,6 +3,11 @@ import { render } from '@testing-library/react-native'
 import React from 'react'
 import TransferQRScannerScreen from './TransferQRScannerScreen'
 
+const mockNavigation = {
+  navigate: jest.fn(),
+  dispatch: jest.fn(),
+} as any
+
 jest.mock('../../../api/hooks/useApi', () => ({
   __esModule: true,
   default: jest.fn(() => ({
@@ -33,7 +38,7 @@ describe('TransferQRScanner', () => {
   it('renders correctly', () => {
     const tree = render(
       <BasicAppContext>
-        <TransferQRScannerScreen />
+        <TransferQRScannerScreen navigation={mockNavigation} />
       </BasicAppContext>
     )
 

--- a/app/src/bcsc-theme/features/account-transfer/transferee/TransferQRScannerScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/TransferQRScannerScreen.tsx
@@ -1,63 +1,24 @@
-import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { PermissionDisabled } from '@/bcsc-theme/components/PermissionDisabled'
 import { LoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
-import { useBCSCApiClient } from '@/bcsc-theme/hooks/useBCSCApiClient'
-import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
-import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
-import { BCSC_EMAIL_NOT_PROVIDED } from '@/constants'
-import { isHandledAppError } from '@/errors/appError'
-import { useAutoRequestPermission } from '@/hooks/useAutoRequestPermission'
-import { BCState } from '@/store'
 import {
   DismissiblePopupModal,
   MaskType,
-  QrCodeScanError,
   ScanCamera,
   SVGOverlay,
   ThemedText,
-  TOKENS,
-  useServices,
-  useStore,
   useTheme,
 } from '@bifold/core'
-import { useNavigation } from '@react-navigation/native'
-import { StackNavigationProp } from '@react-navigation/stack'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, StyleSheet, View } from 'react-native'
-import { createDeviceSignedJWT, getAccount } from 'react-native-bcsc-core'
-import uuid from 'react-native-uuid'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
-import { useCameraPermission } from 'react-native-vision-camera'
+import useTransferQRScannerViewModel from './useTransferQRScannerViewModel'
 
-/**
- * The TransferQRScannerScreen component allows users to scan a QR code to transfer their account from an old verified device to a new, unverified one.
- * Successful scanning and verification will navigate the user to a success screen, then to the home screen of the app.
- *
- * This handles:
- *  - Camera permissions
- *  - QR code scanning
- *  - Device authorization (with IAS backend)
- *  - Device attestation and verification
- *  - Token retrieval and storage
- *
- * @returns {*} {React.ReactElement} The rendered TransferQRScannerScreen component.
- */
 const TransferQRScannerScreen: React.FC = () => {
-  const { deviceAttestation, authorization, token } = useApi()
-  const apiClient = useBCSCApiClient()
-  const { updateTokens } = useSecureActions()
-  const navigator = useNavigation<StackNavigationProp<BCSCVerifyStackParams>>()
-  const [store] = useStore<BCState>()
   const { ColorPalette, Spacing } = useTheme()
-  const [isLoading, setIsLoading] = useState(false)
-  const [scanError, setScanError] = useState<QrCodeScanError | null>(null)
-  const [logger] = useServices([TOKENS.UTIL_LOGGER])
-  const { hasPermission, requestPermission } = useCameraPermission()
   const { t } = useTranslation()
-  const { updateUserInfo, updateDeviceCodes } = useSecureActions()
-  const deviceCodeRef = useRef<string | undefined>(store.bcscSecure.deviceCode)
-  const registrationPromiseRef = useRef<Promise<void>>(Promise.resolve())
+  const { isLoading, isPermissionLoading, hasPermission, scanError, handleScan, dismissError } =
+    useTransferQRScannerViewModel()
 
   const styles = StyleSheet.create({
     container: {
@@ -76,118 +37,6 @@ const TransferQRScannerScreen: React.FC = () => {
     },
   })
 
-  const registerDevice = useCallback(async () => {
-    // we already have a device code, no need to authorize again
-    if (store.bcscSecure.deviceCode) {
-      deviceCodeRef.current = store.bcscSecure.deviceCode
-      return
-    }
-
-    try {
-      const deviceAuth = await authorization.authorizeDevice()
-
-      const expiresAt = new Date(Date.now() + deviceAuth.expires_in * 1000)
-
-      await updateUserInfo({
-        email: deviceAuth.verified_email || BCSC_EMAIL_NOT_PROVIDED,
-        isEmailVerified: !!deviceAuth.verified_email,
-      })
-
-      await updateDeviceCodes({
-        deviceCode: deviceAuth.device_code,
-        userCode: deviceAuth.user_code,
-        deviceCodeExpiresAt: expiresAt,
-      })
-
-      deviceCodeRef.current = deviceAuth.device_code
-    } catch (error) {
-      if (isHandledAppError(error)) {
-        return
-      }
-
-      logger.error('[TransferQRScannerScreen]: Device registration failed', { error })
-    }
-  }, [store.bcscSecure.deviceCode, authorization, updateDeviceCodes, updateUserInfo, logger])
-
-  const { isLoading: isPermissionLoading } = useAutoRequestPermission(hasPermission, requestPermission)
-
-  useEffect(() => {
-    registrationPromiseRef.current = registerDevice()
-  }, [registerDevice])
-
-  const handleScan = useCallback(
-    async (value: string) => {
-      // exit early if processing a scan already or if there's an error showing
-      if (isLoading || scanError != null) {
-        return
-      }
-
-      setIsLoading(true)
-      setScanError(null)
-
-      try {
-        // wait for device registration to complete before proceeding
-        await registrationPromiseRef.current
-
-        const account = await getAccount()
-        if (!account) {
-          throw new QrCodeScanError(t('BCSC.Scan.InvalidQrCode'), value, t('BCSC.Scan.NoAccountFound'))
-        }
-
-        // ias tokens expect times in seconds since epoch
-        const timeInSeconds = Math.floor(Date.now() / 1000)
-        const qrParts = value.split('?')
-        const oldDeviceQRToken = qrParts.length > 1 ? qrParts[1] : undefined
-        if (!oldDeviceQRToken) {
-          throw new QrCodeScanError(t('BCSC.Scan.InvalidQrCode'), value, t('BCSC.Scan.InvalidQrCode'))
-        }
-
-        const newDeviceJWT = await createDeviceSignedJWT({
-          aud: account.issuer,
-          iss: account.clientID,
-          sub: account.clientID,
-          iat: timeInSeconds,
-          exp: timeInSeconds + 60, // give this token 1 minute to live
-          jti: uuid.v4().toString(),
-        })
-
-        const deviceCode = deviceCodeRef.current
-        if (!deviceCode) {
-          throw new QrCodeScanError(t('BCSC.Scan.InvalidQrCode'), value, t('BCSC.Scan.NoDeviceCodeFound'))
-        }
-
-        // Attest: verify the new device
-        const response = await deviceAttestation.verifyAttestation({
-          client_id: account.clientID,
-          device_code: deviceCode,
-          attestation: oldDeviceQRToken,
-          client_assertion: newDeviceJWT,
-        })
-
-        if (!response) {
-          throw t('BCSC.Scan.NoAttestationResponse')
-        }
-
-        // fetch tokens for the new device
-        const deviceToken = await token.deviceToken({
-          client_id: account.clientID,
-          device_code: deviceCode,
-          client_assertion: newDeviceJWT,
-        })
-
-        apiClient.tokens = deviceToken
-        await updateTokens({ refreshToken: deviceToken.refresh_token, accessToken: deviceToken.access_token })
-
-        navigator.navigate(BCSCScreens.VerificationSuccess)
-      } catch (error) {
-        setScanError(new QrCodeScanError(t('BCSC.Scan.InvalidQrCode'), value, (error as Error)?.message))
-      } finally {
-        setIsLoading(false)
-      }
-    },
-    [deviceAttestation, t, token, isLoading, scanError, navigator, updateTokens, apiClient]
-  )
-
   if (isPermissionLoading) {
     return <LoadingScreen />
   }
@@ -199,6 +48,7 @@ const TransferQRScannerScreen: React.FC = () => {
   if (isLoading) {
     return <ActivityIndicator size={'large'} style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }} />
   }
+
   return (
     <View style={styles.container}>
       <ScanCamera handleCodeScan={handleScan} enableCameraOnError={true} error={scanError} />
@@ -214,8 +64,8 @@ const TransferQRScannerScreen: React.FC = () => {
           title={t('BCSC.Scan.ErrorDetails')}
           description={scanError.message}
           onCallToActionLabel={t('BCSC.Scan.Dismiss')}
-          onCallToActionPressed={() => setScanError(null)}
-          onDismissPressed={() => setScanError(null)}
+          onCallToActionPressed={dismissError}
+          onDismissPressed={dismissError}
         />
       )}
     </View>

--- a/app/src/bcsc-theme/features/account-transfer/transferee/TransferQRScannerScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/TransferQRScannerScreen.tsx
@@ -1,17 +1,23 @@
 import { PermissionDisabled } from '@/bcsc-theme/components/PermissionDisabled'
 import { LoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
+import { BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { DismissiblePopupModal, MaskType, ScanCamera, SVGOverlay, ThemedText, useTheme } from '@bifold/core'
+import { StackNavigationProp } from '@react-navigation/stack'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, StyleSheet, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 import useTransferQRScannerViewModel from './useTransferQRScannerViewModel'
 
-const TransferQRScannerScreen: React.FC = () => {
+type TransferQRScannerScreenProps = {
+  navigation: StackNavigationProp<BCSCVerifyStackParams>
+}
+
+const TransferQRScannerScreen: React.FC<TransferQRScannerScreenProps> = ({ navigation }) => {
   const { ColorPalette, Spacing } = useTheme()
   const { t } = useTranslation()
   const { isLoading, isPermissionLoading, hasPermission, scanError, handleScan, dismissError } =
-    useTransferQRScannerViewModel()
+    useTransferQRScannerViewModel(navigation)
 
   const styles = StyleSheet.create({
     container: {

--- a/app/src/bcsc-theme/features/account-transfer/transferee/TransferQRScannerScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/TransferQRScannerScreen.tsx
@@ -22,7 +22,7 @@ import {
 } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, StyleSheet, View } from 'react-native'
 import { createDeviceSignedJWT, getAccount } from 'react-native-bcsc-core'
@@ -56,6 +56,8 @@ const TransferQRScannerScreen: React.FC = () => {
   const { hasPermission, requestPermission } = useCameraPermission()
   const { t } = useTranslation()
   const { updateUserInfo, updateDeviceCodes } = useSecureActions()
+  const deviceCodeRef = useRef<string | undefined>(store.bcscSecure.deviceCode)
+  const registrationPromiseRef = useRef<Promise<void>>(Promise.resolve())
 
   const styles = StyleSheet.create({
     container: {
@@ -77,6 +79,7 @@ const TransferQRScannerScreen: React.FC = () => {
   const registerDevice = useCallback(async () => {
     // we already have a device code, no need to authorize again
     if (store.bcscSecure.deviceCode) {
+      deviceCodeRef.current = store.bcscSecure.deviceCode
       return
     }
 
@@ -95,6 +98,8 @@ const TransferQRScannerScreen: React.FC = () => {
         userCode: deviceAuth.user_code,
         deviceCodeExpiresAt: expiresAt,
       })
+
+      deviceCodeRef.current = deviceAuth.device_code
     } catch (error) {
       if (isHandledAppError(error)) {
         return
@@ -107,7 +112,7 @@ const TransferQRScannerScreen: React.FC = () => {
   const { isLoading: isPermissionLoading } = useAutoRequestPermission(hasPermission, requestPermission)
 
   useEffect(() => {
-    registerDevice()
+    registrationPromiseRef.current = registerDevice()
   }, [registerDevice])
 
   const handleScan = useCallback(
@@ -121,6 +126,9 @@ const TransferQRScannerScreen: React.FC = () => {
       setScanError(null)
 
       try {
+        // wait for device registration to complete before proceeding
+        await registrationPromiseRef.current
+
         const account = await getAccount()
         if (!account) {
           throw new QrCodeScanError(t('BCSC.Scan.InvalidQrCode'), value, t('BCSC.Scan.NoAccountFound'))
@@ -143,40 +151,41 @@ const TransferQRScannerScreen: React.FC = () => {
           jti: uuid.v4().toString(),
         })
 
-        if (store.bcscSecure.deviceCode) {
-          // Attest: verify the new device
-          const response = await deviceAttestation.verifyAttestation({
-            client_id: account.clientID,
-            device_code: store.bcscSecure.deviceCode,
-            attestation: oldDeviceQRToken,
-            client_assertion: newDeviceJWT,
-          })
-
-          if (!response) {
-            throw t('BCSC.Scan.NoAttestationResponse')
-          }
-
-          // fetch tokens for the new device
-          const deviceToken = await token.deviceToken({
-            client_id: account.clientID,
-            device_code: store.bcscSecure.deviceCode,
-            client_assertion: newDeviceJWT,
-          })
-
-          apiClient.tokens = deviceToken
-          await updateTokens({ refreshToken: deviceToken.refresh_token, accessToken: deviceToken.access_token })
-
-          navigator.navigate(BCSCScreens.VerificationSuccess)
-        } else {
+        const deviceCode = deviceCodeRef.current
+        if (!deviceCode) {
           throw new QrCodeScanError(t('BCSC.Scan.InvalidQrCode'), value, t('BCSC.Scan.NoDeviceCodeFound'))
         }
+
+        // Attest: verify the new device
+        const response = await deviceAttestation.verifyAttestation({
+          client_id: account.clientID,
+          device_code: deviceCode,
+          attestation: oldDeviceQRToken,
+          client_assertion: newDeviceJWT,
+        })
+
+        if (!response) {
+          throw t('BCSC.Scan.NoAttestationResponse')
+        }
+
+        // fetch tokens for the new device
+        const deviceToken = await token.deviceToken({
+          client_id: account.clientID,
+          device_code: deviceCode,
+          client_assertion: newDeviceJWT,
+        })
+
+        apiClient.tokens = deviceToken
+        await updateTokens({ refreshToken: deviceToken.refresh_token, accessToken: deviceToken.access_token })
+
+        navigator.navigate(BCSCScreens.VerificationSuccess)
       } catch (error) {
         setScanError(new QrCodeScanError(t('BCSC.Scan.InvalidQrCode'), value, (error as Error)?.message))
       } finally {
         setIsLoading(false)
       }
     },
-    [store, deviceAttestation, t, token, isLoading, scanError, navigator, updateTokens, apiClient]
+    [deviceAttestation, t, token, isLoading, scanError, navigator, updateTokens, apiClient]
   )
 
   if (isPermissionLoading) {

--- a/app/src/bcsc-theme/features/account-transfer/transferee/TransferQRScannerScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/TransferQRScannerScreen.tsx
@@ -1,13 +1,6 @@
 import { PermissionDisabled } from '@/bcsc-theme/components/PermissionDisabled'
 import { LoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
-import {
-  DismissiblePopupModal,
-  MaskType,
-  ScanCamera,
-  SVGOverlay,
-  ThemedText,
-  useTheme,
-} from '@bifold/core'
+import { DismissiblePopupModal, MaskType, ScanCamera, SVGOverlay, ThemedText, useTheme } from '@bifold/core'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, StyleSheet, View } from 'react-native'

--- a/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.test.ts
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.test.ts
@@ -4,8 +4,8 @@ import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCSCScreens } from '@/bcsc-theme/types/navigators'
 import * as Bifold from '@bifold/core'
 import { QrCodeScanError } from '@bifold/core'
-import { renderHook, act, waitFor } from '@testing-library/react-native'
-import { getAccount, createDeviceSignedJWT } from 'react-native-bcsc-core'
+import { act, renderHook, waitFor } from '@testing-library/react-native'
+import { createDeviceSignedJWT, getAccount } from 'react-native-bcsc-core'
 import useTransferQRScannerViewModel from './useTransferQRScannerViewModel'
 
 const mockAuthorizeDevice = jest.fn().mockResolvedValue(null)
@@ -111,10 +111,7 @@ describe('useTransferQRScannerViewModel', () => {
 
     it('should skip registration when device code already exists', async () => {
       const bifoldMock = jest.mocked(Bifold)
-      bifoldMock.useStore.mockReturnValue([
-        { bcscSecure: { deviceCode: 'existing-code' } } as any,
-        jest.fn(),
-      ])
+      bifoldMock.useStore.mockReturnValue([{ bcscSecure: { deviceCode: 'existing-code' } } as any, jest.fn()])
 
       renderHook(() => useTransferQRScannerViewModel(mockNavigation))
 

--- a/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.test.ts
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.test.ts
@@ -1,0 +1,283 @@
+import useApi from '@/bcsc-theme/api/hooks/useApi'
+import { useBCSCApiClient } from '@/bcsc-theme/hooks/useBCSCApiClient'
+import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
+import { BCSCScreens } from '@/bcsc-theme/types/navigators'
+import * as Bifold from '@bifold/core'
+import { QrCodeScanError } from '@bifold/core'
+import { renderHook, act, waitFor } from '@testing-library/react-native'
+import { getAccount, createDeviceSignedJWT } from 'react-native-bcsc-core'
+import useTransferQRScannerViewModel from './useTransferQRScannerViewModel'
+
+const mockAuthorizeDevice = jest.fn().mockResolvedValue(null)
+const mockVerifyAttestation = jest.fn().mockResolvedValue({ success: true })
+const mockDeviceToken = jest.fn().mockResolvedValue({
+  access_token: 'mock-access-token',
+  refresh_token: 'mock-refresh-token',
+})
+const mockUseApi = jest.mocked(useApi)
+
+const mockUpdateTokens = jest.fn()
+const mockUpdateUserInfo = jest.fn()
+const mockUpdateDeviceCodes = jest.fn()
+
+jest.mock('@/bcsc-theme/hooks/useSecureActions')
+const mockUseSecureActions = jest.mocked(useSecureActions)
+
+jest.mock('@/bcsc-theme/hooks/useBCSCApiClient')
+const mockUseBCSCApiClient = jest.mocked(useBCSCApiClient)
+
+jest.mock('@/hooks/useAutoRequestPermission', () => ({
+  useAutoRequestPermission: jest.fn(() => ({ isLoading: false })),
+}))
+
+jest.mock('@bifold/core', () => {
+  const actual = jest.requireActual('@bifold/core')
+  return {
+    ...actual,
+    useStore: jest.fn(),
+    useServices: jest.fn(),
+  }
+})
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  dispatch: jest.fn(),
+} as any
+
+const mockLogger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+}
+
+const mockApiClient = { tokens: null } as any
+
+const mockAccount = {
+  issuer: 'https://issuer.example.com',
+  clientID: 'test-client-id',
+}
+
+const mockDeviceAuth = {
+  device_code: 'test-device-code',
+  user_code: 'ABCD1234',
+  verified_email: 'test@example.com',
+  expires_in: 3600,
+}
+
+const validQrValue = 'https://example.com?mock-attestation-token'
+
+describe('useTransferQRScannerViewModel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockUseApi.mockReturnValue({
+      authorization: { authorizeDevice: mockAuthorizeDevice },
+      deviceAttestation: { verifyAttestation: mockVerifyAttestation },
+      token: { deviceToken: mockDeviceToken },
+    } as any)
+
+    mockUseSecureActions.mockReturnValue({
+      updateTokens: mockUpdateTokens,
+      updateUserInfo: mockUpdateUserInfo,
+      updateDeviceCodes: mockUpdateDeviceCodes,
+    } as any)
+
+    mockUseBCSCApiClient.mockReturnValue(mockApiClient)
+
+    const bifoldMock = jest.mocked(Bifold)
+    bifoldMock.useStore.mockReturnValue([{ bcscSecure: {} } as any, jest.fn()])
+    bifoldMock.useServices.mockReturnValue([mockLogger] as any)
+
+    jest.mocked(getAccount).mockResolvedValue(mockAccount as any)
+    jest.mocked(createDeviceSignedJWT).mockResolvedValue('mock-jwt')
+  })
+
+  describe('device registration', () => {
+    it('should register device on mount when no device code exists', async () => {
+      mockAuthorizeDevice.mockResolvedValue(mockDeviceAuth)
+
+      renderHook(() => useTransferQRScannerViewModel(mockNavigation))
+
+      await waitFor(() => {
+        expect(mockAuthorizeDevice).toHaveBeenCalled()
+        expect(mockUpdateDeviceCodes).toHaveBeenCalledWith({
+          deviceCode: mockDeviceAuth.device_code,
+          userCode: mockDeviceAuth.user_code,
+          deviceCodeExpiresAt: expect.any(Date),
+        })
+      })
+    })
+
+    it('should skip registration when device code already exists', async () => {
+      const bifoldMock = jest.mocked(Bifold)
+      bifoldMock.useStore.mockReturnValue([
+        { bcscSecure: { deviceCode: 'existing-code' } } as any,
+        jest.fn(),
+      ])
+
+      renderHook(() => useTransferQRScannerViewModel(mockNavigation))
+
+      await waitFor(() => {
+        expect(mockAuthorizeDevice).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('handleScan', () => {
+    it('should wait for device registration before processing scan', async () => {
+      let resolveRegistration: () => void
+      const registrationPromise = new Promise<typeof mockDeviceAuth>((resolve) => {
+        resolveRegistration = () => resolve(mockDeviceAuth)
+      })
+      mockAuthorizeDevice.mockReturnValue(registrationPromise)
+
+      const { result } = renderHook(() => useTransferQRScannerViewModel(mockNavigation))
+
+      // Start scan before registration completes
+      let scanPromise: Promise<void>
+      act(() => {
+        scanPromise = result.current.handleScan(validQrValue)
+      })
+
+      // Verify attestation hasn't been called yet (waiting for registration)
+      expect(mockVerifyAttestation).not.toHaveBeenCalled()
+
+      // Complete registration
+      await act(async () => {
+        resolveRegistration!()
+        await scanPromise
+      })
+
+      // Now attestation should have proceeded
+      await waitFor(() => {
+        expect(mockVerifyAttestation).toHaveBeenCalled()
+        expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.VerificationSuccess)
+      })
+    })
+
+    it('should complete full scan flow successfully', async () => {
+      mockAuthorizeDevice.mockResolvedValue(mockDeviceAuth)
+
+      const { result } = renderHook(() => useTransferQRScannerViewModel(mockNavigation))
+
+      // Wait for registration to complete
+      await waitFor(() => {
+        expect(mockAuthorizeDevice).toHaveBeenCalled()
+      })
+
+      await act(async () => {
+        await result.current.handleScan(validQrValue)
+      })
+
+      expect(mockVerifyAttestation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          client_id: mockAccount.clientID,
+          device_code: mockDeviceAuth.device_code,
+          attestation: 'mock-attestation-token',
+        })
+      )
+      expect(mockDeviceToken).toHaveBeenCalled()
+      expect(mockUpdateTokens).toHaveBeenCalledWith({
+        refreshToken: 'mock-refresh-token',
+        accessToken: 'mock-access-token',
+      })
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.VerificationSuccess)
+    })
+
+    it('should set scanError for invalid QR code without token', async () => {
+      mockAuthorizeDevice.mockResolvedValue(mockDeviceAuth)
+
+      const { result } = renderHook(() => useTransferQRScannerViewModel(mockNavigation))
+
+      await waitFor(() => {
+        expect(mockAuthorizeDevice).toHaveBeenCalled()
+      })
+
+      await act(async () => {
+        await result.current.handleScan('https://example.com')
+      })
+
+      expect(result.current.scanError).toBeInstanceOf(QrCodeScanError)
+      expect(mockVerifyAttestation).not.toHaveBeenCalled()
+    })
+
+    it('should set scanError when getAccount returns null', async () => {
+      mockAuthorizeDevice.mockResolvedValue(mockDeviceAuth)
+      jest.mocked(getAccount).mockResolvedValue(null as any)
+
+      const { result } = renderHook(() => useTransferQRScannerViewModel(mockNavigation))
+
+      await waitFor(() => {
+        expect(mockAuthorizeDevice).toHaveBeenCalled()
+      })
+
+      await act(async () => {
+        await result.current.handleScan(validQrValue)
+      })
+
+      expect(result.current.scanError).toBeInstanceOf(QrCodeScanError)
+    })
+
+    it('should preserve QrCodeScanError without re-wrapping', async () => {
+      mockAuthorizeDevice.mockResolvedValue(mockDeviceAuth)
+      jest.mocked(getAccount).mockResolvedValue(null as any)
+
+      const { result } = renderHook(() => useTransferQRScannerViewModel(mockNavigation))
+
+      await waitFor(() => {
+        expect(mockAuthorizeDevice).toHaveBeenCalled()
+      })
+
+      await act(async () => {
+        await result.current.handleScan(validQrValue)
+      })
+
+      // The error message should be the translation key, not a wrapped version
+      expect(result.current.scanError?.message).toBe('BCSC.Scan.InvalidQrCode')
+    })
+
+    it('should handle non-Error throws with String fallback', async () => {
+      mockAuthorizeDevice.mockResolvedValue(mockDeviceAuth)
+      mockVerifyAttestation.mockRejectedValue('raw string error')
+
+      const { result } = renderHook(() => useTransferQRScannerViewModel(mockNavigation))
+
+      await waitFor(() => {
+        expect(mockAuthorizeDevice).toHaveBeenCalled()
+      })
+
+      await act(async () => {
+        await result.current.handleScan(validQrValue)
+      })
+
+      expect(result.current.scanError).toBeInstanceOf(QrCodeScanError)
+      expect(result.current.scanError?.details).toBe('raw string error')
+    })
+  })
+
+  describe('dismissError', () => {
+    it('should clear scanError', async () => {
+      mockAuthorizeDevice.mockResolvedValue(mockDeviceAuth)
+      jest.mocked(getAccount).mockResolvedValue(null as any)
+
+      const { result } = renderHook(() => useTransferQRScannerViewModel(mockNavigation))
+
+      await waitFor(() => {
+        expect(mockAuthorizeDevice).toHaveBeenCalled()
+      })
+
+      await act(async () => {
+        await result.current.handleScan(validQrValue)
+      })
+
+      expect(result.current.scanError).not.toBeNull()
+
+      act(() => {
+        result.current.dismissError()
+      })
+
+      expect(result.current.scanError).toBeNull()
+    })
+  })
+})

--- a/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.ts
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.ts
@@ -1,0 +1,157 @@
+import useApi from '@/bcsc-theme/api/hooks/useApi'
+import { useBCSCApiClient } from '@/bcsc-theme/hooks/useBCSCApiClient'
+import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
+import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
+import { BCSC_EMAIL_NOT_PROVIDED } from '@/constants'
+import { isHandledAppError } from '@/errors/appError'
+import { useAutoRequestPermission } from '@/hooks/useAutoRequestPermission'
+import { BCState } from '@/store'
+import { QrCodeScanError, TOKENS, useServices, useStore } from '@bifold/core'
+import { useNavigation } from '@react-navigation/native'
+import { StackNavigationProp } from '@react-navigation/stack'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { createDeviceSignedJWT, getAccount } from 'react-native-bcsc-core'
+import uuid from 'react-native-uuid'
+import { useCameraPermission } from 'react-native-vision-camera'
+
+const useTransferQRScannerViewModel = () => {
+  const { deviceAttestation, authorization, token } = useApi()
+  const apiClient = useBCSCApiClient()
+  const { updateTokens } = useSecureActions()
+  const navigator = useNavigation<StackNavigationProp<BCSCVerifyStackParams>>()
+  const [store] = useStore<BCState>()
+  const [isLoading, setIsLoading] = useState(false)
+  const [scanError, setScanError] = useState<QrCodeScanError | null>(null)
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const { hasPermission, requestPermission } = useCameraPermission()
+  const { t } = useTranslation()
+  const { updateUserInfo, updateDeviceCodes } = useSecureActions()
+  const deviceCodeRef = useRef<string | undefined>(store.bcscSecure.deviceCode)
+  const registrationPromiseRef = useRef<Promise<void>>(Promise.resolve())
+
+  const registerDevice = useCallback(async () => {
+    // we already have a device code, no need to authorize again
+    if (store.bcscSecure.deviceCode) {
+      deviceCodeRef.current = store.bcscSecure.deviceCode
+      return
+    }
+
+    try {
+      const deviceAuth = await authorization.authorizeDevice()
+
+      const expiresAt = new Date(Date.now() + deviceAuth.expires_in * 1000)
+
+      await updateUserInfo({
+        email: deviceAuth.verified_email || BCSC_EMAIL_NOT_PROVIDED,
+        isEmailVerified: !!deviceAuth.verified_email,
+      })
+
+      await updateDeviceCodes({
+        deviceCode: deviceAuth.device_code,
+        userCode: deviceAuth.user_code,
+        deviceCodeExpiresAt: expiresAt,
+      })
+
+      deviceCodeRef.current = deviceAuth.device_code
+    } catch (error) {
+      if (isHandledAppError(error)) {
+        return
+      }
+
+      logger.error('[TransferQRScannerScreen]: Device registration failed', { error })
+    }
+  }, [store.bcscSecure.deviceCode, authorization, updateDeviceCodes, updateUserInfo, logger])
+
+  const { isLoading: isPermissionLoading } = useAutoRequestPermission(hasPermission, requestPermission)
+
+  useEffect(() => {
+    registrationPromiseRef.current = registerDevice()
+  }, [registerDevice])
+
+  const handleScan = useCallback(
+    async (value: string) => {
+      // exit early if processing a scan already or if there's an error showing
+      if (isLoading || scanError != null) {
+        return
+      }
+
+      setIsLoading(true)
+      setScanError(null)
+
+      try {
+        // wait for device registration to complete before proceeding
+        await registrationPromiseRef.current
+
+        const account = await getAccount()
+        if (!account) {
+          throw new QrCodeScanError(t('BCSC.Scan.InvalidQrCode'), value, t('BCSC.Scan.NoAccountFound'))
+        }
+
+        // ias tokens expect times in seconds since epoch
+        const timeInSeconds = Math.floor(Date.now() / 1000)
+        const qrParts = value.split('?')
+        const oldDeviceQRToken = qrParts.length > 1 ? qrParts[1] : undefined
+        if (!oldDeviceQRToken) {
+          throw new QrCodeScanError(t('BCSC.Scan.InvalidQrCode'), value, t('BCSC.Scan.InvalidQrCode'))
+        }
+
+        const newDeviceJWT = await createDeviceSignedJWT({
+          aud: account.issuer,
+          iss: account.clientID,
+          sub: account.clientID,
+          iat: timeInSeconds,
+          exp: timeInSeconds + 60, // give this token 1 minute to live
+          jti: uuid.v4().toString(),
+        })
+
+        const deviceCode = deviceCodeRef.current
+        if (!deviceCode) {
+          throw new QrCodeScanError(t('BCSC.Scan.InvalidQrCode'), value, t('BCSC.Scan.NoDeviceCodeFound'))
+        }
+
+        // Attest: verify the new device
+        const response = await deviceAttestation.verifyAttestation({
+          client_id: account.clientID,
+          device_code: deviceCode,
+          attestation: oldDeviceQRToken,
+          client_assertion: newDeviceJWT,
+        })
+
+        if (!response) {
+          throw t('BCSC.Scan.NoAttestationResponse')
+        }
+
+        // fetch tokens for the new device
+        const deviceToken = await token.deviceToken({
+          client_id: account.clientID,
+          device_code: deviceCode,
+          client_assertion: newDeviceJWT,
+        })
+
+        apiClient.tokens = deviceToken
+        await updateTokens({ refreshToken: deviceToken.refresh_token, accessToken: deviceToken.access_token })
+
+        navigator.navigate(BCSCScreens.VerificationSuccess)
+      } catch (error) {
+        setScanError(new QrCodeScanError(t('BCSC.Scan.InvalidQrCode'), value, (error as Error)?.message))
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [deviceAttestation, t, token, isLoading, scanError, navigator, updateTokens, apiClient]
+  )
+
+  const dismissError = useCallback(() => setScanError(null), [])
+
+  return {
+    isLoading,
+    isPermissionLoading,
+    hasPermission,
+    scanError,
+    handleScan,
+    dismissError,
+  }
+}
+
+export default useTransferQRScannerViewModel

--- a/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.ts
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.ts
@@ -14,9 +14,7 @@ import { createDeviceSignedJWT, getAccount } from 'react-native-bcsc-core'
 import uuid from 'react-native-uuid'
 import { useCameraPermission } from 'react-native-vision-camera'
 
-const useTransferQRScannerViewModel = (
-  navigation: StackNavigationProp<BCSCVerifyStackParams>
-) => {
+const useTransferQRScannerViewModel = (navigation: StackNavigationProp<BCSCVerifyStackParams>) => {
   const { deviceAttestation, authorization, token } = useApi()
   const apiClient = useBCSCApiClient()
   const { updateTokens, updateUserInfo, updateDeviceCodes } = useSecureActions()

--- a/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.ts
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.ts
@@ -26,6 +26,7 @@ const useTransferQRScannerViewModel = (navigation: StackNavigationProp<BCSCVerif
   const { t } = useTranslation()
   const deviceCodeRef = useRef<string | undefined>(store.bcscSecure.deviceCode)
   const registrationPromiseRef = useRef<Promise<void>>(Promise.resolve())
+  const isProcessingRef = useRef(false)
 
   const registerDevice = useCallback(async () => {
     // we already have a device code, no need to authorize again
@@ -69,10 +70,11 @@ const useTransferQRScannerViewModel = (navigation: StackNavigationProp<BCSCVerif
   const handleScan = useCallback(
     async (value: string) => {
       // exit early if processing a scan already or if there's an error showing
-      if (isLoading || scanError != null) {
+      if (isProcessingRef.current || scanError != null) {
         return
       }
 
+      isProcessingRef.current = true
       setIsLoading(true)
       setScanError(null)
 
@@ -138,10 +140,11 @@ const useTransferQRScannerViewModel = (navigation: StackNavigationProp<BCSCVerif
           setScanError(new QrCodeScanError(t('BCSC.Scan.InvalidQrCode'), value, message))
         }
       } finally {
+        isProcessingRef.current = false
         setIsLoading(false)
       }
     },
-    [deviceAttestation, t, token, isLoading, scanError, navigation, updateTokens, apiClient]
+    [deviceAttestation, t, token, scanError, navigation, updateTokens, apiClient]
   )
 
   const dismissError = useCallback(() => setScanError(null), [])

--- a/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.ts
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.ts
@@ -18,7 +18,7 @@ import { useCameraPermission } from 'react-native-vision-camera'
 const useTransferQRScannerViewModel = () => {
   const { deviceAttestation, authorization, token } = useApi()
   const apiClient = useBCSCApiClient()
-  const { updateTokens } = useSecureActions()
+  const { updateTokens, updateUserInfo, updateDeviceCodes } = useSecureActions()
   const navigator = useNavigation<StackNavigationProp<BCSCVerifyStackParams>>()
   const [store] = useStore<BCState>()
   const [isLoading, setIsLoading] = useState(false)
@@ -26,7 +26,6 @@ const useTransferQRScannerViewModel = () => {
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const { hasPermission, requestPermission } = useCameraPermission()
   const { t } = useTranslation()
-  const { updateUserInfo, updateDeviceCodes } = useSecureActions()
   const deviceCodeRef = useRef<string | undefined>(store.bcscSecure.deviceCode)
   const registrationPromiseRef = useRef<Promise<void>>(Promise.resolve())
 
@@ -119,7 +118,7 @@ const useTransferQRScannerViewModel = () => {
         })
 
         if (!response) {
-          throw t('BCSC.Scan.NoAttestationResponse')
+          throw new QrCodeScanError(t('BCSC.Scan.InvalidQrCode'), value, t('BCSC.Scan.NoAttestationResponse'))
         }
 
         // fetch tokens for the new device

--- a/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.ts
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.ts
@@ -7,7 +7,6 @@ import { isHandledAppError } from '@/errors/appError'
 import { useAutoRequestPermission } from '@/hooks/useAutoRequestPermission'
 import { BCState } from '@/store'
 import { QrCodeScanError, TOKENS, useServices, useStore } from '@bifold/core'
-import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -15,11 +14,12 @@ import { createDeviceSignedJWT, getAccount } from 'react-native-bcsc-core'
 import uuid from 'react-native-uuid'
 import { useCameraPermission } from 'react-native-vision-camera'
 
-const useTransferQRScannerViewModel = () => {
+const useTransferQRScannerViewModel = (
+  navigation: StackNavigationProp<BCSCVerifyStackParams>
+) => {
   const { deviceAttestation, authorization, token } = useApi()
   const apiClient = useBCSCApiClient()
   const { updateTokens, updateUserInfo, updateDeviceCodes } = useSecureActions()
-  const navigator = useNavigation<StackNavigationProp<BCSCVerifyStackParams>>()
   const [store] = useStore<BCState>()
   const [isLoading, setIsLoading] = useState(false)
   const [scanError, setScanError] = useState<QrCodeScanError | null>(null)
@@ -131,14 +131,19 @@ const useTransferQRScannerViewModel = () => {
         apiClient.tokens = deviceToken
         await updateTokens({ refreshToken: deviceToken.refresh_token, accessToken: deviceToken.access_token })
 
-        navigator.navigate(BCSCScreens.VerificationSuccess)
+        navigation.navigate(BCSCScreens.VerificationSuccess)
       } catch (error) {
-        setScanError(new QrCodeScanError(t('BCSC.Scan.InvalidQrCode'), value, (error as Error)?.message))
+        if (error instanceof QrCodeScanError) {
+          setScanError(error)
+        } else {
+          const message = error instanceof Error ? error.message : String(error)
+          setScanError(new QrCodeScanError(t('BCSC.Scan.InvalidQrCode'), value, message))
+        }
       } finally {
         setIsLoading(false)
       }
     },
-    [deviceAttestation, t, token, isLoading, scanError, navigator, updateTokens, apiClient]
+    [deviceAttestation, t, token, isLoading, scanError, navigation, updateTokens, apiClient]
   )
 
   const dismissError = useCallback(() => setScanError(null), [])

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -264,7 +264,7 @@ class BcscCore: NSObject {
   private func generateKeyPair() throws -> String {
     let keyPairManager = KeyPairManager()
     let keys = keyPairManager.findAllPrivateKeys()
-    let initialKeyId = "\(BcscCore.provider)/\(UUID().uuidString)/1" // Use BcscCore.provider
+    let initialKeyId = "\(BcscCore.provider)\(UUID().uuidString)/1"
 
     if let latestKeyInfo = keys.sorted(by: { $0.created > $1.created }).first {
       let existingTag = latestKeyInfo.tag
@@ -292,7 +292,7 @@ class BcscCore: NSObject {
         logger.warning(
           "generateKeyPair - Could not parse or increment existing key tag: \(existingTag). Attempting to generate a new key with a fresh initial ID pattern."
         )
-        let freshGeneratedKeyId = "\(BcscCore.provider)/\(UUID().uuidString)/1"
+        let freshGeneratedKeyId = "\(BcscCore.provider)\(UUID().uuidString)/1"
         logger.log(
           "generateKeyPair - Attempting to generate a new key with ID: \(freshGeneratedKeyId) due to parsing failure of existing key."
         )


### PR DESCRIPTION
## Summary

Fixes two distinct issues causing "Invalid QR code" errors during BCSC account transfer:

### 1. Race condition (Android — intermittent)

The camera could scan a QR code before async device registration (`authorizeDevice()`) completed, causing `deviceCode` to be `undefined` at scan time. The registration promise is now stored in a ref and awaited inside `handleScan`, so the scan blocks until registration finishes. A `deviceCodeRef` avoids stale closure reads of `store.bcscSecure.deviceCode`.

### 2. Double-slash in iOS keypair ID (iOS — 100% failure)

`generateKeyPair()` in `BcscCore.swift` constructed key IDs as `"\(provider)/\(UUID)/1"`, but `provider` already ends with `/`, producing IDs like `https://idsit.gov.bc.ca/device//UUID/1`. This `kid` was embedded in every JWT the device signed. The server normalized the URL during registration (single slash) but received JWTs with the double-slash `kid`, couldn't match the public key, and returned 400 on the attestation endpoint. The old native app used `"\(provider.issuer)\(UUID)/1"` (no extra slash) — this fix matches that behavior.

### Additional cleanup

- **MVVM refactor**: Extracted all business logic from `TransferQRScannerScreen` into `useTransferQRScannerViewModel` hook, leaving the screen as a pure view.
- **Error handling**: Fixed bare `throw t(...)` (string, not Error) that caused blank error descriptions. Catch block now passes through `QrCodeScanError` directly instead of double-wrapping. Non-Error throws use `String(error)` fallback.
- **Navigation param**: View model accepts `navigation` as parameter instead of calling `useNavigation()` internally, matching `useEnterBirthdateViewModel` pattern.
- **Deduplicated hook**: Removed double `useSecureActions()` call.

## Manual Testing

- [ ] **iOS fresh install**: Transfer account via QR scan — should succeed (previously failed 100% of the time)
- [ ] **Android**: Point camera at QR before navigating to scanner screen — should succeed without "Invalid QR code" error
- [ ] Scan an invalid or malformed QR code — error modal should show a non-blank description
- [ ] Dismiss error modal — should close cleanly and allow re-scanning
- [ ] Verify camera permission flow still works (deny then grant)
- [ ] Verify scanner works immediately when `deviceCode` already exists in secure store (no re-registration)