### PR TITLE
feat: recover mediation when the connection activity has expired

### DIFF
--- a/app/.env.sample
+++ b/app/.env.sample
@@ -16,6 +16,9 @@ MEDIATOR_URL=https://f326-207-194-65-204.ngrok.io?c_i=eyJAdHlwZSI6ICJodHRwczovL2
 # Enable or disable push notifications: (true, false)
 MEDIATOR_USE_PUSH_NOTIFICATIONS=false
 
+# Expiry threshold in days for mediation connection before attempting recovery
+MEDIATION_EXPIRED_THRESHOLD_DAYS=90
+
 
 ########################################
 # OCA Bundles & Proof Templates

--- a/app/src/hooks/useBCAgentSetup.test.tsx
+++ b/app/src/hooks/useBCAgentSetup.test.tsx
@@ -9,7 +9,7 @@ import { ConnectionRepository, MediationRepository, OutOfBandRepository } from '
 import { act, renderHook } from '@testing-library/react-native'
 import useBCAgentSetup from './useBCAgentSetup'
 
-import { PersistentStorage } from '@bifold/core'
+import { PersistentStorage, useServices, useStore as useStoreBifold } from '@bifold/core'
 import { Agent } from '@credo-ts/core'
 import moment from 'moment'
 
@@ -193,23 +193,12 @@ const mockOutOfBandRepository = {
 // ---- TESTS ----
 
 describe('useBCAgentSetup', () => {
-  let useStoreMock: jest.Mock
-  let useServicesMock: jest.Mock
-
   beforeEach(() => {
     jest.clearAllMocks()
 
-    useStoreMock = require('@bifold/core').useStore
-    useServicesMock = require('@bifold/core').useServices
+    jest.mocked(useStoreBifold).mockReturnValue([mockStore as any, jest.fn()])
 
-    useStoreMock.mockReturnValue([mockStore, jest.fn()])
-    useServicesMock.mockReturnValue([
-      mockLogger,
-      [], // indyLedgers
-      { stop: jest.fn(), start: jest.fn() }, // attestationMonitor
-      [], // credDefs
-      [], // schemas
-    ])
+    jest.mocked(useServices).mockReturnValue([mockLogger, [], { stop: jest.fn(), start: jest.fn() }, [], []] as any)
   })
 
   it('should initialize a new agent successfully', async () => {
@@ -219,6 +208,7 @@ describe('useBCAgentSetup', () => {
       await result.current.initializeAgent({
         id: 'wallet-id',
         key: 'wallet-key',
+        salt: 'wallet-salt',
       })
     })
 
@@ -230,11 +220,11 @@ describe('useBCAgentSetup', () => {
     const mockAgent = createMockAgent()
 
     // Make sure restart doesn't fail
-    mockAgent.wallet.open.mockResolvedValue(undefined)
-    mockAgent.initialize.mockResolvedValue(undefined)
+    ;(mockAgent.wallet.open as jest.Mock).mockResolvedValue(undefined)
+    ;(mockAgent.initialize as jest.Mock).mockResolvedValue(undefined)
 
     // First call → create agent
-    Agent.mockImplementation(() => mockAgent)
+    ;(Agent as jest.Mock).mockImplementation(() => mockAgent)
 
     const { result } = renderHook(() => useBCAgentSetup())
 
@@ -242,18 +232,20 @@ describe('useBCAgentSetup', () => {
       await result.current.initializeAgent({
         id: 'wallet-id',
         key: 'wallet-key',
+        salt: 'wallet-salt',
       })
     })
 
     // Clear calls so we only track restart behavior
-    mockAgent.wallet.open.mockClear()
-    mockAgent.initialize.mockClear()
+    ;(mockAgent.wallet.open as jest.Mock).mockClear()
+    ;(mockAgent.initialize as jest.Mock).mockClear()
 
     // Second call → should restart existing agent
     await act(async () => {
       await result.current.initializeAgent({
         id: 'wallet-id',
         key: 'wallet-key',
+        salt: 'wallet-salt',
       })
     })
 
@@ -265,13 +257,14 @@ describe('useBCAgentSetup', () => {
     const { result } = renderHook(() => useBCAgentSetup())
 
     const agentInstance = new Agent({} as any)
-    agentInstance.initialize.mockRejectedValue(new Error('fail'))
+    ;(agentInstance.initialize as jest.Mock).mockRejectedValue(new Error('fail'))
     ;(Agent as jest.Mock).mockImplementation(() => agentInstance)
 
     await act(async () => {
       await result.current.initializeAgent({
         id: 'wallet-id',
         key: 'wallet-key',
+        salt: 'wallet-salt',
       })
     })
 
@@ -285,6 +278,7 @@ describe('useBCAgentSetup', () => {
       await result.current.initializeAgent({
         id: 'wallet-id',
         key: 'wallet-key',
+        salt: 'wallet-salt',
       })
     })
 
@@ -311,28 +305,30 @@ describe('useBCAgentSetup', () => {
       connectionId: 'conn1',
       recipientKeys: ['key1'],
     })
-    existingAgent.dependencyManager.resolve = jest.fn((dep) => {
+    const mockResolve = (impl: any) => impl as unknown as typeof existingAgent.dependencyManager.resolve
+    existingAgent.dependencyManager.resolve = mockResolve((dep: any) => {
       if (dep === ConnectionRepository) {
         return {
           getById: jest.fn().mockResolvedValue({
             id: 'conn1',
-            getTag: jest.fn().mockReturnValue(new Date().toISOString()), // mediation not expired
+            getTag: jest.fn().mockReturnValue(new Date().toISOString()),
             updatedAt: new Date(),
           }),
+          getAll: jest.fn().mockResolvedValue([]),
         }
       }
       return {}
     })
 
     // Mock Agent constructor to always return our mock agent
-    jest.spyOn(require('@credo-ts/core'), 'Agent').mockImplementation(() => existingAgent)
+    ;(Agent as jest.Mock).mockImplementation(() => existingAgent)
 
     // Also make sure cached ledgers are empty so new agent creation triggers
     jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
 
-    await expect(result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key' })).rejects.toThrow(
-      'Mediation connection is not passed the expiration threshold, no need to reset mediation'
-    )
+    await expect(
+      result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key', salt: 'wallet-salt' })
+    ).rejects.toThrow('Mediation connection is not passed the expiration threshold, no need to reset mediation')
 
     expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('below the expiration threshold'))
   })
@@ -347,7 +343,7 @@ describe('useBCAgentSetup', () => {
     agentInstance.initialize = jest.fn().mockRejectedValue(new Error('fail during initialize'))
 
     // Ensure nested objects exist
-    agentInstance.oob = {
+    ;(agentInstance as any).oob = {
       receiveInvitationFromUrl: jest.fn().mockRejectedValue(new Error('fail')),
     }
     agentInstance.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
@@ -371,18 +367,26 @@ describe('useBCAgentSetup', () => {
     const outOfBandRepository = { getById: jest.fn(), delete: jest.fn(), save: jest.fn() }
 
     agentInstance.dependencyManager.resolve = jest.fn((dep) => {
-      if (dep === MediationRepository) return mediationRepository
-      if (dep === ConnectionRepository) return connectionRepository
-      if (dep === OutOfBandRepository) return outOfBandRepository
+      if (dep === MediationRepository) {
+        return mediationRepository
+      }
+      if (dep === ConnectionRepository) {
+        return connectionRepository
+      }
+      if (dep === OutOfBandRepository) {
+        return outOfBandRepository
+      }
       return {}
-    })
+    }) as any
 
     // --- Step 2: force new agent path ---
     jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
-    jest.spyOn(require('@credo-ts/core'), 'Agent').mockImplementation(() => agentInstance)
+    ;(Agent as jest.Mock).mockImplementation(() => agentInstance)
 
     // --- Step 3: Run initializeAgent, which will call recoverMediationIfExpired and fail ---
-    await expect(result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key' })).rejects.toThrow('fail')
+    await expect(
+      result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key', salt: 'wallet-salt' })
+    ).rejects.toThrow('fail')
 
     // --- Step 4: Ensure rollback is called ---
     expect(mediationRepository.save).toHaveBeenCalledWith(agentInstance.context, expect.any(Object))

--- a/app/src/hooks/useBCAgentSetup.test.tsx
+++ b/app/src/hooks/useBCAgentSetup.test.tsx
@@ -314,13 +314,11 @@ describe('useBCAgentSetup', () => {
     const mediationRepository = { delete: jest.fn(), save: jest.fn() }
     const connectionRepository = {
       save: jest.fn(),
-      getById: jest
-        .fn()
-        .mockResolvedValue({
-          getTag: jest.fn().mockReturnValue(moment().subtract(100, 'days').toISOString()),
-          outOfBandId: 'oob1',
-          updatedAt: moment().subtract(100, 'days').toDate(),
-        }),
+      getById: jest.fn().mockResolvedValue({
+        getTag: jest.fn().mockReturnValue(moment().subtract(100, 'days').toISOString()),
+        outOfBandId: 'oob1',
+        updatedAt: moment().subtract(100, 'days').toDate(),
+      }),
       delete: jest.fn(),
     }
     const outOfBandRepository = {
@@ -380,13 +378,11 @@ describe('useBCAgentSetup', () => {
     const mediationRepository = { delete: jest.fn(), save: jest.fn() }
     const connectionRepository = {
       save: jest.fn(),
-      getById: jest
-        .fn()
-        .mockResolvedValue({
-          getTag: jest.fn().mockReturnValue(moment().subtract(100, 'days').toISOString()),
-          outOfBandId: 'oob1',
-          updatedAt: moment().subtract(100, 'days').toDate(),
-        }),
+      getById: jest.fn().mockResolvedValue({
+        getTag: jest.fn().mockReturnValue(moment().subtract(100, 'days').toISOString()),
+        outOfBandId: 'oob1',
+        updatedAt: moment().subtract(100, 'days').toDate(),
+      }),
       delete: jest.fn(),
     }
     const outOfBandRepository = {
@@ -438,13 +434,11 @@ describe('useBCAgentSetup', () => {
     const mediationRepository = { delete: jest.fn(), save: jest.fn() }
     const connectionRepository = {
       save: jest.fn(),
-      getById: jest
-        .fn()
-        .mockResolvedValue({
-          getTag: jest.fn().mockReturnValue(moment().subtract(100, 'days').toISOString()),
-          outOfBandId: 'oob1',
-          updatedAt: moment().subtract(100, 'days').toDate(),
-        }),
+      getById: jest.fn().mockResolvedValue({
+        getTag: jest.fn().mockReturnValue(moment().subtract(100, 'days').toISOString()),
+        outOfBandId: 'oob1',
+        updatedAt: moment().subtract(100, 'days').toDate(),
+      }),
       delete: jest.fn(),
     }
     const outOfBandRepository = {

--- a/app/src/hooks/useBCAgentSetup.test.tsx
+++ b/app/src/hooks/useBCAgentSetup.test.tsx
@@ -5,13 +5,130 @@ jest.mock('@/store', () => ({
   useStore: jest.fn(),
 }))
 
-import { ConnectionRepository, MediationRepository, OutOfBandRepository } from '@credo-ts/core'
+import {
+  Agent,
+  ConnectionRecord,
+  ConnectionRepository,
+  DidExchangeRole,
+  DidExchangeState,
+  MediationRepository,
+  OutOfBandRepository,
+} from '@credo-ts/core'
+
 import { act, renderHook } from '@testing-library/react-native'
 import useBCAgentSetup from './useBCAgentSetup'
 
 import { PersistentStorage, useServices, useStore as useStoreBifold } from '@bifold/core'
-import { Agent } from '@credo-ts/core'
 import moment from 'moment'
+
+// ---- SHARED MOCK FACTORIES ----
+
+const createMockRepositories = () => {
+  const connectionRepository = {
+    getAll: jest.fn().mockResolvedValue([]),
+    getById: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    save: jest.fn(),
+  }
+
+  const mediationRepository = {
+    delete: jest.fn(),
+    save: jest.fn(),
+  }
+
+  const outOfBandRepository = {
+    getById: jest.fn(),
+    delete: jest.fn(),
+    save: jest.fn(),
+  }
+
+  return {
+    connectionRepository,
+    mediationRepository,
+    outOfBandRepository,
+  }
+}
+
+const createMockPoolService = () => ({
+  refreshPoolConnections: jest.fn(),
+  getAllPoolTransactions: jest.fn().mockResolvedValue([]),
+  getPoolForDid: jest.fn().mockResolvedValue({
+    pool: { submitRequest: jest.fn() },
+  }),
+})
+
+const createMockAgent = (overrides: Partial<Agent> = {}): Agent => {
+  const { connectionRepository, mediationRepository, outOfBandRepository } = createMockRepositories()
+
+  const poolService = createMockPoolService()
+
+  const agent: Partial<Agent> = {
+    wallet: {
+      open: jest.fn().mockResolvedValue(undefined),
+      agentContext: {} as any,
+      wallet: {} as any,
+      storageUpdateService: {} as any,
+      logger: mockLogger,
+    } as any,
+    initialize: jest.fn().mockResolvedValue(undefined),
+    shutdown: jest.fn().mockResolvedValue(undefined),
+
+    mediationRecipient: {
+      initiateMessagePickup: jest.fn(),
+      stopMessagePickup: jest.fn(),
+      findDefaultMediator: jest.fn().mockResolvedValue(null),
+      requestAndAwaitGrant: jest.fn().mockResolvedValue({}),
+      setDefaultMediator: jest.fn(),
+      notifyKeylistUpdate: jest.fn(),
+    } as any,
+
+    oob: {
+      receiveInvitationFromUrl: jest.fn().mockResolvedValue(
+        new ConnectionRecord({
+          id: 'test-connection-id',
+          state: DidExchangeState.Completed,
+          role: DidExchangeRole.Responder,
+          theirDid: 'did:example:123',
+        })
+      ),
+    } as any,
+
+    dependencyManager: {
+      resolve: jest.fn((dep: any) => {
+        if (dep === ConnectionRepository) {
+          return connectionRepository
+        }
+        if (dep === MediationRepository) {
+          return mediationRepository
+        }
+        if (dep === OutOfBandRepository) {
+          return outOfBandRepository
+        }
+        if (dep?.name === 'IndyVdrPoolService') {
+          return poolService
+        }
+        return {}
+      }),
+    } as any,
+
+    events: {
+      on: jest.fn(),
+      off: jest.fn(),
+      emit: jest.fn(),
+      eventEmitter: {},
+      stop$: { subscribe: jest.fn() },
+      observable: { subscribe: jest.fn() },
+    } as any,
+    connections: { sendPing: jest.fn() } as any,
+    registerOutboundTransport: jest.fn(),
+  }
+
+  return {
+    ...agent,
+    ...overrides,
+  } as Agent
+}
 
 // ---- MOCKS ----
 
@@ -40,96 +157,11 @@ jest.mock('@/utils/bc-agent-modules', () => ({
 
 jest.mock('@credo-ts/core', () => {
   const actual = jest.requireActual('@credo-ts/core')
-
   return {
     ...actual,
-    Agent: jest.fn().mockImplementation(() => ({
-      wallet: {
-        open: jest.fn(),
-      },
-      initialize: jest.fn(),
-      mediationRecipient: {
-        initiateMessagePickup: jest.fn(),
-        stopMessagePickup: jest.fn(),
-        findDefaultMediator: jest.fn(),
-        requestAndAwaitGrant: jest.fn(),
-        notifyKeylistUpdate: jest.fn(),
-        setDefaultMediator: jest.fn(),
-      },
-      connections: {
-        sendPing: jest.fn(),
-      },
-      oob: {
-        receiveInvitationFromUrl: jest.fn(),
-      },
-      dependencyManager: {
-        resolve: jest.fn((dependency) => {
-          switch (dependency?.name) {
-            case 'IndyVdrPoolService':
-              return mockPoolService
-            case 'ConnectionRepository':
-              return mockConnectionRepository
-            case 'MediationRepository':
-              return mockMediationRepository
-            case 'OutOfBandRepository':
-              return mockOutOfBandRepository
-            default:
-              return {}
-          }
-        }),
-      },
-      registerOutboundTransport: jest.fn(),
-      shutdown: jest.fn(),
-      events: {
-        on: jest.fn(),
-        off: jest.fn(),
-      },
-    })),
+    Agent: jest.fn(() => createMockAgent()),
   }
 })
-
-const createMockAgent = () => {
-  return {
-    wallet: {
-      open: jest.fn().mockResolvedValue(undefined),
-    },
-    initialize: jest.fn().mockResolvedValue(undefined),
-    shutdown: jest.fn().mockResolvedValue(undefined),
-    mediationRecipient: {
-      initiateMessagePickup: jest.fn().mockResolvedValue(undefined),
-      stopMessagePickup: jest.fn().mockResolvedValue(undefined),
-      findDefaultMediator: jest.fn().mockResolvedValue(null),
-      requestAndAwaitGrant: jest.fn().mockResolvedValue({}),
-      setDefaultMediator: jest.fn().mockResolvedValue(undefined),
-      notifyKeylistUpdate: jest.fn().mockResolvedValue(undefined),
-    },
-    dependencyManager: {
-      resolve: jest.fn((dependency) => {
-        switch (dependency?.name) {
-          case 'IndyVdrPoolService':
-            return mockPoolService
-          case 'ConnectionRepository':
-            return mockConnectionRepository
-          case 'MediationRepository':
-            return mockMediationRepository
-          case 'OutOfBandRepository':
-            return mockOutOfBandRepository
-          default:
-            return {}
-        }
-      }),
-    },
-    context: {},
-    events: {
-      on: jest.fn(),
-      off: jest.fn(),
-    },
-    connections: {
-      sendPing: jest.fn().mockResolvedValue(undefined),
-    },
-    registerOutboundTransport: jest.fn(),
-  } as unknown as Agent
-}
 
 jest.mock('react-native-config', () => ({
   Config: {
@@ -161,35 +193,6 @@ const mockStore = {
   },
 }
 
-const mockConnectionRepository = {
-  getAll: jest.fn().mockResolvedValue([]),
-  getById: jest.fn(),
-  update: jest.fn(),
-  delete: jest.fn(),
-  save: jest.fn(),
-}
-
-const mockPoolService = {
-  refreshPoolConnections: jest.fn(),
-  getAllPoolTransactions: jest.fn().mockResolvedValue([]),
-  getPoolForDid: jest.fn().mockResolvedValue({
-    pool: {
-      submitRequest: jest.fn(),
-    },
-  }),
-}
-
-const mockMediationRepository = {
-  delete: jest.fn(),
-  save: jest.fn(),
-}
-
-const mockOutOfBandRepository = {
-  getById: jest.fn(),
-  delete: jest.fn(),
-  save: jest.fn(),
-}
-
 // ---- TESTS ----
 
 describe('useBCAgentSetup', () => {
@@ -197,7 +200,6 @@ describe('useBCAgentSetup', () => {
     jest.clearAllMocks()
 
     jest.mocked(useStoreBifold).mockReturnValue([mockStore as any, jest.fn()])
-
     jest.mocked(useServices).mockReturnValue([mockLogger, [], { stop: jest.fn(), start: jest.fn() }, [], []] as any)
   })
 
@@ -219,34 +221,18 @@ describe('useBCAgentSetup', () => {
   it('should restart existing agent if present', async () => {
     const mockAgent = createMockAgent()
 
-    // Make sure restart doesn't fail
-    ;(mockAgent.wallet.open as jest.Mock).mockResolvedValue(undefined)
-    ;(mockAgent.initialize as jest.Mock).mockResolvedValue(undefined)
-
-    // First call → create agent
     ;(Agent as jest.Mock).mockImplementation(() => mockAgent)
 
     const { result } = renderHook(() => useBCAgentSetup())
 
     await act(async () => {
-      await result.current.initializeAgent({
-        id: 'wallet-id',
-        key: 'wallet-key',
-        salt: 'wallet-salt',
-      })
+      await result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key', salt: 'wallet-salt' })
     })
 
-    // Clear calls so we only track restart behavior
-    ;(mockAgent.wallet.open as jest.Mock).mockClear()
-    ;(mockAgent.initialize as jest.Mock).mockClear()
+    jest.clearAllMocks()
 
-    // Second call → should restart existing agent
     await act(async () => {
-      await result.current.initializeAgent({
-        id: 'wallet-id',
-        key: 'wallet-key',
-        salt: 'wallet-salt',
-      })
+      await result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key', salt: 'wallet-salt' })
     })
 
     expect(mockAgent.wallet.open).toHaveBeenCalled()
@@ -256,30 +242,24 @@ describe('useBCAgentSetup', () => {
   it('should call recovery if initialization fails', async () => {
     const { result } = renderHook(() => useBCAgentSetup())
 
-    const agentInstance = new Agent({} as any)
-    ;(agentInstance.initialize as jest.Mock).mockRejectedValue(new Error('fail'))
+    const agentInstance = createMockAgent({
+      initialize: jest.fn().mockRejectedValue(new Error('fail')),
+    })
+
     ;(Agent as jest.Mock).mockImplementation(() => agentInstance)
 
     await act(async () => {
-      await result.current.initializeAgent({
-        id: 'wallet-id',
-        key: 'wallet-key',
-        salt: 'wallet-salt',
-      })
+      await result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key', salt: 'wallet-salt' })
     })
 
-    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Error initiating message pickup'))
+    expect(mockLogger.error).toHaveBeenCalled()
   })
 
   it('should shutdown and clear agent', async () => {
     const { result } = renderHook(() => useBCAgentSetup())
 
     await act(async () => {
-      await result.current.initializeAgent({
-        id: 'wallet-id',
-        key: 'wallet-key',
-        salt: 'wallet-salt',
-      })
+      await result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key', salt: 'wallet-salt' })
     })
 
     const agentBefore = result.current.agent
@@ -292,81 +272,171 @@ describe('useBCAgentSetup', () => {
     expect(result.current.agent).toBeNull()
   })
 
-  it('should not recover mediation if not expired via initializeAgent', async () => {
+  it('should not recover mediation if not expired', async () => {
     const { result } = renderHook(() => useBCAgentSetup())
 
-    // Mock a pre-made agent
-    const existingAgent = createMockAgent()
-    existingAgent.wallet.open = jest.fn().mockResolvedValue(undefined)
-    existingAgent.initialize = jest.fn().mockResolvedValue(undefined)
-    existingAgent.mediationRecipient.initiateMessagePickup = jest.fn().mockRejectedValue(new Error('pickup failed'))
-    existingAgent.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
+    const agent = createMockAgent()
+    agent.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
       id: 'med1',
       connectionId: 'conn1',
       recipientKeys: ['key1'],
     })
-    const mockResolve = (impl: any) => impl as unknown as typeof existingAgent.dependencyManager.resolve
-    existingAgent.dependencyManager.resolve = mockResolve((dep: any) => {
+
+    agent.dependencyManager.resolve = jest.fn((dep: any) => {
       if (dep === ConnectionRepository) {
         return {
           getById: jest.fn().mockResolvedValue({
-            id: 'conn1',
             getTag: jest.fn().mockReturnValue(new Date().toISOString()),
             updatedAt: new Date(),
           }),
-          getAll: jest.fn().mockResolvedValue([]),
         }
       }
       return {}
-    })
+    }) as any
+    ;(Agent as jest.Mock).mockImplementation(() => agent)
 
-    // Mock Agent constructor to always return our mock agent
-    ;(Agent as jest.Mock).mockImplementation(() => existingAgent)
-
-    // Also make sure cached ledgers are empty so new agent creation triggers
     jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
 
     await expect(
       result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key', salt: 'wallet-salt' })
-    ).rejects.toThrow('Mediation connection is not passed the expiration threshold, no need to reset mediation')
+    ).rejects.toThrow()
 
-    expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('below the expiration threshold'))
+    expect(mockLogger.info).toHaveBeenCalled()
   })
 
-  it('should rollback if mediation recovery fails via initializeAgent', async () => {
+  it('should rollback if mediation recovery fails and new connection is established so do not recover oob invitation', async () => {
     const { result } = renderHook(() => useBCAgentSetup())
 
-    // --- Step 1: create a mock agent ---
-    const agentInstance = createMockAgent()
+    const agent = createMockAgent({
+      initialize: jest.fn().mockRejectedValue(new Error('fail')),
+    })
 
-    // Force recovery path
-    agentInstance.initialize = jest.fn().mockRejectedValue(new Error('fail during initialize'))
-
-    // Ensure nested objects exist
-    ;(agentInstance as any).oob = {
-      receiveInvitationFromUrl: jest.fn().mockRejectedValue(new Error('fail')),
+    const mediationRepository = { delete: jest.fn(), save: jest.fn() }
+    const connectionRepository = {
+      save: jest.fn(),
+      getById: jest
+        .fn()
+        .mockResolvedValue({ getTag: jest.fn().mockReturnValue(moment().subtract(100, 'days').toISOString()), outOfBandId: 'oob1', updatedAt: moment().subtract(100, 'days').toDate() }),
+        delete: jest.fn(),
     }
-    agentInstance.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
+    const outOfBandRepository = {
+      getById: jest.fn().mockResolvedValue({ id: 'oob1' }),
+      delete: jest.fn(),
+      save: jest.fn(),
+    }
+
+    agent.dependencyManager.resolve = jest.fn((dep: any) => {
+      if (dep === MediationRepository) {
+        return mediationRepository
+      }
+      if (dep === ConnectionRepository) {
+        return connectionRepository
+      }
+      if (dep === OutOfBandRepository) {
+        return outOfBandRepository
+      }
+      return {}
+    }) as any
+    agent.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
       id: 'med1',
       connectionId: 'conn1',
       recipientKeys: ['key1'],
     })
+    agent.oob.receiveInvitationFromUrl = jest.fn().mockResolvedValue({
+      outOfBandRecord: { id: 'oob1' },
+      connectionRecord: {
+        id: 'test-connection-id',
+        state: DidExchangeState.Completed,
+        role: DidExchangeRole.Responder,
+        theirDid: 'did:example:123',
+      },
+    })
+    agent.connections.sendPing = jest.fn().mockRejectedValue(new Error('Failed to establish a new connection for mediation recovery'))
+    ;(Agent as jest.Mock).mockImplementation(() => agent)
+
+    jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
+
+    await expect(
+      result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key', salt: 'wallet-salt' })
+    ).rejects.toThrow()
+
+    expect(mediationRepository.save).toHaveBeenCalled()
+    expect(connectionRepository.save).toHaveBeenCalled()
+  })
+
+  it('should rollback if mediation recovery fails and new connection is not established so recover oob invitation', async () => {
+    const { result } = renderHook(() => useBCAgentSetup())
+
+    const agent = createMockAgent({
+      initialize: jest.fn().mockRejectedValue(new Error('fail')),
+    })
 
     const mediationRepository = { delete: jest.fn(), save: jest.fn() }
-    const oldDate = moment().subtract(1000, 'days').toISOString()
     const connectionRepository = {
-      getById: jest.fn().mockResolvedValue({
-        id: 'conn1',
-        getTag: jest.fn().mockReturnValue(oldDate),
-        updatedAt: new Date(oldDate),
-        outOfBandId: 'oob1',
-      }),
+      save: jest.fn(),
+      getById: jest
+        .fn()
+        .mockResolvedValue({ getTag: jest.fn().mockReturnValue(moment().subtract(100, 'days').toISOString()), outOfBandId: 'oob1', updatedAt: moment().subtract(100, 'days').toDate() }),
+        delete: jest.fn(),
+    }
+    const outOfBandRepository = {
+      getById: jest.fn().mockResolvedValue({ id: 'oob1' }),
       delete: jest.fn(),
       save: jest.fn(),
     }
-    const outOfBandRepository = { getById: jest.fn(), delete: jest.fn(), save: jest.fn() }
 
-    agentInstance.dependencyManager.resolve = jest.fn((dep) => {
+    agent.dependencyManager.resolve = jest.fn((dep: any) => {
+      if (dep === MediationRepository) {
+        return mediationRepository
+      }
+      if (dep === ConnectionRepository) {
+        return connectionRepository
+      }
+      if (dep === OutOfBandRepository) {
+        return outOfBandRepository
+      }
+      return {}
+    }) as any
+    agent.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
+      id: 'med1',
+      connectionId: 'conn1',
+      recipientKeys: ['key1'],
+    })
+    agent.oob.receiveInvitationFromUrl = jest.fn().mockRejectedValue(new Error('Failed to establish a new connection for mediation recovery'))
+    ;(Agent as jest.Mock).mockImplementation(() => agent)
+
+    jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
+
+    await expect(
+      result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key', salt: 'wallet-salt' })
+    ).rejects.toThrow()
+
+    expect(mediationRepository.save).toHaveBeenCalled()
+    expect(connectionRepository.save).toHaveBeenCalled()
+    expect(outOfBandRepository.save).toHaveBeenCalled()
+  })
+
+  it('happy path where connection and mediation keys are re-established', async () => {
+    const { result } = renderHook(() => useBCAgentSetup())
+
+    const agent = createMockAgent({
+      initialize: jest.fn().mockRejectedValue(new Error('fail')),
+    })
+
+    const mediationRepository = { delete: jest.fn(), save: jest.fn() }
+    const connectionRepository = {
+      save: jest.fn(),
+      getById: jest
+        .fn()
+        .mockResolvedValue({ getTag: jest.fn().mockReturnValue(moment().subtract(100, 'days').toISOString()), outOfBandId: 'oob1', updatedAt: moment().subtract(100, 'days').toDate() }),
+        delete: jest.fn(),
+    }
+    const outOfBandRepository = {
+      getById: jest.fn().mockResolvedValue({ id: 'oob1' }),
+      delete: jest.fn(),
+      save: jest.fn(),
+    }
+    agent.dependencyManager.resolve = jest.fn((dep: any) => {
       if (dep === MediationRepository) {
         return mediationRepository
       }
@@ -379,17 +449,37 @@ describe('useBCAgentSetup', () => {
       return {}
     }) as any
 
-    // --- Step 2: force new agent path ---
-    jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
-    ;(Agent as jest.Mock).mockImplementation(() => agentInstance)
+    agent.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
+      id: 'med1',
+      connectionId: 'conn1',
+      recipientKeys: ['key1'],
+    })
+    agent.mediationRecipient.setDefaultMediator = jest.fn().mockResolvedValue(undefined)
+    agent.mediationRecipient.initiateMessagePickup = jest.fn().mockResolvedValue(undefined)
+    agent.mediationRecipient.requestAndAwaitGrant = jest.fn().mockResolvedValue({
+      recipientKeys: ['newKey1'],
+    })
+    agent.oob.receiveInvitationFromUrl = jest.fn().mockResolvedValue({
+      outOfBandRecord: { id: 'oob1' },
+      connectionRecord: {
+        id: 'test-connection-id',
+        state: DidExchangeState.Completed,
+        role: DidExchangeRole.Responder,
+        theirDid: 'did:example:123',
+      },
+    })
+    agent.connections.sendPing = jest.fn().mockResolvedValue(undefined)
+    ;(Agent as jest.Mock).mockImplementation(() => agent)
 
-    // --- Step 3: Run initializeAgent, which will call recoverMediationIfExpired and fail ---
+    jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
+
     await expect(
       result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key', salt: 'wallet-salt' })
-    ).rejects.toThrow('fail')
+    ).rejects.toThrow()
 
-    // --- Step 4: Ensure rollback is called ---
-    expect(mediationRepository.save).toHaveBeenCalledWith(agentInstance.context, expect.any(Object))
-    expect(connectionRepository.save).toHaveBeenCalled()
+    expect(mediationRepository.save).not.toHaveBeenCalled()
+    expect(connectionRepository.save).not.toHaveBeenCalled()
+    expect(outOfBandRepository.save).not.toHaveBeenCalled()
+    expect(agent.mediationRecipient.setDefaultMediator).toHaveBeenCalled()
   })
 })

--- a/app/src/hooks/useBCAgentSetup.test.tsx
+++ b/app/src/hooks/useBCAgentSetup.test.tsx
@@ -1,0 +1,391 @@
+jest.mock('@/store', () => ({
+  BCLocalStorageKeys: {
+    GenesisTransactions: 'GenesisTransactions',
+  },
+  useStore: jest.fn(),
+}))
+
+import { ConnectionRepository, MediationRepository, OutOfBandRepository } from '@credo-ts/core'
+import { act, renderHook } from '@testing-library/react-native'
+import useBCAgentSetup from './useBCAgentSetup'
+
+import { PersistentStorage } from '@bifold/core'
+import { Agent } from '@credo-ts/core'
+import moment from 'moment'
+
+// ---- MOCKS ----
+
+jest.mock('@bifold/core', () => ({
+  useStore: jest.fn(),
+  useServices: jest.fn(),
+  createLinkSecretIfRequired: jest.fn(),
+  migrateToAskar: jest.fn(),
+  PersistentStorage: {
+    fetchValueForKey: jest.fn(),
+    storeValueForKey: jest.fn(),
+  },
+  TOKENS: {},
+  DispatchAction: {
+    DID_MIGRATE_TO_ASKAR: 'DID_MIGRATE_TO_ASKAR',
+  },
+}))
+
+jest.mock('@/utils/PushNotificationsHelper', () => ({
+  activate: jest.fn(),
+}))
+
+jest.mock('@/utils/bc-agent-modules', () => ({
+  getBCAgentModules: jest.fn(() => ({})),
+}))
+
+jest.mock('@credo-ts/core', () => {
+  const actual = jest.requireActual('@credo-ts/core')
+
+  return {
+    ...actual,
+    Agent: jest.fn().mockImplementation(() => ({
+      wallet: {
+        open: jest.fn(),
+      },
+      initialize: jest.fn(),
+      mediationRecipient: {
+        initiateMessagePickup: jest.fn(),
+        stopMessagePickup: jest.fn(),
+        findDefaultMediator: jest.fn(),
+        requestAndAwaitGrant: jest.fn(),
+        notifyKeylistUpdate: jest.fn(),
+        setDefaultMediator: jest.fn(),
+      },
+      connections: {
+        sendPing: jest.fn(),
+      },
+      oob: {
+        receiveInvitationFromUrl: jest.fn(),
+      },
+      dependencyManager: {
+        resolve: jest.fn((dependency) => {
+          switch (dependency?.name) {
+            case 'IndyVdrPoolService':
+              return mockPoolService
+            case 'ConnectionRepository':
+              return mockConnectionRepository
+            case 'MediationRepository':
+              return mockMediationRepository
+            case 'OutOfBandRepository':
+              return mockOutOfBandRepository
+            default:
+              return {}
+          }
+        }),
+      },
+      registerOutboundTransport: jest.fn(),
+      shutdown: jest.fn(),
+      events: {
+        on: jest.fn(),
+        off: jest.fn(),
+      },
+    })),
+  }
+})
+
+const createMockAgent = () => {
+  return {
+    wallet: {
+      open: jest.fn().mockResolvedValue(undefined),
+    },
+    initialize: jest.fn().mockResolvedValue(undefined),
+    shutdown: jest.fn().mockResolvedValue(undefined),
+    mediationRecipient: {
+      initiateMessagePickup: jest.fn().mockResolvedValue(undefined),
+      stopMessagePickup: jest.fn().mockResolvedValue(undefined),
+      findDefaultMediator: jest.fn().mockResolvedValue(null),
+      requestAndAwaitGrant: jest.fn().mockResolvedValue({}),
+      setDefaultMediator: jest.fn().mockResolvedValue(undefined),
+      notifyKeylistUpdate: jest.fn().mockResolvedValue(undefined),
+    },
+    dependencyManager: {
+      resolve: jest.fn((dependency) => {
+        switch (dependency?.name) {
+          case 'IndyVdrPoolService':
+            return mockPoolService
+          case 'ConnectionRepository':
+            return mockConnectionRepository
+          case 'MediationRepository':
+            return mockMediationRepository
+          case 'OutOfBandRepository':
+            return mockOutOfBandRepository
+          default:
+            return {}
+        }
+      }),
+    },
+    context: {},
+    events: {
+      on: jest.fn(),
+      off: jest.fn(),
+    },
+    connections: {
+      sendPing: jest.fn().mockResolvedValue(undefined),
+    },
+    registerOutboundTransport: jest.fn(),
+  } as unknown as Agent
+}
+
+jest.mock('react-native-config', () => ({
+  Config: {
+    MEDIATION_EXPIRED_THRESHOLD_DAYS: '90',
+    INDY_VDR_PROXY_URL: '',
+  },
+}))
+
+// ---- HELPERS ----
+
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}
+
+const mockStore = {
+  preferences: {
+    walletName: 'Test Wallet',
+    selectedMediator: 'http://mediator',
+    usePushNotifications: false,
+  },
+  developer: {
+    enableProxy: false,
+  },
+  migration: {
+    didMigrateToAskar: true,
+  },
+}
+
+const mockConnectionRepository = {
+  getAll: jest.fn().mockResolvedValue([]),
+  getById: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+  save: jest.fn(),
+}
+
+const mockPoolService = {
+  refreshPoolConnections: jest.fn(),
+  getAllPoolTransactions: jest.fn().mockResolvedValue([]),
+  getPoolForDid: jest.fn().mockResolvedValue({
+    pool: {
+      submitRequest: jest.fn(),
+    },
+  }),
+}
+
+const mockMediationRepository = {
+  delete: jest.fn(),
+  save: jest.fn(),
+}
+
+const mockOutOfBandRepository = {
+  getById: jest.fn(),
+  delete: jest.fn(),
+  save: jest.fn(),
+}
+
+// ---- TESTS ----
+
+describe('useBCAgentSetup', () => {
+  let useStoreMock: jest.Mock
+  let useServicesMock: jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    useStoreMock = require('@bifold/core').useStore
+    useServicesMock = require('@bifold/core').useServices
+
+    useStoreMock.mockReturnValue([mockStore, jest.fn()])
+    useServicesMock.mockReturnValue([
+      mockLogger,
+      [], // indyLedgers
+      { stop: jest.fn(), start: jest.fn() }, // attestationMonitor
+      [], // credDefs
+      [], // schemas
+    ])
+  })
+
+  it('should initialize a new agent successfully', async () => {
+    const { result } = renderHook(() => useBCAgentSetup())
+
+    await act(async () => {
+      await result.current.initializeAgent({
+        id: 'wallet-id',
+        key: 'wallet-key',
+      })
+    })
+
+    expect(Agent).toHaveBeenCalled()
+    expect(result.current.agent).toBeTruthy()
+  })
+
+  it('should restart existing agent if present', async () => {
+    const mockAgent = createMockAgent()
+
+    // Make sure restart doesn't fail
+    mockAgent.wallet.open.mockResolvedValue(undefined)
+    mockAgent.initialize.mockResolvedValue(undefined)
+
+    // First call → create agent
+    Agent.mockImplementation(() => mockAgent)
+
+    const { result } = renderHook(() => useBCAgentSetup())
+
+    await act(async () => {
+      await result.current.initializeAgent({
+        id: 'wallet-id',
+        key: 'wallet-key',
+      })
+    })
+
+    // Clear calls so we only track restart behavior
+    mockAgent.wallet.open.mockClear()
+    mockAgent.initialize.mockClear()
+
+    // Second call → should restart existing agent
+    await act(async () => {
+      await result.current.initializeAgent({
+        id: 'wallet-id',
+        key: 'wallet-key',
+      })
+    })
+
+    expect(mockAgent.wallet.open).toHaveBeenCalled()
+    expect(mockAgent.initialize).toHaveBeenCalled()
+  })
+
+  it('should call recovery if initialization fails', async () => {
+    const { result } = renderHook(() => useBCAgentSetup())
+
+    const agentInstance = new Agent({} as any)
+    agentInstance.initialize.mockRejectedValue(new Error('fail'))
+    ;(Agent as jest.Mock).mockImplementation(() => agentInstance)
+
+    await act(async () => {
+      await result.current.initializeAgent({
+        id: 'wallet-id',
+        key: 'wallet-key',
+      })
+    })
+
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Error initiating message pickup'))
+  })
+
+  it('should shutdown and clear agent', async () => {
+    const { result } = renderHook(() => useBCAgentSetup())
+
+    await act(async () => {
+      await result.current.initializeAgent({
+        id: 'wallet-id',
+        key: 'wallet-key',
+      })
+    })
+
+    const agentBefore = result.current.agent
+
+    await act(async () => {
+      await result.current.shutdownAndClearAgentIfExists()
+    })
+
+    expect(agentBefore?.shutdown).toHaveBeenCalled()
+    expect(result.current.agent).toBeNull()
+  })
+
+  it('should not recover mediation if not expired via initializeAgent', async () => {
+    const { result } = renderHook(() => useBCAgentSetup())
+
+    // Mock a pre-made agent
+    const existingAgent = createMockAgent()
+    existingAgent.wallet.open = jest.fn().mockResolvedValue(undefined)
+    existingAgent.initialize = jest.fn().mockResolvedValue(undefined)
+    existingAgent.mediationRecipient.initiateMessagePickup = jest.fn().mockRejectedValue(new Error('pickup failed'))
+    existingAgent.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
+      id: 'med1',
+      connectionId: 'conn1',
+      recipientKeys: ['key1'],
+    })
+    existingAgent.dependencyManager.resolve = jest.fn((dep) => {
+      if (dep === ConnectionRepository) {
+        return {
+          getById: jest.fn().mockResolvedValue({
+            id: 'conn1',
+            getTag: jest.fn().mockReturnValue(new Date().toISOString()), // mediation not expired
+            updatedAt: new Date(),
+          }),
+        }
+      }
+      return {}
+    })
+
+    // Mock Agent constructor to always return our mock agent
+    jest.spyOn(require('@credo-ts/core'), 'Agent').mockImplementation(() => existingAgent)
+
+    // Also make sure cached ledgers are empty so new agent creation triggers
+    jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
+
+    await expect(result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key' })).rejects.toThrow(
+      'Mediation connection is not passed the expiration threshold, no need to reset mediation'
+    )
+
+    expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('below the expiration threshold'))
+  })
+
+  it('should rollback if mediation recovery fails via initializeAgent', async () => {
+    const { result } = renderHook(() => useBCAgentSetup())
+
+    // --- Step 1: create a mock agent ---
+    const agentInstance = createMockAgent()
+
+    // Force recovery path
+    agentInstance.initialize = jest.fn().mockRejectedValue(new Error('fail during initialize'))
+
+    // Ensure nested objects exist
+    agentInstance.oob = {
+      receiveInvitationFromUrl: jest.fn().mockRejectedValue(new Error('fail')),
+    }
+    agentInstance.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
+      id: 'med1',
+      connectionId: 'conn1',
+      recipientKeys: ['key1'],
+    })
+
+    const mediationRepository = { delete: jest.fn(), save: jest.fn() }
+    const oldDate = moment().subtract(1000, 'days').toISOString()
+    const connectionRepository = {
+      getById: jest.fn().mockResolvedValue({
+        id: 'conn1',
+        getTag: jest.fn().mockReturnValue(oldDate),
+        updatedAt: new Date(oldDate),
+        outOfBandId: 'oob1',
+      }),
+      delete: jest.fn(),
+      save: jest.fn(),
+    }
+    const outOfBandRepository = { getById: jest.fn(), delete: jest.fn(), save: jest.fn() }
+
+    agentInstance.dependencyManager.resolve = jest.fn((dep) => {
+      if (dep === MediationRepository) return mediationRepository
+      if (dep === ConnectionRepository) return connectionRepository
+      if (dep === OutOfBandRepository) return outOfBandRepository
+      return {}
+    })
+
+    // --- Step 2: force new agent path ---
+    jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
+    jest.spyOn(require('@credo-ts/core'), 'Agent').mockImplementation(() => agentInstance)
+
+    // --- Step 3: Run initializeAgent, which will call recoverMediationIfExpired and fail ---
+    await expect(result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key' })).rejects.toThrow('fail')
+
+    // --- Step 4: Ensure rollback is called ---
+    expect(mediationRepository.save).toHaveBeenCalledWith(agentInstance.context, expect.any(Object))
+    expect(connectionRepository.save).toHaveBeenCalled()
+  })
+})

--- a/app/src/hooks/useBCAgentSetup.test.tsx
+++ b/app/src/hooks/useBCAgentSetup.test.tsx
@@ -252,10 +252,13 @@ describe('useBCAgentSetup', () => {
     ;(Agent as jest.Mock).mockImplementation(() => agentInstance)
 
     await act(async () => {
-      await result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key', salt: 'wallet-salt' })
+      await expect(
+        result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key', salt: 'wallet-salt' })
+      ).rejects.toThrow('Failed to initiate message pickup')
     })
 
     expect(mockLogger.error).toHaveBeenCalled()
+    expect(mockLogger.warn).toHaveBeenCalledWith('No mediation record found to delete')
   })
 
   it('should shutdown and clear agent', async () => {

--- a/app/src/hooks/useBCAgentSetup.test.tsx
+++ b/app/src/hooks/useBCAgentSetup.test.tsx
@@ -84,16 +84,15 @@ const createMockAgent = (overrides: Partial<Agent> = {}): Agent => {
     } as any,
 
     oob: {
-      receiveInvitationFromUrl: jest.fn().mockResolvedValue(
-        new ConnectionRecord({
+      receiveInvitationFromUrl: jest.fn().mockResolvedValue({
+        connectionRecord: new ConnectionRecord({
           id: 'test-connection-id',
           state: DidExchangeState.Completed,
           role: DidExchangeRole.Responder,
           theirDid: 'did:example:123',
         })
-      ),
+      }),
     } as any,
-
     dependencyManager: {
       resolve: jest.fn((dep: any) => {
         if (dep === ConnectionRepository) {
@@ -203,6 +202,10 @@ describe('useBCAgentSetup', () => {
     jest.mocked(useServices).mockReturnValue([mockLogger, [], { stop: jest.fn(), start: jest.fn() }, [], []] as any)
   })
 
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
   it('should initialize a new agent successfully', async () => {
     const { result } = renderHook(() => useBCAgentSetup())
 
@@ -242,9 +245,8 @@ describe('useBCAgentSetup', () => {
   it('should call recovery if initialization fails', async () => {
     const { result } = renderHook(() => useBCAgentSetup())
 
-    const agentInstance = createMockAgent({
-      initialize: jest.fn().mockRejectedValue(new Error('fail')),
-    })
+    const agentInstance = createMockAgent()
+    agentInstance.mediationRecipient.initiateMessagePickup = jest.fn().mockRejectedValueOnce(new Error('Failed to initiate message pickup'))
 
     ;(Agent as jest.Mock).mockImplementation(() => agentInstance)
 
@@ -276,6 +278,7 @@ describe('useBCAgentSetup', () => {
     const { result } = renderHook(() => useBCAgentSetup())
 
     const agent = createMockAgent()
+    agent.mediationRecipient.initiateMessagePickup = jest.fn().mockRejectedValueOnce(new Error('Failed to initiate message pickup'))
     agent.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
       id: 'med1',
       connectionId: 'conn1',
@@ -291,15 +294,28 @@ describe('useBCAgentSetup', () => {
           }),
         }
       }
+      if (dep === 'IndyVdrPoolService') {
+        return createMockPoolService()
+      }
       return {}
     }) as any
     ;(Agent as jest.Mock).mockImplementation(() => agent)
 
     jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
 
-    await expect(
-      result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key', salt: 'wallet-salt' })
-    ).rejects.toThrow()
+    let thrownError: unknown
+    await act(async () => {
+      try {
+        await result.current.initializeAgent({
+          id: 'wallet-id',
+          key: 'wallet-key',
+          salt: 'wallet-salt',
+        })
+      } catch (error) {
+        thrownError = error
+      }
+    })
+    expect(thrownError).toBeInstanceOf(Error)
 
     expect(mockLogger.info).toHaveBeenCalled()
   })
@@ -307,9 +323,7 @@ describe('useBCAgentSetup', () => {
   it('should rollback if mediation recovery fails and new connection is established so do not recover oob invitation', async () => {
     const { result } = renderHook(() => useBCAgentSetup())
 
-    const agent = createMockAgent({
-      initialize: jest.fn().mockRejectedValue(new Error('fail')),
-    })
+    const agent = createMockAgent()
 
     const mediationRepository = { delete: jest.fn(), save: jest.fn() }
     const connectionRepository = {
@@ -339,6 +353,7 @@ describe('useBCAgentSetup', () => {
       }
       return {}
     }) as any
+    agent.mediationRecipient.initiateMessagePickup = jest.fn().mockRejectedValue(new Error('Timed out waiting for connection test-connection-id to complete'))
     agent.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
       id: 'med1',
       connectionId: 'conn1',
@@ -360,9 +375,19 @@ describe('useBCAgentSetup', () => {
 
     jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
 
-    await expect(
-      result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key', salt: 'wallet-salt' })
-    ).rejects.toThrow()
+    let thrownError: unknown
+    await act(async () => {
+      try {
+        await result.current.initializeAgent({
+          id: 'wallet-id',
+          key: 'wallet-key',
+          salt: 'wallet-salt',
+        })
+      } catch (error) {
+        thrownError = error
+      }
+    })
+    expect(thrownError).toBeInstanceOf(Error)
 
     expect(mediationRepository.save).toHaveBeenCalled()
     expect(connectionRepository.save).toHaveBeenCalled()
@@ -371,9 +396,7 @@ describe('useBCAgentSetup', () => {
   it('should rollback if mediation recovery fails and new connection is not established so recover oob invitation', async () => {
     const { result } = renderHook(() => useBCAgentSetup())
 
-    const agent = createMockAgent({
-      initialize: jest.fn().mockRejectedValue(new Error('fail')),
-    })
+    const agent = createMockAgent()
 
     const mediationRepository = { delete: jest.fn(), save: jest.fn() }
     const connectionRepository = {
@@ -403,6 +426,8 @@ describe('useBCAgentSetup', () => {
       }
       return {}
     }) as any
+
+    agent.mediationRecipient.initiateMessagePickup = jest.fn().mockRejectedValue(new Error('Failed to initiate message pickup'))
     agent.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
       id: 'med1',
       connectionId: 'conn1',
@@ -415,21 +440,29 @@ describe('useBCAgentSetup', () => {
 
     jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
 
-    await expect(
-      result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key', salt: 'wallet-salt' })
-    ).rejects.toThrow()
+    let thrownError: unknown
+    await act(async () => {
+      try {
+        await result.current.initializeAgent({
+          id: 'wallet-id',
+          key: 'wallet-key',
+          salt: 'wallet-salt',
+        })
+      } catch (error) {
+        thrownError = error
+      }
+    })
+    expect(thrownError).toBeInstanceOf(Error)
 
     expect(mediationRepository.save).toHaveBeenCalled()
     expect(connectionRepository.save).toHaveBeenCalled()
     expect(outOfBandRepository.save).toHaveBeenCalled()
   })
 
-  it('happy path where connection and mediation keys are re-established', async () => {
+  it('on fail recover connection and mediation keys are re-established', async () => {
     const { result } = renderHook(() => useBCAgentSetup())
 
-    const agent = createMockAgent({
-      initialize: jest.fn().mockRejectedValue(new Error('fail')),
-    })
+    const agent = createMockAgent()
 
     const mediationRepository = { delete: jest.fn(), save: jest.fn() }
     const connectionRepository = {
@@ -459,6 +492,7 @@ describe('useBCAgentSetup', () => {
       return {}
     }) as any
 
+    agent.mediationRecipient.initiateMessagePickup = jest.fn().mockRejectedValueOnce(new Error('Failed to initiate message pickup'))
     agent.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
       id: 'med1',
       connectionId: 'conn1',
@@ -483,13 +517,105 @@ describe('useBCAgentSetup', () => {
 
     jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
 
-    await expect(
-      result.current.initializeAgent({ id: 'wallet-id', key: 'wallet-key', salt: 'wallet-salt' })
-    ).rejects.toThrow()
+    let thrownError: unknown
+    await act(async () => {
+      try {
+        await result.current.initializeAgent({
+          id: 'wallet-id',
+          key: 'wallet-key',
+          salt: 'wallet-salt',
+        })
+      } catch (error) {
+        thrownError = error
+      }
+    })
+    expect(thrownError).toBeInstanceOf(Error)
 
     expect(mediationRepository.save).not.toHaveBeenCalled()
     expect(connectionRepository.save).not.toHaveBeenCalled()
     expect(outOfBandRepository.save).not.toHaveBeenCalled()
-    expect(agent.mediationRecipient.setDefaultMediator).toHaveBeenCalled()
+  })
+
+  it('should timeout waiting for mediation connection completion and clean up listener', async () => {
+    jest.useFakeTimers()
+
+    const { result } = renderHook(() => useBCAgentSetup())
+
+    const agent = createMockAgent()
+
+    const mediationRepository = { delete: jest.fn(), save: jest.fn() }
+    const connectionRepository = {
+      save: jest.fn(),
+      getById: jest
+        .fn()
+        .mockResolvedValueOnce({
+          id: 'conn1',
+          getTag: jest.fn().mockReturnValue(moment().subtract(100, 'days').toISOString()),
+          outOfBandId: 'oob1',
+          updatedAt: moment().subtract(100, 'days').toDate(),
+        })
+        .mockResolvedValueOnce({
+          id: 'test-connection-id',
+        }),
+      delete: jest.fn(),
+    }
+    const outOfBandRepository = {
+      getById: jest.fn().mockResolvedValue({ id: 'oob1' }),
+      delete: jest.fn(),
+      save: jest.fn(),
+    }
+
+    agent.dependencyManager.resolve = jest.fn((dep: any) => {
+      if (dep === MediationRepository) {
+        return mediationRepository
+      }
+      if (dep === ConnectionRepository) {
+        return connectionRepository
+      }
+      if (dep === OutOfBandRepository) {
+        return outOfBandRepository
+      }
+      return {}
+    }) as any
+    agent.mediationRecipient.initiateMessagePickup = jest.fn().mockRejectedValue(new Error('Failed to initiate message pickup'))
+    agent.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
+      id: 'med1',
+      connectionId: 'conn1',
+      recipientKeys: ['key1'],
+    })
+    agent.oob.receiveInvitationFromUrl = jest.fn().mockResolvedValue({
+      outOfBandRecord: { id: 'oob1' },
+      connectionRecord: {
+        id: 'test-connection-id',
+        state: DidExchangeState.RequestSent,
+        role: DidExchangeRole.Responder,
+        theirDid: 'did:example:123',
+        isReady: false,
+      },
+    })
+
+    ;(Agent as jest.Mock).mockImplementation(() => agent)
+
+    jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
+
+    await act(async () => {
+      const initializePromise = result.current.initializeAgent({
+        id: 'wallet-id',
+        key: 'wallet-key',
+        salt: 'wallet-salt',
+      })
+      const expectedRejection = (async () => {
+        await expect(initializePromise).rejects.toThrow('Timed out waiting for connection test-connection-id to complete')
+      })()
+
+      await jest.advanceTimersByTimeAsync(30000)
+      await expectedRejection
+    })
+
+    expect(agent.events.on).toHaveBeenCalled()
+    expect(agent.events.off).toHaveBeenCalledWith(expect.any(String), expect.any(Function))
+    expect(mediationRepository.save).toHaveBeenCalled()
+    expect(connectionRepository.save).toHaveBeenCalled()
+    expect(outOfBandRepository.save).not.toHaveBeenCalled()
   })
 })

--- a/app/src/hooks/useBCAgentSetup.test.tsx
+++ b/app/src/hooks/useBCAgentSetup.test.tsx
@@ -316,8 +316,12 @@ describe('useBCAgentSetup', () => {
       save: jest.fn(),
       getById: jest
         .fn()
-        .mockResolvedValue({ getTag: jest.fn().mockReturnValue(moment().subtract(100, 'days').toISOString()), outOfBandId: 'oob1', updatedAt: moment().subtract(100, 'days').toDate() }),
-        delete: jest.fn(),
+        .mockResolvedValue({
+          getTag: jest.fn().mockReturnValue(moment().subtract(100, 'days').toISOString()),
+          outOfBandId: 'oob1',
+          updatedAt: moment().subtract(100, 'days').toDate(),
+        }),
+      delete: jest.fn(),
     }
     const outOfBandRepository = {
       getById: jest.fn().mockResolvedValue({ id: 'oob1' }),
@@ -351,7 +355,9 @@ describe('useBCAgentSetup', () => {
         theirDid: 'did:example:123',
       },
     })
-    agent.connections.sendPing = jest.fn().mockRejectedValue(new Error('Failed to establish a new connection for mediation recovery'))
+    agent.connections.sendPing = jest
+      .fn()
+      .mockRejectedValue(new Error('Failed to establish a new connection for mediation recovery'))
     ;(Agent as jest.Mock).mockImplementation(() => agent)
 
     jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
@@ -376,8 +382,12 @@ describe('useBCAgentSetup', () => {
       save: jest.fn(),
       getById: jest
         .fn()
-        .mockResolvedValue({ getTag: jest.fn().mockReturnValue(moment().subtract(100, 'days').toISOString()), outOfBandId: 'oob1', updatedAt: moment().subtract(100, 'days').toDate() }),
-        delete: jest.fn(),
+        .mockResolvedValue({
+          getTag: jest.fn().mockReturnValue(moment().subtract(100, 'days').toISOString()),
+          outOfBandId: 'oob1',
+          updatedAt: moment().subtract(100, 'days').toDate(),
+        }),
+      delete: jest.fn(),
     }
     const outOfBandRepository = {
       getById: jest.fn().mockResolvedValue({ id: 'oob1' }),
@@ -402,7 +412,9 @@ describe('useBCAgentSetup', () => {
       connectionId: 'conn1',
       recipientKeys: ['key1'],
     })
-    agent.oob.receiveInvitationFromUrl = jest.fn().mockRejectedValue(new Error('Failed to establish a new connection for mediation recovery'))
+    agent.oob.receiveInvitationFromUrl = jest
+      .fn()
+      .mockRejectedValue(new Error('Failed to establish a new connection for mediation recovery'))
     ;(Agent as jest.Mock).mockImplementation(() => agent)
 
     jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
@@ -428,8 +440,12 @@ describe('useBCAgentSetup', () => {
       save: jest.fn(),
       getById: jest
         .fn()
-        .mockResolvedValue({ getTag: jest.fn().mockReturnValue(moment().subtract(100, 'days').toISOString()), outOfBandId: 'oob1', updatedAt: moment().subtract(100, 'days').toDate() }),
-        delete: jest.fn(),
+        .mockResolvedValue({
+          getTag: jest.fn().mockReturnValue(moment().subtract(100, 'days').toISOString()),
+          outOfBandId: 'oob1',
+          updatedAt: moment().subtract(100, 'days').toDate(),
+        }),
+      delete: jest.fn(),
     }
     const outOfBandRepository = {
       getById: jest.fn().mockResolvedValue({ id: 'oob1' }),

--- a/app/src/hooks/useBCAgentSetup.test.tsx
+++ b/app/src/hooks/useBCAgentSetup.test.tsx
@@ -90,7 +90,7 @@ const createMockAgent = (overrides: Partial<Agent> = {}): Agent => {
           state: DidExchangeState.Completed,
           role: DidExchangeRole.Responder,
           theirDid: 'did:example:123',
-        })
+        }),
       }),
     } as any,
     dependencyManager: {
@@ -246,8 +246,9 @@ describe('useBCAgentSetup', () => {
     const { result } = renderHook(() => useBCAgentSetup())
 
     const agentInstance = createMockAgent()
-    agentInstance.mediationRecipient.initiateMessagePickup = jest.fn().mockRejectedValueOnce(new Error('Failed to initiate message pickup'))
-
+    agentInstance.mediationRecipient.initiateMessagePickup = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Failed to initiate message pickup'))
     ;(Agent as jest.Mock).mockImplementation(() => agentInstance)
 
     await act(async () => {
@@ -278,7 +279,9 @@ describe('useBCAgentSetup', () => {
     const { result } = renderHook(() => useBCAgentSetup())
 
     const agent = createMockAgent()
-    agent.mediationRecipient.initiateMessagePickup = jest.fn().mockRejectedValueOnce(new Error('Failed to initiate message pickup'))
+    agent.mediationRecipient.initiateMessagePickup = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Failed to initiate message pickup'))
     agent.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
       id: 'med1',
       connectionId: 'conn1',
@@ -353,7 +356,9 @@ describe('useBCAgentSetup', () => {
       }
       return {}
     }) as any
-    agent.mediationRecipient.initiateMessagePickup = jest.fn().mockRejectedValue(new Error('Timed out waiting for connection test-connection-id to complete'))
+    agent.mediationRecipient.initiateMessagePickup = jest
+      .fn()
+      .mockRejectedValue(new Error('Timed out waiting for connection test-connection-id to complete'))
     agent.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
       id: 'med1',
       connectionId: 'conn1',
@@ -427,7 +432,9 @@ describe('useBCAgentSetup', () => {
       return {}
     }) as any
 
-    agent.mediationRecipient.initiateMessagePickup = jest.fn().mockRejectedValue(new Error('Failed to initiate message pickup'))
+    agent.mediationRecipient.initiateMessagePickup = jest
+      .fn()
+      .mockRejectedValue(new Error('Failed to initiate message pickup'))
     agent.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
       id: 'med1',
       connectionId: 'conn1',
@@ -492,7 +499,9 @@ describe('useBCAgentSetup', () => {
       return {}
     }) as any
 
-    agent.mediationRecipient.initiateMessagePickup = jest.fn().mockRejectedValueOnce(new Error('Failed to initiate message pickup'))
+    agent.mediationRecipient.initiateMessagePickup = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Failed to initiate message pickup'))
     agent.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
       id: 'med1',
       connectionId: 'conn1',
@@ -577,7 +586,9 @@ describe('useBCAgentSetup', () => {
       }
       return {}
     }) as any
-    agent.mediationRecipient.initiateMessagePickup = jest.fn().mockRejectedValue(new Error('Failed to initiate message pickup'))
+    agent.mediationRecipient.initiateMessagePickup = jest
+      .fn()
+      .mockRejectedValue(new Error('Failed to initiate message pickup'))
     agent.mediationRecipient.findDefaultMediator = jest.fn().mockResolvedValue({
       id: 'med1',
       connectionId: 'conn1',
@@ -593,7 +604,6 @@ describe('useBCAgentSetup', () => {
         isReady: false,
       },
     })
-
     ;(Agent as jest.Mock).mockImplementation(() => agent)
 
     jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValue(undefined)
@@ -605,7 +615,9 @@ describe('useBCAgentSetup', () => {
         salt: 'wallet-salt',
       })
       const expectedRejection = (async () => {
-        await expect(initializePromise).rejects.toThrow('Timed out waiting for connection test-connection-id to complete')
+        await expect(initializePromise).rejects.toThrow(
+          'Timed out waiting for connection test-connection-id to complete'
+        )
       })()
 
       await jest.advanceTimersByTimeAsync(30000)

--- a/app/src/hooks/useBCAgentSetup.ts
+++ b/app/src/hooks/useBCAgentSetup.ts
@@ -35,6 +35,7 @@ import { Config } from 'react-native-config'
 import { CachesDirectoryPath } from 'react-native-fs'
 
 const DEFAULT_MEDIATION_EXPIRED_THRESHOLD_DAYS = '90'
+const CONNECTION_COMPLETION_TIMEOUT_MS = 10000
 
 const loadCachedLedgers = async (): Promise<IndyVdrPoolConfig[] | undefined> => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -195,7 +196,8 @@ const useBCAgentSetup = () => {
     if (connection.state === DidExchangeState.Completed) {
       return connection
     }
-    return new Promise((resolve) => {
+
+    return new Promise<ConnectionRecord>((resolve, reject) => {
       const listener = (event: ConnectionStateChangedEvent) => {
         const { connectionRecord } = event.payload
 
@@ -204,12 +206,22 @@ const useBCAgentSetup = () => {
           connectionRecord.state === DidExchangeState.Completed &&
           connectionRecord.isReady
         ) {
-          agent.events.off(ConnectionEventTypes.ConnectionStateChanged, listener)
+          cleanup()
           resolve(connectionRecord)
         }
       }
 
+      const cleanup = () => {
+        agent.events.off(ConnectionEventTypes.ConnectionStateChanged, listener)
+        clearTimeout(timeoutId)
+      }
+
       agent.events.on(ConnectionEventTypes.ConnectionStateChanged, listener)
+
+      const timeoutId = setTimeout(() => {
+        cleanup()
+        reject(new Error(`Timed out waiting for connection ${connection.id} to complete`))
+      }, CONNECTION_COMPLETION_TIMEOUT_MS)
     })
   }
 
@@ -262,14 +274,20 @@ const useBCAgentSetup = () => {
       }
 
       const daysSinceLastSeen = moment().diff(moment(lastSeen), 'days')
-      const mediationExpiredThresholdDays = Number.parseInt(
-        Config.MEDIATION_EXPIRED_THRESHOLD_DAYS || DEFAULT_MEDIATION_EXPIRED_THRESHOLD_DAYS
-      )
+      const mediationExpiredThresholdConfig = Config.MEDIATION_EXPIRED_THRESHOLD_DAYS || DEFAULT_MEDIATION_EXPIRED_THRESHOLD_DAYS
+      let mediationExpiredThresholdDays = Number.parseInt(mediationExpiredThresholdConfig, 10)
+      if (Number.isNaN(mediationExpiredThresholdDays)) {
+        logger.warn(
+          `Invalid mediation expired threshold config value: ${mediationExpiredThresholdConfig}. Falling back to default of ${DEFAULT_MEDIATION_EXPIRED_THRESHOLD_DAYS} days.`
+        )
+        mediationExpiredThresholdDays = Number.parseInt(DEFAULT_MEDIATION_EXPIRED_THRESHOLD_DAYS, 10)
+      }
+
       if (daysSinceLastSeen < mediationExpiredThresholdDays) {
         logger.info(
           `Mediation connection last seen ${daysSinceLastSeen} days ago, which is below the expiration threshold. No need to reset mediation.`
         )
-        throw new Error('Mediation connection is not passed the expiration threshold, no need to reset mediation')
+        return
       }
       logger.info(
         `Mediation connection last seen ${daysSinceLastSeen} days ago, which is above the expiration threshold. Proceeding with mediation reset.`
@@ -305,7 +323,7 @@ const useBCAgentSetup = () => {
         logger.info(`New connection created ${connectionRecord?.id}. Waiting for completion...`)
 
         if (!connectionRecord) {
-          return
+          throw new Error('Failed to establish mediation connection: no connection record returned from invitation')
         }
 
         await waitForConnectionCompleted(agent, connectionRecord)
@@ -367,10 +385,10 @@ const useBCAgentSetup = () => {
       logger.info('Migrating agent if required...')
       await migrateIfRequired(newAgent, walletSecret)
 
-      try {
-        logger.info('Initializing agent...')
-        await newAgent.initialize()
+      logger.info('Initializing agent...')
+      await newAgent.initialize()
 
+      try {
         await newAgent.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
       } catch (error) {
         logger.error(`Error initiating message pickup: ${error}`)

--- a/app/src/hooks/useBCAgentSetup.ts
+++ b/app/src/hooks/useBCAgentSetup.ts
@@ -262,7 +262,7 @@ const useBCAgentSetup = () => {
       }
 
       const daysSinceLastSeen = moment().diff(moment(lastSeen), 'days')
-      const mediationExpiredThresholdDays = parseInt(
+      const mediationExpiredThresholdDays = Number.parseInt(
         Config.MEDIATION_EXPIRED_THRESHOLD_DAYS || DEFAULT_MEDIATION_EXPIRED_THRESHOLD_DAYS
       )
       if (daysSinceLastSeen < mediationExpiredThresholdDays) {
@@ -391,7 +391,9 @@ const useBCAgentSetup = () => {
       refreshAttestationMonitor(newAgent)
 
       logger.info('Tag mediation connection with last seen time')
-      void updateLastSeen(newAgent)
+      updateLastSeen(newAgent).catch((e) =>
+        logger.error(`Failed to update last seen tag on mediation connection: ${e}`)
+      )
 
       logger.info('Setting new agent...')
       agentInstanceRef.current = newAgent

--- a/app/src/hooks/useBCAgentSetup.ts
+++ b/app/src/hooks/useBCAgentSetup.ts
@@ -11,7 +11,21 @@ import {
   useStore,
   WalletSecret,
 } from '@bifold/core'
-import { Agent, ConnectionEventTypes, ConnectionRecord, ConnectionRepository, ConnectionStateChangedEvent, ConnectionType, DidExchangeState, HttpOutboundTransport, KeylistUpdateAction, MediationEventTypes, MediationRepository, MediationRole, MediationStateChangedEvent, MediatorPickupStrategy, MediatorService, OutOfBandRepository, WsOutboundTransport } from '@credo-ts/core'
+import {
+  Agent,
+  ConnectionEventTypes,
+  ConnectionRecord,
+  ConnectionRepository,
+  ConnectionStateChangedEvent,
+  ConnectionType,
+  DidExchangeState,
+  HttpOutboundTransport,
+  KeylistUpdateAction,
+  MediationRepository,
+  MediatorPickupStrategy,
+  OutOfBandRepository,
+  WsOutboundTransport,
+} from '@credo-ts/core'
 import { IndyVdrPoolConfig, IndyVdrPoolService } from '@credo-ts/indy-vdr/build/pool'
 import { agentDependencies } from '@credo-ts/react-native'
 import { GetCredentialDefinitionRequest, GetSchemaRequest } from '@hyperledger/indy-vdr-shared'

--- a/app/src/hooks/useBCAgentSetup.ts
+++ b/app/src/hooks/useBCAgentSetup.ts
@@ -274,7 +274,8 @@ const useBCAgentSetup = () => {
       }
 
       const daysSinceLastSeen = moment().diff(moment(lastSeen), 'days')
-      const mediationExpiredThresholdConfig = Config.MEDIATION_EXPIRED_THRESHOLD_DAYS || DEFAULT_MEDIATION_EXPIRED_THRESHOLD_DAYS
+      const mediationExpiredThresholdConfig =
+        Config.MEDIATION_EXPIRED_THRESHOLD_DAYS || DEFAULT_MEDIATION_EXPIRED_THRESHOLD_DAYS
       let mediationExpiredThresholdDays = Number.parseInt(mediationExpiredThresholdConfig, 10)
       if (Number.isNaN(mediationExpiredThresholdDays)) {
         logger.warn(

--- a/app/src/hooks/useBCAgentSetup.ts
+++ b/app/src/hooks/useBCAgentSetup.ts
@@ -291,6 +291,7 @@ const useBCAgentSetup = () => {
         await outOfBandRepository.delete(agent.context, oldOobRecord)
       }
 
+      let newConnectionEstablished = false
       try {
         logger.info('Mediation state cleared. Creating new mediation connection...')
 
@@ -299,6 +300,7 @@ const useBCAgentSetup = () => {
           autoAcceptConnection: true,
           autoAcceptInvitation: true,
         })
+        newConnectionEstablished = true
 
         logger.info(`New connection created ${connectionRecord?.id}. Waiting for completion...`)
 
@@ -328,7 +330,7 @@ const useBCAgentSetup = () => {
         logger.error(`Error during mediation recovery. Attempting recovery of the deleted mediation records: ${error}`)
         await mediationRepository.save(agent.context, oldMediationRecord)
         await connectionRepository.save(agent.context, oldMediatorConnectionRecord)
-        if (oldOobRecord) {
+        if (oldOobRecord && !newConnectionEstablished) {
           await outOfBandRepository.save(agent.context, oldOobRecord)
         }
         throw error

--- a/app/src/hooks/useBCAgentSetup.ts
+++ b/app/src/hooks/useBCAgentSetup.ts
@@ -11,7 +11,7 @@ import {
   useStore,
   WalletSecret,
 } from '@bifold/core'
-import { Agent, HttpOutboundTransport, MediatorPickupStrategy, WsOutboundTransport } from '@credo-ts/core'
+import { Agent, ConnectionEventTypes, ConnectionRecord, ConnectionRepository, ConnectionStateChangedEvent, ConnectionType, DidExchangeState, HttpOutboundTransport, KeylistUpdateAction, MediationEventTypes, MediationRepository, MediationRole, MediationStateChangedEvent, MediatorPickupStrategy, MediatorService, OutOfBandRepository, WsOutboundTransport } from '@credo-ts/core'
 import { IndyVdrPoolConfig, IndyVdrPoolService } from '@credo-ts/indy-vdr/build/pool'
 import { agentDependencies } from '@credo-ts/react-native'
 import { GetCredentialDefinitionRequest, GetSchemaRequest } from '@hyperledger/indy-vdr-shared'
@@ -19,6 +19,8 @@ import moment from 'moment'
 import { useCallback, useRef, useState } from 'react'
 import { Config } from 'react-native-config'
 import { CachesDirectoryPath } from 'react-native-fs'
+
+const DEFAULT_MEDIATION_EXPIRED_THRESHOLD_DAYS = '90'
 
 const loadCachedLedgers = async (): Promise<IndyVdrPoolConfig[] | undefined> => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -175,6 +177,154 @@ const useBCAgentSetup = () => {
     [credDefs, schemas]
   )
 
+  const waitForConnectionCompleted = async (agent: Agent, connection: ConnectionRecord) => {
+    if (connection.state === DidExchangeState.Completed) {
+      return connection
+    }
+    return new Promise((resolve) => {
+      const listener = (event: ConnectionStateChangedEvent) => {
+        const { connectionRecord } = event.payload
+
+        if (
+          connectionRecord.id === connection.id &&
+          connectionRecord.state === DidExchangeState.Completed &&
+          connectionRecord.isReady
+        ) {
+          agent.events.off(ConnectionEventTypes.ConnectionStateChanged, listener)
+          resolve(connectionRecord)
+        }
+      }
+
+      agent.events.on(ConnectionEventTypes.ConnectionStateChanged, listener)
+    })
+  }
+
+  const updateLastSeen = useCallback(async (agent: Agent) => {
+    const connectionRepository = agent.dependencyManager.resolve(ConnectionRepository)
+
+    const connectionRecords = await connectionRepository.getAll(agent.context)
+    const defaultMediatorConnection = connectionRecords.find((record) =>
+      record.connectionTypes?.includes(ConnectionType.Mediator)
+    )
+    defaultMediatorConnection?.setTag('lastSeen', new Date().toISOString())
+    if (defaultMediatorConnection) {
+      await connectionRepository.update(agent.context, defaultMediatorConnection)
+    }
+  }, [])
+
+  const recoverMediationIfExpired = useCallback(
+    async (agent: Agent, mediatorUrl: string) => {
+      logger.info('Resetting mediation state and creating a new connection...')
+
+      try {
+        await agent.mediationRecipient.stopMessagePickup()
+      } catch (e) {
+        logger.warn(`No active message pickup to stop: ${e}`)
+      }
+
+      const mediationRepository = agent.dependencyManager.resolve(MediationRepository)
+      const connectionRepository = agent.dependencyManager.resolve(ConnectionRepository)
+      const outOfBandRepository = agent.dependencyManager.resolve(OutOfBandRepository)
+
+      const oldMediationRecord = await agent.mediationRecipient.findDefaultMediator()
+      if (!oldMediationRecord) {
+        logger.warn('No mediation record found to delete')
+        return
+      }
+
+      const mediationConnectionRecord = await connectionRepository.getById(
+        agent.context,
+        oldMediationRecord.connectionId
+      )
+      if (!mediationConnectionRecord) {
+        logger.warn('No connection record found for mediation record')
+        return
+      }
+
+      let lastSeen = mediationConnectionRecord.getTag('lastSeen')?.toString()
+
+      if (!lastSeen) {
+        lastSeen = mediationConnectionRecord.updatedAt?.toISOString()
+      }
+
+      const daysSinceLastSeen = moment().diff(moment(lastSeen), 'days')
+      const mediationExpiredThresholdDays = parseInt(
+        Config.MEDIATION_EXPIRED_THRESHOLD_DAYS || DEFAULT_MEDIATION_EXPIRED_THRESHOLD_DAYS
+      )
+      if (daysSinceLastSeen < mediationExpiredThresholdDays) {
+        logger.info(
+          `Mediation connection last seen ${daysSinceLastSeen} days ago, which is below the expiration threshold. No need to reset mediation.`
+        )
+        throw new Error('Mediation connection is not passed the expiration threshold, no need to reset mediation')
+      }
+      logger.info(
+        `Mediation connection last seen ${daysSinceLastSeen} days ago, which is above the expiration threshold. Proceeding with mediation reset.`
+      )
+
+      // Delete all of the default mediation records.
+      logger.info(`Deleting mediation record ${oldMediationRecord.id}...`)
+      await mediationRepository.delete(agent.context, oldMediationRecord)
+      const oldMediatorConnectionRecord = await connectionRepository.getById(
+        agent.context,
+        oldMediationRecord.connectionId
+      )
+      logger.info(`Deleting mediator connection record ${oldMediatorConnectionRecord.id}...`)
+      await connectionRepository.delete(agent.context, oldMediatorConnectionRecord)
+      let oldOobRecord = undefined
+      if (oldMediatorConnectionRecord.outOfBandId) {
+        logger.info(`Deleting out-of-band record ${oldMediatorConnectionRecord.outOfBandId}...`)
+        oldOobRecord = await outOfBandRepository.getById(agent.context, oldMediatorConnectionRecord.outOfBandId)
+        await outOfBandRepository.delete(agent.context, oldOobRecord)
+      }
+
+      try {
+        logger.info('Mediation state cleared. Creating new mediation connection...')
+
+        const { connectionRecord } = await agent.oob.receiveInvitationFromUrl(mediatorUrl, {
+          reuseConnection: false,
+          autoAcceptConnection: true,
+          autoAcceptInvitation: true,
+        })
+
+        logger.info(`New connection created ${connectionRecord?.id}. Waiting for completion...`)
+
+        if (!connectionRecord) {
+          return
+        }
+
+        await waitForConnectionCompleted(agent, connectionRecord)
+        const freshConnection = await connectionRepository.getById(agent.context, connectionRecord.id)
+
+        // Ping ensures the session is created on the mediator side for the new connection.
+        await agent.connections.sendPing(freshConnection.id, { responseRequested: true })
+
+        // Request mediation grant for the new connection and register the existing recipient keys.
+        const newMediationRecord = await agent.mediationRecipient.requestAndAwaitGrant(freshConnection)
+        for (const key of oldMediationRecord.recipientKeys) {
+          logger.debug(`Adding key to key list: ${key}`)
+          await agent.mediationRecipient.notifyKeylistUpdate(freshConnection, key, KeylistUpdateAction.add)
+        }
+
+        await agent.mediationRecipient.setDefaultMediator(newMediationRecord)
+        await agent.mediationRecipient.initiateMessagePickup(
+          newMediationRecord,
+          MediatorPickupStrategy.PickUpV2LiveMode
+        )
+      } catch (error) {
+        logger.error(`Error during mediation recovery. Attempting recovery of the deleted mediation records: ${error}`)
+        await mediationRepository.save(agent.context, oldMediationRecord)
+        await connectionRepository.save(agent.context, oldMediatorConnectionRecord)
+        if (oldOobRecord) {
+          await outOfBandRepository.save(agent.context, oldOobRecord)
+        }
+        throw error
+      }
+
+      logger.info('Mediation re-established successfully')
+    },
+    [logger]
+  )
+
   const initializeAgent = useCallback(
     async (walletSecret: WalletSecret): Promise<void> => {
       const mediatorUrl = store.preferences.selectedMediator
@@ -201,11 +351,15 @@ const useBCAgentSetup = () => {
       logger.info('Migrating agent if required...')
       await migrateIfRequired(newAgent, walletSecret)
 
-      logger.info('Initializing agent...')
-      await newAgent.initialize()
+      try {
+        logger.info('Initializing agent...')
+        await newAgent.initialize()
 
-      logger.info(`checking mediator type for ${mediatorUrl}`)
-      await newAgent.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
+        await newAgent.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
+      } catch (error) {
+        logger.error(`Error initiating message pickup: ${error}`)
+        await recoverMediationIfExpired(newAgent, mediatorUrl)
+      }
 
       logger.info('Warming up cache...')
       await warmUpCache(newAgent, cachedLedgers)
@@ -222,6 +376,9 @@ const useBCAgentSetup = () => {
       logger.info('Starting attestation monitor...')
       refreshAttestationMonitor(newAgent)
 
+      logger.info('Tag mediation connection with last seen time')
+      void updateLastSeen(newAgent)
+
       logger.info('Setting new agent...')
       agentInstanceRef.current = newAgent
       setAgent(newAgent)
@@ -236,6 +393,8 @@ const useBCAgentSetup = () => {
       warmUpCache,
       refreshAttestationMonitor,
       restartExistingAgent,
+      updateLastSeen,
+      recoverMediationIfExpired,
     ]
   )
 

--- a/app/src/hooks/useBCAgentSetup.ts
+++ b/app/src/hooks/useBCAgentSetup.ts
@@ -239,7 +239,7 @@ const useBCAgentSetup = () => {
   }, [])
 
   const recoverMediationIfExpired = useCallback(
-    async (agent: Agent, mediatorUrl: string) => {
+    async (agent: Agent, mediatorUrl: string, originalError: Error) => {
       logger.info('Resetting mediation state and creating a new connection...')
 
       try {
@@ -255,7 +255,7 @@ const useBCAgentSetup = () => {
       const oldMediationRecord = await agent.mediationRecipient.findDefaultMediator()
       if (!oldMediationRecord) {
         logger.warn('No mediation record found to delete')
-        return
+        throw originalError
       }
 
       const mediationConnectionRecord = await connectionRepository.getById(
@@ -264,7 +264,7 @@ const useBCAgentSetup = () => {
       )
       if (!mediationConnectionRecord) {
         logger.warn('No connection record found for mediation record')
-        return
+        throw originalError
       }
 
       let lastSeen = mediationConnectionRecord.getTag('lastSeen')?.toString()
@@ -297,16 +297,12 @@ const useBCAgentSetup = () => {
       // Delete all of the default mediation records.
       logger.info(`Deleting mediation record ${oldMediationRecord.id}...`)
       await mediationRepository.delete(agent.context, oldMediationRecord)
-      const oldMediatorConnectionRecord = await connectionRepository.getById(
-        agent.context,
-        oldMediationRecord.connectionId
-      )
-      logger.info(`Deleting mediator connection record ${oldMediatorConnectionRecord.id}...`)
-      await connectionRepository.delete(agent.context, oldMediatorConnectionRecord)
+      logger.info(`Deleting mediator connection record ${mediationConnectionRecord.id}...`)
+      await connectionRepository.delete(agent.context, mediationConnectionRecord)
       let oldOobRecord = undefined
-      if (oldMediatorConnectionRecord.outOfBandId) {
-        logger.info(`Deleting out-of-band record ${oldMediatorConnectionRecord.outOfBandId}...`)
-        oldOobRecord = await outOfBandRepository.getById(agent.context, oldMediatorConnectionRecord.outOfBandId)
+      if (mediationConnectionRecord.outOfBandId) {
+        logger.info(`Deleting out-of-band record ${mediationConnectionRecord.outOfBandId}...`)
+        oldOobRecord = await outOfBandRepository.getById(agent.context, mediationConnectionRecord.outOfBandId)
         await outOfBandRepository.delete(agent.context, oldOobRecord)
       }
 
@@ -348,7 +344,7 @@ const useBCAgentSetup = () => {
       } catch (error) {
         logger.error(`Error during mediation recovery. Attempting recovery of the deleted mediation records: ${error}`)
         await mediationRepository.save(agent.context, oldMediationRecord)
-        await connectionRepository.save(agent.context, oldMediatorConnectionRecord)
+        await connectionRepository.save(agent.context, mediationConnectionRecord)
         if (oldOobRecord && !newConnectionEstablished) {
           await outOfBandRepository.save(agent.context, oldOobRecord)
         }
@@ -393,7 +389,7 @@ const useBCAgentSetup = () => {
         await newAgent.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
       } catch (error) {
         logger.error(`Error initiating message pickup: ${error}`)
-        await recoverMediationIfExpired(newAgent, mediatorUrl)
+        await recoverMediationIfExpired(newAgent, mediatorUrl, error as Error)
       }
 
       logger.info('Warming up cache...')


### PR DESCRIPTION
# Summary of Changes

This PR will tag mediation connections with a last seen value. Then if an initialization/pickup fails when a connection has expired due to lack of activity the agent will delete the mediation records and create new ones, and register the previous recipient keys with the mediator. 

This allows the mediator to delete records when they have become stale and prevent the DB from growing indefinitely. If an agent is started up after activity check has expired it can recover and existing connections will continue to work with a new mediation record.

An edge case where the mediation is created multiple times without it being deleted in the mediator DB will be handled on the mediator side.

Only will try to recover if the expiry time has be reached. Meaning the wallet hasn't been active or opened for that period of time. This expiry time should be coordinated between the cron job clean up process, but has some fail proof guards if they weren't coordinated.

# Testing Instructions
1. Initialize a new agent and establish a mediation connection.
2. Create connections with issuers/verifiers
3. Close the agent.
4. Delete the mediation and related records from the mediator DB.
5. Reopen the existing agent with expiry set to 0 days.
6. The initial connection pickup request will timeout and a new mediation connection will be established. There will be an error displayed in dev mode saying pickup failed. This is expected
7. Existing issuer/verifier connections continue to work as if nothing happened.

Edge cases. 
 - With the mediator update to enable this feature we have planned the mediation will recover even if it's not deleted from the mediation DB. It will remove the recipient keys from the old mediation record and allow them to be created on a new mediation record.
 - If the recover process fails for some reason like connection issues it will attempt to restore to previous state.

Other services:
 - Mediator --> https://github.com/openwallet-foundation/didcomm-mediator-credo/tree/live-mode-postgres commit https://github.com/openwallet-foundation/didcomm-mediator-credo/commit/4101fa818206d14d4a341a72f7d54da45bc13d0c . Contains tagging and allowing a new mediation record with same recipient keys features
 - https://github.com/openwallet-foundation/acapy-tools/pull/86 This is the current cron job for cleaning mediation records. example usage 
 ```
askar-tools --strategy mediator-cleanup --uri postgres://myuser:mypassword@localhost:5432/mediator_wallet_test --wallet-name mediator_wallet_test --wallet-key mediator_wallet_key --inactive-days-threshold 0 --pickup-repository-uri postgres://myuser:mypassword@localhost:5432/messagepickuprepository
```