### PR TITLE
fix: leave call error handling

### DIFF
--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
@@ -1,9 +1,9 @@
-import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { AppBannerSection as BannerSection, BCSCBanner } from '@/bcsc-theme/components/AppBanner'
 import { useBCSCActivity } from '@/bcsc-theme/contexts/BCSCActivityContext'
 import { useFcmService } from '@/bcsc-theme/features/fcm'
 import useVideoCallFlow from '@/bcsc-theme/features/verify/live-call/hooks/useVideoCallFlow'
 import { VideoCallFlowState } from '@/bcsc-theme/features/verify/live-call/types/live-call'
+import { useTokenService } from '@/bcsc-theme/services/hooks/useTokenService'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { CROP_DELAY_MS } from '@/constants'
 import { useAlerts } from '@/hooks/useAlerts'
@@ -44,10 +44,11 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
   const [systemVolume, setSystemVolume] = useState<number>(1)
   const timerIntervalRef = useRef<NodeJS.Timeout | null>(null)
   const cropDelayTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const { token } = useApi()
+  const tokenService = useTokenService()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const { liveCallHavingTroubleAlert } = useAlerts(navigation)
   const { pauseActivityTracking, resumeActivityTracking } = useBCSCActivity()
+  const { unknownErrorModal } = useAlerts(navigation)
 
   // check if verified, save token if so, and then navigate accordingly
   const leaveCall = useCallback(async () => {
@@ -56,8 +57,26 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
         throw new Error(t('BCSC.VideoCall.DeviceCodeError'))
       }
 
-      // checkDeviceCodeStatus already calls updateTokens internally, no need to call it again
-      await token.checkDeviceCodeStatus(store.bcscSecure.deviceCode, store.bcscSecure.userCode)
+      // checkVerificationStatus already calls updateTokens internally, no need to call it again
+      const isVerified = await tokenService.checkVerificationStatus(
+        store.bcscSecure.deviceCode,
+        store.bcscSecure.userCode
+      )
+
+      if (!isVerified) {
+        logger.info('[LiveCallScreen.leaveCall] User not verified')
+        navigation.dispatch(
+          CommonActions.reset({
+            index: 2,
+            routes: [
+              { name: BCSCScreens.SetupSteps },
+              { name: BCSCScreens.VerificationMethodSelection },
+              { name: BCSCScreens.VerifyNotComplete },
+            ],
+          })
+        )
+        return
+      }
 
       navigation.dispatch(
         CommonActions.reset({
@@ -65,23 +84,10 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
           routes: [{ name: BCSCScreens.VerificationSuccess }],
         })
       )
-    } catch {
-      // TODO (bm): as of Sept 10th 2025, the API throws if the user is not
-      // verified even though it isn't truly an error. We should check for
-      // this case specifically and only throw if it's some other error
-      logger.info('User not verified')
-      navigation.dispatch(
-        CommonActions.reset({
-          index: 2,
-          routes: [
-            { name: BCSCScreens.SetupSteps },
-            { name: BCSCScreens.VerificationMethodSelection },
-            { name: BCSCScreens.VerifyNotComplete },
-          ],
-        })
-      )
+    } catch (error) {
+      unknownErrorModal(error)
     }
-  }, [store.bcscSecure.deviceCode, store.bcscSecure.userCode, token, navigation, logger, t])
+  }, [store.bcscSecure.deviceCode, store.bcscSecure.userCode, tokenService, logger, navigation, t, unknownErrorModal])
 
   // we pass the leaveCall function to the hook so it can use it when the other side disconnects as well
   const {

--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
@@ -46,9 +46,8 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
   const cropDelayTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const tokenService = useTokenService()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
-  const { liveCallHavingTroubleAlert } = useAlerts(navigation)
+  const { liveCallHavingTroubleAlert, unknownErrorModal } = useAlerts(navigation)
   const { pauseActivityTracking, resumeActivityTracking } = useBCSCActivity()
-  const { unknownErrorModal } = useAlerts(navigation)
 
   /**
    * Handles leaving the call by navigating to the appropriate screen based on the verification status.

--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
@@ -50,7 +50,11 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
   const { pauseActivityTracking, resumeActivityTracking } = useBCSCActivity()
   const { unknownErrorModal } = useAlerts(navigation)
 
-  // check if verified, save token if so, and then navigate accordingly
+  /**
+   * Handles leaving the call by navigating to the appropriate screen based on the verification status.
+   *
+   * @returns A promise that resolves when the navigation action is dispatched.
+   */
   const leaveCall = useCallback(async () => {
     try {
       if (!store.bcscSecure.deviceCode || !store.bcscSecure.userCode) {

--- a/app/src/bcsc-theme/services/hooks/useTokenService.test.tsx
+++ b/app/src/bcsc-theme/services/hooks/useTokenService.test.tsx
@@ -111,6 +111,75 @@ describe('useTokenService', () => {
     })
   })
 
+  describe('checkVerificationStatus', () => {
+    it('should return true when device code status check succeeds', async () => {
+      const tokenApi = {
+        checkDeviceCodeStatus: jest.fn().mockResolvedValue(undefined),
+      } as any
+
+      jest.spyOn(useTokenApiModule, 'default').mockReturnValue(tokenApi)
+      jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue({} as any)
+
+      const { result } = renderHook(() => useTokenService())
+
+      const status = await result.current.checkVerificationStatus('device-code', 'confirmation-code')
+
+      expect(tokenApi.checkDeviceCodeStatus).toHaveBeenCalledWith('device-code', 'confirmation-code')
+      expect(status).toBe(true)
+    })
+
+    it('should return false when authorization is pending', async () => {
+      const mockError = mockAppError(AppEventCode.AUTHORIZATION_PENDING)
+      const tokenApi = {
+        checkDeviceCodeStatus: jest.fn().mockRejectedValue(mockError),
+      } as any
+
+      jest.spyOn(useTokenApiModule, 'default').mockReturnValue(tokenApi)
+      jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue({} as any)
+
+      const { result } = renderHook(() => useTokenService())
+
+      const status = await result.current.checkVerificationStatus('device-code', 'confirmation-code')
+
+      expect(tokenApi.checkDeviceCodeStatus).toHaveBeenCalledWith('device-code', 'confirmation-code')
+      expect(status).toBe(false)
+    })
+
+    it('should return true when already verified', async () => {
+      const mockError = mockAppError(AppEventCode.ALREADY_VERIFIED)
+      const tokenApi = {
+        checkDeviceCodeStatus: jest.fn().mockRejectedValue(mockError),
+      } as any
+
+      jest.spyOn(useTokenApiModule, 'default').mockReturnValue(tokenApi)
+      jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue({} as any)
+
+      const { result } = renderHook(() => useTokenService())
+
+      const status = await result.current.checkVerificationStatus('device-code', 'confirmation-code')
+
+      expect(tokenApi.checkDeviceCodeStatus).toHaveBeenCalledWith('device-code', 'confirmation-code')
+      expect(status).toBe(true)
+    })
+
+    it('should rethrow error when error is not authorization pending', async () => {
+      const mockError = mockAppError('ERR_SOME_OTHER_ERROR')
+      const tokenApi = {
+        checkDeviceCodeStatus: jest.fn().mockRejectedValue(mockError),
+      } as any
+
+      jest.spyOn(useTokenApiModule, 'default').mockReturnValue(tokenApi)
+      jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue({} as any)
+
+      const { result } = renderHook(() => useTokenService())
+
+      await expect(result.current.checkVerificationStatus('device-code', 'confirmation-code')).rejects.toThrow(
+        mockError
+      )
+      expect(tokenApi.checkDeviceCodeStatus).toHaveBeenCalledWith('device-code', 'confirmation-code')
+    })
+  })
+
   it('should return memoized functions', () => {
     const tokenApi = {
       getCachedIdTokenMetadata: jest.fn(),

--- a/app/src/bcsc-theme/services/hooks/useTokenService.test.tsx
+++ b/app/src/bcsc-theme/services/hooks/useTokenService.test.tsx
@@ -145,6 +145,23 @@ describe('useTokenService', () => {
       expect(status).toBe(false)
     })
 
+    it('should return false when verification is not complete', async () => {
+      const mockError = mockAppError(AppEventCode.VERIFY_NOT_COMPLETE)
+      const tokenApi = {
+        checkDeviceCodeStatus: jest.fn().mockRejectedValue(mockError),
+      } as any
+
+      jest.spyOn(useTokenApiModule, 'default').mockReturnValue(tokenApi)
+      jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue({} as any)
+
+      const { result } = renderHook(() => useTokenService())
+
+      const status = await result.current.checkVerificationStatus('device-code', 'confirmation-code')
+
+      expect(tokenApi.checkDeviceCodeStatus).toHaveBeenCalledWith('device-code', 'confirmation-code')
+      expect(status).toBe(false)
+    })
+
     it('should return true when already verified', async () => {
       const mockError = mockAppError(AppEventCode.ALREADY_VERIFIED)
       const tokenApi = {

--- a/app/src/bcsc-theme/services/hooks/useTokenService.tsx
+++ b/app/src/bcsc-theme/services/hooks/useTokenService.tsx
@@ -75,6 +75,10 @@ export const useTokenService = () => {
           return false
         }
 
+        if (isAppError(error, AppEventCode.ALREADY_VERIFIED)) {
+          return true
+        }
+
         throw error
       }
     },

--- a/app/src/bcsc-theme/services/hooks/useTokenService.tsx
+++ b/app/src/bcsc-theme/services/hooks/useTokenService.tsx
@@ -63,7 +63,7 @@ export const useTokenService = () => {
    *
    * @param deviceCode - The device code to check
    * @param confirmationCode - The confirmation code to check
-   * @return Promise resolving to true if verified, false if pending, or throws an error for other issues
+   * @returns Promise resolving to true if verified, false if pending, or throws an error for other issues
    */
   const checkVerificationStatus = useCallback(
     async (deviceCode: string, confirmationCode: string) => {

--- a/app/src/bcsc-theme/services/hooks/useTokenService.tsx
+++ b/app/src/bcsc-theme/services/hooks/useTokenService.tsx
@@ -56,11 +56,37 @@ export const useTokenService = () => {
     [alerts, tokenApi]
   )
 
+  /**
+   * Checks the verification status of a device code and confirmation code.
+   *
+   * @see {@link tokenApi.checkDeviceCodeStatus} for the underlying API call and error handling logic.
+   *
+   * @param deviceCode - The device code to check
+   * @param confirmationCode - The confirmation code to check
+   * @return Promise resolving to true if verified, false if pending, or throws an error for other issues
+   */
+  const checkVerificationStatus = useCallback(
+    async (deviceCode: string, confirmationCode: string) => {
+      try {
+        await tokenApi.checkDeviceCodeStatus(deviceCode, confirmationCode)
+        return true
+      } catch (error) {
+        if (isAppError(error, AppEventCode.AUTHORIZATION_PENDING)) {
+          return false
+        }
+
+        throw error
+      }
+    },
+    [tokenApi]
+  )
+
   return useMemo(
     () => ({
       ...tokenApi, // Spread the base token API to include all its methods
       getCachedIdTokenMetadata,
+      checkVerificationStatus,
     }),
-    [getCachedIdTokenMetadata, tokenApi]
+    [checkVerificationStatus, getCachedIdTokenMetadata, tokenApi]
   )
 }

--- a/app/src/bcsc-theme/services/hooks/useTokenService.tsx
+++ b/app/src/bcsc-theme/services/hooks/useTokenService.tsx
@@ -75,6 +75,10 @@ export const useTokenService = () => {
           return false
         }
 
+        if (isAppError(error, AppEventCode.VERIFY_NOT_COMPLETE)) {
+          return false
+        }
+
         if (isAppError(error, AppEventCode.ALREADY_VERIFIED)) {
           return true
         }

--- a/app/src/errors/errorRegistry.ts
+++ b/app/src/errors/errorRegistry.ts
@@ -387,6 +387,13 @@ export const ErrorRegistry = {
     category: ErrorCategory.VERIFICATION,
     message: 'Verification request was already completed in a previous session',
   },
+  AUTHORIZATION_PENDING: {
+    statusCode: 2411,
+    appEvent: AppEventCode.AUTHORIZATION_PENDING,
+    severity: ErrorSeverity.INFO,
+    category: ErrorCategory.VERIFICATION,
+    message: 'Verification request is still pending - agent has yet to verify request',
+  },
 
   // ============================================
   // Token/Crypto Errors (2500-2599)

--- a/app/src/errors/errorRegistry.ts
+++ b/app/src/errors/errorRegistry.ts
@@ -392,7 +392,7 @@ export const ErrorRegistry = {
     appEvent: AppEventCode.AUTHORIZATION_PENDING,
     severity: ErrorSeverity.INFO,
     category: ErrorCategory.VERIFICATION,
-    message: 'Verification request is still pending - agent has yet to verify request',
+    message: 'Verification request is still pending — agent has yet to verify request',
   },
 
   // ============================================

--- a/app/src/events/appEventCode.ts
+++ b/app/src/events/appEventCode.ts
@@ -109,6 +109,7 @@ export enum AppEventCode {
   ERR_300_EMPTY_RESPONSE = 'err_300_empty_response',
   ERR_500_INVALID_URL = 'err_500_invalid_url',
   ERR_501_INVALID_REGISTRATION_REQUEST = 'err_501_invalid_registration_request',
+  AUTHORIZATION_PENDING = 'authorization_pending',
   RATE_IN_APP_STORE = 'rate_in_app_store',
   VOLUME_TOO_LOW = 'volume_too_low',
   CANCEL_PENDING_BACKCHECK_VERIFICATION = 'cancel_pending_backcheck_verification',


### PR DESCRIPTION
# Summary of Changes

This PR adds proper error handling and pathing for the LiveCallScreen leave call action.

It wil now detect if the authorization request is pending, verified or render an error modal as a catch-all.

# Testing Instructions

Replace this text with detailed instructions on how to test the changes included in this PR.

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
