### PR TITLE
chore: bump bc wallet version

### DIFF
--- a/variants/bcwallet-prod/variant.env
+++ b/variants/bcwallet-prod/variant.env
@@ -3,7 +3,7 @@
 # The apply-variant script exits as a no-op for this variant.
 
 APP_NAME='BC Wallet'
-APP_VERSION='1.0.27'
+APP_VERSION='1.0.28'
 BUILD_TARGET='bcwallet'
 DEFAULT_ENVIRONMENT='PROD'
 


### PR DESCRIPTION
# Summary of Changes

Bump the next version of BC Wallet to 1.0.28 to account for the hot fix for #3625 and #3268. 