### PR TITLE
fix: updated service screen

### DIFF
--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
@@ -1,6 +1,7 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { useQuickLoginURL } from '@/bcsc-theme/hooks/useQuickLoginUrl'
 import { BCSCMainStackParams, BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
+import { Spacing } from '@/bcwallet-theme/theme'
 import { HelpCentreUrl, hitSlop, REPORT_SUSPICIOUS_URL } from '@/constants'
 import { BCState, Mode } from '@/store'
 import {
@@ -47,14 +48,58 @@ type ServiceLoginUnavailableViewProps = {
 
 const RenderState = {
   Loading: 'Loading',
-  Unavailable: 'Unavailable',
-  Default: 'Default',
+  Unavailable: 'Unavailable', // quick login in 'unavailable' so the links take the user out of the app
+  Default: 'Default', // Quick login is available
 } as const
+
+// This compares fields in LocalState to determine if the service supports quicklogin. v3 checks against these same fields
+const isQuickLoginAvailable = (state: LocalState): boolean =>
+  state.service?.initiate_login_uri != null &&
+  state.service?.claims_description != null &&
+  state.service?.policy_uri != null
 
 const ServiceLoginLoadingView = () => (
   <SafeAreaView edges={['bottom']} style={{ flex: 1, justifyContent: 'center' }}>
     <ActivityIndicator size="large" />
   </SafeAreaView>
+)
+
+type DevicePreferenceURLViewProps = {
+  serviceClientUri?: string
+  ColorPalette: ReturnType<typeof useTheme>['ColorPalette']
+  t: (key: string, options?: Record<string, unknown>) => string
+}
+
+const DevicePreferenceURLView: React.FC<DevicePreferenceURLViewProps> = ({ serviceClientUri, ColorPalette, t }) =>
+  serviceClientUri ? (
+    <View style={{ marginTop: Spacing.lg }}>
+      <View
+        style={{
+          borderBottomWidth: 1,
+          borderBottomColor: ColorPalette.grayscale.white,
+          marginBottom: Spacing.lg,
+        }}
+      />
+      <ThemedText variant={'bold'}>{t('BCSC.Services.PreferOtherDevice')}</ThemedText>
+      <ThemedText style={{ textAlign: 'center' }}>{t('BCSC.Services.Goto')}</ThemedText>
+      <ThemedText style={{ textAlign: 'center' }}>{serviceClientUri}</ThemedText>
+    </View>
+  ) : null
+
+type ReportSuspiciousLinkProps = {
+  t: (key: string, options?: Record<string, unknown>) => string
+  testID?: string
+}
+
+const ReportSuspiciousLink: React.FC<ReportSuspiciousLinkProps> = ({ t, testID }) => (
+  <ThemedText variant={'bold'}>
+    {t('BCSC.Services.ReportSuspiciousPrefix')}{' '}
+    <Link
+      linkText={t('BCSC.Services.ReportSuspicious')}
+      testID={testID}
+      onPress={() => Linking.openURL(REPORT_SUSPICIOUS_URL)}
+    />
+  </ThemedText>
 )
 
 const ServiceLoginUnavailableView = ({ state, styles, ColorPalette, t, logger }: ServiceLoginUnavailableViewProps) => (
@@ -88,15 +133,8 @@ const ServiceLoginUnavailableView = ({ state, styles, ColorPalette, t, logger }:
             <Icon name="open-in-new" size={30} color={ColorPalette.brand.primary} />
           </View>
         </TouchableOpacity>
-
-        <ThemedText variant={'bold'}>
-          {t('BCSC.Services.ReportSuspiciousPrefix')}{' '}
-          <Link
-            linkText={t('BCSC.Services.ReportSuspicious')}
-            testID={testIdWithKey('ReportSuspiciousLink')}
-            onPress={() => Linking.openURL(REPORT_SUSPICIOUS_URL)}
-          />
-        </ThemedText>
+        <DevicePreferenceURLView serviceClientUri={state.serviceClientUri} ColorPalette={ColorPalette} t={t} />
+        <ReportSuspiciousLink t={t} testID={testIdWithKey('ReportSuspiciousLink')} />
       </View>
     </ScrollView>
   </SafeAreaView>
@@ -162,13 +200,6 @@ const ServiceLoginDefaultView = ({
             </TouchableOpacity>
           ) : null}
         </View>
-
-        <View>
-          <ThemedText variant={'bold'}>{t('BCSC.Services.PreferOtherDevice')}</ThemedText>
-          {state.serviceClientUri ? (
-            <ThemedText>{t('BCSC.Services.GotoUrl', { url: state.serviceClientUri })}</ThemedText>
-          ) : null}
-        </View>
       </View>
       <View style={styles.buttonsContainer}>
         <View style={styles.continueButtonContainer}>
@@ -188,6 +219,8 @@ const ServiceLoginDefaultView = ({
           onPress={onCancel}
         />
       </View>
+      <DevicePreferenceURLView serviceClientUri={state.serviceClientUri} ColorPalette={ColorPalette} t={t} />
+      <ReportSuspiciousLink t={t} testID={testIdWithKey('ReportSuspiciousLink')} />
     </ScrollView>
   </SafeAreaView>
 )
@@ -238,7 +271,7 @@ export const ServiceLoginScreen: React.FC<ServiceLoginScreenProps> = ({
       gap: Spacing.md,
     },
     buttonsContainer: {
-      marginTop: 'auto',
+      marginTop: Spacing.lg,
     },
     infoContainer: {
       display: 'flex',
@@ -380,13 +413,12 @@ export const ServiceLoginScreen: React.FC<ServiceLoginScreenProps> = ({
       return RenderState.Loading
     }
 
-    if (!state.serviceInitiateLoginUri && !state.pairingCode) {
-      return RenderState.Unavailable
+    if (isQuickLoginAvailable(state)) {
+      return RenderState.Default
     }
 
-    return RenderState.Default
+    return RenderState.Unavailable
   })()
-
   switch (renderState) {
     case RenderState.Loading:
       return <ServiceLoginLoadingView />

--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
@@ -70,7 +70,11 @@ type DevicePreferenceURLViewProps = {
   t: (key: string, options?: Record<string, unknown>) => string
 }
 
-const DevicePreferenceURLView: React.FC<DevicePreferenceURLViewProps> = ({ serviceClientUri, ColorPalette, t }) =>
+const DevicePreferenceURLView: React.FC<DevicePreferenceURLViewProps> = ({
+  serviceClientUri,
+  ColorPalette,
+  t,
+}: DevicePreferenceURLViewProps) =>
   serviceClientUri ? (
     <View style={{ marginTop: Spacing.lg }}>
       <View
@@ -91,7 +95,7 @@ type ReportSuspiciousLinkProps = {
   testID?: string
 }
 
-const ReportSuspiciousLink: React.FC<ReportSuspiciousLinkProps> = ({ t, testID }) => (
+const ReportSuspiciousLink: React.FC<ReportSuspiciousLinkProps> = ({ t, testID }: ReportSuspiciousLinkProps) => (
   <ThemedText variant={'bold'}>
     {t('BCSC.Services.ReportSuspiciousPrefix')}{' '}
     <Link

--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
@@ -52,13 +52,6 @@ const RenderState = {
   Default: 'Default', // Quick login is available
 } as const
 
-// This compares fields in LocalState to determine if the service supports quicklogin
-const isQuickLoginAvailable = (state: LocalState): boolean =>
-  state.service?.initiate_login_uri != null &&
-  state.service?.claims_description != null &&
-  state.service?.policy_uri != null &&
-  state.pairingCode != null
-
 const ServiceLoginLoadingView = () => (
   <SafeAreaView edges={['bottom']} style={{ flex: 1, justifyContent: 'center' }}>
     <ActivityIndicator size="large" />
@@ -436,12 +429,11 @@ export const ServiceLoginScreen: React.FC<ServiceLoginScreenProps> = ({
     if (isLoading || !serviceHydrated) {
       return RenderState.Loading
     }
-
-    if (isQuickLoginAvailable(state)) {
-      return RenderState.Default
+    if (!state.serviceInitiateLoginUri && !state.pairingCode) {
+      return RenderState.Unavailable
     }
 
-    return RenderState.Unavailable
+    return RenderState.Default
   })()
   switch (renderState) {
     case RenderState.Loading:

--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
@@ -80,7 +80,7 @@ const DevicePreferenceURLView: React.FC<DevicePreferenceURLViewProps> = ({
       <View
         style={{
           borderBottomWidth: 1,
-          borderBottomColor: ColorPalette.grayscale.white,
+          borderBottomColor: ColorPalette.grayscale.greyLight,
           marginBottom: Spacing.lg,
         }}
       />

--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
@@ -52,11 +52,12 @@ const RenderState = {
   Default: 'Default', // Quick login is available
 } as const
 
-// This compares fields in LocalState to determine if the service supports quicklogin. v3 checks against these same fields
+// This compares fields in LocalState to determine if the service supports quicklogin
 const isQuickLoginAvailable = (state: LocalState): boolean =>
   state.service?.initiate_login_uri != null &&
   state.service?.claims_description != null &&
-  state.service?.policy_uri != null
+  state.service?.policy_uri != null &&
+  state.pairingCode != null
 
 const ServiceLoginLoadingView = () => (
   <SafeAreaView edges={['bottom']} style={{ flex: 1, justifyContent: 'center' }}>

--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
@@ -82,7 +82,7 @@ const DevicePreferenceURLView: React.FC<DevicePreferenceURLViewProps> = ({
       <View
         style={{
           borderBottomWidth: 1,
-          borderBottomColor: ColorPalette.grayscale.greyLight,
+          borderBottomColor: ColorPalette.grayscale.lightGrey,
           marginBottom: Spacing.lg,
         }}
       />

--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
@@ -1,7 +1,6 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { useQuickLoginURL } from '@/bcsc-theme/hooks/useQuickLoginUrl'
 import { BCSCMainStackParams, BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
-import { Spacing } from '@/bcwallet-theme/theme'
 import { HelpCentreUrl, hitSlop, REPORT_SUSPICIOUS_URL } from '@/constants'
 import { BCState, Mode } from '@/store'
 import {
@@ -42,6 +41,7 @@ type ServiceLoginUnavailableViewProps = {
   state: LocalState
   styles: ReturnType<typeof StyleSheet.create>
   ColorPalette: ReturnType<typeof useTheme>['ColorPalette']
+  Spacing: ReturnType<typeof useTheme>['Spacing']
   t: (key: string, options?: Record<string, unknown>) => string
   logger: any
 }
@@ -68,12 +68,14 @@ type DevicePreferenceURLViewProps = {
   serviceClientUri?: string
   ColorPalette: ReturnType<typeof useTheme>['ColorPalette']
   t: (key: string, options?: Record<string, unknown>) => string
+  Spacing: ReturnType<typeof useTheme>['Spacing']
 }
 
 const DevicePreferenceURLView: React.FC<DevicePreferenceURLViewProps> = ({
   serviceClientUri,
   ColorPalette,
   t,
+  Spacing,
 }: DevicePreferenceURLViewProps) =>
   serviceClientUri ? (
     <View style={{ marginTop: Spacing.lg }}>
@@ -106,7 +108,14 @@ const ReportSuspiciousLink: React.FC<ReportSuspiciousLinkProps> = ({ t, testID }
   </ThemedText>
 )
 
-const ServiceLoginUnavailableView = ({ state, styles, ColorPalette, t, logger }: ServiceLoginUnavailableViewProps) => (
+const ServiceLoginUnavailableView = ({
+  state,
+  styles,
+  ColorPalette,
+  t,
+  logger,
+  Spacing,
+}: ServiceLoginUnavailableViewProps) => (
   <SafeAreaView edges={['bottom']} style={{ flex: 1 }}>
     <ScrollView contentContainerStyle={styles.screenContainer}>
       <View style={styles.contentContainer}>
@@ -137,7 +146,12 @@ const ServiceLoginUnavailableView = ({ state, styles, ColorPalette, t, logger }:
             <Icon name="open-in-new" size={30} color={ColorPalette.brand.primary} />
           </View>
         </TouchableOpacity>
-        <DevicePreferenceURLView serviceClientUri={state.serviceClientUri} ColorPalette={ColorPalette} t={t} />
+        <DevicePreferenceURLView
+          serviceClientUri={state.serviceClientUri}
+          ColorPalette={ColorPalette}
+          t={t}
+          Spacing={Spacing}
+        />
         <ReportSuspiciousLink t={t} testID={testIdWithKey('ReportSuspiciousLink')} />
       </View>
     </ScrollView>
@@ -223,7 +237,12 @@ const ServiceLoginDefaultView = ({
           onPress={onCancel}
         />
       </View>
-      <DevicePreferenceURLView serviceClientUri={state.serviceClientUri} ColorPalette={ColorPalette} t={t} />
+      <DevicePreferenceURLView
+        serviceClientUri={state.serviceClientUri}
+        ColorPalette={ColorPalette}
+        t={t}
+        Spacing={Spacing}
+      />
       <ReportSuspiciousLink t={t} testID={testIdWithKey('ReportSuspiciousLink')} />
     </ScrollView>
   </SafeAreaView>
@@ -428,7 +447,14 @@ export const ServiceLoginScreen: React.FC<ServiceLoginScreenProps> = ({
       return <ServiceLoginLoadingView />
     case RenderState.Unavailable:
       return (
-        <ServiceLoginUnavailableView state={state} styles={styles} ColorPalette={ColorPalette} t={t} logger={logger} />
+        <ServiceLoginUnavailableView
+          state={state}
+          styles={styles}
+          ColorPalette={ColorPalette}
+          t={t}
+          logger={logger}
+          Spacing={Spacing}
+        />
       )
     default:
       return (

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -305,7 +305,7 @@ const translation = {
       "OpenUrlErrorMessage": "Could not open the service URL. Please try again later.",
       "NoLoginInstructions": "You will need to go to their website first if you want to log in to it. You can't log in to services directly from this app.",
       "NoLoginProof": "You will use this app to prove who you are when you log in.",
-      "Goto": "Go to",
+      "Goto": "On that device, go to:",
       "GotoService": "Go to {{- service}}",
       "GotoUrl": "Go to: {{- url}}",
       "NotListed": "Services not listed?",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -305,7 +305,7 @@ const translation = {
       "OpenUrlErrorMessage": "Could not open the service URL. Please try again later. (FR)",
       "NoLoginInstructions": "You will need to go to their website first if you want to log in to it. You can't log in to services directly from this app. (FR)",
       "NoLoginProof": "You will use this app to prove who you are when you log in. (FR)",
-      "Goto": "Go to (FR)",
+      "Goto": "On that device, go to: (FR)",
       "GotoService": "Go to {{- service}} (FR)",
       "GotoUrl": "Go to: {{- url}} (FR)",
       "NotListed": "Services not listed? (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -305,7 +305,7 @@ const translation = {
       "OpenUrlErrorMessage": "Could not open the service URL. Please try again later. (PT-BR)",
       "NoLoginInstructions": "You will need to go to their website first if you want to log in to it. You can't log in to services directly from this app. (PT-BR)",
       "NoLoginProof": "You will use this app to prove who you are when you log in. (PT-BR)",
-      "Goto": "Go to (PT-BR)",
+      "Goto": "On that device, go to: (PT-BR)",
       "GotoService": "Go to {{- service}} (PT-BR)",
       "GotoUrl": "Go to: {{- url}} (PT-BR)",
       "NotListed": "Services not listed? (PT-BR)",


### PR DESCRIPTION
# Summary of Changes

- componentized Not you? and Prefer to use on another device?
- added Prefer to use component onto both quick login and other screen

# Testing Instructions

- Verify a user
- navigate to services list
- Click on "BC parks Discover Camping" and see:
  - "Go to BC Parks..." button
  - "Prefer to use on another...." text at the bottom
- Click on "Government Gateway OIDC" and see:
  - "From your account ..." text with help button
  - "Privacy notice" button
  - Continue and Cancel button 
  - "Prefer to use another device" text at the bottom

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

[BC-Wallet: 3457](https://github.com/bcgov/bc-wallet-mobile/issues/3457)
