### PR TITLE
fix: from app switch navigation on android

### DIFF
--- a/app/src/bcsc-theme/features/pairing/PairingConfirmation.test.tsx
+++ b/app/src/bcsc-theme/features/pairing/PairingConfirmation.test.tsx
@@ -153,6 +153,28 @@ describe('PairingConfirmation', () => {
       expect(queryByTestId('com.ariesbifold:id/Close')).toBeTruthy()
     })
 
+    it('navigates home when the app goes to background', () => {
+      let appStateCallback: (state: AppStateStatus) => void
+      const removeSpy = jest.fn()
+      const addEventSpy = jest.spyOn(AppState, 'addEventListener').mockImplementation((_, callback) => {
+        appStateCallback = callback as (state: AppStateStatus) => void
+        return { remove: removeSpy } as any
+      })
+
+      const route = { params: { ...defaultRoute.params, fromAppSwitch: true } }
+
+      render(
+        <BasicAppContext>
+          <PairingConfirmation navigation={mockNavigation as never} route={route as never} />
+        </BasicAppContext>
+      )
+
+      appStateCallback!('background')
+
+      expect(mockNavigation.dispatch).toHaveBeenCalled()
+      addEventSpy.mockRestore()
+    })
+
     it('calls BackHandler.exitApp when Close is pressed', () => {
       const exitAppSpy = jest.spyOn(BackHandler, 'exitApp').mockImplementation(jest.fn())
       const route = { params: { ...defaultRoute.params, fromAppSwitch: true } }
@@ -172,6 +194,20 @@ describe('PairingConfirmation', () => {
   })
 
   describe('when without fromAppSwitch', () => {
+    it('does not register an AppState listener', () => {
+      Platform.OS = 'android'
+      const addEventSpy = jest.spyOn(AppState, 'addEventListener')
+
+      render(
+        <BasicAppContext>
+          <PairingConfirmation navigation={mockNavigation as never} route={defaultRoute as never} />
+        </BasicAppContext>
+      )
+
+      expect(addEventSpy).not.toHaveBeenCalled()
+      addEventSpy.mockRestore()
+    })
+
     it('resets navigation to the Tab stack when Close is pressed', () => {
       Platform.OS = 'android'
 

--- a/app/src/bcsc-theme/features/pairing/PairingConfirmation.tsx
+++ b/app/src/bcsc-theme/features/pairing/PairingConfirmation.tsx
@@ -19,13 +19,12 @@ const PairingConfirmation: React.FC<PairingConfirmationProps> = ({ navigation, r
   const showIOSAppSwitchGuide = Platform.OS === 'ios' && fromAppSwitch
 
   useEffect(() => {
-    if (!showIOSAppSwitchGuide) {
+    if (!fromAppSwitch) {
       return
     }
 
-    // On iOS, if the user backgrounds the app while on this screen -> navigate back to home screen
     const subscription = AppState.addEventListener('change', (nextAppState) => {
-      if (nextAppState === 'background' && showIOSAppSwitchGuide) {
+      if (nextAppState === 'background' && fromAppSwitch) {
         navigation.dispatch(
           CommonActions.reset({
             index: 0,
@@ -36,7 +35,7 @@ const PairingConfirmation: React.FC<PairingConfirmationProps> = ({ navigation, r
     })
 
     return subscription.remove
-  }, [navigation, showIOSAppSwitchGuide])
+  }, [navigation, fromAppSwitch])
 
   const onClose = () => {
     if (fromAppSwitch && Platform.OS === 'android') {


### PR DESCRIPTION
# Summary of Changes

This PR fixes an issue on Android where users would get stuck in a loop unable to leave the "You're done in this app" screen, simply by using the same automatic navigation that iOS uses.

# Testing Instructions

On Android, go through the deep link login process, ensure you don't get stuck on the aforementioned screen.

# Acceptance Criteria

Don't get stuck

# Screenshots, videos, or gifs

N/A

# Related Issues

#3502 