### PR TITLE
fix: prevent initial layout shift

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -105,8 +105,8 @@ const App = () => {
   }, [])
 
   return (
-    <SafeAreaProvider initialMetrics={initialWindowMetrics}>
-      <ErrorBoundaryWrapper logger={logger}>
+    <ErrorBoundaryWrapper logger={logger}>
+      <SafeAreaProvider initialMetrics={initialWindowMetrics}>
         <ContainerProvider value={bcwContainer}>
           <StoreProvider initialState={initialState} reducer={reducer}>
             <ThemeProvider
@@ -145,8 +145,8 @@ const App = () => {
             </ThemeProvider>
           </StoreProvider>
         </ContainerProvider>
-      </ErrorBoundaryWrapper>
-    </SafeAreaProvider>
+      </SafeAreaProvider>
+    </ErrorBoundaryWrapper>
   )
 }
 

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -42,6 +42,7 @@ import Config from 'react-native-config'
 import { isTablet } from 'react-native-device-info'
 import { KeyboardProvider } from 'react-native-keyboard-controller'
 import Orientation from 'react-native-orientation-locker'
+import { initialWindowMetrics, SafeAreaProvider } from 'react-native-safe-area-context'
 import SplashScreen from 'react-native-splash-screen'
 import Toast from 'react-native-toast-message'
 import { container } from 'tsyringe'
@@ -104,46 +105,48 @@ const App = () => {
   }, [])
 
   return (
-    <ErrorBoundaryWrapper logger={logger}>
-      <ContainerProvider value={bcwContainer}>
-        <StoreProvider initialState={initialState} reducer={reducer}>
-          <ThemeProvider
-            themes={themes}
-            defaultThemeName={Config.BUILD_TARGET === Mode.BCSC ? BCThemeNames.BCSC : BCThemeNames.BCWallet}
-          >
-            <NavigationContainerProvider>
-              <PairingServiceProvider service={pairingService}>
-                <FcmServiceProvider service={fcmService} viewModel={fcmViewModel}>
-                  <VerificationResponseServiceProvider service={verificationResponseService}>
-                    <AnimatedComponentsProvider value={animatedComponents}>
-                      <AuthProvider>
-                        <NetworkProvider>
-                          <ErrorModal enableReport />
-                          <WebDisplay
-                            destinationUrl={surveyMonkeyUrl}
-                            exitUrl={surveyMonkeyExitUrl}
-                            visible={surveyVisible}
-                            onClose={() => setSurveyVisible(false)}
-                          />
-                          <TourProvider tours={tours} overlayColor={'black'} overlayOpacity={0.7}>
-                            <ErrorAlertProvider enableReport>
-                              <KeyboardProvider statusBarTranslucent={true} navigationBarTranslucent={true}>
-                                <Root />
-                              </KeyboardProvider>
-                            </ErrorAlertProvider>
-                          </TourProvider>
-                          <Toast topOffset={15} config={toastConfig} />
-                        </NetworkProvider>
-                      </AuthProvider>
-                    </AnimatedComponentsProvider>
-                  </VerificationResponseServiceProvider>
-                </FcmServiceProvider>
-              </PairingServiceProvider>
-            </NavigationContainerProvider>
-          </ThemeProvider>
-        </StoreProvider>
-      </ContainerProvider>
-    </ErrorBoundaryWrapper>
+    <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+      <ErrorBoundaryWrapper logger={logger}>
+        <ContainerProvider value={bcwContainer}>
+          <StoreProvider initialState={initialState} reducer={reducer}>
+            <ThemeProvider
+              themes={themes}
+              defaultThemeName={Config.BUILD_TARGET === Mode.BCSC ? BCThemeNames.BCSC : BCThemeNames.BCWallet}
+            >
+              <NavigationContainerProvider>
+                <PairingServiceProvider service={pairingService}>
+                  <FcmServiceProvider service={fcmService} viewModel={fcmViewModel}>
+                    <VerificationResponseServiceProvider service={verificationResponseService}>
+                      <AnimatedComponentsProvider value={animatedComponents}>
+                        <AuthProvider>
+                          <NetworkProvider>
+                            <ErrorModal enableReport />
+                            <WebDisplay
+                              destinationUrl={surveyMonkeyUrl}
+                              exitUrl={surveyMonkeyExitUrl}
+                              visible={surveyVisible}
+                              onClose={() => setSurveyVisible(false)}
+                            />
+                            <TourProvider tours={tours} overlayColor={'black'} overlayOpacity={0.7}>
+                              <ErrorAlertProvider enableReport>
+                                <KeyboardProvider statusBarTranslucent={true} navigationBarTranslucent={true}>
+                                  <Root />
+                                </KeyboardProvider>
+                              </ErrorAlertProvider>
+                            </TourProvider>
+                            <Toast topOffset={15} config={toastConfig} />
+                          </NetworkProvider>
+                        </AuthProvider>
+                      </AnimatedComponentsProvider>
+                    </VerificationResponseServiceProvider>
+                  </FcmServiceProvider>
+                </PairingServiceProvider>
+              </NavigationContainerProvider>
+            </ThemeProvider>
+          </StoreProvider>
+        </ContainerProvider>
+      </ErrorBoundaryWrapper>
+    </SafeAreaProvider>
   )
 }
 


### PR DESCRIPTION
# Summary of Changes

Fixes a layout shift after opening the app from a cold start. 

Uses SafeAreaProvider with initialMetrics to prevent layout from shifting when SetupSteps mount.

# Testing Instructions

Replace this text with detailed instructions on how to test the changes included in this PR.

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

### Before (shifts when SetupSteps mounts)
Note: Sometimes hard to see, might need to replay this video a few times to see it.

https://github.com/user-attachments/assets/15719205-7142-414c-93d2-f8bb41397903

### After (no shifting)
https://github.com/user-attachments/assets/4c556f52-dfa6-4132-b584-018b3b199e77



# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
