### PR TITLE
fix: cleanup incomplete evidence metadata on hydrate

### DIFF
--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.tsx
@@ -68,14 +68,15 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
     },
   })
 
-  // Clean up any incomplete evidence entries when the screen focuses
-  // This handles the case where user selected a card but backed out before completing
+  // Clean up any incomplete evidence entries when the screen focuses.
+  // This handles the case where user selected a card but backed out before completing.
+  // Intentionally empty deps — run only once per focus, not when evidence changes,
+  // because removeIncompleteEvidence itself updates the evidence array.
   useFocusEffect(
     useCallback(() => {
       removeIncompleteEvidence(store.bcscSecure.additionalEvidenceData)
-      // prevent infinite loop
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [store.bcscSecure.additionalEvidenceData])
+    }, [])
   )
 
   useEffect(() => {

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.tsx
@@ -72,10 +72,10 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
   // This handles the case where user selected a card but backed out before completing
   useFocusEffect(
     useCallback(() => {
-      removeIncompleteEvidence()
+      removeIncompleteEvidence(store.bcscSecure.additionalEvidenceData)
       // prevent infinite loop
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
+    }, [store.bcscSecure.additionalEvidenceData])
   )
 
   useEffect(() => {

--- a/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
@@ -13,7 +13,12 @@ jest.mock('react-native-bcsc-core', () => ({
 jest.mock('./useBCSCApiClient')
 
 const mockDispatch = jest.fn()
-const mockLogger = new MockLogger()
+const mockLogger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+}
 
 const makeEvidence = (overrides: Partial<EvidenceMetadata> = {}): EvidenceMetadata => ({
   metadata: [],

--- a/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
@@ -1,0 +1,149 @@
+import { BCDispatchAction } from '@/store'
+import * as Bifold from '@bifold/core'
+import { MockLogger } from '@bifold/core'
+import { act, renderHook } from '@testing-library/react-native'
+import { EvidenceMetadata, setEvidence } from 'react-native-bcsc-core'
+import * as useBCSCApiClientModule from './useBCSCApiClient'
+import { useSecureActions } from './useSecureActions'
+
+jest.mock('@bifold/core')
+jest.mock('./useBCSCApiClient')
+
+const mockDispatch = jest.fn()
+const mockLogger = new MockLogger()
+
+const makeEvidence = (overrides: Partial<EvidenceMetadata> = {}): EvidenceMetadata => ({
+  metadata: [],
+  ...overrides,
+})
+
+describe('useSecureActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.mocked(Bifold.useStore).mockReturnValue([
+      {
+        bcscSecure: {
+          isHydrated: true,
+          additionalEvidenceData: [],
+        },
+      } as any,
+      mockDispatch,
+    ])
+    jest.mocked(Bifold.useServices).mockReturnValue([mockLogger] as any)
+    jest.mocked(useBCSCApiClientModule.useBCSCApiClientState).mockReturnValue({
+      client: {} as any,
+      isClientReady: false,
+      error: undefined,
+    } as any)
+  })
+
+  describe('removeIncompleteEvidence', () => {
+    it('should return empty array when given empty evidence', async () => {
+      const { result } = renderHook(() => useSecureActions())
+
+      let cleaned: EvidenceMetadata[] = []
+      await act(async () => {
+        cleaned = await result.current.removeIncompleteEvidence([])
+      })
+
+      expect(cleaned).toEqual([])
+      expect(mockDispatch).not.toHaveBeenCalled()
+      expect(setEvidence).not.toHaveBeenCalled()
+    })
+
+    it('should keep evidence that has metadata and documentNumber', async () => {
+      const { result } = renderHook(() => useSecureActions())
+
+      const completeEvidence = makeEvidence({
+        evidenceType: { evidence_type: 'drivers_licence' } as any,
+        metadata: [{ uri: 'photo.jpg' } as any],
+        documentNumber: 'DL123',
+      })
+
+      let cleaned: EvidenceMetadata[] = []
+      await act(async () => {
+        cleaned = await result.current.removeIncompleteEvidence([completeEvidence])
+      })
+
+      expect(cleaned).toEqual([completeEvidence])
+      expect(setEvidence).toHaveBeenCalledWith([completeEvidence])
+    })
+
+    it('should remove evidence with no photo metadata', async () => {
+      const { result } = renderHook(() => useSecureActions())
+
+      const noPhotos = makeEvidence({
+        evidenceType: { evidence_type: 'drivers_licence' } as any,
+        metadata: [],
+        documentNumber: 'DL123',
+      })
+
+      let cleaned: EvidenceMetadata[] = []
+      await act(async () => {
+        cleaned = await result.current.removeIncompleteEvidence([noPhotos])
+      })
+
+      expect(cleaned).toEqual([])
+      expect(setEvidence).toHaveBeenCalledWith([])
+    })
+
+    it('should remove evidence with no documentNumber', async () => {
+      const { result } = renderHook(() => useSecureActions())
+
+      const noDocNumber = makeEvidence({
+        evidenceType: { evidence_type: 'passport' } as any,
+        metadata: [{ uri: 'photo.jpg' } as any],
+      })
+
+      let cleaned: EvidenceMetadata[] = []
+      await act(async () => {
+        cleaned = await result.current.removeIncompleteEvidence([noDocNumber])
+      })
+
+      expect(cleaned).toEqual([])
+      expect(setEvidence).toHaveBeenCalledWith([])
+    })
+
+    it('should keep complete entries and remove incomplete ones', async () => {
+      const { result } = renderHook(() => useSecureActions())
+
+      const complete = makeEvidence({
+        evidenceType: { evidence_type: 'drivers_licence' } as any,
+        metadata: [{ uri: 'front.jpg' } as any],
+        documentNumber: 'DL456',
+      })
+      const incomplete = makeEvidence({
+        evidenceType: { evidence_type: 'passport' } as any,
+        metadata: [{ uri: 'page.jpg' } as any],
+        // no documentNumber
+      })
+
+      let cleaned: EvidenceMetadata[] = []
+      await act(async () => {
+        cleaned = await result.current.removeIncompleteEvidence([complete, incomplete])
+      })
+
+      expect(cleaned).toEqual([complete])
+      expect(setEvidence).toHaveBeenCalledWith([complete])
+    })
+
+    it('should dispatch updated evidence to store', async () => {
+      const { result } = renderHook(() => useSecureActions())
+
+      const complete = makeEvidence({
+        evidenceType: { evidence_type: 'drivers_licence' } as any,
+        metadata: [{ uri: 'photo.jpg' } as any],
+        documentNumber: 'DL789',
+      })
+
+      await act(async () => {
+        await result.current.removeIncompleteEvidence([complete])
+      })
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_SECURE_EVIDENCE_METADATA,
+        payload: [[complete]],
+      })
+    })
+  })
+})

--- a/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
@@ -7,6 +7,9 @@ import * as useBCSCApiClientModule from './useBCSCApiClient'
 import { useSecureActions } from './useSecureActions'
 
 jest.mock('@bifold/core')
+jest.mock('react-native-bcsc-core', () => ({
+  setEvidence: jest.fn(),
+}))
 jest.mock('./useBCSCApiClient')
 
 const mockDispatch = jest.fn()

--- a/app/src/bcsc-theme/hooks/useSecureActions.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.tsx
@@ -620,20 +620,32 @@ export const useSecureActions = () => {
 
   /**
    * Remove incomplete evidence entries and persist to native storage
+   *
+   * @param evidence Array of evidence metadata to filter and persist
+   * @returns A updated list of evidence metadata with incomplete entries removed
    */
-  const removeIncompleteEvidence = useCallback(async () => {
-    // Filter out incomplete evidence (those without photo metadata)
-    const updatedEvidence = store.bcscSecure.additionalEvidenceData.filter(
-      (evidence) => evidence.metadata && evidence.metadata.length > 0
-    )
+  const removeIncompleteEvidence = useCallback(
+    async (evidence: EvidenceMetadata[]) => {
+      if (!evidence.length) {
+        return []
+      }
 
-    dispatch({
-      type: BCDispatchAction.UPDATE_SECURE_EVIDENCE_METADATA,
-      payload: [updatedEvidence],
-    })
+      // Filter out incomplete evidence (those without photo metadata)
+      const updatedEvidence = evidence.filter(
+        (evidence) => evidence.metadata && evidence.metadata.length > 0 && evidence.documentNumber
+      )
 
-    await persistEvidenceData(updatedEvidence)
-  }, [dispatch, persistEvidenceData, store.bcscSecure.additionalEvidenceData])
+      dispatch({
+        type: BCDispatchAction.UPDATE_SECURE_EVIDENCE_METADATA,
+        payload: [updatedEvidence],
+      })
+
+      await persistEvidenceData(updatedEvidence)
+
+      return updatedEvidence
+    },
+    [dispatch, persistEvidenceData]
+  )
 
   /**
    * Clear all additional evidence data and persist to native storage
@@ -796,6 +808,8 @@ export const useSecureActions = () => {
         .filter((s: NativeSavedService) => s.bookmarked)
         .map((s: NativeSavedService) => s.clientRefId)
 
+      const cleanedEvidence = await removeIncompleteEvidence(evidenceData)
+
       const secureData: BCSCSecureState = {
         isHydrated: true,
 
@@ -825,7 +839,7 @@ export const useSecureActions = () => {
           : undefined,
 
         verificationRequestId: authRequest?.backCheckVerificationId,
-        additionalEvidenceData: evidenceData,
+        additionalEvidenceData: cleanedEvidence,
         userMetadata,
         savedServices,
       }
@@ -842,7 +856,7 @@ export const useSecureActions = () => {
       logger.error('Failed to hydrate secure state:', error as Error)
       throwAppError(error, ErrorRegistry.STORAGE_READ_ERROR)
     }
-  }, [logger, updateTokens, dispatch, apiClient, isClientReady])
+  }, [logger, apiClient, isClientReady, updateTokens, removeIncompleteEvidence, dispatch])
 
   /**
    * Clears secure state from store (does not delete from native storage).

--- a/app/src/bcsc-theme/hooks/useSecureActions.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.tsx
@@ -622,7 +622,7 @@ export const useSecureActions = () => {
    * Remove incomplete evidence entries and persist to native storage
    *
    * @param evidence Array of evidence metadata to filter and persist
-   * @returns A updated list of evidence metadata with incomplete entries removed
+   * @returns An updated list of evidence metadata with incomplete entries removed
    */
   const removeIncompleteEvidence = useCallback(
     async (evidence: EvidenceMetadata[]) => {

--- a/app/src/bcsc-theme/hooks/useSecureActions.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.tsx
@@ -622,11 +622,7 @@ export const useSecureActions = () => {
    * Remove incomplete evidence entries and persist to native storage
    *
    * @param evidence Array of evidence metadata to filter and persist
-<<<<<<< HEAD
-   * @returns A updated list of evidence metadata with incomplete entries removed
-=======
    * @returns An updated list of evidence metadata with incomplete entries removed
->>>>>>> e139362a3bd45813462d5ddbfd7d84e4c737b980
    */
   const removeIncompleteEvidence = useCallback(
     async (evidence: EvidenceMetadata[]) => {
@@ -636,11 +632,7 @@ export const useSecureActions = () => {
 
       // Filter out incomplete evidence (those without photo metadata)
       const updatedEvidence = evidence.filter(
-<<<<<<< HEAD
-        (evidence) => evidence.metadata && evidence.metadata.length > 0 && evidence.documentNumber
-=======
         (item) => item.metadata && item.metadata.length > 0 && item.documentNumber
->>>>>>> e139362a3bd45813462d5ddbfd7d84e4c737b980
       )
 
       dispatch({

--- a/app/src/bcsc-theme/hooks/useSecureActions.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.tsx
@@ -632,7 +632,7 @@ export const useSecureActions = () => {
 
       // Filter out incomplete evidence (those without photo metadata)
       const updatedEvidence = evidence.filter(
-        (evidence) => evidence.metadata && evidence.metadata.length > 0 && evidence.documentNumber
+        (item) => item.metadata && item.metadata.length > 0 && item.documentNumber
       )
 
       dispatch({

--- a/app/src/bcsc-theme/hooks/useSecureActions.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.tsx
@@ -620,20 +620,32 @@ export const useSecureActions = () => {
 
   /**
    * Remove incomplete evidence entries and persist to native storage
+   *
+   * @param evidence Array of evidence metadata to filter and persist
+   * @returns A updated list of evidence metadata with incomplete entries removed
    */
-  const removeIncompleteEvidence = useCallback(async () => {
-    // Filter out incomplete evidence (those without photo metadata)
-    const updatedEvidence = store.bcscSecure.additionalEvidenceData.filter(
-      (evidence) => evidence.metadata && evidence.metadata.length > 0
-    )
+  const removeIncompleteEvidence = useCallback(
+    async (evidence: EvidenceMetadata[]) => {
+      if (!evidence.length) {
+        return []
+      }
 
-    dispatch({
-      type: BCDispatchAction.UPDATE_SECURE_EVIDENCE_METADATA,
-      payload: [updatedEvidence],
-    })
+      // Filter out incomplete evidence (those without photo metadata)
+      const updatedEvidence = evidence.filter(
+        (evidence) => evidence.metadata && evidence.metadata.length > 0 && evidence.documentNumber
+      )
 
-    await persistEvidenceData(updatedEvidence)
-  }, [dispatch, persistEvidenceData, store.bcscSecure.additionalEvidenceData])
+      dispatch({
+        type: BCDispatchAction.UPDATE_SECURE_EVIDENCE_METADATA,
+        payload: [updatedEvidence],
+      })
+
+      await persistEvidenceData(updatedEvidence)
+
+      return updatedEvidence
+    },
+    [dispatch, persistEvidenceData]
+  )
 
   /**
    * Clear all additional evidence data and persist to native storage
@@ -796,6 +808,14 @@ export const useSecureActions = () => {
         .filter((s: NativeSavedService) => s.bookmarked)
         .map((s: NativeSavedService) => s.clientRefId)
 
+      let cleanedEvidence = evidenceData
+      try {
+        cleanedEvidence = await removeIncompleteEvidence(evidenceData)
+      } catch (error) {
+        // If removing incomplete evidence fails, log the error but continue hydration
+        logger.error('Error removing incomplete evidence during hydration:', error as Error)
+      }
+
       const secureData: BCSCSecureState = {
         isHydrated: true,
 
@@ -825,7 +845,7 @@ export const useSecureActions = () => {
           : undefined,
 
         verificationRequestId: authRequest?.backCheckVerificationId,
-        additionalEvidenceData: evidenceData,
+        additionalEvidenceData: cleanedEvidence,
         userMetadata,
         savedServices,
       }
@@ -842,7 +862,7 @@ export const useSecureActions = () => {
       logger.error('Failed to hydrate secure state:', error as Error)
       throwAppError(error, ErrorRegistry.STORAGE_READ_ERROR)
     }
-  }, [logger, updateTokens, dispatch, apiClient, isClientReady])
+  }, [logger, apiClient, isClientReady, updateTokens, removeIncompleteEvidence, dispatch])
 
   /**
    * Clears secure state from store (does not delete from native storage).


### PR DESCRIPTION
# Summary of Changes

This PR fixes a bug that was incorrectly persisting ID evidence metadata when the app was shutdown. Now the incomplete evidence is removed on hydration.

# Testing Instructions

Replace this text with detailed instructions on how to test the changes included in this PR.

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

https://github.com/orgs/bcgov/projects/108/views/1?pane=issue&itemId=166456987&issue=bcgov%7Cbc-wallet-mobile%7C3474
