### PR TITLE
fix: specify utf8 charset

### DIFF
--- a/app/src/bcsc-theme/api/client.test.ts
+++ b/app/src/bcsc-theme/api/client.test.ts
@@ -8,6 +8,13 @@ describe('BCSC Client', () => {
     initLanguages(localization)
   })
 
+  it('should set Content-Type default header to application/json with charset=utf-8', () => {
+    const mockLogger = { info: jest.fn(), error: jest.fn() }
+    const client = new BCSCApiClient('https://example.com', mockLogger as any)
+
+    expect(client.client.defaults.headers['Content-Type']).toBe('application/json; charset=utf-8')
+  })
+
   it('should suppress logging for status codes if suppressStatusCodeLogs prop is set', async () => {
     const mockLogger = { error: jest.fn(), info: jest.fn() }
     const baseURL = 'https://example.com'

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -74,7 +74,7 @@ class BCSCApiClient {
     this.logger = logger
     this.client = axios.create({
       headers: {
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/json; charset=utf-8',
       },
     })
 

--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
@@ -286,7 +286,7 @@ describe('useRegistrationApi', () => {
       expect(data).toEqual(mockRegistrationResponse)
     })
 
-    it('should preserve utf8 characters in the nickname for update registration', async () => {
+    it('should send nickname unchanged and include charset header', async () => {
       const chineseNickname = '我的钱包'
       const mockBody = JSON.stringify({ client_name: chineseNickname, software_statement: 'mock-jwt' })
       jest.mocked(getDynamicClientRegistrationBody).mockResolvedValue(mockBody)

--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
@@ -115,7 +115,7 @@ describe('useRegistrationApi', () => {
         'mock-ios-receipt'
       )
       expect(mockApiClient.post).toHaveBeenCalledWith(mockApiClient.endpoints.registration, expect.any(String), {
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json; charset=utf-8' },
         skipBearerAuth: true,
       })
       expect(setAccount).toHaveBeenCalledWith({
@@ -284,6 +284,44 @@ describe('useRegistrationApi', () => {
         registrationAccessToken: mockRegistrationResponse.registration_access_token,
       })
       expect(data).toEqual(mockRegistrationResponse)
+    })
+
+    it('should preserve utf8 characters in the nickname for update registration', async () => {
+      const chineseNickname = '我的钱包'
+      const mockBody = JSON.stringify({ client_name: chineseNickname, software_statement: 'mock-jwt' })
+      jest.mocked(getDynamicClientRegistrationBody).mockResolvedValue(mockBody)
+
+      const { result } = renderHook(() => useRegistrationApi(mockApiClient as any))
+
+      await result.current.updateRegistration('reg-access-token', chineseNickname)
+
+      expect(getDynamicClientRegistrationBody).toHaveBeenCalledWith(
+        'mock-fcm-token',
+        'mock-device-token',
+        'mock-ios-receipt',
+        chineseNickname
+      )
+
+      // Verify the payload sent to the server contains the original Chinese characters in client_name
+      const putPayload = mockApiClient.put.mock.calls[0][1]
+      expect(putPayload.client_name).toBe(chineseNickname)
+
+      expect(mockApiClient.put).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Object),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json; charset=utf-8',
+          }),
+        })
+      )
+
+      expect(setAccount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nickname: chineseNickname,
+          didPostNicknameToServer: true,
+        })
+      )
     })
 
     it('should throw if client is not ready (with existing account)', async () => {

--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
@@ -115,7 +115,6 @@ describe('useRegistrationApi', () => {
         'mock-ios-receipt'
       )
       expect(mockApiClient.post).toHaveBeenCalledWith(mockApiClient.endpoints.registration, expect.any(String), {
-        headers: { 'Content-Type': 'application/json; charset=utf-8' },
         skipBearerAuth: true,
       })
       expect(setAccount).toHaveBeenCalledWith({
@@ -284,44 +283,6 @@ describe('useRegistrationApi', () => {
         registrationAccessToken: mockRegistrationResponse.registration_access_token,
       })
       expect(data).toEqual(mockRegistrationResponse)
-    })
-
-    it('should send nickname unchanged and include charset header', async () => {
-      const chineseNickname = '我的钱包'
-      const mockBody = JSON.stringify({ client_name: chineseNickname, software_statement: 'mock-jwt' })
-      jest.mocked(getDynamicClientRegistrationBody).mockResolvedValue(mockBody)
-
-      const { result } = renderHook(() => useRegistrationApi(mockApiClient as any))
-
-      await result.current.updateRegistration('reg-access-token', chineseNickname)
-
-      expect(getDynamicClientRegistrationBody).toHaveBeenCalledWith(
-        'mock-fcm-token',
-        'mock-device-token',
-        'mock-ios-receipt',
-        chineseNickname
-      )
-
-      // Verify the payload sent to the server contains the original Chinese characters in client_name
-      const putPayload = mockApiClient.put.mock.calls[0][1]
-      expect(putPayload.client_name).toBe(chineseNickname)
-
-      expect(mockApiClient.put).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(Object),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            'Content-Type': 'application/json; charset=utf-8',
-          }),
-        })
-      )
-
-      expect(setAccount).toHaveBeenCalledWith(
-        expect.objectContaining({
-          nickname: chineseNickname,
-          didPostNicknameToServer: true,
-        })
-      )
     })
 
     it('should throw if client is not ready (with existing account)', async () => {

--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
@@ -187,7 +187,6 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
       logger.info('Generated dynamic client registration body')
 
       const { data } = await apiClient.post<RegistrationResponseData>(apiClient.endpoints.registration, body, {
-        headers: { 'Content-Type': 'application/json; charset=utf-8' },
         skipBearerAuth: true,
       })
 
@@ -307,7 +306,6 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
             {
               skipBearerAuth: true,
               headers: {
-                'Content-Type': 'application/json; charset=utf-8',
                 Authorization: `Bearer ${registrationAccessToken}`,
               },
             }

--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
@@ -187,7 +187,7 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
       logger.info('Generated dynamic client registration body')
 
       const { data } = await apiClient.post<RegistrationResponseData>(apiClient.endpoints.registration, body, {
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json; charset=utf-8' },
         skipBearerAuth: true,
       })
 
@@ -307,7 +307,7 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
             {
               skipBearerAuth: true,
               headers: {
-                'Content-Type': 'application/json',
+                'Content-Type': 'application/json; charset=utf-8',
                 Authorization: `Bearer ${registrationAccessToken}`,
               },
             }

--- a/packages/bcsc-core/android/src/test/java/com/bcsccore/JSONSerializationTest.kt
+++ b/packages/bcsc-core/android/src/test/java/com/bcsccore/JSONSerializationTest.kt
@@ -1,0 +1,145 @@
+package com.bcsccore
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Verifies that org.json.JSONObject preserves Unicode characters
+ * in the same patterns used by getDynamicClientRegistrationBody.
+ */
+@RunWith(RobolectricTestRunner::class)
+class JSONSerializationTest {
+    // MARK: - client_name round-trip
+
+    @Test
+    fun `client_name preserves Chinese characters`() {
+        val nickname = "我的钱包"
+
+        val json =
+            JSONObject().apply {
+                put("client_name", nickname)
+                put("token_endpoint_auth_method", "private_key_jwt")
+                put("application_type", "native")
+            }
+
+        val jsonString = json.toString()
+        assertTrue("JSON string should contain original Chinese characters", jsonString.contains(nickname))
+
+        // Round-trip: parse back and verify
+        val parsed = JSONObject(jsonString)
+        assertEquals(nickname, parsed.getString("client_name"))
+    }
+
+    @Test
+    fun `client_name preserves Japanese characters`() {
+        val nickname = "私の財布"
+
+        val json =
+            JSONObject().apply {
+                put("client_name", nickname)
+                put("application_type", "native")
+            }
+
+        val jsonString = json.toString()
+        assertTrue(jsonString.contains(nickname))
+
+        val parsed = JSONObject(jsonString)
+        assertEquals(nickname, parsed.getString("client_name"))
+    }
+
+    @Test
+    fun `client_name preserves Korean characters`() {
+        val nickname = "내 지갑"
+
+        val json =
+            JSONObject().apply {
+                put("client_name", nickname)
+                put("application_type", "native")
+            }
+
+        val jsonString = json.toString()
+        assertTrue(jsonString.contains(nickname))
+
+        val parsed = JSONObject(jsonString)
+        assertEquals(nickname, parsed.getString("client_name"))
+    }
+
+    @Test
+    fun `client_name preserves emoji`() {
+        val nickname = "My Wallet 🔐"
+
+        val json =
+            JSONObject().apply {
+                put("client_name", nickname)
+                put("application_type", "native")
+            }
+
+        val parsed = JSONObject(json.toString())
+        assertEquals(nickname, parsed.getString("client_name"))
+    }
+
+    @Test
+    fun `client_name preserves mixed scripts`() {
+        val nickname = "My钱包Wallet"
+
+        val json =
+            JSONObject().apply {
+                put("client_name", nickname)
+                put("application_type", "native")
+            }
+
+        val jsonString = json.toString()
+        assertTrue(jsonString.contains(nickname))
+
+        val parsed = JSONObject(jsonString)
+        assertEquals(nickname, parsed.getString("client_name"))
+    }
+
+    // MARK: - Full DCR body shape
+
+    @Test
+    fun `full registration body preserves Unicode client_name`() {
+        val nickname = "我的钱包"
+
+        val json =
+            JSONObject().apply {
+                put("client_name", nickname)
+                put("redirect_uris", JSONArray().apply { put("http://localhost:8080/") })
+                put("grant_types", JSONArray().apply { put("authorization_code") })
+                put("token_endpoint_auth_method", "private_key_jwt")
+                put(
+                    "jwks",
+                    JSONObject().apply {
+                        put(
+                            "keys",
+                            JSONArray().apply {
+                                put(
+                                    JSONObject().apply {
+                                        put("kty", "RSA")
+                                        put("e", "AQAB")
+                                        put("n", "mock-modulus")
+                                        put("kid", "key-1")
+                                        put("alg", "RS512")
+                                    },
+                                )
+                            },
+                        )
+                    },
+                )
+                put("device_info", "eyJhbGciOiJub25lIn0.eyJkZXZpY2UiOiJ0ZXN0In0.")
+                put("application_type", "native")
+            }
+
+        val jsonString = json.toString()
+        assertTrue("Full DCR body should preserve Chinese client_name", jsonString.contains(nickname))
+
+        // Round-trip
+        val parsed = JSONObject(jsonString)
+        assertEquals(nickname, parsed.getString("client_name"))
+    }
+}

--- a/packages/bcsc-core/android/src/test/java/com/bcsccore/JSONSerializationTest.kt
+++ b/packages/bcsc-core/android/src/test/java/com/bcsccore/JSONSerializationTest.kt
@@ -3,7 +3,6 @@ package com.bcsccore
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -27,11 +26,8 @@ class JSONSerializationTest {
                 put("application_type", "native")
             }
 
-        val jsonString = json.toString()
-        assertTrue("JSON string should contain original Chinese characters", jsonString.contains(nickname))
-
         // Round-trip: parse back and verify
-        val parsed = JSONObject(jsonString)
+        val parsed = JSONObject(json.toString())
         assertEquals(nickname, parsed.getString("client_name"))
     }
 
@@ -45,10 +41,7 @@ class JSONSerializationTest {
                 put("application_type", "native")
             }
 
-        val jsonString = json.toString()
-        assertTrue(jsonString.contains(nickname))
-
-        val parsed = JSONObject(jsonString)
+        val parsed = JSONObject(json.toString())
         assertEquals(nickname, parsed.getString("client_name"))
     }
 
@@ -62,10 +55,7 @@ class JSONSerializationTest {
                 put("application_type", "native")
             }
 
-        val jsonString = json.toString()
-        assertTrue(jsonString.contains(nickname))
-
-        val parsed = JSONObject(jsonString)
+        val parsed = JSONObject(json.toString())
         assertEquals(nickname, parsed.getString("client_name"))
     }
 
@@ -93,10 +83,7 @@ class JSONSerializationTest {
                 put("application_type", "native")
             }
 
-        val jsonString = json.toString()
-        assertTrue(jsonString.contains(nickname))
-
-        val parsed = JSONObject(jsonString)
+        val parsed = JSONObject(json.toString())
         assertEquals(nickname, parsed.getString("client_name"))
     }
 
@@ -135,11 +122,8 @@ class JSONSerializationTest {
                 put("application_type", "native")
             }
 
-        val jsonString = json.toString()
-        assertTrue("Full DCR body should preserve Chinese client_name", jsonString.contains(nickname))
-
         // Round-trip
-        val parsed = JSONObject(jsonString)
+        val parsed = JSONObject(json.toString())
         assertEquals(nickname, parsed.getString("client_name"))
     }
 }

--- a/packages/bcsc-core/ios/BcscCoreTests/JSONSerializationTests.swift
+++ b/packages/bcsc-core/ios/BcscCoreTests/JSONSerializationTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+
+/// Verifies that Foundation's JSONSerialization preserves Unicode characters
+/// in the same patterns used by getDynamicClientRegistrationBody.
+final class JSONSerializationTests: XCTestCase {
+  // MARK: - client_name round-trip
+
+  func testClientNamePreservesChineseCharacters() throws {
+    let nickname = "我的钱包"
+
+    let registrationData: [String: Any] = [
+      "client_name": nickname,
+      "token_endpoint_auth_method": "private_key_jwt",
+      "application_type": "native",
+    ]
+
+    let jsonData = try JSONSerialization.data(withJSONObject: registrationData, options: [])
+    let jsonString = String(data: jsonData, encoding: .utf8)
+
+    XCTAssertNotNil(jsonString)
+    XCTAssertTrue(
+      try XCTUnwrap(jsonString?.contains(nickname)),
+      "JSON string should contain original Chinese characters"
+    )
+
+    // Round-trip: parse back and verify
+    let parsed = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+    XCTAssertEqual(parsed["client_name"] as? String, nickname)
+  }
+
+  func testClientNamePreservesJapaneseCharacters() throws {
+    let nickname = "私の財布"
+
+    let registrationData: [String: Any] = [
+      "client_name": nickname,
+      "application_type": "native",
+    ]
+
+    let jsonData = try JSONSerialization.data(withJSONObject: registrationData, options: [])
+    let jsonString = String(data: jsonData, encoding: .utf8)
+
+    XCTAssertNotNil(jsonString)
+    XCTAssertTrue(try XCTUnwrap(jsonString?.contains(nickname)))
+
+    let parsed = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+    XCTAssertEqual(parsed["client_name"] as? String, nickname)
+  }
+
+  func testClientNamePreservesKoreanCharacters() throws {
+    let nickname = "내 지갑"
+
+    let registrationData: [String: Any] = [
+      "client_name": nickname,
+      "application_type": "native",
+    ]
+
+    let jsonData = try JSONSerialization.data(withJSONObject: registrationData, options: [])
+    let jsonString = String(data: jsonData, encoding: .utf8)
+
+    XCTAssertNotNil(jsonString)
+    XCTAssertTrue(try XCTUnwrap(jsonString?.contains(nickname)))
+
+    let parsed = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+    XCTAssertEqual(parsed["client_name"] as? String, nickname)
+  }
+
+  func testClientNamePreservesEmoji() throws {
+    let nickname = "My Wallet 🔐"
+
+    let registrationData: [String: Any] = [
+      "client_name": nickname,
+      "application_type": "native",
+    ]
+
+    let jsonData = try JSONSerialization.data(withJSONObject: registrationData, options: [])
+
+    let parsed = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+    XCTAssertEqual(parsed["client_name"] as? String, nickname)
+  }
+
+  func testClientNamePreservesMixedScripts() throws {
+    let nickname = "My钱包Wallet"
+
+    let registrationData: [String: Any] = [
+      "client_name": nickname,
+      "application_type": "native",
+    ]
+
+    let jsonData = try JSONSerialization.data(withJSONObject: registrationData, options: [])
+    let jsonString = String(data: jsonData, encoding: .utf8)
+
+    XCTAssertNotNil(jsonString)
+    XCTAssertTrue(try XCTUnwrap(jsonString?.contains(nickname)))
+
+    let parsed = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+    XCTAssertEqual(parsed["client_name"] as? String, nickname)
+  }
+
+  // MARK: - Full DCR body shape
+
+  func testFullRegistrationBodyPreservesUnicodeClientName() throws {
+    let nickname = "我的钱包"
+
+    let registrationData: [String: Any] = [
+      "client_name": nickname,
+      "redirect_uris": ["http://localhost:8080/"],
+      "grant_types": ["authorization_code"],
+      "token_endpoint_auth_method": "private_key_jwt",
+      "jwks": [
+        "keys": [
+          ["kty": "RSA", "e": "AQAB", "n": "mock-modulus", "kid": "key-1", "alg": "RS512"],
+        ],
+      ],
+      "device_info": "eyJhbGciOiJub25lIn0.eyJkZXZpY2UiOiJ0ZXN0In0.",
+      "application_type": "native",
+    ]
+
+    let jsonData = try JSONSerialization.data(withJSONObject: registrationData, options: [])
+    let jsonString = String(data: jsonData, encoding: .utf8)
+
+    XCTAssertNotNil(jsonString)
+    XCTAssertTrue(try XCTUnwrap(jsonString?.contains(nickname)), "Full DCR body should preserve Chinese client_name")
+
+    // Verify round-trip
+    let parsed = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+    XCTAssertEqual(parsed["client_name"] as? String, nickname)
+  }
+}

--- a/packages/bcsc-core/ios/BcscCoreTests/JSONSerializationTests.swift
+++ b/packages/bcsc-core/ios/BcscCoreTests/JSONSerializationTests.swift
@@ -15,13 +15,6 @@ final class JSONSerializationTests: XCTestCase {
     ]
 
     let jsonData = try JSONSerialization.data(withJSONObject: registrationData, options: [])
-    let jsonString = String(data: jsonData, encoding: .utf8)
-
-    XCTAssertNotNil(jsonString)
-    XCTAssertTrue(
-      try XCTUnwrap(jsonString?.contains(nickname)),
-      "JSON string should contain original Chinese characters"
-    )
 
     // Round-trip: parse back and verify
     let parsed = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
@@ -37,10 +30,6 @@ final class JSONSerializationTests: XCTestCase {
     ]
 
     let jsonData = try JSONSerialization.data(withJSONObject: registrationData, options: [])
-    let jsonString = String(data: jsonData, encoding: .utf8)
-
-    XCTAssertNotNil(jsonString)
-    XCTAssertTrue(try XCTUnwrap(jsonString?.contains(nickname)))
 
     let parsed = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
     XCTAssertEqual(parsed["client_name"] as? String, nickname)
@@ -55,10 +44,6 @@ final class JSONSerializationTests: XCTestCase {
     ]
 
     let jsonData = try JSONSerialization.data(withJSONObject: registrationData, options: [])
-    let jsonString = String(data: jsonData, encoding: .utf8)
-
-    XCTAssertNotNil(jsonString)
-    XCTAssertTrue(try XCTUnwrap(jsonString?.contains(nickname)))
 
     let parsed = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
     XCTAssertEqual(parsed["client_name"] as? String, nickname)
@@ -87,10 +72,6 @@ final class JSONSerializationTests: XCTestCase {
     ]
 
     let jsonData = try JSONSerialization.data(withJSONObject: registrationData, options: [])
-    let jsonString = String(data: jsonData, encoding: .utf8)
-
-    XCTAssertNotNil(jsonString)
-    XCTAssertTrue(try XCTUnwrap(jsonString?.contains(nickname)))
 
     let parsed = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
     XCTAssertEqual(parsed["client_name"] as? String, nickname)
@@ -116,10 +97,6 @@ final class JSONSerializationTests: XCTestCase {
     ]
 
     let jsonData = try JSONSerialization.data(withJSONObject: registrationData, options: [])
-    let jsonString = String(data: jsonData, encoding: .utf8)
-
-    XCTAssertNotNil(jsonString)
-    XCTAssertTrue(try XCTUnwrap(jsonString?.contains(nickname)), "Full DCR body should preserve Chinese client_name")
 
     // Verify round-trip
     let parsed = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])


### PR DESCRIPTION
# Summary of Changes

This PR simply specifies utf-8 as the charset for application/json requests and then adds a bunch of tests to confirm. It does appear to fix the jumbled data the backend is receiving even though that should be the default anyway according to axios docs. 

# Testing Instructions

Do a send video request with non-latin, non-numeric characters (eg. korean) in your nickname or other text fields and ensure they make it successfully through to IDCheck.

# Acceptance Criteria

any utf-8 is preserved

# Screenshots, videos, or gifs

<img width="621" height="315" alt="bobby" src="https://github.com/user-attachments/assets/dc27daa0-2d50-4b6c-8745-6ddecc8a8ef4" />

# Related Issues

#3472 