### PR TITLE
fix: use pexip-provided stun/turn servers

### DIFF
--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.test.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.test.ts
@@ -1,0 +1,181 @@
+import { BifoldLogger } from '@bifold/core'
+import type { Result as PexipTokenResult } from '@pexip/infinity-api/dist/token/types'
+import { buildIceServers } from './connect'
+
+const mockLogger: BifoldLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+} as unknown as BifoldLogger
+
+const baseTokenResult: PexipTokenResult = {
+  token: 'test-token',
+  expires: '120',
+  participant_uuid: 'test-uuid',
+  display_name: 'Test User',
+  role: 'GUEST',
+  current_service_type: 'conference',
+  version: {},
+}
+
+describe('buildIceServers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should fall back to Google STUN when no STUN or TURN servers provided', () => {
+    const result = buildIceServers(baseTokenResult, mockLogger)
+
+    expect(result).toEqual([{ url: 'stun:stun.l.google.com:19302' }])
+    expect(mockLogger.warn).toHaveBeenCalledWith('No ICE servers from Pexip, falling back to Google public STUN')
+  })
+
+  it('should fall back to Google STUN when stun and turn are empty arrays', () => {
+    const result = buildIceServers({ ...baseTokenResult, stun: [], turn: [] }, mockLogger)
+
+    expect(result).toEqual([{ url: 'stun:stun.l.google.com:19302' }])
+  })
+
+  it('should use STUN servers from token response', () => {
+    const result = buildIceServers({ ...baseTokenResult, stun: [{ url: 'stun:pexip.example.com:3478' }] }, mockLogger)
+
+    expect(result).toEqual([{ url: 'stun:pexip.example.com:3478' }])
+    expect(mockLogger.warn).not.toHaveBeenCalled()
+  })
+
+  it('should use multiple STUN servers', () => {
+    const result = buildIceServers(
+      {
+        ...baseTokenResult,
+        stun: [{ url: 'stun:stun1.example.com:3478' }, { url: 'stun:stun2.example.com:3478' }],
+      },
+      mockLogger
+    )
+
+    expect(result).toEqual([{ url: 'stun:stun1.example.com:3478' }, { url: 'stun:stun2.example.com:3478' }])
+  })
+
+  it('should include STUN entries with empty url (passes through from Pexip)', () => {
+    const result = buildIceServers(
+      { ...baseTokenResult, stun: [{ url: '' }, { url: 'stun:valid.com:3478' }] },
+      mockLogger
+    )
+
+    expect(result).toEqual([{ url: '' }, { url: 'stun:valid.com:3478' }])
+  })
+
+  it('should use TURN servers with credentials', () => {
+    const result = buildIceServers(
+      {
+        ...baseTokenResult,
+        turn: [
+          {
+            urls: ['turn:turn.example.com:3478?transport=udp', 'turn:turn.example.com:3478?transport=tcp'],
+            username: 'user',
+            credential: 'pass',
+          },
+        ],
+      },
+      mockLogger
+    )
+
+    expect(result).toEqual([
+      {
+        urls: ['turn:turn.example.com:3478?transport=udp', 'turn:turn.example.com:3478?transport=tcp'],
+        username: 'user',
+        credential: 'pass',
+      },
+    ])
+  })
+
+  it('should include TURN servers missing username (passes through from Pexip)', () => {
+    const result = buildIceServers(
+      {
+        ...baseTokenResult,
+        stun: [{ url: 'stun:stun.example.com:3478' }],
+        turn: [{ urls: ['turn:turn.example.com:3478'], credential: 'pass' }],
+      },
+      mockLogger
+    )
+
+    expect(result).toEqual([
+      { url: 'stun:stun.example.com:3478' },
+      { urls: ['turn:turn.example.com:3478'], credential: 'pass', username: undefined },
+    ])
+  })
+
+  it('should include TURN servers missing credential (passes through from Pexip)', () => {
+    const result = buildIceServers(
+      {
+        ...baseTokenResult,
+        stun: [{ url: 'stun:stun.example.com:3478' }],
+        turn: [{ urls: ['turn:turn.example.com:3478'], username: 'user' }],
+      },
+      mockLogger
+    )
+
+    expect(result).toEqual([
+      { url: 'stun:stun.example.com:3478' },
+      { urls: ['turn:turn.example.com:3478'], username: 'user', credential: undefined },
+    ])
+  })
+
+  it('should include TURN servers with empty string credentials (passes through from Pexip)', () => {
+    const result = buildIceServers(
+      {
+        ...baseTokenResult,
+        stun: [{ url: 'stun:stun.example.com:3478' }],
+        turn: [{ urls: ['turn:turn.example.com:3478'], username: '', credential: '' }],
+      },
+      mockLogger
+    )
+
+    expect(result).toEqual([
+      { url: 'stun:stun.example.com:3478' },
+      { urls: ['turn:turn.example.com:3478'], username: '', credential: '' },
+    ])
+  })
+
+  it('should include TURN servers with empty urls array (passes through from Pexip)', () => {
+    const result = buildIceServers(
+      {
+        ...baseTokenResult,
+        stun: [{ url: 'stun:stun.example.com:3478' }],
+        turn: [{ urls: [], username: 'user', credential: 'pass' }],
+      },
+      mockLogger
+    )
+
+    expect(result).toEqual([{ url: 'stun:stun.example.com:3478' }, { urls: [], username: 'user', credential: 'pass' }])
+  })
+
+  it('should combine STUN and TURN servers', () => {
+    const result = buildIceServers(
+      {
+        ...baseTokenResult,
+        stun: [{ url: 'stun:stun.example.com:3478' }],
+        turn: [{ urls: ['turn:turn.example.com:3478'], username: 'user', credential: 'pass' }],
+      },
+      mockLogger
+    )
+
+    expect(result).toEqual([
+      { url: 'stun:stun.example.com:3478' },
+      { urls: ['turn:turn.example.com:3478'], username: 'user', credential: 'pass' },
+    ])
+  })
+
+  it('should log the configured ICE server count', () => {
+    buildIceServers(
+      {
+        ...baseTokenResult,
+        stun: [{ url: 'stun:stun.example.com:3478' }],
+        turn: [{ urls: ['turn:turn.example.com:3478'], username: 'user', credential: 'pass' }],
+      },
+      mockLogger
+    )
+
+    expect(mockLogger.info).toHaveBeenCalledWith('ICE servers configured:', { count: 2 })
+  })
+})

--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
@@ -14,6 +14,26 @@ import { mediaDevices, MediaStream, RTCIceCandidate, RTCPeerConnection } from 'r
 import { RTCOfferOptions } from 'react-native-webrtc/lib/typescript/RTCUtil'
 import type { ConnectionRequest, ConnectResult } from '../types/live-call'
 
+interface PexipIceServerEntry {
+  url?: string
+  username?: string
+  credential?: string
+}
+
+interface PexipTokenResult {
+  token: string
+  participant_uuid: string
+  stun?: PexipIceServerEntry[]
+  turn?: PexipIceServerEntry[]
+  [key: string]: unknown
+}
+
+interface IceServer {
+  urls: string | string[]
+  username?: string
+  credential?: string
+}
+
 // WebRTC Events need handlers even if we don't do anything with some of them
 const noop = () => {}
 
@@ -41,9 +61,9 @@ export const connect = async (
     throw new Error('Cannot establish the connection. Pexip unavailable (1):', response.status)
   }
 
-  const participantUuid = response.data.result.participant_uuid
-  let currentToken = response.data.result.token
-  const tokenResult = response.data.result
+  const tokenResult: PexipTokenResult = response.data.result
+  const participantUuid = tokenResult.participant_uuid
+  let currentToken = tokenResult.token
 
   logger.info('Creating WebRTC peer connection...')
   const peerConnection: RTCPeerConnection = await createPeerConnection(localStream, tokenResult, logger)
@@ -315,13 +335,13 @@ const requestInfinityToken = async (request: ConnectionRequest): Promise<any> =>
   return response
 }
 
-const buildIceServers = (tokenResult: Record<string, any>, logger: BifoldLogger) => {
-  const iceServers: Array<{ urls: string; username?: string; credential?: string }> = []
+const buildIceServers = (tokenResult: PexipTokenResult, logger: BifoldLogger): IceServer[] => {
+  const iceServers: IceServer[] = []
 
   // Use STUN servers from Pexip token response
   if (Array.isArray(tokenResult.stun) && tokenResult.stun.length > 0) {
     for (const entry of tokenResult.stun) {
-      if (entry.url) {
+      if (entry && typeof entry.url === 'string') {
         iceServers.push({ urls: entry.url })
       }
     }
@@ -330,11 +350,21 @@ const buildIceServers = (tokenResult: Record<string, any>, logger: BifoldLogger)
   // Use TURN servers from Pexip token response
   if (Array.isArray(tokenResult.turn) && tokenResult.turn.length > 0) {
     for (const entry of tokenResult.turn) {
-      if (entry.url) {
+      if (
+        entry &&
+        typeof entry.url === 'string' &&
+        typeof entry.username === 'string' &&
+        typeof entry.credential === 'string'
+      ) {
         iceServers.push({
           urls: entry.url,
-          ...(entry.username && { username: entry.username }),
-          ...(entry.credential && { credential: entry.credential }),
+          username: entry.username,
+          credential: entry.credential,
+        })
+      } else if (entry && typeof entry.url === 'string') {
+        logger.warn('Skipping TURN server with missing username or credential', {
+          hasUsername: typeof entry.username === 'string',
+          hasCredential: typeof entry.credential === 'string',
         })
       }
     }
@@ -346,15 +376,11 @@ const buildIceServers = (tokenResult: Record<string, any>, logger: BifoldLogger)
     iceServers.push({ urls: 'stun:stun.l.google.com:19302' })
   }
 
-  logger.info('ICE servers configured:', { count: iceServers.length, urls: iceServers.map((s) => s.urls) })
+  logger.info('ICE servers configured:', { count: iceServers.length })
   return iceServers
 }
 
-const createPeerConnection = async (
-  localStream: MediaStream,
-  tokenResult: Record<string, any>,
-  logger: BifoldLogger
-) => {
+const createPeerConnection = async (localStream: MediaStream, tokenResult: PexipTokenResult, logger: BifoldLogger) => {
   const peerConstraints = {
     iceServers: buildIceServers(tokenResult, logger),
   }

--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
@@ -43,9 +43,10 @@ export const connect = async (
 
   const participantUuid = response.data.result.participant_uuid
   let currentToken = response.data.result.token
+  const tokenResult = response.data.result
 
   logger.info('Creating WebRTC peer connection...')
-  const peerConnection: RTCPeerConnection = await createPeerConnection(localStream)
+  const peerConnection: RTCPeerConnection = await createPeerConnection(localStream, tokenResult, logger)
 
   let connectionEstablished = false
   let remoteStreamReceived = false
@@ -314,14 +315,48 @@ const requestInfinityToken = async (request: ConnectionRequest): Promise<any> =>
   return response
 }
 
-const createPeerConnection = async (localStream: MediaStream) => {
+const buildIceServers = (tokenResult: Record<string, any>, logger: BifoldLogger) => {
+  const iceServers: Array<{ urls: string; username?: string; credential?: string }> = []
+
+  // Use STUN servers from Pexip token response
+  if (Array.isArray(tokenResult.stun) && tokenResult.stun.length > 0) {
+    for (const entry of tokenResult.stun) {
+      if (entry.url) {
+        iceServers.push({ urls: entry.url })
+      }
+    }
+  }
+
+  // Use TURN servers from Pexip token response
+  if (Array.isArray(tokenResult.turn) && tokenResult.turn.length > 0) {
+    for (const entry of tokenResult.turn) {
+      if (entry.url) {
+        iceServers.push({
+          urls: entry.url,
+          ...(entry.username && { username: entry.username }),
+          ...(entry.credential && { credential: entry.credential }),
+        })
+      }
+    }
+  }
+
+  // Fallback to Google public STUN if Pexip provided nothing
+  if (iceServers.length === 0) {
+    logger.warn('No ICE servers from Pexip, falling back to Google public STUN')
+    iceServers.push({ urls: 'stun:stun.l.google.com:19302' })
+  }
+
+  logger.info('ICE servers configured:', { count: iceServers.length, urls: iceServers.map((s) => s.urls) })
+  return iceServers
+}
+
+const createPeerConnection = async (
+  localStream: MediaStream,
+  tokenResult: Record<string, any>,
+  logger: BifoldLogger
+) => {
   const peerConstraints = {
-    iceServers: [
-      {
-        // TODO (bm): determine which STUN/TURN servers to use in which environments
-        urls: 'stun:stun.l.google.com:19302',
-      },
-    ],
+    iceServers: buildIceServers(tokenResult, logger),
   }
 
   const peerConnection = new RTCPeerConnection(peerConstraints)

--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
@@ -9,30 +9,13 @@ import {
   withPin,
   withToken,
 } from '@pexip/infinity-api'
+import type { Result as PexipTokenResult, Stun, Turn } from '@pexip/infinity-api/dist/token/types'
 import EventSource from 'react-native-sse'
 import { mediaDevices, MediaStream, RTCIceCandidate, RTCPeerConnection } from 'react-native-webrtc'
 import { RTCOfferOptions } from 'react-native-webrtc/lib/typescript/RTCUtil'
 import type { ConnectionRequest, ConnectResult } from '../types/live-call'
 
-interface PexipIceServerEntry {
-  url?: string
-  username?: string
-  credential?: string
-}
-
-interface PexipTokenResult {
-  token: string
-  participant_uuid: string
-  stun?: PexipIceServerEntry[]
-  turn?: PexipIceServerEntry[]
-  [key: string]: unknown
-}
-
-interface IceServer {
-  urls: string | string[]
-  username?: string
-  credential?: string
-}
+type IceServer = Stun | Turn
 
 // WebRTC Events need handlers even if we don't do anything with some of them
 const noop = () => {}
@@ -335,45 +318,31 @@ const requestInfinityToken = async (request: ConnectionRequest): Promise<any> =>
   return response
 }
 
-const buildIceServers = (tokenResult: PexipTokenResult, logger: BifoldLogger): IceServer[] => {
+export const buildIceServers = (tokenResult: PexipTokenResult, logger: BifoldLogger): IceServer[] => {
   const iceServers: IceServer[] = []
 
   // Use STUN servers from Pexip token response
-  if (Array.isArray(tokenResult.stun) && tokenResult.stun.length > 0) {
+  if (tokenResult.stun?.length) {
     for (const entry of tokenResult.stun) {
-      if (entry && typeof entry.url === 'string') {
-        iceServers.push({ urls: entry.url })
-      }
+      iceServers.push({ url: entry.url })
     }
   }
 
   // Use TURN servers from Pexip token response
-  if (Array.isArray(tokenResult.turn) && tokenResult.turn.length > 0) {
+  if (tokenResult.turn?.length) {
     for (const entry of tokenResult.turn) {
-      if (
-        entry &&
-        typeof entry.url === 'string' &&
-        typeof entry.username === 'string' &&
-        typeof entry.credential === 'string'
-      ) {
-        iceServers.push({
-          urls: entry.url,
-          username: entry.username,
-          credential: entry.credential,
-        })
-      } else if (entry && typeof entry.url === 'string') {
-        logger.warn('Skipping TURN server with missing username or credential', {
-          hasUsername: typeof entry.username === 'string',
-          hasCredential: typeof entry.credential === 'string',
-        })
-      }
+      iceServers.push({
+        urls: entry.urls,
+        username: entry.username,
+        credential: entry.credential,
+      })
     }
   }
 
   // Fallback to Google public STUN if Pexip provided nothing
   if (iceServers.length === 0) {
     logger.warn('No ICE servers from Pexip, falling back to Google public STUN')
-    iceServers.push({ urls: 'stun:stun.l.google.com:19302' })
+    iceServers.push({ url: 'stun:stun.l.google.com:19302' })
   }
 
   logger.info('ICE servers configured:', { count: iceServers.length })


### PR DESCRIPTION
# Summary of Changes

This PR ensures we use the Pexip provided STUN / TURN servers, falling back to the public one we were already using. Under the hood, the Pexip conference actually happens to use the same STUN server we were already hardcoding, but now if Pexip changes that, it will already be handled.

# Testing Instructions

Do a live call, you still connect to the queue

# Acceptance Criteria

Live call still works

# Screenshots, videos, or gifs

N/A

# Related Issues

#3426 