### PR TITLE
fix: normalize inputwithvalidation padding for android and ios

### DIFF
--- a/app/src/bcsc-theme/components/InputWithValidation.tsx
+++ b/app/src/bcsc-theme/components/InputWithValidation.tsx
@@ -61,6 +61,7 @@ export const InputWithValidation: React.FC<InputWithValidationProps> = (props: I
     },
     input: {
       flex: 1,
+      padding: 0,
       color: props.error ? ColorPalette.semantic.error : Inputs.textInput.color,
       fontSize: Inputs.textInput.fontSize,
     },

--- a/app/src/bcsc-theme/components/__snapshots__/DateInput.test.tsx.snap
+++ b/app/src/bcsc-theme/components/__snapshots__/DateInput.test.tsx.snap
@@ -107,6 +107,7 @@ exports[`DateInput Component Rendering renders correctly 1`] = `
             "color": "#313132",
             "flex": 1,
             "fontSize": 16,
+            "padding": 0,
           },
           undefined,
         ]

--- a/app/src/bcsc-theme/features/verify/EnterBirthdate/__snapshots__/EnterBirthdateScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/EnterBirthdate/__snapshots__/EnterBirthdateScreen.test.tsx.snap
@@ -210,6 +210,7 @@ exports[`EnterBirthdate renders correctly 1`] = `
                     "color": "#313132",
                     "flex": 1,
                     "fontSize": 16,
+                    "padding": 0,
                   },
                   undefined,
                 ]

--- a/app/src/bcsc-theme/features/verify/__snapshots__/ResidentialAddressScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/__snapshots__/ResidentialAddressScreen.test.tsx.snap
@@ -188,6 +188,7 @@ exports[`ResidentialAddress renders correctly 1`] = `
                       "color": "#313132",
                       "flex": 1,
                       "fontSize": 16,
+                      "padding": 0,
                     },
                     undefined,
                   ]
@@ -342,6 +343,7 @@ exports[`ResidentialAddress renders correctly 1`] = `
                       "color": "#313132",
                       "flex": 1,
                       "fontSize": 16,
+                      "padding": 0,
                     },
                     undefined,
                   ]
@@ -496,6 +498,7 @@ exports[`ResidentialAddress renders correctly 1`] = `
                       "color": "#313132",
                       "flex": 1,
                       "fontSize": 16,
+                      "padding": 0,
                     },
                     undefined,
                   ]
@@ -793,6 +796,7 @@ exports[`ResidentialAddress renders correctly 1`] = `
                       "color": "#313132",
                       "flex": 1,
                       "fontSize": 16,
+                      "padding": 0,
                     },
                     undefined,
                   ]

--- a/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/EvidenceIDCollectionScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/EvidenceIDCollectionScreen.test.tsx.snap
@@ -216,6 +216,7 @@ exports[`EvidenceIDCollection renders correctly 1`] = `
                         "color": "#313132",
                         "flex": 1,
                         "fontSize": 16,
+                        "padding": 0,
                       },
                       undefined,
                     ]


### PR DESCRIPTION
# Summary of Changes

Normalizes padding for InputWithValidation between both platforms.
https://github.com/bcgov/bc-wallet-mobile/issues/3288#issuecomment-4076580015

# Testing Instructions

iOS and Android padding for InputWithValidation component should be the same.

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
