### PR TITLE
fix: detect keyboard activity as user activity

### DIFF
--- a/app/src/bcsc-theme/components/CodeInput.tsx
+++ b/app/src/bcsc-theme/components/CodeInput.tsx
@@ -1,3 +1,4 @@
+import { useBCSCActivity } from '@/bcsc-theme/contexts/BCSCActivityContext'
 import { PAIRING_CODE_LENGTH as CELL_COUNT } from '@/constants'
 import { ThemedText, useTheme } from '@bifold/core'
 import React, { Fragment, useCallback } from 'react'
@@ -19,13 +20,15 @@ interface CodeInputProps {
 
 const CodeInput = ({ value, onChange, error, onErrorClear, separator, textInputProps }: CodeInputProps) => {
   const { ColorPalette, Spacing, Inputs } = useTheme()
+  const { reportActivity } = useBCSCActivity() ?? {}
 
   const onChangeText = useCallback(
     (text: string) => {
+      reportActivity?.()
       onErrorClear?.()
       onChange(text)
     },
-    [onChange, onErrorClear]
+    [onChange, onErrorClear, reportActivity]
   )
 
   const [props, getCellOnLayoutHandler] = useClearByFocusCell({

--- a/app/src/bcsc-theme/components/InputWithValidation.tsx
+++ b/app/src/bcsc-theme/components/InputWithValidation.tsx
@@ -1,3 +1,4 @@
+import { useBCSCActivity } from '@/bcsc-theme/contexts/BCSCActivityContext'
 import { hitSlop } from '@/constants'
 import { a11yLabel } from '@/utils/accessibility'
 import { testIdWithKey, ThemedText, useTheme } from '@bifold/core'
@@ -46,6 +47,7 @@ type InputWithValidationProps = {
  */
 export const InputWithValidation: React.FC<InputWithValidationProps> = (props: InputWithValidationProps) => {
   const { Inputs, ColorPalette, Spacing } = useTheme()
+  const { reportActivity } = useBCSCActivity() ?? {}
   const inputRef = useRef<TextInput>(null)
   const [isFocused, setIsFocused] = useState(false)
 
@@ -119,6 +121,7 @@ export const InputWithValidation: React.FC<InputWithValidationProps> = (props: I
             style={[styles.input, props.inputProps]}
             value={props.value}
             onChangeText={(text) => {
+              reportActivity?.()
               if (props.error) {
                 props.onErrorClear?.()
               }

--- a/app/src/bcsc-theme/contexts/BCSCActivityContext.test.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCActivityContext.test.tsx
@@ -89,7 +89,7 @@ describe('BCSCActivityContext', () => {
     const removeMock = jest.fn()
     const addListenerSpy = jest.spyOn(Keyboard, 'addListener').mockReturnValue({
       remove: removeMock,
-    })
+    } as unknown as ReturnType<typeof Keyboard.addListener>)
 
     const { unmount } = renderHook(() => useBCSCActivity(), { wrapper })
 

--- a/app/src/bcsc-theme/contexts/BCSCActivityContext.test.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCActivityContext.test.tsx
@@ -1,0 +1,103 @@
+import { BasicAppContext } from '@mocks/helpers/app'
+import { act, renderHook } from '@testing-library/react-native'
+import { Keyboard } from 'react-native'
+
+import { BCSCActivityProvider, useBCSCActivity } from './BCSCActivityContext'
+
+jest.mock('@/bcsc-theme/hooks/useSecureActions', () => ({
+  __esModule: true,
+  default: () => ({ logout: jest.fn() }),
+}))
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <BasicAppContext>
+    <BCSCActivityProvider>{children}</BCSCActivityProvider>
+  </BasicAppContext>
+)
+
+describe('BCSCActivityContext', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('should expose reportActivity on the context', () => {
+    const { result } = renderHook(() => useBCSCActivity(), { wrapper })
+
+    expect(result.current.reportActivity).toBeDefined()
+    expect(typeof result.current.reportActivity).toBe('function')
+  })
+
+  it('should reset inactivity timeout when reportActivity is called', () => {
+    const { result } = renderHook(() => useBCSCActivity(), { wrapper })
+
+    // Advance most of the way through the default 5-minute timeout
+    act(() => {
+      jest.advanceTimersByTime(4 * 60 * 1000)
+    })
+
+    // Report activity — should reset the timer
+    act(() => {
+      result.current.reportActivity()
+    })
+
+    // Advance another 4 minutes — would have exceeded 5 min total without reset
+    act(() => {
+      jest.advanceTimersByTime(4 * 60 * 1000)
+    })
+
+    // Should still have a valid context (not logged out)
+    expect(result.current.reportActivity).toBeDefined()
+  })
+
+  it('should not reset timeout when reportActivity is called while paused', () => {
+    const { result } = renderHook(() => useBCSCActivity(), { wrapper })
+
+    act(() => {
+      result.current.pauseActivityTracking()
+    })
+
+    // reportActivity should be a no-op when paused
+    act(() => {
+      result.current.reportActivity()
+    })
+
+    // Resuming should work normally after
+    act(() => {
+      result.current.resumeActivityTracking()
+    })
+
+    expect(result.current.reportActivity).toBeDefined()
+  })
+
+  it('should subscribe to keyboardDidShow and keyboardDidHide events', () => {
+    const addListenerSpy = jest.spyOn(Keyboard, 'addListener')
+
+    renderHook(() => useBCSCActivity(), { wrapper })
+
+    const eventNames = addListenerSpy.mock.calls.map((call) => call[0])
+    expect(eventNames).toContain('keyboardDidShow')
+    expect(eventNames).toContain('keyboardDidHide')
+
+    addListenerSpy.mockRestore()
+  })
+
+  it('should clean up keyboard listeners on unmount', () => {
+    const removeMock = jest.fn()
+    const addListenerSpy = jest.spyOn(Keyboard, 'addListener').mockReturnValue({
+      remove: removeMock,
+    })
+
+    const { unmount } = renderHook(() => useBCSCActivity(), { wrapper })
+
+    unmount()
+
+    // Two keyboard listeners should have been removed
+    expect(removeMock).toHaveBeenCalledTimes(2)
+
+    addListenerSpy.mockRestore()
+  })
+})

--- a/app/src/bcsc-theme/contexts/BCSCActivityContext.test.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCActivityContext.test.tsx
@@ -4,9 +4,11 @@ import { Keyboard } from 'react-native'
 
 import { BCSCActivityProvider, useBCSCActivity } from './BCSCActivityContext'
 
+const mockLogout = jest.fn()
+
 jest.mock('@/bcsc-theme/hooks/useSecureActions', () => ({
   __esModule: true,
-  default: () => ({ logout: jest.fn() }),
+  default: () => ({ logout: mockLogout }),
 }))
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -18,6 +20,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 describe('BCSCActivityContext', () => {
   beforeEach(() => {
     jest.useFakeTimers()
+    mockLogout.mockClear()
   })
 
   afterEach(() => {
@@ -49,8 +52,14 @@ describe('BCSCActivityContext', () => {
       jest.advanceTimersByTime(4 * 60 * 1000)
     })
 
-    // Should still have a valid context (not logged out)
-    expect(result.current.reportActivity).toBeDefined()
+    expect(mockLogout).not.toHaveBeenCalled()
+
+    // Advance past the full 5 min from last reset — should trigger logout
+    act(() => {
+      jest.advanceTimersByTime(2 * 60 * 1000)
+    })
+
+    expect(mockLogout).toHaveBeenCalledTimes(1)
   })
 
   it('should not reset timeout when reportActivity is called while paused', () => {
@@ -65,12 +74,12 @@ describe('BCSCActivityContext', () => {
       result.current.reportActivity()
     })
 
-    // Resuming should work normally after
+    // Advance well past the timeout — logout should not fire while paused
     act(() => {
-      result.current.resumeActivityTracking()
+      jest.advanceTimersByTime(10 * 60 * 1000)
     })
 
-    expect(result.current.reportActivity).toBeDefined()
+    expect(mockLogout).not.toHaveBeenCalled()
   })
 
   it('should subscribe to keyboardDidShow and keyboardDidHide events', () => {

--- a/app/src/bcsc-theme/contexts/BCSCActivityContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCActivityContext.tsx
@@ -161,16 +161,12 @@ export const BCSCActivityProvider: React.FC<PropsWithChildren> = ({ children }) 
   const panResponder = useMemo(() => {
     return PanResponder.create({
       onStartShouldSetPanResponderCapture: () => {
-        // some user interaction detected, reset timeout (unless paused)
-        if (!isPausedRef.current) {
-          resetInactivityTimeout(timeoutInMilliseconds.current)
-        }
-
+        reportActivity()
         // returns false so the PanResponder doesn't consume the touch event
         return false
       },
     })
-  }, [resetInactivityTimeout])
+  }, [reportActivity])
 
   const contextValue = useMemo(
     () => ({ appStateStatus, pauseActivityTracking, reportActivity, resumeActivityTracking }),

--- a/app/src/bcsc-theme/contexts/BCSCActivityContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCActivityContext.tsx
@@ -12,11 +12,12 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { AppState, AppStateStatus, PanResponder, View } from 'react-native'
+import { AppState, AppStateStatus, Keyboard, PanResponder, View } from 'react-native'
 
 export interface BCSCActivityContext {
   appStateStatus: AppStateStatus
   pauseActivityTracking: () => void
+  reportActivity: () => void
   resumeActivityTracking: () => void
 }
 
@@ -94,6 +95,12 @@ export const BCSCActivityProvider: React.FC<PropsWithChildren> = ({ children }) 
     resetInactivityTimeout(timeoutInMilliseconds.current)
   }, [logger, resetInactivityTimeout])
 
+  const reportActivity = useCallback(() => {
+    if (!isPausedRef.current) {
+      resetInactivityTimeout(timeoutInMilliseconds.current)
+    }
+  }, [resetInactivityTimeout])
+
   useEffect(() => {
     // listener for backgrounding / foregrounding
     const eventSubscription = AppState.addEventListener('change', async (nextAppState) => {
@@ -124,14 +131,20 @@ export const BCSCActivityProvider: React.FC<PropsWithChildren> = ({ children }) 
       setAppStateStatus(nextAppState)
     })
 
+    // keyboard activity resets the inactivity timeout
+    const keyboardDidShowSubscription = Keyboard.addListener('keyboardDidShow', reportActivity)
+    const keyboardDidHideSubscription = Keyboard.addListener('keyboardDidHide', reportActivity)
+
     // initial timeout setup
     resetInactivityTimeout(timeoutInMilliseconds.current)
 
     return () => {
       clearInactivityTimeoutIfExists()
       eventSubscription.remove()
+      keyboardDidShowSubscription.remove()
+      keyboardDidHideSubscription.remove()
     }
-  }, [clearInactivityTimeoutIfExists, handleInactivityTimeout, resetInactivityTimeout, logger])
+  }, [clearInactivityTimeoutIfExists, handleInactivityTimeout, resetInactivityTimeout, reportActivity, logger])
 
   useEffect(() => {
     // user has updated settings for auto lock time
@@ -160,8 +173,8 @@ export const BCSCActivityProvider: React.FC<PropsWithChildren> = ({ children }) 
   }, [resetInactivityTimeout])
 
   const contextValue = useMemo(
-    () => ({ appStateStatus, pauseActivityTracking, resumeActivityTracking }),
-    [appStateStatus, pauseActivityTracking, resumeActivityTracking]
+    () => ({ appStateStatus, pauseActivityTracking, reportActivity, resumeActivityTracking }),
+    [appStateStatus, pauseActivityTracking, reportActivity, resumeActivityTracking]
   )
 
   return (

--- a/app/src/bcsc-theme/features/services/Services.tsx
+++ b/app/src/bcsc-theme/features/services/Services.tsx
@@ -1,4 +1,5 @@
 import TabScreenWrapper from '@/bcsc-theme/components/TabScreenWrapper'
+import { useBCSCActivity } from '@/bcsc-theme/contexts/BCSCActivityContext'
 import useDataLoader from '@/bcsc-theme/hooks/useDataLoader'
 import { useTokenService } from '@/bcsc-theme/services/hooks/useTokenService'
 import { BCSCMainStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
@@ -27,6 +28,7 @@ type ServicesNavigationProp = StackNavigationProp<BCSCMainStackParams, BCSCScree
  * @return {*} {React.ReactElement} The Services screen component.
  */
 const Services: React.FC = () => {
+  const { reportActivity } = useBCSCActivity() ?? {}
   const token = useTokenService()
   const { t } = useTranslation()
   const [store] = useStore<BCState>()
@@ -109,6 +111,7 @@ const Services: React.FC = () => {
             // disable autocorrect to prevent completion when clearing search text
             autoCorrect={false}
             onChangeText={(newText) => {
+              reportActivity?.()
               // Dismiss keyboard when clearing search text
               if (search.length > 0 && newText === '') {
                 Keyboard.dismiss()


### PR DESCRIPTION
## Summary

- Expose `reportActivity` on `BCSCActivityContext` and subscribe to `keyboardDidShow`/`keyboardDidHide` events to reset the inactivity timer when the keyboard opens or closes
- Call `reportActivity()` from `InputWithValidation` on every keystroke so typing resets the inactivity timer and prevents auto-lockout

Closes #3554

## Test plan

- set the apps minute to 1 minutes
- begin setup, get to a text input field (i.e passport number)
- enter 1 number every 20 seconds for 5 numbers.
- the app should not lock.
