### PR TITLE
fix: use build-time DEFAULT_ENVIRONMENT for initial IAS environment

### DIFF
--- a/.github/workflows/actions/create-environment-settings/action.yml
+++ b/.github/workflows/actions/create-environment-settings/action.yml
@@ -37,6 +37,9 @@ inputs:
   snowplow_collector_url:
     description: 'The Snowplow collector URL'
     required: true
+  default_environment:
+    description: 'The default IAS environment (e.g. SIT, PROD, QA, TEST)'
+    required: false
 
 runs:
   using: composite
@@ -54,6 +57,7 @@ runs:
         REMOTE_LOGGING_URL: ${{ inputs.remote_logging_url }}
         INDY_VDR_PROXY_URL: ${{ inputs.indy_vdr_proxy_url }}
         SNOWPLOW_COLLECTOR_URL: ${{ inputs.snowplow_collector_url }}
+        DEFAULT_ENVIRONMENT: ${{ inputs.default_environment }}
       run: |
         echo "BUILD_TARGET=${BUILD_TARGET}" >.env
         echo "MEDIATOR_USE_PUSH_NOTIFICATIONS=${MEDIATOR_USE_PUSH_NOTIFICATIONS}" >>.env
@@ -64,6 +68,7 @@ runs:
         echo "REMOTE_LOGGING_URL=${REMOTE_LOGGING_URL}" >>.env
         echo "INDY_VDR_PROXY_URL=${INDY_VDR_PROXY_URL}" >>.env
         echo "SNOWPLOW_COLLECTOR_URL=${SNOWPLOW_COLLECTOR_URL}" >>.env
+        echo "DEFAULT_ENVIRONMENT=${DEFAULT_ENVIRONMENT}" >>.env
 
     - name: Write Google Services credentials
       shell: bash

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -556,6 +556,7 @@ jobs:
           google_services_credentials_base64: ${{ secrets[env.IOS_GOOGLE_SERVICES_SECRET] }}
           platform: ios
           snowplow_collector_url: ${{ vars.SNOWPLOW_COLLECTOR_URL }}
+          default_environment: ${{ env.DEFAULT_ENVIRONMENT }}
 
       - name: Update APS environment
         run: |
@@ -831,6 +832,7 @@ jobs:
           google_services_credentials_base64: ${{ secrets[env.ANDROID_GOOGLE_SERVICES_SECRET] }}
           platform: android
           snowplow_collector_url: ${{ vars.SNOWPLOW_COLLECTOR_URL }}
+          default_environment: ${{ env.DEFAULT_ENVIRONMENT }}
 
       - name: Create release keystore
         # This step will not work in a `fork` because it will not have access

--- a/app/.env.sample
+++ b/app/.env.sample
@@ -4,6 +4,10 @@
 # Specify the build target: (bcwallet, bcsc)
 BUILD_TARGET=bcsc
 
+# Default IAS environment for initial app launch (PROD, SIT, QA, TEST, DEV, DEV2, PREPROD)
+# Leave empty for local dev — __DEV__ builds default to SIT automatically.
+DEFAULT_ENVIRONMENT=
+
 ########################################
 # Mediator Configuration
 ########################################

--- a/app/.env.sample
+++ b/app/.env.sample
@@ -5,7 +5,7 @@
 BUILD_TARGET=bcsc
 
 # Default IAS environment for initial app launch (PROD, SIT, QA, TEST, DEV, DEV2, PREPROD)
-# Leave empty for local dev — __DEV__ builds default to SIT automatically.
+# Leave empty for local dev — in __DEV__ BCSC builds the default is SIT; in __DEV__ bcwallet builds the default is PROD.
 DEFAULT_ENVIRONMENT=
 
 ########################################

--- a/app/src/store.test.ts
+++ b/app/src/store.test.ts
@@ -1,0 +1,71 @@
+import Config from 'react-native-config'
+import { getInitialEnvironment, IASEnvironment } from './store'
+
+jest.mock('react-native-config', () => ({
+  BUILD_TARGET: 'bcsc',
+  DEFAULT_ENVIRONMENT: '',
+}))
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn(() => '4.0.0'),
+}))
+
+jest.mock('react-native-bcsc-core', () => ({}))
+jest.mock('@bifold/core', () => ({
+  defaultState: { preferences: {}, tours: {}, onboarding: {}, loginAttempt: {}, migration: {} },
+  mergeReducers: jest.fn(),
+  reducer: jest.fn(),
+}))
+
+const configMock = Config as { DEFAULT_ENVIRONMENT: string; BUILD_TARGET: string }
+
+describe('getInitialEnvironment', () => {
+  afterEach(() => {
+    configMock.DEFAULT_ENVIRONMENT = ''
+    configMock.BUILD_TARGET = 'bcsc'
+  })
+
+  it('returns SIT when DEFAULT_ENVIRONMENT is SIT', () => {
+    configMock.DEFAULT_ENVIRONMENT = 'SIT'
+    expect(getInitialEnvironment()).toBe(IASEnvironment.SIT)
+  })
+
+  it('returns PROD when DEFAULT_ENVIRONMENT is PROD', () => {
+    configMock.DEFAULT_ENVIRONMENT = 'PROD'
+    expect(getInitialEnvironment()).toBe(IASEnvironment.PROD)
+  })
+
+  it('returns QA when DEFAULT_ENVIRONMENT is QA', () => {
+    configMock.DEFAULT_ENVIRONMENT = 'QA'
+    expect(getInitialEnvironment()).toBe(IASEnvironment.QA)
+  })
+
+  it('returns TEST when DEFAULT_ENVIRONMENT is TEST', () => {
+    configMock.DEFAULT_ENVIRONMENT = 'TEST'
+    expect(getInitialEnvironment()).toBe(IASEnvironment.TEST)
+  })
+
+  it('is case-insensitive', () => {
+    configMock.DEFAULT_ENVIRONMENT = 'sit'
+    expect(getInitialEnvironment()).toBe(IASEnvironment.SIT)
+  })
+
+  it('falls back to SIT for __DEV__ BCSC builds when DEFAULT_ENVIRONMENT is empty', () => {
+    configMock.DEFAULT_ENVIRONMENT = ''
+    configMock.BUILD_TARGET = 'bcsc'
+    // __DEV__ is true in test environment
+    expect(getInitialEnvironment()).toBe(IASEnvironment.SIT)
+  })
+
+  it('falls back to PROD when DEFAULT_ENVIRONMENT is empty and not a __DEV__ BCSC build', () => {
+    configMock.DEFAULT_ENVIRONMENT = ''
+    configMock.BUILD_TARGET = 'bcwallet'
+    expect(getInitialEnvironment()).toBe(IASEnvironment.PROD)
+  })
+
+  it('falls back when DEFAULT_ENVIRONMENT is an invalid value', () => {
+    configMock.DEFAULT_ENVIRONMENT = 'INVALID'
+    configMock.BUILD_TARGET = 'bcwallet'
+    expect(getInitialEnvironment()).toBe(IASEnvironment.PROD)
+  })
+})

--- a/app/src/store.test.ts
+++ b/app/src/store.test.ts
@@ -18,13 +18,13 @@ jest.mock('@bifold/core', () => ({
 }))
 
 const configMock = Config as { DEFAULT_ENVIRONMENT: string; BUILD_TARGET: string }
+const originalDev = __DEV__
 
 describe('getInitialEnvironment', () => {
-  const originalDev = global.__DEV__
-
   afterEach(() => {
     configMock.DEFAULT_ENVIRONMENT = ''
     configMock.BUILD_TARGET = 'bcsc'
+    // @ts-expect-error - set global DEV
     global.__DEV__ = originalDev
   })
 
@@ -54,6 +54,7 @@ describe('getInitialEnvironment', () => {
   })
 
   it('falls back to SIT for __DEV__ BCSC builds when DEFAULT_ENVIRONMENT is empty', () => {
+    // @ts-expect-error - set global DEV
     global.__DEV__ = true
     configMock.DEFAULT_ENVIRONMENT = ''
     configMock.BUILD_TARGET = 'bcsc'
@@ -61,6 +62,7 @@ describe('getInitialEnvironment', () => {
   })
 
   it('falls back to PROD when DEFAULT_ENVIRONMENT is empty and not a __DEV__ BCSC build', () => {
+    // @ts-expect-error - set global DEV
     global.__DEV__ = true
     configMock.DEFAULT_ENVIRONMENT = ''
     configMock.BUILD_TARGET = 'bcwallet'
@@ -68,6 +70,7 @@ describe('getInitialEnvironment', () => {
   })
 
   it('falls back to PROD when __DEV__ is false and DEFAULT_ENVIRONMENT is empty', () => {
+    // @ts-expect-error - set global DEV
     global.__DEV__ = false
     configMock.DEFAULT_ENVIRONMENT = ''
     configMock.BUILD_TARGET = 'bcsc'
@@ -75,6 +78,7 @@ describe('getInitialEnvironment', () => {
   })
 
   it('falls back when DEFAULT_ENVIRONMENT is an invalid value', () => {
+    // @ts-expect-error - set global DEV
     global.__DEV__ = true
     configMock.DEFAULT_ENVIRONMENT = 'INVALID'
     configMock.BUILD_TARGET = 'bcwallet'

--- a/app/src/store.test.ts
+++ b/app/src/store.test.ts
@@ -20,9 +20,12 @@ jest.mock('@bifold/core', () => ({
 const configMock = Config as { DEFAULT_ENVIRONMENT: string; BUILD_TARGET: string }
 
 describe('getInitialEnvironment', () => {
+  const originalDev = global.__DEV__
+
   afterEach(() => {
     configMock.DEFAULT_ENVIRONMENT = ''
     configMock.BUILD_TARGET = 'bcsc'
+    global.__DEV__ = originalDev
   })
 
   it('returns SIT when DEFAULT_ENVIRONMENT is SIT', () => {
@@ -51,19 +54,28 @@ describe('getInitialEnvironment', () => {
   })
 
   it('falls back to SIT for __DEV__ BCSC builds when DEFAULT_ENVIRONMENT is empty', () => {
+    global.__DEV__ = true
     configMock.DEFAULT_ENVIRONMENT = ''
     configMock.BUILD_TARGET = 'bcsc'
-    // __DEV__ is true in test environment
     expect(getInitialEnvironment()).toBe(IASEnvironment.SIT)
   })
 
   it('falls back to PROD when DEFAULT_ENVIRONMENT is empty and not a __DEV__ BCSC build', () => {
+    global.__DEV__ = true
     configMock.DEFAULT_ENVIRONMENT = ''
     configMock.BUILD_TARGET = 'bcwallet'
     expect(getInitialEnvironment()).toBe(IASEnvironment.PROD)
   })
 
+  it('falls back to PROD when __DEV__ is false and DEFAULT_ENVIRONMENT is empty', () => {
+    global.__DEV__ = false
+    configMock.DEFAULT_ENVIRONMENT = ''
+    configMock.BUILD_TARGET = 'bcsc'
+    expect(getInitialEnvironment()).toBe(IASEnvironment.PROD)
+  })
+
   it('falls back when DEFAULT_ENVIRONMENT is an invalid value', () => {
+    global.__DEV__ = true
     configMock.DEFAULT_ENVIRONMENT = 'INVALID'
     configMock.BUILD_TARGET = 'bcwallet'
     expect(getInitialEnvironment()).toBe(IASEnvironment.PROD)

--- a/app/src/store.tsx
+++ b/app/src/store.tsx
@@ -8,14 +8,12 @@ import {
 } from '@bifold/core'
 import { BCSCCardProcess, EvidenceMetadata } from 'react-native-bcsc-core'
 import Config from 'react-native-config'
-import { getInstallerPackageNameSync, getVersion } from 'react-native-device-info'
+import { getVersion } from 'react-native-device-info'
 import { DeviceVerificationOption } from './bcsc-theme/api/hooks/useAuthorizationApi'
 import { VerificationPhotoUploadPayload, VerificationPrompt } from './bcsc-theme/api/hooks/useEvidenceApi'
 import { BCSCBannerMessage } from './bcsc-theme/components/AppBanner'
 import { ProvinceCode } from './bcsc-theme/utils/address-utils'
 import { ANALYTICS_APP_ID_PREFIX } from './constants'
-
-const TESTFLIGHT_PACKAGE_NAME = 'TestFlight'
 
 export interface IASEnvironment {
   name: string
@@ -295,14 +293,13 @@ const getAnalyticsAppId = (domain: string): string => {
 }
 
 export const getInitialEnvironment = (): IASEnvironment => {
-  if (__DEV__ && Config.BUILD_TARGET === Mode.BCSC) {
-    // Local development builds for BCSC use SIT environment
-    return IASEnvironment.SIT
+  const envName = Config.DEFAULT_ENVIRONMENT?.toUpperCase()
+  if (envName && envName in IASEnvironment) {
+    return IASEnvironment[envName as keyof typeof IASEnvironment]
   }
 
-  // FIXME: Remove this once #3253 or #3259 issues are resolved
-  if (Config.BUILD_TARGET === Mode.BCSC && getInstallerPackageNameSync() === TESTFLIGHT_PACKAGE_NAME) {
-    // TestFlight builds for BCSC use SIT environment (temporarily allows testing V3 migration)
+  // Fallback: local dev builds for BCSC use SIT
+  if (__DEV__ && Config.BUILD_TARGET === Mode.BCSC) {
     return IASEnvironment.SIT
   }
 

--- a/variants/bcsc-dev/variant.env
+++ b/variants/bcsc-dev/variant.env
@@ -2,6 +2,7 @@
 APP_NAME='BC Services Card'
 APP_VERSION='4.0.0'
 BUILD_TARGET='bcsc'
+DEFAULT_ENVIRONMENT='SIT'
 
 # Android
 ANDROID_PACKAGE_NAME='ca.bc.gov.id.servicescard.dev'

--- a/variants/bcsc-prod/variant.env
+++ b/variants/bcsc-prod/variant.env
@@ -2,6 +2,7 @@
 APP_NAME='BC Services Card'
 APP_VERSION='4.0.0'
 BUILD_TARGET='bcsc'
+DEFAULT_ENVIRONMENT='PROD'
 
 # Android
 ANDROID_PACKAGE_NAME='ca.bc.gov.id.servicescard'

--- a/variants/bcsc-qa/variant.env
+++ b/variants/bcsc-qa/variant.env
@@ -2,6 +2,7 @@
 APP_NAME='BC Services Card'
 APP_VERSION='4.0.0'
 BUILD_TARGET='bcsc'
+DEFAULT_ENVIRONMENT='QA'
 
 # Android
 ANDROID_PACKAGE_NAME='ca.bc.gov.id.servicescard.qa'

--- a/variants/bcsc-test/variant.env
+++ b/variants/bcsc-test/variant.env
@@ -2,6 +2,7 @@
 APP_NAME='BC Services Card'
 APP_VERSION='4.0.0'
 BUILD_TARGET='bcsc'
+DEFAULT_ENVIRONMENT='TEST'
 
 # Android
 ANDROID_PACKAGE_NAME='ca.bc.gov.id.servicescard.test'

--- a/variants/bcwallet-prod/variant.env
+++ b/variants/bcwallet-prod/variant.env
@@ -5,6 +5,7 @@
 APP_NAME='BC Wallet'
 APP_VERSION='1.0.27'
 BUILD_TARGET='bcwallet'
+DEFAULT_ENVIRONMENT='PROD'
 
 # Android
 ANDROID_PACKAGE_NAME='ca.bc.gov.BCWallet'


### PR DESCRIPTION
## Summary
- Replaces the fragile TestFlight-only runtime check with an explicit `DEFAULT_ENVIRONMENT` config variable baked into the binary via `.env`
- Each variant now declares its default environment (`SIT`, `PROD`, `QA`, `TEST`), fixing Android BCSC Dev builds incorrectly defaulting to PROD instead of SIT
- Removes `getInstallerPackageNameSync` dependency and the FIXME hack

Closes #3499

## Test plan
- [x] Verify `yarn typecheck` passes
- [x] Verify `yarn test` passes (includes 8 new tests for `getInitialEnvironment()`)
- [x] CI builds for `bcsc-dev` variant: confirm Android defaults to SIT
- [x] CI builds for `bcsc-prod` variant: confirm both platforms default to PROD
- [x] Local dev build (`__DEV__`): confirm BCSC still defaults to SIT without `DEFAULT_ENVIRONMENT` set