### PR TITLE
feat: add proper user-agent string to WebViews and API client

### DIFF
--- a/app/__mocks__/react-native-device-info.ts
+++ b/app/__mocks__/react-native-device-info.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const diMock = require('react-native-device-info/jest/react-native-device-info-mock')
+
+diMock.getApplicationName = jest.fn(() => 'BCServicesCard')
+diMock.getVersion = jest.fn(() => '4.0.0')
+diMock.getBuildNumber = jest.fn(() => '142')
+diMock.getSystemName = jest.fn(() => 'iOS')
+diMock.getSystemVersion = jest.fn(() => '17.4')
+
+module.exports = diMock

--- a/app/__mocks__/react-native-device-info.ts
+++ b/app/__mocks__/react-native-device-info.ts
@@ -1,4 +1,5 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports
+// The package mock is a CJS module — ESM import causes hoisting issues in Jest.
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const diMock = require('react-native-device-info/jest/react-native-device-info-mock')
 
 diMock.getApplicationName = jest.fn(() => 'BCServicesCard')

--- a/app/jestSetup.js
+++ b/app/jestSetup.js
@@ -61,8 +61,11 @@ console.warn = createFilteredConsole('warn', [...suppressedPatterns, ...expected
 // eslint-disable-next-line no-console
 console.error = createFilteredConsole('error', [...suppressedPatterns, ...expectedReactWarnings])
 
-mockRNDeviceInfo.getVersion = jest.fn(() => '1')
-mockRNDeviceInfo.getBuildNumber = jest.fn(() => '1')
+mockRNDeviceInfo.getApplicationName = jest.fn(() => 'BCServicesCard')
+mockRNDeviceInfo.getVersion = jest.fn(() => '2.1.0')
+mockRNDeviceInfo.getBuildNumber = jest.fn(() => '142')
+mockRNDeviceInfo.getSystemName = jest.fn(() => 'iOS')
+mockRNDeviceInfo.getSystemVersion = jest.fn(() => '17.4')
 
 jest.mock('react-native-safe-area-context', () => mockSafeAreaContext)
 jest.mock('@react-native-community/netinfo', () => mockRNCNetInfo)

--- a/app/jestSetup.js
+++ b/app/jestSetup.js
@@ -62,7 +62,7 @@ console.warn = createFilteredConsole('warn', [...suppressedPatterns, ...expected
 console.error = createFilteredConsole('error', [...suppressedPatterns, ...expectedReactWarnings])
 
 mockRNDeviceInfo.getApplicationName = jest.fn(() => 'BCServicesCard')
-mockRNDeviceInfo.getVersion = jest.fn(() => '2.1.0')
+mockRNDeviceInfo.getVersion = jest.fn(() => '4.0.0')
 mockRNDeviceInfo.getBuildNumber = jest.fn(() => '142')
 mockRNDeviceInfo.getSystemName = jest.fn(() => 'iOS')
 mockRNDeviceInfo.getSystemVersion = jest.fn(() => '17.4')

--- a/app/jestSetup.js
+++ b/app/jestSetup.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-undef */
 import mockRNCNetInfo from '@react-native-community/netinfo/jest/netinfo-mock.js'
 import React from 'react'
-import mockRNDeviceInfo from 'react-native-device-info/jest/react-native-device-info-mock'
 import 'react-native-gesture-handler/jestSetup'
 import mockRNLocalize from 'react-native-localize/mock'
 import mockSafeAreaContext from 'react-native-safe-area-context/jest/mock'
@@ -61,15 +60,8 @@ console.warn = createFilteredConsole('warn', [...suppressedPatterns, ...expected
 // eslint-disable-next-line no-console
 console.error = createFilteredConsole('error', [...suppressedPatterns, ...expectedReactWarnings])
 
-mockRNDeviceInfo.getApplicationName = jest.fn(() => 'BCServicesCard')
-mockRNDeviceInfo.getVersion = jest.fn(() => '4.0.0')
-mockRNDeviceInfo.getBuildNumber = jest.fn(() => '142')
-mockRNDeviceInfo.getSystemName = jest.fn(() => 'iOS')
-mockRNDeviceInfo.getSystemVersion = jest.fn(() => '17.4')
-
 jest.mock('react-native-safe-area-context', () => mockSafeAreaContext)
 jest.mock('@react-native-community/netinfo', () => mockRNCNetInfo)
-jest.mock('react-native-device-info', () => mockRNDeviceInfo)
 jest.mock('react-native-localize', () => mockRNLocalize)
 jest.mock('react-native-vision-camera', () => {
   return require('./__mocks__/custom/react-native-camera')

--- a/app/src/bcsc-theme/api/client.test.ts
+++ b/app/src/bcsc-theme/api/client.test.ts
@@ -15,6 +15,13 @@ describe('BCSC Client', () => {
     expect(client.client.defaults.headers['Content-Type']).toBe('application/json; charset=utf-8')
   })
 
+  it('should set User-Agent default header', () => {
+    const mockLogger = { info: jest.fn(), error: jest.fn() }
+    const client = new BCSCApiClient('https://example.com', mockLogger as any)
+
+    expect(client.client.defaults.headers['User-Agent']).toBeDefined()
+  })
+
   it('should suppress logging for status codes if suppressStatusCodeLogs prop is set', async () => {
     const mockLogger = { error: jest.fn(), info: jest.fn() }
     const baseURL = 'https://example.com'

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -1,7 +1,7 @@
-import { getUserAgentString } from '@utils/user-agent'
 import { AppError } from '@/errors/appError'
 import { ErrorRegistry } from '@/errors/errorRegistry'
 import { RemoteLogger } from '@bifold/remote-logs'
+import { getUserAgentString } from '@utils/user-agent'
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { jwtDecode } from 'jwt-decode'
 import merge from 'lodash.merge'

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -1,3 +1,4 @@
+import { getUserAgentString } from '@utils/user-agent'
 import { AppError } from '@/errors/appError'
 import { ErrorRegistry } from '@/errors/errorRegistry'
 import { RemoteLogger } from '@bifold/remote-logs'
@@ -75,6 +76,7 @@ class BCSCApiClient {
     this.client = axios.create({
       headers: {
         'Content-Type': 'application/json; charset=utf-8',
+        'User-Agent': getUserAgentString(),
       },
     })
 

--- a/app/src/bcsc-theme/features/onboarding/__snapshots__/TermsOfUseScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/onboarding/__snapshots__/TermsOfUseScreen.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`TermsOfUse renders correctly after loading terms 1`] = `
     testID="mocked-webview"
     textZoom={200}
     thirdPartyCookiesEnabled={true}
-    userAgent="Single App"
+    userAgent="unknown/1 (unknown unknown; Build 1)"
   />
   <View
     style={

--- a/app/src/bcsc-theme/features/onboarding/__snapshots__/TermsOfUseScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/onboarding/__snapshots__/TermsOfUseScreen.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`TermsOfUse renders correctly after loading terms 1`] = `
     testID="mocked-webview"
     textZoom={200}
     thirdPartyCookiesEnabled={true}
-    userAgent="BCServicesCard/2.1.0 (iOS 17.4; Build 142)"
+    userAgent="BCServicesCard/4.0.0 (iOS 17.4; Build 142)"
   />
   <View
     style={

--- a/app/src/bcsc-theme/features/onboarding/__snapshots__/TermsOfUseScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/onboarding/__snapshots__/TermsOfUseScreen.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`TermsOfUse renders correctly after loading terms 1`] = `
     testID="mocked-webview"
     textZoom={200}
     thirdPartyCookiesEnabled={true}
-    userAgent="unknown/1 (unknown unknown; Build 1)"
+    userAgent="BCServicesCard/2.1.0 (iOS 17.4; Build 142)"
   />
   <View
     style={

--- a/app/src/bcsc-theme/features/settings/__snapshots__/AuthSettingsScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/settings/__snapshots__/AuthSettingsScreen.test.tsx.snap
@@ -604,7 +604,7 @@ exports[`AuthSettings renders correctly 1`] = `
                     ]
                   }
                 >
-                  Version 2.1.0 (142)
+                  Version 4.0.0 (142)
                 </Text>
               </View>
             </View>

--- a/app/src/bcsc-theme/features/settings/__snapshots__/AuthSettingsScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/settings/__snapshots__/AuthSettingsScreen.test.tsx.snap
@@ -604,7 +604,7 @@ exports[`AuthSettings renders correctly 1`] = `
                     ]
                   }
                 >
-                  Version 1 (1)
+                  Version 2.1.0 (142)
                 </Text>
               </View>
             </View>

--- a/app/src/bcsc-theme/features/settings/__snapshots__/MainSettingsScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/settings/__snapshots__/MainSettingsScreen.test.tsx.snap
@@ -604,7 +604,7 @@ exports[`MainSettings renders correctly 1`] = `
                     ]
                   }
                 >
-                  Version 1 (1)
+                  Version 2.1.0 (142)
                 </Text>
               </View>
             </View>

--- a/app/src/bcsc-theme/features/settings/__snapshots__/MainSettingsScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/settings/__snapshots__/MainSettingsScreen.test.tsx.snap
@@ -604,7 +604,7 @@ exports[`MainSettings renders correctly 1`] = `
                     ]
                   }
                 >
-                  Version 2.1.0 (142)
+                  Version 4.0.0 (142)
                 </Text>
               </View>
             </View>

--- a/app/src/bcsc-theme/features/settings/__snapshots__/VerifySettingsScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/settings/__snapshots__/VerifySettingsScreen.test.tsx.snap
@@ -604,7 +604,7 @@ exports[`VerifySettings renders correctly 1`] = `
                     ]
                   }
                 >
-                  Version 2.1.0 (142)
+                  Version 4.0.0 (142)
                 </Text>
               </View>
             </View>

--- a/app/src/bcsc-theme/features/settings/__snapshots__/VerifySettingsScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/settings/__snapshots__/VerifySettingsScreen.test.tsx.snap
@@ -604,7 +604,7 @@ exports[`VerifySettings renders correctly 1`] = `
                     ]
                   }
                 >
-                  Version 1 (1)
+                  Version 2.1.0 (142)
                 </Text>
               </View>
             </View>

--- a/app/src/bcsc-theme/features/webview/WebViewContent.tsx
+++ b/app/src/bcsc-theme/features/webview/WebViewContent.tsx
@@ -1,6 +1,6 @@
-import { getUserAgentString } from '@utils/user-agent'
 import { useBCSCApiClient } from '@/bcsc-theme/hooks/useBCSCApiClient'
 import { TOKENS, useServices, useTheme } from '@bifold/core'
+import { getUserAgentString } from '@utils/user-agent'
 import React, { useCallback } from 'react'
 import { ActivityIndicator, StyleSheet, useWindowDimensions, View } from 'react-native'
 import { WebView } from 'react-native-webview'

--- a/app/src/bcsc-theme/features/webview/WebViewContent.tsx
+++ b/app/src/bcsc-theme/features/webview/WebViewContent.tsx
@@ -1,3 +1,4 @@
+import { getUserAgentString } from '@utils/user-agent'
 import { useBCSCApiClient } from '@/bcsc-theme/hooks/useBCSCApiClient'
 import { TOKENS, useServices, useTheme } from '@bifold/core'
 import React, { useCallback } from 'react'
@@ -110,7 +111,7 @@ const WebViewContent: React.FC<WebViewContentProps> = ({ url, html, onLoaded }) 
       mixedContentMode="compatibility"
       sharedCookiesEnabled={true}
       thirdPartyCookiesEnabled={true}
-      userAgent="Single App"
+      userAgent={getUserAgentString()}
       textZoom={Math.round(fontScale * 100)}
       onLoad={onLoaded}
     />

--- a/app/src/bcsc-theme/features/webview/__snapshots__/WebViewScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/webview/__snapshots__/WebViewScreen.test.tsx.snap
@@ -33,6 +33,6 @@ exports[`WebViewScreen renders correctly 1`] = `
   testID="mocked-webview"
   textZoom={200}
   thirdPartyCookiesEnabled={true}
-  userAgent="Single App"
+  userAgent="unknown/1 (unknown unknown; Build 1)"
 />
 `;

--- a/app/src/bcsc-theme/features/webview/__snapshots__/WebViewScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/webview/__snapshots__/WebViewScreen.test.tsx.snap
@@ -33,6 +33,6 @@ exports[`WebViewScreen renders correctly 1`] = `
   testID="mocked-webview"
   textZoom={200}
   thirdPartyCookiesEnabled={true}
-  userAgent="unknown/1 (unknown unknown; Build 1)"
+  userAgent="BCServicesCard/2.1.0 (iOS 17.4; Build 142)"
 />
 `;

--- a/app/src/bcsc-theme/features/webview/__snapshots__/WebViewScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/webview/__snapshots__/WebViewScreen.test.tsx.snap
@@ -33,6 +33,6 @@ exports[`WebViewScreen renders correctly 1`] = `
   testID="mocked-webview"
   textZoom={200}
   thirdPartyCookiesEnabled={true}
-  userAgent="BCServicesCard/2.1.0 (iOS 17.4; Build 142)"
+  userAgent="BCServicesCard/4.0.0 (iOS 17.4; Build 142)"
 />
 `;

--- a/app/src/screens/WebDisplay.tsx
+++ b/app/src/screens/WebDisplay.tsx
@@ -1,3 +1,4 @@
+import { getUserAgentString } from '@utils/user-agent'
 import { SafeAreaModal } from '@bifold/core'
 import React from 'react'
 import { StyleSheet } from 'react-native'
@@ -27,6 +28,7 @@ const WebDisplay = ({ destinationUrl, exitUrl, visible, onClose }: WebDisplayPro
         source={{ uri: destinationUrl }}
         javaScriptEnabled={true}
         domStorageEnabled={true}
+        userAgent={getUserAgentString()}
         onNavigationStateChange={(nav: WebViewNavigation) => {
           if (exitUrl && nav.url.includes(exitUrl)) {
             onClose()

--- a/app/src/screens/WebDisplay.tsx
+++ b/app/src/screens/WebDisplay.tsx
@@ -1,5 +1,5 @@
-import { getUserAgentString } from '@utils/user-agent'
 import { SafeAreaModal } from '@bifold/core'
+import { getUserAgentString } from '@utils/user-agent'
 import React from 'react'
 import { StyleSheet } from 'react-native'
 import { WebView, WebViewNavigation } from 'react-native-webview'

--- a/app/src/utils/user-agent.test.ts
+++ b/app/src/utils/user-agent.test.ts
@@ -11,11 +11,4 @@ jest.mock('react-native-device-info', () => ({
 describe('getUserAgentString', () => {
   it('returns a formatted user-agent string', () => {
     expect(getUserAgentString()).toBe('BCServicesCard/2.1.0 (iOS 17.4; Build 142)')
-  })
-
-  it('returns the cached value on subsequent calls', () => {
-    const first = getUserAgentString()
-    const second = getUserAgentString()
-    expect(second).toBe(first)
-  })
-})
+  })})

--- a/app/src/utils/user-agent.test.ts
+++ b/app/src/utils/user-agent.test.ts
@@ -1,0 +1,15 @@
+import { getUserAgentString } from './user-agent'
+
+jest.mock('react-native-device-info', () => ({
+  getApplicationName: () => 'BC Services Card',
+  getVersion: () => '2.1.0',
+  getBuildNumber: () => '142',
+  getSystemName: () => 'iOS',
+  getSystemVersion: () => '17.4',
+}))
+
+describe('getUserAgentString', () => {
+  it('returns a formatted user-agent string', () => {
+    expect(getUserAgentString()).toBe('BCServicesCard/2.1.0 (iOS 17.4; Build 142)')
+  })
+})

--- a/app/src/utils/user-agent.test.ts
+++ b/app/src/utils/user-agent.test.ts
@@ -2,6 +2,6 @@ import { getUserAgentString } from './user-agent'
 
 describe('getUserAgentString', () => {
   it('returns a formatted user-agent string', () => {
-    expect(getUserAgentString()).toBe('BCServicesCard/2.1.0 (iOS 17.4; Build 142)')
+    expect(getUserAgentString()).toBe('BCServicesCard/4.0.0 (iOS 17.4; Build 142)')
   })
 })

--- a/app/src/utils/user-agent.test.ts
+++ b/app/src/utils/user-agent.test.ts
@@ -12,4 +12,10 @@ describe('getUserAgentString', () => {
   it('returns a formatted user-agent string', () => {
     expect(getUserAgentString()).toBe('BCServicesCard/2.1.0 (iOS 17.4; Build 142)')
   })
+
+  it('returns the cached value on subsequent calls', () => {
+    const first = getUserAgentString()
+    const second = getUserAgentString()
+    expect(second).toBe(first)
+  })
 })

--- a/app/src/utils/user-agent.test.ts
+++ b/app/src/utils/user-agent.test.ts
@@ -1,14 +1,7 @@
 import { getUserAgentString } from './user-agent'
 
-jest.mock('react-native-device-info', () => ({
-  getApplicationName: () => 'BC Services Card',
-  getVersion: () => '2.1.0',
-  getBuildNumber: () => '142',
-  getSystemName: () => 'iOS',
-  getSystemVersion: () => '17.4',
-}))
-
 describe('getUserAgentString', () => {
   it('returns a formatted user-agent string', () => {
     expect(getUserAgentString()).toBe('BCServicesCard/2.1.0 (iOS 17.4; Build 142)')
-  })})
+  })
+})

--- a/app/src/utils/user-agent.ts
+++ b/app/src/utils/user-agent.ts
@@ -6,12 +6,17 @@ import {
   getVersion,
 } from 'react-native-device-info'
 
+let cachedUserAgentString: string | undefined
+
 export const getUserAgentString = (): string => {
-  const appName = getApplicationName().replace(/\s+/g, '')
+  if (cachedUserAgentString) return cachedUserAgentString
+
+  const appName = getApplicationName().replaceAll(/\s+/g, '')
   const version = getVersion()
   const systemName = getSystemName()
   const systemVersion = getSystemVersion()
   const buildNumber = getBuildNumber()
 
-  return `${appName}/${version} (${systemName} ${systemVersion}; Build ${buildNumber})`
+  cachedUserAgentString = `${appName}/${version} (${systemName} ${systemVersion}; Build ${buildNumber})`
+  return cachedUserAgentString
 }

--- a/app/src/utils/user-agent.ts
+++ b/app/src/utils/user-agent.ts
@@ -1,0 +1,11 @@
+import { getApplicationName, getBuildNumber, getSystemName, getSystemVersion, getVersion } from 'react-native-device-info'
+
+export const getUserAgentString = (): string => {
+  const appName = getApplicationName().replace(/\s+/g, '')
+  const version = getVersion()
+  const systemName = getSystemName()
+  const systemVersion = getSystemVersion()
+  const buildNumber = getBuildNumber()
+
+  return `${appName}/${version} (${systemName} ${systemVersion}; Build ${buildNumber})`
+}

--- a/app/src/utils/user-agent.ts
+++ b/app/src/utils/user-agent.ts
@@ -9,7 +9,9 @@ import {
 let cachedUserAgentString: string | undefined
 
 export const getUserAgentString = (): string => {
-  if (cachedUserAgentString) return cachedUserAgentString
+  if (cachedUserAgentString) {
+    return cachedUserAgentString
+  }
 
   const appName = getApplicationName().replaceAll(/\s+/g, '')
   const version = getVersion()

--- a/app/src/utils/user-agent.ts
+++ b/app/src/utils/user-agent.ts
@@ -1,4 +1,10 @@
-import { getApplicationName, getBuildNumber, getSystemName, getSystemVersion, getVersion } from 'react-native-device-info'
+import {
+  getApplicationName,
+  getBuildNumber,
+  getSystemName,
+  getSystemVersion,
+  getVersion,
+} from 'react-native-device-info'
 
 export const getUserAgentString = (): string => {
   const appName = getApplicationName().replace(/\s+/g, '')


### PR DESCRIPTION
## Summary
- Adds centralized `getUserAgentString()` utility that builds `AppName/Version (OS OSVersion; Build BuildNumber)` using `react-native-device-info`
- Replaces hardcoded `"Single App"` WebView user-agent in `WebViewContent`
- Adds `User-Agent` header to axios API client default headers
- Adds `userAgent` prop to shared `WebDisplay` WebView

Closes #3471

## Test plan
- [x] Unit test for `getUserAgentString()` format

## Manual testing

You can look in Grafana. `Filter Environment = SIT` and Line `Contains = YOUR BUILD NUMBER`

<img width="512" alt="Screenshot 2026-03-18 at 1 55 42 PM" src="https://github.com/user-attachments/assets/f5396ae0-6d71-42d4-be33-b67e211d5295" />
