### PR TITLE
fix: navigate to CancelledReview on cancelled verification push notification

### DIFF
--- a/app/src/bcsc-theme/features/verification-response/useVerificationResponseListener.test.tsx
+++ b/app/src/bcsc-theme/features/verification-response/useVerificationResponseListener.test.tsx
@@ -190,6 +190,7 @@ describe('useVerificationResponseListener', () => {
           params: { agentReason: undefined },
         })
       })
+      expect(mockDispatch).toHaveBeenCalled()
       expect(mockCheckDeviceCodeStatus).not.toHaveBeenCalled()
     })
 

--- a/app/src/bcsc-theme/features/verification-response/useVerificationResponseListener.test.tsx
+++ b/app/src/bcsc-theme/features/verification-response/useVerificationResponseListener.test.tsx
@@ -13,6 +13,7 @@ jest.mock('@react-navigation/native', () => ({
   })),
   CommonActions: {
     reset: jest.fn((config) => ({ type: 'RESET', payload: config })),
+    navigate: jest.fn((config) => ({ type: 'NAVIGATE', payload: config })),
   },
 }))
 
@@ -146,6 +147,50 @@ describe('useVerificationResponseListener', () => {
         })
       })
       expect(mockDispatch).toHaveBeenCalled()
+    })
+
+    it('should navigate to CancelledReview when status is cancelled', async () => {
+      mockGetVerificationRequestStatus.mockResolvedValueOnce({
+        status: 'cancelled',
+        status_message: 'Face does not match',
+      })
+
+      renderHook(() => useVerificationResponseListener())
+
+      act(() => {
+        mockVerificationResponseService.handleRequestReviewed()
+      })
+
+      await waitFor(() => {
+        expect(mockGetVerificationRequestStatus).toHaveBeenCalledWith('test-verification-request-id')
+      })
+
+      await waitFor(() => {
+        expect(CommonActions.navigate).toHaveBeenCalledWith({
+          name: BCSCScreens.CancelledReview,
+          params: { agentReason: 'Face does not match' },
+        })
+      })
+      expect(mockDispatch).toHaveBeenCalled()
+      expect(mockCheckDeviceCodeStatus).not.toHaveBeenCalled()
+    })
+
+    it('should navigate to CancelledReview with undefined reason when status_message is missing', async () => {
+      mockGetVerificationRequestStatus.mockResolvedValueOnce({ status: 'cancelled' })
+
+      renderHook(() => useVerificationResponseListener())
+
+      act(() => {
+        mockVerificationResponseService.handleRequestReviewed()
+      })
+
+      await waitFor(() => {
+        expect(CommonActions.navigate).toHaveBeenCalledWith({
+          name: BCSCScreens.CancelledReview,
+          params: { agentReason: undefined },
+        })
+      })
+      expect(mockCheckDeviceCodeStatus).not.toHaveBeenCalled()
     })
 
     it('should not navigate if status is not verified', async () => {

--- a/app/src/bcsc-theme/features/verification-response/useVerificationResponseListener.tsx
+++ b/app/src/bcsc-theme/features/verification-response/useVerificationResponseListener.tsx
@@ -10,17 +10,18 @@ import { useCallback, useEffect } from 'react'
 import { BCSCScreens } from '../../types/navigators'
 
 /**
- * Hook that listens for verification response push notifications and navigates to the success screen.
+ * Hook that listens for verification response push notifications and navigates accordingly.
  *
  * This hook should be used in the VerifyStack navigator to handle the case where a user
- * receives a push notification indicating their verification has been approved.
+ * receives a push notification indicating their verification has been reviewed.
  *
  * Handles verification response events:
  *
  * Request reviewed (send-video): The notification indicates the video was reviewed.
  *    - First checks verification status via API
  *    - If status is 'verified', fetches tokens via checkDeviceCodeStatus, then navigates to success
- *    - If not verified, does not navigate (user should check manually)
+ *    - If status is 'cancelled', navigates to CancelledReview with the agent reason
+ *    - If status is 'pending', does not navigate (user should check manually)
  *
  * Token fetching happens in this hook before navigation. VerificationSuccessScreen handles
  * final account setup (marking verified, metadata cleanup, registration update).
@@ -80,7 +81,12 @@ export const useVerificationResponseListener = () => {
 
       if (status === 'cancelled') {
         logger.info('[useVerificationResponseListener] Verification request cancelled, navigating to CancelledReview')
-        navigation.dispatch(CommonActions.navigate({ name: BCSCScreens.CancelledReview, params: { agentReason: status_message } }))
+        navigation.dispatch(
+          CommonActions.navigate({
+            name: BCSCScreens.CancelledReview,
+            params: { agentReason: status_message },
+          })
+        )
         return
       }
 

--- a/app/src/bcsc-theme/features/verification-response/useVerificationResponseListener.tsx
+++ b/app/src/bcsc-theme/features/verification-response/useVerificationResponseListener.tsx
@@ -67,7 +67,7 @@ export const useVerificationResponseListener = () => {
 
       // Check the verification request status (same as Check Status button)
       logger.info('[useVerificationResponseListener] Checking verification request status')
-      const { status } = await evidence.getVerificationRequestStatus(verificationRequestId)
+      const { status, status_message } = await evidence.getVerificationRequestStatus(verificationRequestId)
       logger.info(`[useVerificationResponseListener] Verification request status: ${status}`)
 
       if (status === 'verified') {
@@ -79,8 +79,8 @@ export const useVerificationResponseListener = () => {
       }
 
       if (status === 'cancelled') {
-        // TODO: (ke) handle verification request cancelled
-        logger.info(`[useVerificationResponseListener] Verification request cancelled, not navigating`)
+        logger.info('[useVerificationResponseListener] Verification request cancelled, navigating to CancelledReview')
+        navigation.dispatch(CommonActions.navigate({ name: BCSCScreens.CancelledReview, params: { agentReason: status_message } }))
         return
       }
 
@@ -93,7 +93,7 @@ export const useVerificationResponseListener = () => {
       const message = error instanceof Error ? error.message : String(error)
       logger.error(`[useVerificationResponseListener] Failed to handle request reviewed: ${message}`)
     }
-  }, [logger, store.bcscSecure, evidence, navigateToSuccess, token])
+  }, [logger, store.bcscSecure, evidence, navigation, navigateToSuccess, token])
 
   /**
    * Route the event to the appropriate handler based on event type.

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledRerivewViewModel.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledRerivewViewModel.ts
@@ -9,11 +9,13 @@ import { useCallback } from 'react'
  */
 const useCancelledReviewViewModel = () => {
   const [, dispatch] = useStore<BCState>()
-  const { updateAccountFlags } = useSecureActions()
+  const { updateAccountFlags, updateVerificationRequest } = useSecureActions()
   const cleanUpVerificationData = useCallback(() => {
+    updateVerificationRequest(null, null)
     dispatch({ type: BCDispatchAction.RESET_SEND_VIDEO })
+    dispatch({ type: BCDispatchAction.UPDATE_VIDEO_PROMPTS, payload: [undefined] })
     updateAccountFlags({ userSubmittedVerificationVideo: false })
-  }, [dispatch, updateAccountFlags])
+  }, [dispatch, updateAccountFlags, updateVerificationRequest])
   return {
     cleanUpVerificationData,
   }


### PR DESCRIPTION
## Summary
- Handle the `cancelled` status in `useVerificationResponseListener` by navigating to `CancelledReview` with the agent reason, matching the existing "Check Status" button behavior
- Previously the cancelled branch was a TODO that only logged and returned without navigating, leaving the user in a stale state

## Test Plan
- [x] Added test: navigates to `CancelledReview` when status is `cancelled` with `status_message`
- [x] Added test: navigates to `CancelledReview` with `undefined` reason when `status_message` is missing
- [x] All 13 existing + new tests pass

## Manual Testing
- [ ] Setup a new card, submit a video.
- [ ] In id check select the top radio for the first three questions
- [ ] Last question, select "not confident enough to verify for other reason"

<img width="1241" alt="Screenshot 2026-03-17 at 4 55 21 PM" src="https://github.com/user-attachments/assets/b742fd35-c191-4346-bccd-4d68189260c6" />

- [ ] Press continue
- [ ] I usually mark the "Partial or blurry ID image" box, and enter anything in the two text fields.
- [ ]  Repeat your video submission, the 2nd attempt should be accepted.

When done, the mobile app will recieve a push notification and automatically update the status.




Closes #3427