### PR TITLE
feat(devops): deploy loki logstack to production

### DIFF
--- a/devops/README.md
+++ b/devops/README.md
@@ -54,7 +54,7 @@ helm install bcwallet ./devops/charts/loki-logstack \
   --set-string minio_access_key=$MINIO_ACCESS_KEY \
   --set-string minio_secret_key=$MINIO_SECRET_KEY \
   --set-string proxyUserName=$PROXY_USER_NAME \
-  --set-string proxyPassword=$(htpasswd -nbB $PROXY_USER_NAME $PROXY_PASSWORD | awk -F: '{ print $2 }' | tr -d '[:space:]' | base64)
+  --set-string proxyPassword=$(htpasswd -nbB $PROXY_USER_NAME $PROXY_PASSWORD | awk -F: '{ print $2 }' | tr -d '[:space:]')
 ```
 
 For example, to deploy to prod:
@@ -66,7 +66,7 @@ helm install bcwallet ./devops/charts/loki-logstack \
   --set-string minio_access_key=$MINIO_ACCESS_KEY \
   --set-string minio_secret_key=$MINIO_SECRET_KEY \
   --set-string proxyUserName=$PROXY_USER_NAME \
-  --set-string proxyPassword=$(htpasswd -nbB $PROXY_USER_NAME $PROXY_PASSWORD | awk -F: '{ print $2 }' | tr -d '[:space:]' | base64)
+  --set-string proxyPassword=$(htpasswd -nbB $PROXY_USER_NAME $PROXY_PASSWORD | awk -F: '{ print $2 }' | tr -d '[:space:]')
 ```
 
 #### Parameters
@@ -75,7 +75,7 @@ helm install bcwallet ./devops/charts/loki-logstack \
 | ------------------ | ----------------------------------------------------------------------------------- |
 | `namespace`        | Target namespace. Used by Caddy to resolve the Loki service via cluster DNS.        |
 | `proxyUserName`    | Plaintext username for Caddy Basic Auth.                                            |
-| `proxyPassword`    | Base64-encoded bcrypt hash of the password (the `htpasswd` pipeline handles this).  |
+| `proxyPassword`    | Bcrypt hash of the password (the `htpasswd` pipeline handles this).                 |
 | `minio_access_key` | Minio access key (stored in a Secret).                                              |
 | `minio_secret_key` | Minio secret key (stored in a Secret).                                              |
 

--- a/devops/README.md
+++ b/devops/README.md
@@ -6,124 +6,114 @@ This directory contains the source code for supporting infrastructure components
 
 ## Loki Logstack
 
-The Loki Logstack is a set of components for gathering and storing logs temporarily, which helps with troubleshooting and analyzing issues for the BC Wallet's advanced support team.
+The Loki Logstack gathers and stores logs temporarily for troubleshooting and analysis by the BC Wallet advanced support team.
 
-When turned on, the BC Wallet sends its logs to the Loki Logstack through the Loki Proxy. This proxy then forwards the logs to Loki for safekeeping. To ensure security, the Loki Proxy needs proper login details. It will only accept logs from the BC Wallet if the correct credentials are provided.
+When enabled, the BC Wallet sends logs to Loki through a Caddy reverse proxy. The proxy authenticates requests using HTTP Basic Auth and forwards them to Loki for storage.
 
-The components to the Loki Logstack deployment are as follows:
+### Components
 
-1. Loki - a log aggregation system
+| Component    | Role                           | Kind         | Details                                           |
+| ------------ | ------------------------------ | ------------ | ------------------------------------------------- |
+| **Loki**     | Log aggregation                | Deployment   | [grafana.com/oss/loki](https://grafana.com/oss/loki/) |
+| **Proxy**    | Auth gateway (Caddy)           | Deployment   | [caddyserver.com](https://caddyserver.com/)       |
+| **Minio**    | Object storage (S3-compatible) | StatefulSet  |                                                   |
+| **Memcached**| Query/chunk caching            | StatefulSet  |                                                   |
 
-Read more about Loki [here](https://grafana.com/oss/loki/).
+### Environments
 
-2. Proxy - a gatekeeper for the Loki system
+| Environment | Namespace      | Values File        | Replicas | Autoscaling |
+| ----------- | -------------- | ------------------ | -------- | ----------- |
+| Dev         | `ca7f8f-dev`   | `values_dev.yaml`  | 1        | No          |
+| Test        | `ca7f8f-test`  | `values_test.yaml` | 2        | No          |
+| Prod        | `ca7f8f-prod`  | `values_prod.yaml` | 3        | Yes (3-5)   |
 
-The current proxy implementation is Caddy. Read more about Caddy [here](https://caddyserver.com/).
+Production uses HorizontalPodAutoscalers on the Loki and Proxy deployments (80% CPU target).
 
-3. Minio - a high-performance object storage server
-4. Memcached - a high-performance, distributed memory object caching system
+### Credential Generation
+
+Each environment needs its own set of credentials. Generate them before deploying:
+
+```bash
+# Minio credentials
+export MINIO_ACCESS_KEY=$(openssl rand -hex 16)
+export MINIO_SECRET_KEY=$(openssl rand -hex 16)
+
+# Proxy credentials (username: 8 hex chars, password: 16 hex chars)
+export PROXY_USER_NAME=$(openssl rand -hex 8)
+export PROXY_PASSWORD=$(openssl rand -hex 16)
+```
 
 ### Deployment
 
-Deploy the Loki Logstack using the following command, substituting the appropriate values file and namespace for the target environment:
-
-**Dev:**
+Deploy the Loki Logstack by substituting the values file and namespace for the target environment:
 
 ```bash
-helm install bcwallet ./devops/charts/loki-logstack -f ./devops/charts/loki-logstack/values_dev.yaml \
---set-string namespace=ca7f8f-dev \
---set-string minio_access_key=$MINIO_ACCESS_KEY \
---set-string minio_secret_key=$MINIO_SECRET_KEY \
---set-string proxyUserName=$PROXY_USER_NAME \
---set-string proxyPassword=$(htpasswd -nbB $PROXY_USER_NAME $PROXY_PASSWORD| awk -F: '{ print $2 }'|tr -d '[:space:]'|base64)
+helm install bcwallet ./devops/charts/loki-logstack \
+  -f ./devops/charts/loki-logstack/<VALUES_FILE> \
+  --set-string namespace=<NAMESPACE> \
+  --set-string minio_access_key=$MINIO_ACCESS_KEY \
+  --set-string minio_secret_key=$MINIO_SECRET_KEY \
+  --set-string proxyUserName=$PROXY_USER_NAME \
+  --set-string proxyPassword=$(htpasswd -nbB $PROXY_USER_NAME $PROXY_PASSWORD | awk -F: '{ print $2 }' | tr -d '[:space:]' | base64)
 ```
 
-**Test:**
+For example, to deploy to prod:
 
 ```bash
-helm install bcwallet ./devops/charts/loki-logstack -f ./devops/charts/loki-logstack/values_test.yaml \
---set-string namespace=ca7f8f-test \
---set-string minio_access_key=$MINIO_ACCESS_KEY \
---set-string minio_secret_key=$MINIO_SECRET_KEY \
---set-string proxyUserName=$PROXY_USER_NAME \
---set-string proxyPassword=$(htpasswd -nbB $PROXY_USER_NAME $PROXY_PASSWORD| awk -F: '{ print $2 }'|tr -d '[:space:]'|base64)
+helm install bcwallet ./devops/charts/loki-logstack \
+  -f ./devops/charts/loki-logstack/values_prod.yaml \
+  --set-string namespace=ca7f8f-prod \
+  --set-string minio_access_key=$MINIO_ACCESS_KEY \
+  --set-string minio_secret_key=$MINIO_SECRET_KEY \
+  --set-string proxyUserName=$PROXY_USER_NAME \
+  --set-string proxyPassword=$(htpasswd -nbB $PROXY_USER_NAME $PROXY_PASSWORD | awk -F: '{ print $2 }' | tr -d '[:space:]' | base64)
 ```
 
-**Prod:**
+#### Parameters
+
+| Value              | Description                                                                         |
+| ------------------ | ----------------------------------------------------------------------------------- |
+| `namespace`        | Target namespace. Used by Caddy to resolve the Loki service via cluster DNS.        |
+| `proxyUserName`    | Plaintext username for Caddy Basic Auth.                                            |
+| `proxyPassword`    | Base64-encoded bcrypt hash of the password (the `htpasswd` pipeline handles this).  |
+| `minio_access_key` | Minio access key (stored in a Secret).                                              |
+| `minio_secret_key` | Minio secret key (stored in a Secret).                                              |
+
+### Verifying the Deployment
+
+Check pods are running:
 
 ```bash
-helm install bcwallet ./devops/charts/loki-logstack -f ./devops/charts/loki-logstack/values_prod.yaml \
---set-string namespace=ca7f8f-prod \
---set-string minio_access_key=$MINIO_ACCESS_KEY \
---set-string minio_secret_key=$MINIO_SECRET_KEY \
---set-string proxyUserName=$PROXY_USER_NAME \
---set-string proxyPassword=$(htpasswd -nbB $PROXY_USER_NAME $PROXY_PASSWORD| awk -F: '{ print $2 }'|tr -d '[:space:]'|base64)
+oc get pods -l "app.kubernetes.io/name=logstack" -n <NAMESPACE>
 ```
 
-The parameters passed in via the `--set-string` argument for this command are as follows:
+Check the proxy route exists:
 
-| Value            | Description                                                                                         |
-| ---------------- | --------------------------------------------------------------------------------------------------- |
-| namespace        | The namespace in which to deploy the Loki Logstack. This is used by Caddy to find the Loki service. |
-| proxyUserName    | The username for the Loki Proxy. This is part of the authentication credentials.                    |
-| proxyPassword    | The password for the Loki Proxy.This is part of the authentication credentials.                     |
-| minio_access_key | The access key associated with Minio                                                                |
-| minio_secret_key | The secret key associated with Minio                                                                |
-
-**Pro Tip 🤓**
-
-- Use `openssl rand -hex 8` to generate a random password. The number `8` can be changed to any number to generate a password of that length. i.e `MINIO_SECRET_KEY=$(openssl rand -hex 16)` will generate a 16 character password.
-
-Once deployed there will be several pods running, depending on your replication count, that can be verified with the following command:
-
-```console
-➜  vc-wallet-mobile git:(feat/loki-ha) ✗ oc get pods -l "app.kubernetes.io/name=logstack"
-
-NAME                                       READY   STATUS    RESTARTS   AGE
-bcwallet-logstack-loki-79b7dfd4b4-2ffsb    1/1     Running   0          16h
-bcwallet-logstack-loki-79b7dfd4b4-mds8h    1/1     Running   0          16h
-bcwallet-logstack-memcached-0              1/1     Running   0          18h
-bcwallet-logstack-memcached-1              1/1     Running   0          18h
-bcwallet-logstack-minio-0                  1/1     Running   0          18h
-bcwallet-logstack-minio-1                  1/1     Running   0          18h
-bcwallet-logstack-proxy-5946c98d97-925qp   1/1     Running   0          18h
-bcwallet-logstack-proxy-5946c98d97-clzlg   1/1     Running   0          18h
-```
-
-In addition to the pods, there will be a route created for the Loki Proxy. This route is used by the BC Wallet to send its logs to the Loki Proxy. The route can be verified with the following command:
-
-```console
-➜  vc-wallet-mobile oc get routes -l "app.kubernetes.io/name=logstack"
-
-NAME                      HOST/PORT                                                         PATH   SERVICES                  PORT   TERMINATION     WILDCARD
-bcwallet-logstack-proxy   bcwallet-logstack-proxy-abc123-test.apps.silver.devops.gov.bc.ca          bcwallet-logstack-proxy   2015   edge/Redirect   None
+```bash
+oc get routes -l "app.kubernetes.io/name=logstack" -n <NAMESPACE>
 ```
 
 ### Usage
 
-To use the Loki Logstack, the BC Wallet needs to be configured to send its logs to the Loki Proxy. This is done by setting the following environment variables (in the .env):
+Configure the BC Wallet to send logs by setting `REMOTE_LOGGING_URL` in `app/.env`:
 
-| Variable Name      | Description                                                |
-| ------------------ | ---------------------------------------------------------- |
-| REMOTE_LOGGING_URL | The route from above with basic authentication credentials |
-
-For example:
-
-```console
-REMOTE_LOGGING_URL=https://<USERNAME>:<PASSWORD>@bcwallet-logstack-proxy-ab123-test.apps.silver.devops.gov.bc.ca/loki/api/v1/push
+```
+REMOTE_LOGGING_URL=https://<USERNAME>:<PASSWORD>@<PROXY_ROUTE_HOST>/loki/api/v1/push
 ```
 
-You can use the following cURL command to the entire log stack. Loki does not accept outdated logs, so you will need to change the timestamp `1705256799868099100` to the current time.
+Where `<USERNAME>` and `<PASSWORD>` are the plaintext proxy credentials (not the bcrypt hash), and `<PROXY_ROUTE_HOST>` is the hostname from the route above.
 
-Get and updated timestamp:
+#### Testing the Log Stack
 
-```console
-➜  vc-wallet-mobile ✗ node -e "console.log(Date.now() + '099100')"
-1705256928213099100
-```
-
-Send a sample log with the updated timestamp:
+Send a sample log to verify the full pipeline. Loki rejects outdated timestamps, so generate a current one first:
 
 ```bash
-curl -v -H "Content-Type: application/json" -u $PROXY_USER_NAME:$PROXY_PASSWORD -X POST "https://bcwallet-logstack-proxy-caZZZZ-dev.apps.silver.devops.gov.bc.ca/loki/api/v1/push" --data-raw '{"streams":[{"stream":{"job":"react-native-logs","level":"debug","application":"bc wallet","version":"1.0.1-444","system":"iOS v16.7.4","session_id":"463217"},"values":[["1734028898448000000","{\"message\":\"Successfully connected to WebSocket wss://aries-mediator-agent.blah.gov.bc.ca\"}"]]}]}'
+# Get a current nanosecond timestamp
+TIMESTAMP=$(node -e "console.log(Date.now() + '000000')")
+
+# Send a test log entry
+curl -v -H "Content-Type: application/json" \
+  -u $PROXY_USER_NAME:$PROXY_PASSWORD \
+  -X POST "https://<PROXY_ROUTE_HOST>/loki/api/v1/push" \
+  --data-raw "{\"streams\":[{\"stream\":{\"job\":\"react-native-logs\",\"level\":\"debug\",\"application\":\"bc wallet\",\"version\":\"1.0.0\",\"system\":\"iOS\",\"session_id\":\"test\"},\"values\":[[\"$TIMESTAMP\",\"{\\\"message\\\":\\\"Test log entry\\\"}\"  ]]}]}"
 ```

--- a/devops/README.md
+++ b/devops/README.md
@@ -25,11 +25,35 @@ The current proxy implementation is Caddy. Read more about Caddy [here](https://
 
 ### Deployment
 
-Deploy the Loki Logstack using the following command:
+Deploy the Loki Logstack using the following command, substituting the appropriate values file and namespace for the target environment:
+
+**Dev:**
 
 ```bash
 helm install bcwallet ./devops/charts/loki-logstack -f ./devops/charts/loki-logstack/values_dev.yaml \
---set-string namespace=ca7123-dev \
+--set-string namespace=ca7f8f-dev \
+--set-string minio_access_key=$MINIO_ACCESS_KEY \
+--set-string minio_secret_key=$MINIO_SECRET_KEY \
+--set-string proxyUserName=$PROXY_USER_NAME \
+--set-string proxyPassword=$(htpasswd -nbB $PROXY_USER_NAME $PROXY_PASSWORD| awk -F: '{ print $2 }'|tr -d '[:space:]'|base64)
+```
+
+**Test:**
+
+```bash
+helm install bcwallet ./devops/charts/loki-logstack -f ./devops/charts/loki-logstack/values_test.yaml \
+--set-string namespace=ca7f8f-test \
+--set-string minio_access_key=$MINIO_ACCESS_KEY \
+--set-string minio_secret_key=$MINIO_SECRET_KEY \
+--set-string proxyUserName=$PROXY_USER_NAME \
+--set-string proxyPassword=$(htpasswd -nbB $PROXY_USER_NAME $PROXY_PASSWORD| awk -F: '{ print $2 }'|tr -d '[:space:]'|base64)
+```
+
+**Prod:**
+
+```bash
+helm install bcwallet ./devops/charts/loki-logstack -f ./devops/charts/loki-logstack/values_prod.yaml \
+--set-string namespace=ca7f8f-prod \
 --set-string minio_access_key=$MINIO_ACCESS_KEY \
 --set-string minio_secret_key=$MINIO_SECRET_KEY \
 --set-string proxyUserName=$PROXY_USER_NAME \

--- a/devops/charts/loki-logstack/templates/configmap.yaml
+++ b/devops/charts/loki-logstack/templates/configmap.yaml
@@ -34,7 +34,7 @@ data:
 
     common:
       path_prefix: /var/loki
-      replication_factor: 3
+      replication_factor: {{ .Values.loki.replicationFactor | default .Values.replicaCount }}
       storage:
         s3:
           access_key_id: ${MINIO_ACCESS_KEY}

--- a/devops/charts/loki-logstack/templates/deployment.yaml
+++ b/devops/charts/loki-logstack/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   name: {{ include "logstack.fullname" . }}-loki
   labels: {{- include "logstack.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: loki
@@ -84,7 +86,9 @@ metadata:
   name: {{ include "logstack.fullname" . }}-proxy
   labels: {{- include "logstack.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: proxy

--- a/devops/charts/loki-logstack/templates/deployment.yaml
+++ b/devops/charts/loki-logstack/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   name: {{ include "logstack.fullname" . }}-loki
   labels: {{- include "logstack.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if .Values.autoscaling.enabled }}
+  replicas: {{ .Values.autoscaling.minReplicas }}
+  {{- else }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   selector:
@@ -86,7 +88,9 @@ metadata:
   name: {{ include "logstack.fullname" . }}-proxy
   labels: {{- include "logstack.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if .Values.autoscaling.enabled }}
+  replicas: {{ .Values.autoscaling.minReplicas }}
+  {{- else }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   selector:

--- a/devops/charts/loki-logstack/templates/hpa.yaml
+++ b/devops/charts/loki-logstack/templates/hpa.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "logstack.fullname" . }}-loki
+  labels: {{- include "logstack.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "logstack.fullname" . }}-loki
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "logstack.fullname" . }}-proxy
+  labels: {{- include "logstack.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "logstack.fullname" . }}-proxy
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/devops/charts/loki-logstack/values_dev.yaml
+++ b/devops/charts/loki-logstack/values_dev.yaml
@@ -124,6 +124,7 @@ volumeMounts: []
 # Loki configuration that is likely to change between
 # deployments
 loki:
+  replicationFactor: 1
   retention:
     retention_period: 3d
 

--- a/devops/charts/loki-logstack/values_prod.yaml
+++ b/devops/charts/loki-logstack/values_prod.yaml
@@ -1,10 +1,13 @@
-# Default values for logstack.
+# Production values for logstack.
 # Declare variables to be passed into your templates.
 
-replicaCount: 2
+replicaCount: 3
 
 autoscaling:
-  enabled: false
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
 
 podAnnotations: {}
 podLabels: {}
@@ -41,28 +44,28 @@ env:
 resources:
   loki:
     requests:
-      memory: 192Mi
-      cpu: 10m
+      memory: 230Mi
+      cpu: 12m
     limits:
-      memory: 256Mi
+      memory: 310Mi
   proxy:
     requests:
-      memory: 64Mi
-      cpu: 10m
+      memory: 80Mi
+      cpu: 12m
     limits:
-      memory: 92Mi
+      memory: 112Mi
   memcached:
     limits:
-      memory: 32Mi
+      memory: 40Mi
     requests:
-      cpu: 10m
-      memory: 32Mi
+      cpu: 12m
+      memory: 40Mi
   minio:
     requests:
-      memory: 192Mi
-      cpu: 20m
+      memory: 230Mi
+      cpu: 24m
     limits:
-      memory: 192Mi
+      memory: 230Mi
 
 services:
   loki:
@@ -90,29 +93,11 @@ route:
   annotations:
     haproxy.router.openshift.io/timeout: 60s
 
-# serviceAccount:
-#   # Specifies whether a service account should be created
-#   create: true
-#   # Automatically mount a ServiceAccount's API credentials?
-#   automount: true
-#   # Annotations to add to the service account
-#   annotations: {}
-#   # The name of the service account to use.
-#   # If not set and create is true, a name is generated using the fullname template
-#   name: ""
-
 # Additional volumes on the output Deployment definition.
 volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
 
 # Additional volumeMounts on the output Deployment definition.
 volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
 
 #
 # Loki configuration
@@ -121,7 +106,7 @@ volumeMounts: []
 # Loki configuration that is likely to change between
 # deployments
 loki:
-  replicationFactor: 2
+  replicationFactor: 3
   retention:
     retention_period: 3d
 
@@ -130,4 +115,4 @@ loki:
 #
 
 caddy:
-  logLevel: INFO
+  logLevel: WARN


### PR DESCRIPTION
## Summary
- Add `values_prod.yaml` with replicaCount 3, HPA (min 3 / max 5), and production-tuned resources (~20% above test)
- Add `templates/hpa.yaml` for loki and proxy Deployments, gated by `autoscaling.enabled`
- Parameterize `replication_factor` in configmap (was hardcoded to 3, now per-environment)
- Rewrite `devops/README.md` with environments table, credential generation steps, and consolidated deployment instructions

## Post-merge ops tasks
- [ ] Generate proxy + minio credentials for prod
- [ ] Create `minio-creds` secret in `ca7f8f-prod`
- [ ] Deploy chart to `ca7f8f-prod`
- [ ] Update CI/CD `REMOTE_LOGGING_URL` secret with prod proxy route
- [ ] Add Loki datasource in shared Grafana

## Test plan
- [ ] `helm template` with each values file renders correctly
- [ ] Deploy to dev/test with updated values (replicationFactor fix) — verify no regression
- [ ] Deploy to prod namespace and verify all pods reach Running state
- [ ] Send test log via curl and confirm it appears in Grafana

Closes #3551