### PR TITLE
fix: updated server outage banner design

### DIFF
--- a/app/src/bcsc-theme/components/AppBanner.tsx
+++ b/app/src/bcsc-theme/components/AppBanner.tsx
@@ -15,10 +15,11 @@ export enum BCSCBanner {
 
 export interface BCSCBannerMessage {
   id: BCSCBanner
-  title: string
+  title: string | undefined
   description?: string
   type: 'error' | 'warning' | 'info' | 'success'
   dismissible?: boolean
+  metadata?: Record<string, unknown>
 }
 
 export interface AppBannerSectionProps extends BCSCBannerMessage {
@@ -75,6 +76,8 @@ export const AppBannerSection: React.FC<AppBannerSectionProps> = ({
     },
     icon: {
       marginRight: Spacing.md,
+      // Aligns the icon and the first line of text vertically (assuming the icon is 24px and line height is 24)
+      marginTop: 2,
     },
   })
 
@@ -132,15 +135,17 @@ export const AppBannerSection: React.FC<AppBannerSectionProps> = ({
         testID={testIdWithKey(`icon-${type}`)}
       />
       <View style={styles.textContainer}>
-        <ThemedText
-          variant={'bold'}
-          style={{
-            color: type === 'warning' ? ColorPalette.brand.secondaryBackground : ColorPalette.grayscale.white,
-          }}
-          testID={testIdWithKey(`text-${type}`)}
-        >
-          {title}
-        </ThemedText>
+        {title ? (
+          <ThemedText
+            variant={'bold'}
+            style={{
+              color: type === 'warning' ? ColorPalette.brand.secondaryBackground : ColorPalette.grayscale.white,
+            }}
+            testID={testIdWithKey(`text-${type}`)}
+          >
+            {title}
+          </ThemedText>
+        ) : null}
         {description ? (
           <ThemedText
             style={{

--- a/app/src/bcsc-theme/components/NotificationBannerContainer.tsx
+++ b/app/src/bcsc-theme/components/NotificationBannerContainer.tsx
@@ -1,12 +1,12 @@
 import { BCDispatchAction, BCState } from '@/store'
-import { SafeAreaModal, useStore } from '@bifold/core'
+import { SafeAreaModal, TOKENS, useServices, useStore } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useCallback, useRef, useState } from 'react'
-import { View } from 'react-native'
+import { Linking, View } from 'react-native'
 import { ReviewDevices } from '../features/settings/components/ReviewDevices'
 import { BCSCMainStackParams, BCSCScreens } from '../types/navigators'
-import { AppBanner, BCSCBanner } from './AppBanner'
+import { AppBanner, BCSCBanner, BCSCBannerMessage } from './AppBanner'
 
 interface NotificationBannerContainerProps {
   onManageDevices: () => void
@@ -20,19 +20,32 @@ interface NotificationBannerContainerProps {
  */
 export const NotificationBannerContainer = ({ onManageDevices }: NotificationBannerContainerProps) => {
   const [store, dispatch] = useStore<BCState>()
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const [devicesModalVisible, setDevicesModalVisible] = useState(false)
   const devicesModalShouldAnimate = useRef(true)
   const navigation = useNavigation<StackNavigationProp<BCSCMainStackParams>>()
 
-  const handleBannerPress = (bannerId: BCSCBanner): void => {
+  const handleBannerPress = async (banner: BCSCBannerMessage): Promise<void> => {
+    const bannerId = banner.id
     // Handle other banner types as needed
 
-    if (bannerId === BCSCBanner.DEVICE_LIMIT_EXCEEDED) {
+    if (banner.id === BCSCBanner.DEVICE_LIMIT_EXCEEDED) {
       return setDevicesModalVisible(true)
     }
 
-    if (bannerId === BCSCBanner.ACCOUNT_EXPIRING_SOON) {
+    if (banner.id === BCSCBanner.ACCOUNT_EXPIRING_SOON) {
       navigation.navigate(BCSCScreens.AccountRenewalInformation)
+    }
+
+    if (
+      (banner.id === BCSCBanner.IAS_SERVER_NOTIFICATION || banner.id === BCSCBanner.IAS_SERVER_UNAVAILABLE) &&
+      typeof banner.metadata?.contactLink === 'string'
+    ) {
+      try {
+        await Linking.openURL(banner.metadata.contactLink)
+      } catch (error) {
+        logger.error('Failed to open URL from banner:', error as Error)
+      }
     }
 
     const message = store.bcsc.bannerMessages.find((banner) => banner.id === bannerId)
@@ -71,7 +84,7 @@ export const NotificationBannerContainer = ({ onManageDevices }: NotificationBan
           description: banner.description,
           type: banner.type,
           dismissible: banner.dismissible,
-          onPress: () => handleBannerPress(banner.id),
+          onPress: () => handleBannerPress(banner),
         }))}
       />
     </View>

--- a/app/src/bcsc-theme/components/NotificationBannerContainer.tsx
+++ b/app/src/bcsc-theme/components/NotificationBannerContainer.tsx
@@ -1,9 +1,10 @@
 import { BCDispatchAction, BCState } from '@/store'
+import { openLink } from '@/utils/links'
 import { SafeAreaModal, TOKENS, useServices, useStore } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useCallback, useRef, useState } from 'react'
-import { Linking, View } from 'react-native'
+import { View } from 'react-native'
 import { ReviewDevices } from '../features/settings/components/ReviewDevices'
 import { BCSCMainStackParams, BCSCScreens } from '../types/navigators'
 import { AppBanner, BCSCBanner, BCSCBannerMessage } from './AppBanner'
@@ -42,7 +43,7 @@ export const NotificationBannerContainer = ({ onManageDevices }: NotificationBan
       typeof banner.metadata?.contactLink === 'string'
     ) {
       try {
-        await Linking.openURL(banner.metadata.contactLink)
+        await openLink(banner.metadata.contactLink)
       } catch (error) {
         logger.error('Failed to open URL from banner:', error as Error)
       }

--- a/app/src/bcsc-theme/features/account/__snapshots__/AccountExpiredScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/account/__snapshots__/AccountExpiredScreen.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`AccountExpired renders correctly 1`] = `
           },
           {
             "marginRight": 16,
+            "marginTop": 2,
           },
           {
             "fontFamily": "Material Design Icons",

--- a/app/src/services/system-checks/ServerStatusSystemCheck.ts
+++ b/app/src/services/system-checks/ServerStatusSystemCheck.ts
@@ -5,10 +5,10 @@ import { SystemCheckStrategy, SystemCheckUtils } from './system-checks'
 
 /**
  * Checks the IAS server status and dispatches banner messages based on availability.
- * Will show error banner if server is unavailable, or info banner if there is a status message.
+ * Will show info banner if server is unavailable or if there is a status message from the server.
  *
  * Note:
- *   On failure, it dispatches a warning banner message.
+ *   On failure, it dispatches a info banner message.
  *   On success, it removes the banner if it exists.
  *
  * @class ServerStatusStartupCheck
@@ -33,7 +33,7 @@ export class ServerStatusSystemCheck implements SystemCheckStrategy {
   }
 
   /**
-   * Handles the failure of the server status check by dispatching an error banner message.
+   * Handles the failure of the server status check by dispatching an info banner message.
    *
    * @returns {*} {void}
    */
@@ -43,6 +43,7 @@ export class ServerStatusSystemCheck implements SystemCheckStrategy {
       payload: [
         {
           id: BCSCBanner.IAS_SERVER_UNAVAILABLE,
+          title: undefined, // Note: Status messages can be verbose, using description for better formatting
           description:
             this.serverStatus.statusMessage ??
             this.utils.translation('BCSC.SystemChecks.ServerStatus.UnavailableBannerTitle'),
@@ -58,7 +59,7 @@ export class ServerStatusSystemCheck implements SystemCheckStrategy {
   }
 
   /**
-   * Handles the success of the server status check by removing the error banner message if it exists.
+   * Handles the success of the server status check by removing the info banner message if it exists.
    *
    * @returns {*} {void}
    */
@@ -76,7 +77,7 @@ export class ServerStatusSystemCheck implements SystemCheckStrategy {
       payload: [
         {
           id: BCSCBanner.IAS_SERVER_NOTIFICATION,
-          title: undefined, // Note: Staus messages can be verbose, using description for better formatting
+          title: undefined, // Note: Status messages can be verbose, using description for better formatting
           description: this.serverStatus.statusMessage,
           type: 'info',
           variant: 'summary',

--- a/app/src/services/system-checks/ServerStatusSystemCheck.ts
+++ b/app/src/services/system-checks/ServerStatusSystemCheck.ts
@@ -43,12 +43,16 @@ export class ServerStatusSystemCheck implements SystemCheckStrategy {
       payload: [
         {
           id: BCSCBanner.IAS_SERVER_UNAVAILABLE,
-          title:
-            this.serverStatus?.statusMessage ??
+          title: undefined, // Note: Staus messages can be verbose, using description for better formatting
+          description:
+            this.serverStatus.statusMessage ??
             this.utils.translation('BCSC.SystemChecks.ServerStatus.UnavailableBannerTitle'),
-          type: 'error',
+          type: 'info',
           variant: 'summary',
           dismissible: true,
+          metadata: {
+            contactLink: this.serverStatus.contactLink,
+          },
         },
       ],
     })
@@ -73,10 +77,14 @@ export class ServerStatusSystemCheck implements SystemCheckStrategy {
       payload: [
         {
           id: BCSCBanner.IAS_SERVER_NOTIFICATION,
-          title: this.serverStatus.statusMessage,
+          title: undefined, // Note: Staus messages can be verbose, using description for better formatting
+          description: this.serverStatus.statusMessage,
           type: 'info',
           variant: 'summary',
           dismissible: true,
+          metadata: {
+            contactLink: this.serverStatus.contactLink,
+          },
         },
       ],
     })

--- a/app/src/services/system-checks/ServerStatusSystemCheck.ts
+++ b/app/src/services/system-checks/ServerStatusSystemCheck.ts
@@ -43,7 +43,6 @@ export class ServerStatusSystemCheck implements SystemCheckStrategy {
       payload: [
         {
           id: BCSCBanner.IAS_SERVER_UNAVAILABLE,
-          title: undefined, // Note: Staus messages can be verbose, using description for better formatting
           description:
             this.serverStatus.statusMessage ??
             this.utils.translation('BCSC.SystemChecks.ServerStatus.UnavailableBannerTitle'),

--- a/app/src/services/system-checks/system-checks.test.ts
+++ b/app/src/services/system-checks/system-checks.test.ts
@@ -209,50 +209,34 @@ describe('System Checks', () => {
 
   describe('ServerStatusSystemCheck', () => {
     describe('runCheck', () => {
-      it('should return true when server status ok', async () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn() as any,
-          logger: {} as any,
-        }
-        const serverStatus: any = { status: 'ok' }
+      it('should return true when server status ok', () => {
+        const mockUtils = { dispatch: jest.fn(), translation: jest.fn() as any, logger: {} as any }
+        const check = new ServerStatusSystemCheck({ status: 'ok' } as any, mockUtils)
 
-        const deviceCountCheck = new ServerStatusSystemCheck(serverStatus, mockUtils)
-
-        const result = deviceCountCheck.runCheck()
-
-        expect(result).toBe(true)
+        expect(check.runCheck()).toBe(true)
       })
 
-      it('should return false when server status not ok', async () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn() as any,
-          logger: {} as any,
-        }
-        const serverStatus: any = { status: 'unknown' }
+      it('should return false when server status not ok', () => {
+        const mockUtils = { dispatch: jest.fn(), translation: jest.fn() as any, logger: {} as any }
+        const check = new ServerStatusSystemCheck({ status: 'unknown' } as any, mockUtils)
 
-        const deviceCountCheck = new ServerStatusSystemCheck(serverStatus, mockUtils)
-
-        const result = deviceCountCheck.runCheck()
-
-        expect(result).toBe(false)
+        expect(check.runCheck()).toBe(false)
       })
     })
 
     describe('onFail', () => {
-      it('should dispatch an error banner message', async () => {
+      it('should dispatch an info banner with translated description when no statusMessage', () => {
         const mockUtils = {
           dispatch: jest.fn(),
           translation: jest.fn().mockReturnValue('Server unavailable') as any,
           logger: {} as any,
         }
-        const serverStatus: any = { status: 'ok', contactLink: 'https://status.com' }
+        const check = new ServerStatusSystemCheck(
+          { status: 'down', contactLink: 'https://status.com' } as any,
+          mockUtils
+        )
 
-        const serverStatusCheck: any = new ServerStatusSystemCheck(serverStatus, mockUtils)
-        serverStatusCheck.serverStatus.contactLink = 'https://status.com'
-
-        serverStatusCheck.onFail()
+        check.onFail()
 
         expect(mockUtils.dispatch).toHaveBeenCalledTimes(1)
         expect(mockUtils.dispatch).toHaveBeenCalledWith({
@@ -263,31 +247,25 @@ describe('System Checks', () => {
               title: undefined,
               description: 'Server unavailable',
               type: 'info',
-              variant: 'summary',
               dismissible: true,
-              metadata: {
-                contactLink: 'https://status.com',
-              },
+              metadata: { contactLink: 'https://status.com' },
             }),
           ],
         })
       })
 
-      it('should use server status message if available', async () => {
+      it('should use statusMessage as description when available', () => {
         const mockUtils = {
           dispatch: jest.fn(),
           translation: jest.fn().mockReturnValue('Server unavailable') as any,
           logger: {} as any,
         }
+        const check = new ServerStatusSystemCheck(
+          { status: 'down', contactLink: 'https://status.com', statusMessage: 'Custom server down message' } as any,
+          mockUtils
+        )
 
-        const serverStatus: any = { status: 'ok' }
-
-        const serverStatusCheck: any = new ServerStatusSystemCheck(serverStatus, mockUtils)
-
-        serverStatusCheck.serverStatus.contactLink = 'https://status.com'
-        serverStatusCheck.serverStatus.statusMessage = 'Custom server down message'
-
-        serverStatusCheck.onFail()
+        check.onFail()
 
         expect(mockUtils.dispatch).toHaveBeenCalledTimes(1)
         expect(mockUtils.dispatch).toHaveBeenCalledWith({
@@ -295,14 +273,9 @@ describe('System Checks', () => {
           payload: [
             expect.objectContaining({
               id: BCSCBanner.IAS_SERVER_UNAVAILABLE,
-              title: undefined,
               description: 'Custom server down message',
               type: 'info',
-              variant: 'summary',
-              dismissible: true,
-              metadata: {
-                contactLink: 'https://status.com',
-              },
+              metadata: { contactLink: 'https://status.com' },
             }),
           ],
         })
@@ -310,40 +283,31 @@ describe('System Checks', () => {
     })
 
     describe('onSuccess', () => {
-      it('should dispatch action to remove the banner message', async () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn() as any,
-          logger: {} as any,
-        }
+      it('should remove both banner messages when no statusMessage', () => {
+        const mockUtils = { dispatch: jest.fn(), translation: jest.fn() as any, logger: {} as any }
+        const check = new ServerStatusSystemCheck({ status: 'ok' } as any, mockUtils)
 
-        const serverStatus: any = { status: 'ok' }
-
-        const serverStatusCheck = new ServerStatusSystemCheck(serverStatus, mockUtils)
-
-        serverStatusCheck.onSuccess()
+        check.onSuccess()
 
         expect(mockUtils.dispatch).toHaveBeenCalledTimes(2)
+        expect(mockUtils.dispatch).toHaveBeenCalledWith({
+          type: BCDispatchAction.REMOVE_BANNER_MESSAGE,
+          payload: [BCSCBanner.IAS_SERVER_NOTIFICATION],
+        })
         expect(mockUtils.dispatch).toHaveBeenCalledWith({
           type: BCDispatchAction.REMOVE_BANNER_MESSAGE,
           payload: [BCSCBanner.IAS_SERVER_UNAVAILABLE],
         })
       })
 
-      it('should dispatch info banner if server status message exists', async () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn() as any,
-          logger: {} as any,
-        }
+      it('should dispatch info banner if statusMessage exists', () => {
+        const mockUtils = { dispatch: jest.fn(), translation: jest.fn() as any, logger: {} as any }
+        const check = new ServerStatusSystemCheck(
+          { status: 'ok', contactLink: 'https://status.com', statusMessage: 'Server maintenance scheduled' } as any,
+          mockUtils
+        )
 
-        const serverStatus: any = { status: 'ok', contactLink: 'https://status.com' }
-
-        const serverStatusCheck: any = new ServerStatusSystemCheck(serverStatus, mockUtils)
-
-        serverStatusCheck.serverStatus.statusMessage = 'Server maintenance scheduled'
-
-        serverStatusCheck.onSuccess()
+        check.onSuccess()
 
         expect(mockUtils.dispatch).toHaveBeenCalledTimes(3)
         expect(mockUtils.dispatch).toHaveBeenCalledWith({
@@ -351,14 +315,10 @@ describe('System Checks', () => {
           payload: [
             expect.objectContaining({
               id: BCSCBanner.IAS_SERVER_NOTIFICATION,
-              title: undefined,
               description: 'Server maintenance scheduled',
               type: 'info',
-              variant: 'summary',
               dismissible: true,
-              metadata: {
-                contactLink: 'https://status.com',
-              },
+              metadata: { contactLink: 'https://status.com' },
             }),
           ],
         })

--- a/app/src/services/system-checks/system-checks.test.ts
+++ b/app/src/services/system-checks/system-checks.test.ts
@@ -247,9 +247,10 @@ describe('System Checks', () => {
           translation: jest.fn().mockReturnValue('Server unavailable') as any,
           logger: {} as any,
         }
-        const serverStatus: any = { status: 'ok' }
+        const serverStatus: any = { status: 'ok', contactLink: 'https://status.com' }
 
-        const serverStatusCheck = new ServerStatusSystemCheck(serverStatus, mockUtils)
+        const serverStatusCheck: any = new ServerStatusSystemCheck(serverStatus, mockUtils)
+        serverStatusCheck.serverStatus.contactLink = 'https://status.com'
 
         serverStatusCheck.onFail()
 
@@ -259,10 +260,14 @@ describe('System Checks', () => {
           payload: [
             expect.objectContaining({
               id: BCSCBanner.IAS_SERVER_UNAVAILABLE,
-              title: 'Server unavailable',
-              type: 'error',
+              title: undefined,
+              description: 'Server unavailable',
+              type: 'info',
               variant: 'summary',
               dismissible: true,
+              metadata: {
+                contactLink: 'https://status.com',
+              },
             }),
           ],
         })
@@ -279,7 +284,7 @@ describe('System Checks', () => {
 
         const serverStatusCheck: any = new ServerStatusSystemCheck(serverStatus, mockUtils)
 
-        serverStatusCheck.serverStatus = {}
+        serverStatusCheck.serverStatus.contactLink = 'https://status.com'
         serverStatusCheck.serverStatus.statusMessage = 'Custom server down message'
 
         serverStatusCheck.onFail()
@@ -290,10 +295,14 @@ describe('System Checks', () => {
           payload: [
             expect.objectContaining({
               id: BCSCBanner.IAS_SERVER_UNAVAILABLE,
-              title: 'Custom server down message',
-              type: 'error',
+              title: undefined,
+              description: 'Custom server down message',
+              type: 'info',
               variant: 'summary',
               dismissible: true,
+              metadata: {
+                contactLink: 'https://status.com',
+              },
             }),
           ],
         })
@@ -328,11 +337,10 @@ describe('System Checks', () => {
           logger: {} as any,
         }
 
-        const serverStatus: any = { status: 'ok' }
+        const serverStatus: any = { status: 'ok', contactLink: 'https://status.com' }
 
         const serverStatusCheck: any = new ServerStatusSystemCheck(serverStatus, mockUtils)
 
-        serverStatusCheck.serverStatus = {}
         serverStatusCheck.serverStatus.statusMessage = 'Server maintenance scheduled'
 
         serverStatusCheck.onSuccess()
@@ -343,10 +351,14 @@ describe('System Checks', () => {
           payload: [
             expect.objectContaining({
               id: BCSCBanner.IAS_SERVER_NOTIFICATION,
-              title: 'Server maintenance scheduled',
+              title: undefined,
+              description: 'Server maintenance scheduled',
               type: 'info',
               variant: 'summary',
               dismissible: true,
+              metadata: {
+                contactLink: 'https://status.com',
+              },
             }),
           ],
         })


### PR DESCRIPTION
# Summary of Changes

This PR updates the "Server Outage" banner design to follow the Figma design spec. Also includes a new onPress action for linking to the outage information.

# Testing Instructions

1. Server outage renders on app startup
2. Pressing server outage opens web-browser

# Acceptance Criteria

1. Server outage banner renders
2. Pressing outage dismisses and opens documetation

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

https://github.com/orgs/bcgov/projects/108/views/1?pane=issue&itemId=167204121&issue=bcgov%7Cbc-wallet-mobile%7C3497