### PR TITLE
feat: show notification banner on account selector screen

### DIFF
--- a/app/src/bcsc-theme/features/auth/AccountSelectorScreen.tsx
+++ b/app/src/bcsc-theme/features/auth/AccountSelectorScreen.tsx
@@ -1,5 +1,6 @@
 import { CardButton } from '@/bcsc-theme/components/CardButton'
 import GenericCardImage from '@/bcsc-theme/components/GenericCardImage'
+import { NotificationBannerContainer } from '@/bcsc-theme/components/NotificationBannerContainer'
 import { useAuthentication } from '@/bcsc-theme/hooks/useAuthentication'
 import { BCSCAuthStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { BCDispatchAction, BCState } from '@/store'
@@ -56,12 +57,15 @@ const AccountSelectorScreen = ({ navigation }: AccountSelectorScreenProps) => {
   )
 
   return (
-    <ScreenWrapper scrollable scrollViewContainerStyle={styles.contentContainer} controls={controls}>
-      <GenericCardImage />
-      <ThemedText variant={'headingFour'} style={{ textAlign: 'center' }}>
-        {t('BCSC.AccountSetup.Title')}
-      </ThemedText>
-    </ScreenWrapper>
+    <>
+      <NotificationBannerContainer onManageDevices={() => {}} />
+      <ScreenWrapper scrollable scrollViewContainerStyle={styles.contentContainer} controls={controls}>
+        <GenericCardImage />
+        <ThemedText variant={'headingFour'} style={{ textAlign: 'center' }}>
+          {t('BCSC.AccountSetup.Title')}
+        </ThemedText>
+      </ScreenWrapper>
+    </>
   )
 }
 

--- a/app/src/bcsc-theme/features/auth/__snapshots__/AccountSelectorScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/auth/__snapshots__/AccountSelectorScreen.test.tsx.snap
@@ -1,416 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AccountSetup when nicknames exist renders correctly with nickname buttons 1`] = `
-<RNCSafeAreaView
-  edges={
-    {
-      "bottom": "additive",
-      "left": "additive",
-      "right": "additive",
-      "top": "off",
-    }
-  }
-  style={
-    [
+[
+  <View />,
+  <RNCSafeAreaView
+    edges={
       {
-        "backgroundColor": "#F2F2F2",
-        "flex": 1,
-      },
-      undefined,
-    ]
-  }
->
-  <RCTScrollView
-    contentContainerStyle={
-      [
-        {
-          "padding": 16,
-        },
-        {
-          "alignItems": "center",
-          "flexGrow": 1,
-          "justifyContent": "center",
-        },
-      ]
+        "bottom": "additive",
+        "left": "additive",
+        "right": "additive",
+        "top": "off",
+      }
     }
-    showsVerticalScrollIndicator={false}
-  >
-    <View>
-      <View
-        style={
-          {
-            "alignSelf": "center",
-            "backgroundColor": "#FFFFFF",
-            "borderRadius": 8,
-            "margin": 24,
-            "padding": 8,
-          }
-        }
-      >
-        <
-          height={75}
-          width={120}
-        />
-      </View>
-      <Text
-        maxFontSizeMultiplier={2}
-        style={
-          [
-            {
-              "color": "#313132",
-              "fontFamily": "BCSans-Regular",
-              "fontSize": 21,
-              "fontWeight": "bold",
-            },
-            {
-              "textAlign": "center",
-            },
-          ]
-        }
-      >
-        BCSC.AccountSetup.Title
-      </Text>
-    </View>
-  </RCTScrollView>
-  <View
     style={
       [
         {
-          "gap": 16,
-        },
-        {
-          "paddingBottom": 16,
-          "paddingHorizontal": 16,
+          "backgroundColor": "#F2F2F2",
+          "flex": 1,
         },
         undefined,
       ]
     }
   >
-    <Text
-      maxFontSizeMultiplier={2}
-      style={
+    <RCTScrollView
+      contentContainerStyle={
         [
           {
-            "color": "#313132",
-            "fontFamily": "BCSans-Regular",
-            "fontSize": 21,
-            "fontWeight": "bold",
+            "padding": 16,
           },
-          undefined,
-        ]
-      }
-    >
-      BCSC.AccountSetup.ContinueAs
-    </Text>
-    <View
-      style={
-        {
-          "gap": 8,
-        }
-      }
-    >
-      <View
-        accessibilityLabel="John"
-        accessibilityRole="button"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": undefined,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          {
-            "backgroundColor": "#FFFFFF",
-            "borderColor": "#D9EAF7",
-            "borderRadius": 4,
-            "borderWidth": 1,
-            "opacity": 1,
-            "padding": 16,
-          }
-        }
-        testID="com.ariesbifold:id/CardButton-John"
-      >
-        <View
-          style={
-            {
-              "gap": 8,
-            }
-          }
-        >
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "space-between",
-              }
-            }
-          >
-            <Text
-              maxFontSizeMultiplier={2}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontFamily": "BCSans-Regular",
-                    "fontSize": 18,
-                    "fontWeight": "normal",
-                  },
-                  {
-                    "color": "#003366",
-                    "fontSize": 20,
-                    "fontWeight": "bold",
-                  },
-                ]
-              }
-            >
-              John
-            </Text>
-          </View>
-        </View>
-      </View>
-      <View
-        accessibilityLabel="Jane"
-        accessibilityRole="button"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": undefined,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          {
-            "backgroundColor": "#FFFFFF",
-            "borderColor": "#D9EAF7",
-            "borderRadius": 4,
-            "borderWidth": 1,
-            "opacity": 1,
-            "padding": 16,
-          }
-        }
-        testID="com.ariesbifold:id/CardButton-Jane"
-      >
-        <View
-          style={
-            {
-              "gap": 8,
-            }
-          }
-        >
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "space-between",
-              }
-            }
-          >
-            <Text
-              maxFontSizeMultiplier={2}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontFamily": "BCSans-Regular",
-                    "fontSize": 18,
-                    "fontWeight": "normal",
-                  },
-                  {
-                    "color": "#003366",
-                    "fontSize": 20,
-                    "fontWeight": "bold",
-                  },
-                ]
-              }
-            >
-              Jane
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-</RNCSafeAreaView>
-`;
-
-exports[`AccountSetup when no nicknames exist renders Continue setting up account button 1`] = `
-<RNCSafeAreaView
-  edges={
-    {
-      "bottom": "additive",
-      "left": "additive",
-      "right": "additive",
-      "top": "off",
-    }
-  }
-  style={
-    [
-      {
-        "backgroundColor": "#F2F2F2",
-        "flex": 1,
-      },
-      undefined,
-    ]
-  }
->
-  <RCTScrollView
-    contentContainerStyle={
-      [
-        {
-          "padding": 16,
-        },
-        {
-          "alignItems": "center",
-          "flexGrow": 1,
-          "justifyContent": "center",
-        },
-      ]
-    }
-    showsVerticalScrollIndicator={false}
-  >
-    <View>
-      <View
-        style={
-          {
-            "alignSelf": "center",
-            "backgroundColor": "#FFFFFF",
-            "borderRadius": 8,
-            "margin": 24,
-            "padding": 8,
-          }
-        }
-      >
-        <
-          height={75}
-          width={120}
-        />
-      </View>
-      <Text
-        maxFontSizeMultiplier={2}
-        style={
-          [
-            {
-              "color": "#313132",
-              "fontFamily": "BCSans-Regular",
-              "fontSize": 21,
-              "fontWeight": "bold",
-            },
-            {
-              "textAlign": "center",
-            },
-          ]
-        }
-      >
-        BCSC.AccountSetup.Title
-      </Text>
-    </View>
-  </RCTScrollView>
-  <View
-    style={
-      [
-        {
-          "gap": 16,
-        },
-        {
-          "paddingBottom": 16,
-          "paddingHorizontal": 16,
-        },
-        undefined,
-      ]
-    }
-  >
-    <View
-      accessibilityLabel="Continue setting up account"
-      accessibilityRole="button"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        {
-          "backgroundColor": "#003366",
-          "borderRadius": 4,
-          "opacity": 1,
-          "padding": 16,
-        }
-      }
-      testID="com.ariesbifold:id/ContinueSetup"
-    >
-      <View
-        style={
           {
             "alignItems": "center",
-            "flexDirection": "row",
+            "flexGrow": 1,
             "justifyContent": "center",
+          },
+        ]
+      }
+      showsVerticalScrollIndicator={false}
+    >
+      <View>
+        <View
+          style={
+            {
+              "alignSelf": "center",
+              "backgroundColor": "#FFFFFF",
+              "borderRadius": 8,
+              "margin": 24,
+              "padding": 8,
+            }
           }
-        }
-      >
+        >
+          <
+            height={75}
+            width={120}
+          />
+        </View>
         <Text
           maxFontSizeMultiplier={2}
           style={
@@ -418,27 +61,390 @@ exports[`AccountSetup when no nicknames exist renders Continue setting up accoun
               {
                 "color": "#313132",
                 "fontFamily": "BCSans-Regular",
-                "fontSize": 18,
-                "fontWeight": "normal",
+                "fontSize": 21,
+                "fontWeight": "bold",
               },
-              [
-                {
-                  "color": "#FFFFFF",
-                  "fontFamily": "BCSans-Regular",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
-                  "textAlign": "center",
-                },
-                false,
-                false,
-              ],
+              {
+                "textAlign": "center",
+              },
             ]
           }
         >
-          Continue setting up account
+          BCSC.AccountSetup.Title
         </Text>
       </View>
+    </RCTScrollView>
+    <View
+      style={
+        [
+          {
+            "gap": 16,
+          },
+          {
+            "paddingBottom": 16,
+            "paddingHorizontal": 16,
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        maxFontSizeMultiplier={2}
+        style={
+          [
+            {
+              "color": "#313132",
+              "fontFamily": "BCSans-Regular",
+              "fontSize": 21,
+              "fontWeight": "bold",
+            },
+            undefined,
+          ]
+        }
+      >
+        BCSC.AccountSetup.ContinueAs
+      </Text>
+      <View
+        style={
+          {
+            "gap": 8,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="John"
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "backgroundColor": "#FFFFFF",
+              "borderColor": "#D9EAF7",
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "opacity": 1,
+              "padding": 16,
+            }
+          }
+          testID="com.ariesbifold:id/CardButton-John"
+        >
+          <View
+            style={
+              {
+                "gap": 8,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                }
+              }
+            >
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "normal",
+                    },
+                    {
+                      "color": "#003366",
+                      "fontSize": 20,
+                      "fontWeight": "bold",
+                    },
+                  ]
+                }
+              >
+                John
+              </Text>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityLabel="Jane"
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "backgroundColor": "#FFFFFF",
+              "borderColor": "#D9EAF7",
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "opacity": 1,
+              "padding": 16,
+            }
+          }
+          testID="com.ariesbifold:id/CardButton-Jane"
+        >
+          <View
+            style={
+              {
+                "gap": 8,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                }
+              }
+            >
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "normal",
+                    },
+                    {
+                      "color": "#003366",
+                      "fontSize": 20,
+                      "fontWeight": "bold",
+                    },
+                  ]
+                }
+              >
+                Jane
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
     </View>
-  </View>
-</RNCSafeAreaView>
+  </RNCSafeAreaView>,
+]
+`;
+
+exports[`AccountSetup when no nicknames exist renders Continue setting up account button 1`] = `
+[
+  <View />,
+  <RNCSafeAreaView
+    edges={
+      {
+        "bottom": "additive",
+        "left": "additive",
+        "right": "additive",
+        "top": "off",
+      }
+    }
+    style={
+      [
+        {
+          "backgroundColor": "#F2F2F2",
+          "flex": 1,
+        },
+        undefined,
+      ]
+    }
+  >
+    <RCTScrollView
+      contentContainerStyle={
+        [
+          {
+            "padding": 16,
+          },
+          {
+            "alignItems": "center",
+            "flexGrow": 1,
+            "justifyContent": "center",
+          },
+        ]
+      }
+      showsVerticalScrollIndicator={false}
+    >
+      <View>
+        <View
+          style={
+            {
+              "alignSelf": "center",
+              "backgroundColor": "#FFFFFF",
+              "borderRadius": 8,
+              "margin": 24,
+              "padding": 8,
+            }
+          }
+        >
+          <
+            height={75}
+            width={120}
+          />
+        </View>
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 21,
+                "fontWeight": "bold",
+              },
+              {
+                "textAlign": "center",
+              },
+            ]
+          }
+        >
+          BCSC.AccountSetup.Title
+        </Text>
+      </View>
+    </RCTScrollView>
+    <View
+      style={
+        [
+          {
+            "gap": 16,
+          },
+          {
+            "paddingBottom": 16,
+            "paddingHorizontal": 16,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        accessibilityLabel="Continue setting up account"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "backgroundColor": "#003366",
+            "borderRadius": 4,
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/ContinueSetup"
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            maxFontSizeMultiplier={2}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                },
+                [
+                  {
+                    "color": "#FFFFFF",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                    "textAlign": "center",
+                  },
+                  false,
+                  false,
+                ],
+              ]
+            }
+          >
+            Continue setting up account
+          </Text>
+        </View>
+      </View>
+    </View>
+  </RNCSafeAreaView>,
+]
 `;

--- a/app/src/bcsc-theme/features/modal/ServiceOutage.test.tsx
+++ b/app/src/bcsc-theme/features/modal/ServiceOutage.test.tsx
@@ -1,0 +1,63 @@
+import { testIdWithKey } from '@bifold/core'
+import { BasicAppContext } from '@mocks/helpers/app'
+import { fireEvent, render } from '@testing-library/react-native'
+import React from 'react'
+import { ServiceOutage } from './ServiceOutage'
+
+const mockHandleCheckAgain = jest.fn()
+const mockHandleLearnMore = jest.fn()
+
+jest.mock('./useServiceOutageViewModel', () => () => ({
+  headerText: 'Service unavailable',
+  contentText: ['The service is currently down.'],
+  learnMoreText: 'Learn more',
+  buttonText: 'Check again',
+  isCheckDisabled: false,
+  handleCheckAgain: mockHandleCheckAgain,
+  handleLearnMore: mockHandleLearnMore,
+}))
+
+jest.mock('@/hooks/usePreventGestureBack', () => jest.fn())
+
+describe('ServiceOutage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders header, content, and buttons', () => {
+    const { getByText } = render(
+      <BasicAppContext>
+        <ServiceOutage />
+      </BasicAppContext>
+    )
+
+    expect(getByText('Service unavailable')).toBeTruthy()
+    expect(getByText('The service is currently down.')).toBeTruthy()
+    expect(getByText('Learn more')).toBeTruthy()
+    expect(getByText('Check again')).toBeTruthy()
+  })
+
+  it('calls handleCheckAgain when Check again button is pressed', () => {
+    const { getByTestId } = render(
+      <BasicAppContext>
+        <ServiceOutage />
+      </BasicAppContext>
+    )
+
+    fireEvent.press(getByTestId(testIdWithKey('ServiceOutageCheckAgain')))
+
+    expect(mockHandleCheckAgain).toHaveBeenCalled()
+  })
+
+  it('calls handleLearnMore when Learn more button is pressed', () => {
+    const { getByTestId } = render(
+      <BasicAppContext>
+        <ServiceOutage />
+      </BasicAppContext>
+    )
+
+    fireEvent.press(getByTestId(testIdWithKey('ServiceOutageHelpCentre')))
+
+    expect(mockHandleLearnMore).toHaveBeenCalled()
+  })
+})

--- a/app/src/bcsc-theme/features/modal/ServiceOutage.tsx
+++ b/app/src/bcsc-theme/features/modal/ServiceOutage.tsx
@@ -3,6 +3,7 @@ import { HELP_URL } from '@/constants'
 import { Button, ButtonType, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Linking, ScrollView, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialIcons'
@@ -10,6 +11,7 @@ import useServiceOutageViewModel from './useServiceOutageViewModel'
 
 export const ServiceOutage = (): React.ReactElement => {
   const { headerText, contentText, buttonText, isCheckDisabled, handleCheckAgain } = useServiceOutageViewModel()
+  const { t } = useTranslation()
   const { Spacing, ColorPalette } = useTheme()
   const navigation = useNavigation()
 
@@ -18,11 +20,10 @@ export const ServiceOutage = (): React.ReactElement => {
       flex: 1,
       backgroundColor: ColorPalette.brand.modalPrimaryBackground,
     },
-    scollContainer: {
-      alignItems: 'center',
-    },
+    scollContainer: {},
     icon: {
       paddingVertical: Spacing.lg,
+      alignSelf: 'center',
     },
     buttonContainer: {
       padding: Spacing.md,
@@ -61,7 +62,7 @@ export const ServiceOutage = (): React.ReactElement => {
             </ThemedText>
           ))}
           <CardButton
-            title={headerText}
+            title={t('BCSC.Modals.ServiceOutage.LearnMore')}
             onPress={() => Linking.openURL(HELP_URL)}
             endIcon="open-in-new"
             testID={testIdWithKey('ServiceOutageHelpCentre')}

--- a/app/src/bcsc-theme/features/modal/ServiceOutage.tsx
+++ b/app/src/bcsc-theme/features/modal/ServiceOutage.tsx
@@ -1,7 +1,6 @@
 import { CardButton } from '@/bcsc-theme/components/CardButton'
+import usePreventGestureBack from '@/hooks/usePreventGestureBack'
 import { Button, ButtonType, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
-import { useFocusEffect, useNavigation } from '@react-navigation/native'
-import { useCallback } from 'react'
 import { ScrollView, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialIcons'
@@ -11,7 +10,8 @@ export const ServiceOutage = (): React.ReactElement => {
   const { headerText, contentText, learnMoreText, buttonText, isCheckDisabled, handleCheckAgain, handleLearnMore } =
     useServiceOutageViewModel()
   const { Spacing, ColorPalette } = useTheme()
-  const navigation = useNavigation()
+
+  usePreventGestureBack()
 
   const styles = StyleSheet.create({
     container: {
@@ -34,19 +34,6 @@ export const ServiceOutage = (): React.ReactElement => {
       gap: Spacing.lg,
     },
   })
-
-  useFocusEffect(
-    useCallback(() => {
-      const beforeRemove = navigation.addListener('beforeRemove', (event) => {
-        if (!event.data.action.source) {
-          event.preventDefault()
-        }
-      })
-      return () => {
-        beforeRemove()
-      }
-    }, [navigation])
-  )
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>

--- a/app/src/bcsc-theme/features/modal/ServiceOutage.tsx
+++ b/app/src/bcsc-theme/features/modal/ServiceOutage.tsx
@@ -1,17 +1,15 @@
 import { CardButton } from '@/bcsc-theme/components/CardButton'
-import { HELP_URL } from '@/constants'
 import { Button, ButtonType, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import { useCallback } from 'react'
-import { useTranslation } from 'react-i18next'
-import { Linking, ScrollView, StyleSheet, View } from 'react-native'
+import { ScrollView, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import useServiceOutageViewModel from './useServiceOutageViewModel'
 
 export const ServiceOutage = (): React.ReactElement => {
-  const { headerText, contentText, buttonText, isCheckDisabled, handleCheckAgain } = useServiceOutageViewModel()
-  const { t } = useTranslation()
+  const { headerText, contentText, learnMoreText, buttonText, isCheckDisabled, handleCheckAgain, handleLearnMore } =
+    useServiceOutageViewModel()
   const { Spacing, ColorPalette } = useTheme()
   const navigation = useNavigation()
 
@@ -20,7 +18,7 @@ export const ServiceOutage = (): React.ReactElement => {
       flex: 1,
       backgroundColor: ColorPalette.brand.modalPrimaryBackground,
     },
-    scollContainer: {},
+    scrollContainer: {},
     icon: {
       paddingVertical: Spacing.lg,
       alignSelf: 'center',
@@ -52,7 +50,7 @@ export const ServiceOutage = (): React.ReactElement => {
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
-      <ScrollView contentContainerStyle={styles.scollContainer}>
+      <ScrollView contentContainerStyle={styles.scrollContainer}>
         <Icon name="error-outline" size={200} color={ColorPalette.brand.icon} style={styles.icon} />
         <View style={styles.textContainer}>
           <ThemedText variant="headingThree">{headerText}</ThemedText>
@@ -62,8 +60,8 @@ export const ServiceOutage = (): React.ReactElement => {
             </ThemedText>
           ))}
           <CardButton
-            title={t('BCSC.Modals.ServiceOutage.LearnMore')}
-            onPress={() => Linking.openURL(HELP_URL)}
+            title={learnMoreText}
+            onPress={handleLearnMore}
             endIcon="open-in-new"
             testID={testIdWithKey('ServiceOutageHelpCentre')}
           />

--- a/app/src/bcsc-theme/features/modal/ServiceOutage.tsx
+++ b/app/src/bcsc-theme/features/modal/ServiceOutage.tsx
@@ -1,17 +1,84 @@
-import { SystemModal } from './components/SystemModal'
+import { CardButton } from '@/bcsc-theme/components/CardButton'
+import { HELP_URL } from '@/constants'
+import { Button, ButtonType, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
+import { useFocusEffect, useNavigation } from '@react-navigation/native'
+import { useCallback } from 'react'
+import { Linking, ScrollView, StyleSheet, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import Icon from 'react-native-vector-icons/MaterialIcons'
 import useServiceOutageViewModel from './useServiceOutageViewModel'
 
 export const ServiceOutage = (): React.ReactElement => {
   const { headerText, contentText, buttonText, isCheckDisabled, handleCheckAgain } = useServiceOutageViewModel()
+  const { Spacing, ColorPalette } = useTheme()
+  const navigation = useNavigation()
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: ColorPalette.brand.modalPrimaryBackground,
+    },
+    scollContainer: {
+      alignItems: 'center',
+    },
+    icon: {
+      paddingVertical: Spacing.lg,
+    },
+    buttonContainer: {
+      padding: Spacing.md,
+    },
+    textContent: {
+      lineHeight: 30,
+    },
+    textContainer: {
+      padding: Spacing.md,
+      gap: Spacing.lg,
+    },
+  })
+
+  useFocusEffect(
+    useCallback(() => {
+      const beforeRemove = navigation.addListener('beforeRemove', (event) => {
+        if (!event.data.action.source) {
+          event.preventDefault()
+        }
+      })
+      return () => {
+        beforeRemove()
+      }
+    }, [navigation])
+  )
 
   return (
-    <SystemModal
-      iconName="error-outline"
-      headerText={headerText}
-      contentText={contentText}
-      buttonText={buttonText}
-      buttonDisabled={isCheckDisabled}
-      onButtonPress={handleCheckAgain}
-    />
+    <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
+      <ScrollView contentContainerStyle={styles.scollContainer}>
+        <Icon name="error-outline" size={200} color={ColorPalette.brand.icon} style={styles.icon} />
+        <View style={styles.textContainer}>
+          <ThemedText variant="headingThree">{headerText}</ThemedText>
+          {contentText.filter(Boolean).map((text) => (
+            <ThemedText key={text} style={styles.textContent}>
+              {text}
+            </ThemedText>
+          ))}
+          <CardButton
+            title={headerText}
+            onPress={() => Linking.openURL(HELP_URL)}
+            endIcon="open-in-new"
+            testID={testIdWithKey('ServiceOutageHelpCentre')}
+          />
+        </View>
+      </ScrollView>
+
+      <View style={styles.buttonContainer}>
+        <Button
+          title={buttonText}
+          buttonType={ButtonType.Primary}
+          onPress={handleCheckAgain}
+          disabled={isCheckDisabled}
+          accessibilityLabel={buttonText}
+          testID={testIdWithKey('ServiceOutageCheckAgain')}
+        />
+      </View>
+    </SafeAreaView>
   )
 }

--- a/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
+++ b/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
@@ -1,6 +1,5 @@
+import usePreventGestureBack from '@/hooks/usePreventGestureBack'
 import { Button, ButtonType, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
-import { useFocusEffect, useNavigation } from '@react-navigation/native'
-import { useCallback } from 'react'
 import { ScrollView, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialIcons'
@@ -57,7 +56,8 @@ export const SystemModal = ({
   testID,
 }: SystemModalProps): React.ReactElement => {
   const { Spacing, ColorPalette } = useTheme()
-  const navigation = useNavigation()
+
+  usePreventGestureBack()
 
   const styles = StyleSheet.create({
     container: {
@@ -81,25 +81,6 @@ export const SystemModal = ({
       gap: Spacing.lg,
     },
   })
-
-  /**
-   * Prevents the user from navigating back to the previous screen on Android,
-   * but allows programmatic navigation (e.g., when button is pressed).
-   * Note: gestureEnabled: false works for iOS, but Android requires this listener.
-   */
-  useFocusEffect(
-    useCallback(() => {
-      const beforeRemove = navigation.addListener('beforeRemove', (event) => {
-        if (!event.data.action.source) {
-          // gesture navigation has no action source so we prevent it
-          event.preventDefault()
-        }
-      })
-      return () => {
-        beforeRemove()
-      }
-    }, [navigation])
-  )
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>

--- a/app/src/bcsc-theme/features/modal/useServiceOutageViewModel.test.ts
+++ b/app/src/bcsc-theme/features/modal/useServiceOutageViewModel.test.ts
@@ -1,0 +1,214 @@
+import { useBCSCApiClientState } from '@/bcsc-theme/hooks/useBCSCApiClient'
+import { HELP_URL } from '@/constants'
+import { ServerStatusSystemCheck } from '@/services/system-checks/ServerStatusSystemCheck'
+import { openLink } from '@/utils/links'
+import * as Bifold from '@bifold/core'
+import { useRoute } from '@react-navigation/native'
+import { act, renderHook, waitFor } from '@testing-library/react-native'
+import useServiceOutageViewModel from './useServiceOutageViewModel'
+
+jest.mock('@/utils/links', () => ({
+  openLink: jest.fn(),
+}))
+
+jest.mock('@/bcsc-theme/hooks/useBCSCApiClient')
+const mockUseBCSCApiClientState = jest.mocked(useBCSCApiClientState)
+
+const mockGetServerStatus = jest.fn()
+jest.mock('@/bcsc-theme/api/hooks/useConfigApi', () => () => ({
+  getServerStatus: mockGetServerStatus,
+}))
+
+jest.mock('@/services/system-checks/ServerStatusSystemCheck')
+const MockServerStatusSystemCheck = jest.mocked(ServerStatusSystemCheck)
+
+jest.mock('@bifold/core', () => {
+  const actual = jest.requireActual('@bifold/core')
+  return {
+    ...actual,
+    useStore: jest.fn(),
+    useServices: jest.fn(),
+  }
+})
+
+const mockLogger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+}
+
+const mockDispatch = jest.fn()
+
+describe('useServiceOutageViewModel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    const bifoldMock = jest.mocked(Bifold)
+    bifoldMock.useStore.mockReturnValue([{} as any, mockDispatch])
+    bifoldMock.useServices.mockReturnValue([mockLogger] as any)
+
+    mockUseBCSCApiClientState.mockReturnValue({ client: {}, isClientReady: true } as any)
+
+    jest
+      .mocked(useRoute)
+      .mockReturnValue({ params: { statusMessage: 'Server is down' }, key: 'test', name: 'ServiceOutage' as any })
+  })
+
+  it('returns localized text fields', () => {
+    const { result } = renderHook(() => useServiceOutageViewModel())
+
+    expect(result.current.headerText).toBe('BCSC.Modals.ServiceOutage.Header')
+    expect(result.current.buttonText).toBe('BCSC.Modals.ServiceOutage.CheckAgainButton')
+    expect(result.current.learnMoreText).toBe('BCSC.Modals.ServiceOutage.LearnMore')
+  })
+
+  it('uses route statusMessage for contentText', () => {
+    const { result } = renderHook(() => useServiceOutageViewModel())
+
+    expect(result.current.contentText).toEqual(['Server is down'])
+  })
+
+  it('falls back to translation key when no statusMessage in route', () => {
+    jest.mocked(useRoute).mockReturnValue({ params: {}, key: 'test', name: 'ServiceOutage' as any })
+
+    const { result } = renderHook(() => useServiceOutageViewModel())
+
+    expect(result.current.contentText).toEqual(['BCSC.SystemChecks.ServerStatus.UnavailableBannerTitle'])
+  })
+
+  it('isCheckDisabled is false when client is ready and not checking', () => {
+    const { result } = renderHook(() => useServiceOutageViewModel())
+
+    expect(result.current.isCheckDisabled).toBe(false)
+  })
+
+  it('isCheckDisabled is true when client is not ready', () => {
+    mockUseBCSCApiClientState.mockReturnValue({ client: {}, isClientReady: false } as any)
+
+    const { result } = renderHook(() => useServiceOutageViewModel())
+
+    expect(result.current.isCheckDisabled).toBe(true)
+  })
+
+  it('handleLearnMore calls openLink with HELP_URL', () => {
+    const { result } = renderHook(() => useServiceOutageViewModel())
+
+    result.current.handleLearnMore()
+
+    expect(openLink).toHaveBeenCalledWith(HELP_URL)
+  })
+
+  it('handleCheckAgain does nothing when client is not ready', async () => {
+    mockUseBCSCApiClientState.mockReturnValue({ client: {}, isClientReady: false } as any)
+
+    const { result } = renderHook(() => useServiceOutageViewModel())
+
+    await act(async () => {
+      await result.current.handleCheckAgain()
+    })
+
+    expect(mockGetServerStatus).not.toHaveBeenCalled()
+  })
+
+  it('handleCheckAgain calls onSuccess when server status is ok', async () => {
+    const mockOnSuccess = jest.fn()
+    const mockRunCheck = jest.fn().mockReturnValue(true)
+
+    MockServerStatusSystemCheck.mockImplementation(
+      () =>
+        ({
+          runCheck: mockRunCheck,
+          onSuccess: mockOnSuccess,
+          onFail: jest.fn(),
+        }) as any
+    )
+
+    mockGetServerStatus.mockResolvedValue({ status: 'ok', statusMessage: undefined })
+
+    const { result } = renderHook(() => useServiceOutageViewModel())
+
+    await act(async () => {
+      await result.current.handleCheckAgain()
+    })
+
+    expect(mockRunCheck).toHaveBeenCalled()
+    expect(mockOnSuccess).toHaveBeenCalled()
+  })
+
+  it('handleCheckAgain calls onFail when server status is not ok', async () => {
+    const mockOnFail = jest.fn()
+    const mockRunCheck = jest.fn().mockReturnValue(false)
+
+    MockServerStatusSystemCheck.mockImplementation(
+      () =>
+        ({
+          runCheck: mockRunCheck,
+          onSuccess: jest.fn(),
+          onFail: mockOnFail,
+        }) as any
+    )
+
+    mockGetServerStatus.mockResolvedValue({ status: 'unavailable', statusMessage: 'Maintenance' })
+
+    const { result } = renderHook(() => useServiceOutageViewModel())
+
+    await act(async () => {
+      await result.current.handleCheckAgain()
+    })
+
+    expect(mockOnFail).toHaveBeenCalled()
+  })
+
+  it('handleCheckAgain logs error on failure', async () => {
+    const error = new Error('Network error')
+    mockGetServerStatus.mockRejectedValue(error)
+
+    const { result } = renderHook(() => useServiceOutageViewModel())
+
+    await act(async () => {
+      await result.current.handleCheckAgain()
+    })
+
+    expect(mockLogger.error).toHaveBeenCalledWith('ServiceOutage: Failed to re-check server status', error)
+  })
+
+  it('handleCheckAgain sets isCheckDisabled during check', async () => {
+    let resolveStatus: (value: any) => void
+    mockGetServerStatus.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStatus = resolve
+      })
+    )
+
+    const mockRunCheck = jest.fn().mockReturnValue(true)
+    MockServerStatusSystemCheck.mockImplementation(
+      () =>
+        ({
+          runCheck: mockRunCheck,
+          onSuccess: jest.fn(),
+          onFail: jest.fn(),
+        }) as any
+    )
+
+    const { result } = renderHook(() => useServiceOutageViewModel())
+
+    expect(result.current.isCheckDisabled).toBe(false)
+
+    let checkPromise: Promise<void>
+    act(() => {
+      checkPromise = result.current.handleCheckAgain()
+    })
+
+    await waitFor(() => {
+      expect(result.current.isCheckDisabled).toBe(true)
+    })
+
+    await act(async () => {
+      resolveStatus!({ status: 'ok' })
+      await checkPromise!
+    })
+
+    expect(result.current.isCheckDisabled).toBe(false)
+  })
+})

--- a/app/src/bcsc-theme/features/modal/useServiceOutageViewModel.ts
+++ b/app/src/bcsc-theme/features/modal/useServiceOutageViewModel.ts
@@ -2,8 +2,10 @@ import BCSCApiClient from '@/bcsc-theme/api/client'
 import useConfigApi from '@/bcsc-theme/api/hooks/useConfigApi'
 import { useBCSCApiClientState } from '@/bcsc-theme/hooks/useBCSCApiClient'
 import { BCSCAuthStackParams, BCSCModals } from '@/bcsc-theme/types/navigators'
+import { HELP_URL } from '@/constants'
 import { ServerStatusSystemCheck } from '@/services/system-checks/ServerStatusSystemCheck'
 import { BCState } from '@/store'
+import { openLink } from '@/utils/links'
 import { TOKENS, useServices, useStore } from '@bifold/core'
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native'
 import { useCallback, useState } from 'react'
@@ -49,12 +51,18 @@ const useServiceOutageViewModel = () => {
 
   const contentText = statusMessage ? [statusMessage] : [t('BCSC.SystemChecks.ServerStatus.UnavailableBannerTitle')]
 
+  const handleLearnMore = useCallback(() => {
+    openLink(HELP_URL)
+  }, [])
+
   return {
     headerText: t('BCSC.Modals.ServiceOutage.Header'),
     contentText,
+    learnMoreText: t('BCSC.Modals.ServiceOutage.LearnMore'),
     buttonText: t('BCSC.Modals.ServiceOutage.CheckAgainButton'),
     isCheckDisabled: isChecking || !isClientReady,
     handleCheckAgain,
+    handleLearnMore,
   }
 }
 

--- a/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
+++ b/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
@@ -80,9 +80,8 @@ export const useCreateSystemChecks = (): UseGetSystemChecksReturn => {
    * @returns Array of system check strategies
    */
   const getStartupSystemChecks = useCallback(async (): Promise<SystemCheckStrategy[]> => {
-    // Clear stale server status banners from previous session before fresh check
-    utils.dispatch({ type: BCDispatchAction.REMOVE_BANNER_MESSAGE, payload: [BCSCBanner.IAS_SERVER_UNAVAILABLE] })
-    utils.dispatch({ type: BCDispatchAction.REMOVE_BANNER_MESSAGE, payload: [BCSCBanner.IAS_SERVER_NOTIFICATION] })
+    // TODO: Removed stale banner clearing to verify VPN banner behavior.
+    // Previously cleared IAS_SERVER_UNAVAILABLE and IAS_SERVER_NOTIFICATION here.
 
     const serverStatus = await configApi.getServerStatus()
 

--- a/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
+++ b/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
@@ -1,5 +1,5 @@
 import BCSCApiClient from '@/bcsc-theme/api/client'
-import { BCSCBanner } from '@/bcsc-theme/components/AppBanner'
+
 import { useBCSCApiClientState } from '@/bcsc-theme/hooks/useBCSCApiClient'
 import { useErrorAlert } from '@/contexts/ErrorAlertContext'
 import { useNavigationContainer } from '@/contexts/NavigationContainerContext'
@@ -80,8 +80,8 @@ export const useCreateSystemChecks = (): UseGetSystemChecksReturn => {
    * @returns Array of system check strategies
    */
   const getStartupSystemChecks = useCallback(async (): Promise<SystemCheckStrategy[]> => {
-    // TODO: Removed stale banner clearing to verify VPN banner behavior.
-    // Previously cleared IAS_SERVER_UNAVAILABLE and IAS_SERVER_NOTIFICATION here.
+    // Server status banners are not cleared on startup so they persist across app restarts
+    // and remain visible for VPN users who bypass the blocking outage modal.
 
     const serverStatus = await configApi.getServerStatus()
 

--- a/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
+++ b/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
@@ -1,4 +1,4 @@
-gimport BCSCApiClient from '@/bcsc-theme/api/client'
+import BCSCApiClient from '@/bcsc-theme/api/client'
 
 import { useBCSCApiClientState } from '@/bcsc-theme/hooks/useBCSCApiClient'
 import { useErrorAlert } from '@/contexts/ErrorAlertContext'

--- a/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
+++ b/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
@@ -1,4 +1,4 @@
-import BCSCApiClient from '@/bcsc-theme/api/client'
+gimport BCSCApiClient from '@/bcsc-theme/api/client'
 
 import { useBCSCApiClientState } from '@/bcsc-theme/hooks/useBCSCApiClient'
 import { useErrorAlert } from '@/contexts/ErrorAlertContext'
@@ -11,7 +11,7 @@ import { ServerClockSkewSystemCheck } from '@/services/system-checks/ServerClock
 import { ServerStatusSystemCheck } from '@/services/system-checks/ServerStatusSystemCheck'
 import { UpdateAppSystemCheck } from '@/services/system-checks/UpdateAppSystemCheck'
 import { UpdateDeviceRegistrationSystemCheck } from '@/services/system-checks/UpdateDeviceRegistrationSystemCheck'
-import { BCDispatchAction, BCState } from '@/store'
+import { BCState } from '@/store'
 import { Analytics } from '@/utils/analytics/analytics-singleton'
 import { TOKENS, useServices, useStore } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'

--- a/app/src/hooks/usePreventGestureBack.test.ts
+++ b/app/src/hooks/usePreventGestureBack.test.ts
@@ -1,0 +1,64 @@
+import { useFocusEffect, useNavigation } from '@react-navigation/native'
+import { renderHook } from '@testing-library/react-native'
+import usePreventGestureBack from './usePreventGestureBack'
+
+const mockAddListener = jest.fn()
+const mockUseFocusEffect = jest.mocked(useFocusEffect)
+
+describe('usePreventGestureBack', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    const nav = useNavigation() as any
+    nav.addListener = mockAddListener
+  })
+
+  it('registers a beforeRemove listener via useFocusEffect', () => {
+    mockUseFocusEffect.mockImplementation((cb) => cb())
+    mockAddListener.mockReturnValue(jest.fn())
+
+    renderHook(() => usePreventGestureBack())
+
+    expect(mockUseFocusEffect).toHaveBeenCalled()
+    expect(mockAddListener).toHaveBeenCalledWith('beforeRemove', expect.any(Function))
+  })
+
+  it('prevents navigation when action has no source (gesture)', () => {
+    mockUseFocusEffect.mockImplementation((cb) => cb())
+    mockAddListener.mockReturnValue(jest.fn())
+
+    renderHook(() => usePreventGestureBack())
+
+    const handler = mockAddListener.mock.calls[0][1]
+    const event = { data: { action: {} }, preventDefault: jest.fn() }
+    handler(event)
+
+    expect(event.preventDefault).toHaveBeenCalled()
+  })
+
+  it('allows navigation when action has a source (programmatic)', () => {
+    mockUseFocusEffect.mockImplementation((cb) => cb())
+    mockAddListener.mockReturnValue(jest.fn())
+
+    renderHook(() => usePreventGestureBack())
+
+    const handler = mockAddListener.mock.calls[0][1]
+    const event = { data: { action: { source: 'some-screen' } }, preventDefault: jest.fn() }
+    handler(event)
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('returns unsubscribe function from useFocusEffect cleanup', () => {
+    const mockUnsubscribe = jest.fn()
+    mockAddListener.mockReturnValue(mockUnsubscribe)
+
+    let cleanup: (() => void) | undefined
+    mockUseFocusEffect.mockImplementation((cb) => {
+      cleanup = cb() as any
+    })
+
+    renderHook(() => usePreventGestureBack())
+
+    expect(cleanup).toBe(mockUnsubscribe)
+  })
+})

--- a/app/src/hooks/usePreventGestureBack.ts
+++ b/app/src/hooks/usePreventGestureBack.ts
@@ -1,0 +1,25 @@
+import { useFocusEffect, useNavigation } from '@react-navigation/native'
+import { useCallback } from 'react'
+
+/**
+ * Prevents gesture-based back navigation (Android hardware back, swipe) while
+ * still allowing programmatic navigation (e.g. navigation.goBack()).
+ *
+ * gestureEnabled: false handles iOS; this hook handles Android's beforeRemove.
+ */
+const usePreventGestureBack = () => {
+  const navigation = useNavigation()
+
+  useFocusEffect(
+    useCallback(() => {
+      const unsubscribe = navigation.addListener('beforeRemove', (event) => {
+        if (!event.data.action.source) {
+          event.preventDefault()
+        }
+      })
+      return unsubscribe
+    }, [navigation])
+  )
+}
+
+export default usePreventGestureBack

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -345,6 +345,7 @@ const translation = {
       "ServiceOutage": {
         "Header": "Service unavailable",
         "CheckAgainButton": "Check again",
+        "LearnMore": "Learn more",
       },
     },
     "Home": {

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -345,6 +345,7 @@ const translation = {
       "ServiceOutage": {
         "Header": "Service unavailable (FR)",
         "CheckAgainButton": "Check again (FR)",
+        "LearnMore": "Learn more (FR)",
       },
     },
     "Home": {

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -345,6 +345,7 @@ const translation = {
       "ServiceOutage": {
         "Header": "Service unavailable (PT-BR)",
         "CheckAgainButton": "Check again (PT-BR)",
+        "LearnMore": "Learn more (PT-BR)",
       },
     },
     "Home": {


### PR DESCRIPTION
## Summary

- Adds `NotificationBannerContainer` to `AccountSelectorScreen` so server status banners are visible on that screen
- Adds a Help Centre link (via `CardButton`) to the `ServiceOutage` screen, opening the help URL in the browser
- Removes the startup logic that cleared `IAS_SERVER_UNAVAILABLE` and `IAS_SERVER_NOTIFICATION` banners on each app launch, allowing persistent banners to survive session restarts
- Extracts `usePreventGestureBack` hook from duplicated `beforeRemove` listener logic in `SystemModal` and `ServiceOutage`

## Test plan

- [x] Launch app with an active IAS server notification — confirm banner appears on the Account Selector screen
- [x] Navigate to the Service Outage screen — confirm Help Centre card button is present and opens the correct URL
- [x] Restart the app while a server status banner is active — confirm the banner is not cleared on startup
- [x] Verify no regression on normal (non-outage) startup flows

## Manual testing: simulating server status

You can either schedule a 5m service outage or hijack the network response as per below:

To test outage/banner behavior locally, override the `getServerStatus` return in `app/src/bcsc-theme/api/hooks/useConfigApi.tsx`:

```ts
// Add after the headers.date check, before the existing return:
return {
  ...data,
  status: 'unavailable' as const, // or 'ok' for VPN bypass simulation
  statusMessage: data.statusMessage ?? 'Service maintenance in progress.',
  serverTimestamp: new Date(headers.date),
}
```

- `status: 'unavailable'` — triggers the blocking ServiceOutage modal
- `status: 'ok'` with `statusMessage` — simulates VPN bypass, shows notification banner only