### PR TITLE
fix: prevent glitch on secure app screen

### DIFF
--- a/app/src/bcsc-theme/features/auth/components/SecurityMethodSelector.tsx
+++ b/app/src/bcsc-theme/features/auth/components/SecurityMethodSelector.tsx
@@ -13,7 +13,7 @@ import {
 import { upperFirst } from 'lodash'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Platform, StyleSheet, View } from 'react-native'
+import { ActivityIndicator, Platform, StyleSheet, View } from 'react-native'
 import {
   AccountSecurityMethod,
   BiometricType,
@@ -69,6 +69,7 @@ export const SecurityMethodSelector: React.FC<SecurityMethodSelectorProps> = ({
   const { startLoading } = useLoadingScreen()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
 
+  const [isLoading, setIsLoading] = useState(true)
   const [isDeviceAuthAvailable, setIsDeviceAuthAvailable] = useState(false)
   const [deviceAuthMethodName, setDeviceAuthMethodName] = useState('')
 
@@ -105,6 +106,8 @@ export const SecurityMethodSelector: React.FC<SecurityMethodSelectorProps> = ({
         const errMessage = error instanceof Error ? error.message : String(error)
         logger.error(`Error checking device auth availability: ${errMessage}`)
         setIsDeviceAuthAvailable(false)
+      } finally {
+        setIsLoading(false)
       }
     }
 
@@ -185,6 +188,14 @@ export const SecurityMethodSelector: React.FC<SecurityMethodSelectorProps> = ({
       />
     </>
   )
+
+  if (isLoading) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator size="large" color={ColorPalette.brand.primary} />
+      </View>
+    )
+  }
 
   // When device auth is available, show both options
   if (isDeviceAuthAvailable) {

--- a/app/src/bcsc-theme/features/auth/components/SecurityMethodSelector.tsx
+++ b/app/src/bcsc-theme/features/auth/components/SecurityMethodSelector.tsx
@@ -191,9 +191,9 @@ export const SecurityMethodSelector: React.FC<SecurityMethodSelectorProps> = ({
 
   if (isLoading) {
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <ActivityIndicator size="large" color={ColorPalette.brand.primary} />
-      </View>
+      <ScreenWrapper scrollViewContainerStyle={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator size="large" color={ColorPalette.grayscale.white} />
+      </ScreenWrapper>
     )
   }
 


### PR DESCRIPTION
# Summary of Changes

This PR fixes a glitch that appears on slower phones on the SecureAppScreen (where users decide between using device auth or a PIN) by not showing the content until the relevant content has been decided.

# Testing Instructions

On the device that found the original bug, go through onboarding with device auth available and enabled on the device

# Acceptance Criteria

No glitch

# Screenshots, videos, or gifs

N/A

# Related Issues

#3561 