### PR TITLE
fix: service errors

### DIFF
--- a/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
@@ -14,6 +14,7 @@ import {
   failedToRetrieveStringResourceErrorPolicy,
   globalAlertErrorPolicy,
   iasErrorPolicy,
+  invalidClientMetadataErrorPolicy,
   invalidRegistrationRequestErrorPolicy,
   invalidUrlErrorPolicy,
   noTokensReturnedErrorPolicy,
@@ -101,6 +102,96 @@ describe('clientErrorPolicies', () => {
         const context = { endpoint: 'https://example.com/device/register', statusCode: 400, apiEndpoints: {} }
         const policy = ClientErrorHandlingPolicies.find((p) => p.matches(error, context as any))
         expect(policy).toBe(iasErrorPolicy)
+      })
+    })
+  })
+
+  describe('invalidClientMetadataErrorPolicy', () => {
+    const newInvalidClientMetadataError = (technicalMessage?: string): AxiosAppError => {
+      const err = new AppError(
+        'This is a test error',
+        {
+          appEvent: AppEventCode.INVALID_CLIENT_METADATA,
+          category: ErrorCategory.GENERAL,
+          statusCode: 2824,
+        },
+        { cause: technicalMessage ? new Error(technicalMessage) : new Error() }
+      )
+      // The policy currently checks `error.code === AppEventCode.INVALID_CLIENT_METADATA`,
+      // so override the auto-generated composite code to satisfy that comparison.
+      err.code = AppEventCode.INVALID_CLIENT_METADATA
+      return err as AxiosAppError
+    }
+
+    describe('matches()', () => {
+      it('should match invalid_client_metadata app event', () => {
+        const error = newInvalidClientMetadataError()
+        expect(invalidClientMetadataErrorPolicy.matches(error, {} as any)).toBeTruthy()
+      })
+
+      it('should NOT match other app events', () => {
+        const error = newError('add_card_server_configuration')
+        expect(invalidClientMetadataErrorPolicy.matches(error, {} as any)).toBeFalsy()
+      })
+
+      it('should resolve to invalidClientMetadataErrorPolicy via ClientErrorHandlingPolicies', () => {
+        const error = newInvalidClientMetadataError()
+        const context = { endpoint: 'https://example.com/device/register', statusCode: 400, apiEndpoints: {} }
+        const policy = ClientErrorHandlingPolicies.find((p) => p.matches(error, context as any))
+        expect(policy).toBe(invalidClientMetadataErrorPolicy)
+      })
+    })
+
+    describe('handle()', () => {
+      it('should call invalidClientMetadataAlert when technicalMessage is missing', () => {
+        const error = newInvalidClientMetadataError()
+        const invalidClientMetadataAlert = jest.fn()
+        const dynamicRegistrationErrorAlert = jest.fn()
+        const context = {
+          alerts: { invalidClientMetadataAlert, dynamicRegistrationErrorAlert },
+        }
+        invalidClientMetadataErrorPolicy.handle(error, context as any)
+        expect(invalidClientMetadataAlert).toHaveBeenCalledTimes(1)
+        expect(invalidClientMetadataAlert).toHaveBeenCalledWith(error)
+        expect(dynamicRegistrationErrorAlert).not.toHaveBeenCalled()
+      })
+
+      it('should call invalidClientMetadataAlert for unrelated technicalMessage', () => {
+        const error = newInvalidClientMetadataError('some unrelated technical detail')
+        const invalidClientMetadataAlert = jest.fn()
+        const dynamicRegistrationErrorAlert = jest.fn()
+        const context = {
+          alerts: { invalidClientMetadataAlert, dynamicRegistrationErrorAlert },
+        }
+        invalidClientMetadataErrorPolicy.handle(error, context as any)
+        expect(invalidClientMetadataAlert).toHaveBeenCalledTimes(1)
+        expect(invalidClientMetadataAlert).toHaveBeenCalledWith(error)
+        expect(dynamicRegistrationErrorAlert).not.toHaveBeenCalled()
+      })
+
+      it('should call dynamicRegistrationErrorAlert when technicalMessage indicates unsupported os', () => {
+        const error = newInvalidClientMetadataError('unsupported os version')
+        const invalidClientMetadataAlert = jest.fn()
+        const dynamicRegistrationErrorAlert = jest.fn()
+        const context = {
+          alerts: { invalidClientMetadataAlert, dynamicRegistrationErrorAlert },
+        }
+        invalidClientMetadataErrorPolicy.handle(error, context as any)
+        expect(dynamicRegistrationErrorAlert).toHaveBeenCalledTimes(1)
+        expect(dynamicRegistrationErrorAlert).toHaveBeenCalledWith(error)
+        expect(invalidClientMetadataAlert).not.toHaveBeenCalled()
+      })
+
+      it('should match unsupported os check case-insensitively', () => {
+        const error = newInvalidClientMetadataError('Client registration failed: Unsupported OS Version detected')
+        const invalidClientMetadataAlert = jest.fn()
+        const dynamicRegistrationErrorAlert = jest.fn()
+        const context = {
+          alerts: { invalidClientMetadataAlert, dynamicRegistrationErrorAlert },
+        }
+        invalidClientMetadataErrorPolicy.handle(error, context as any)
+        expect(dynamicRegistrationErrorAlert).toHaveBeenCalledTimes(1)
+        expect(invalidClientMetadataAlert).not.toHaveBeenCalled()
       })
     })
   })

--- a/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
@@ -107,91 +107,44 @@ describe('clientErrorPolicies', () => {
   })
 
   describe('invalidClientMetadataErrorPolicy', () => {
-    const newInvalidClientMetadataError = (technicalMessage?: string): AxiosAppError => {
-      const err = new AppError(
-        'This is a test error',
-        {
-          appEvent: AppEventCode.INVALID_CLIENT_METADATA,
-          category: ErrorCategory.GENERAL,
-          statusCode: 2824,
-        },
-        { cause: technicalMessage ? new Error(technicalMessage) : new Error() }
-      )
-      // The policy currently checks `error.code === AppEventCode.INVALID_CLIENT_METADATA`,
-      // so override the auto-generated composite code to satisfy that comparison.
-      err.code = AppEventCode.INVALID_CLIENT_METADATA
-      return err as AxiosAppError
-    }
-
     describe('matches()', () => {
-      it('should match invalid_client_metadata app event', () => {
-        const error = newInvalidClientMetadataError()
+      it('should match invalid_client_metadata', () => {
+        const error = newError('invalid_client_metadata')
+        error.code = 'invalid_client_metadata'
         expect(invalidClientMetadataErrorPolicy.matches(error, {} as any)).toBeTruthy()
       })
 
-      it('should NOT match other app events', () => {
-        const error = newError('add_card_server_configuration')
+      it('should NOT match other errors', () => {
+        const error = newError('some_other_error')
         expect(invalidClientMetadataErrorPolicy.matches(error, {} as any)).toBeFalsy()
-      })
-
-      it('should resolve to invalidClientMetadataErrorPolicy via ClientErrorHandlingPolicies', () => {
-        const error = newInvalidClientMetadataError()
-        const context = { endpoint: 'https://example.com/device/register', statusCode: 400, apiEndpoints: {} }
-        const policy = ClientErrorHandlingPolicies.find((p) => p.matches(error, context as any))
-        expect(policy).toBe(invalidClientMetadataErrorPolicy)
       })
     })
 
     describe('handle()', () => {
-      it('should call invalidClientMetadataAlert when technicalMessage is missing', () => {
-        const error = newInvalidClientMetadataError()
-        const invalidClientMetadataAlert = jest.fn()
-        const dynamicRegistrationErrorAlert = jest.fn()
-        const context = {
-          alerts: { invalidClientMetadataAlert, dynamicRegistrationErrorAlert },
-        }
+      it('should show invalid client metadata alert', () => {
+        const error = newError('invalid_client_metadata')
+        const mockAlert = jest.fn()
+        const context = { alerts: { invalidClientMetadataAlert: mockAlert } }
         invalidClientMetadataErrorPolicy.handle(error, context as any)
-        expect(invalidClientMetadataAlert).toHaveBeenCalledTimes(1)
-        expect(invalidClientMetadataAlert).toHaveBeenCalledWith(error)
-        expect(dynamicRegistrationErrorAlert).not.toHaveBeenCalled()
+        expect(mockAlert).toHaveBeenCalledWith(error)
       })
 
-      it('should call invalidClientMetadataAlert for unrelated technicalMessage', () => {
-        const error = newInvalidClientMetadataError('some unrelated technical detail')
-        const invalidClientMetadataAlert = jest.fn()
-        const dynamicRegistrationErrorAlert = jest.fn()
-        const context = {
-          alerts: { invalidClientMetadataAlert, dynamicRegistrationErrorAlert },
-        }
+      it('should show dynamic registration alert when technicalMessage indicates unsupported os', () => {
+        const error = newError('invalid_client_metadata')
+        error.cause = new Error('unsupported os version') as AxiosError
+        const mockAlert = jest.fn()
+        const context = { alerts: { dynamicRegistrationErrorAlert: mockAlert } }
         invalidClientMetadataErrorPolicy.handle(error, context as any)
-        expect(invalidClientMetadataAlert).toHaveBeenCalledTimes(1)
-        expect(invalidClientMetadataAlert).toHaveBeenCalledWith(error)
-        expect(dynamicRegistrationErrorAlert).not.toHaveBeenCalled()
-      })
-
-      it('should call dynamicRegistrationErrorAlert when technicalMessage indicates unsupported os', () => {
-        const error = newInvalidClientMetadataError('unsupported os version')
-        const invalidClientMetadataAlert = jest.fn()
-        const dynamicRegistrationErrorAlert = jest.fn()
-        const context = {
-          alerts: { invalidClientMetadataAlert, dynamicRegistrationErrorAlert },
-        }
-        invalidClientMetadataErrorPolicy.handle(error, context as any)
-        expect(dynamicRegistrationErrorAlert).toHaveBeenCalledTimes(1)
-        expect(dynamicRegistrationErrorAlert).toHaveBeenCalledWith(error)
-        expect(invalidClientMetadataAlert).not.toHaveBeenCalled()
+        expect(mockAlert).toHaveBeenCalledWith(error)
       })
 
       it('should match unsupported os check case-insensitively', () => {
-        const error = newInvalidClientMetadataError('Client registration failed: Unsupported OS Version detected')
-        const invalidClientMetadataAlert = jest.fn()
-        const dynamicRegistrationErrorAlert = jest.fn()
-        const context = {
-          alerts: { invalidClientMetadataAlert, dynamicRegistrationErrorAlert },
-        }
+        const error = newError('invalid_client_metadata')
+        error.cause = new Error('Client registration failed: Unsupported OS Version detected') as AxiosError
+        const mockAlert = jest.fn()
+        const context = { alerts: { dynamicRegistrationErrorAlert: mockAlert } }
         invalidClientMetadataErrorPolicy.handle(error, context as any)
-        expect(dynamicRegistrationErrorAlert).toHaveBeenCalledTimes(1)
-        expect(invalidClientMetadataAlert).not.toHaveBeenCalled()
+        expect(mockAlert).toHaveBeenCalledWith(error)
       })
     })
   })

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -11,6 +11,8 @@ import { VerificationCardError } from '../features/verify/verificationCardError'
 import { BCSCScreens } from '../types/navigators'
 import { BCSCEndpoints } from './client'
 
+const IAS_UNSUPPORTED_OS_MESSAGE = 'Unsupported OS version'
+
 export type ErrorMatcherContext = {
   endpoint: string // current route name for context
   statusCode: number // HTTP status code for context
@@ -73,6 +75,7 @@ const _getIasErrorAlertMap = (alerts?: AppAlerts) => {
   return new Map([
     [AppEventCode.ADD_CARD_SERVER_CONFIGURATION, alerts?.serverConfigurationAlert],
     [AppEventCode.ADD_CARD_DYNAMIC_REGISTRATION, alerts?.dynamicRegistrationErrorAlert],
+    [AppEventCode.INVALID_CLIENT_METADATA, alerts?.invalidClientMetadataAlert],
     [AppEventCode.ADD_CARD_TERMS_OF_USE, alerts?.termsOfUseErrorAlert],
     [AppEventCode.ADD_CARD_INCORRECT_OS, alerts?.incorrectOsAlert],
     [AppEventCode.ADD_CARD_PROVIDER, alerts?.addCardNotAvailableAlert],
@@ -104,6 +107,12 @@ export const iasErrorPolicy: ErrorHandlingPolicy = {
 
     if (!alert) {
       context.logger.warn(`[IasErrorPolicy] No alert defined for app event: ${error.appEvent}`)
+      return
+    }
+
+    if (error.technicalMessage?.includes(IAS_UNSUPPORTED_OS_MESSAGE)) {
+      // Special case for unsupported OS
+      context.alerts.dynamicRegistrationErrorAlert(error)
       return
     }
 

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -11,7 +11,7 @@ import { VerificationCardError } from '../features/verify/verificationCardError'
 import { BCSCScreens } from '../types/navigators'
 import { BCSCEndpoints } from './client'
 
-const IAS_UNSUPPORTED_OS_MESSAGE = 'Unsupported OS version'
+const UNSUPPORTED_OS_TECHNICAL_MESSAGE = 'unsupported os version'
 
 export type ErrorMatcherContext = {
   endpoint: string // current route name for context
@@ -110,7 +110,7 @@ export const iasErrorPolicy: ErrorHandlingPolicy = {
       return
     }
 
-    if (error.technicalMessage?.includes(IAS_UNSUPPORTED_OS_MESSAGE)) {
+    if (error.technicalMessage?.toLowerCase().includes(UNSUPPORTED_OS_TECHNICAL_MESSAGE)) {
       // Special case for unsupported OS
       context.alerts.dynamicRegistrationErrorAlert(error)
       return

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -75,7 +75,6 @@ const _getIasErrorAlertMap = (alerts?: AppAlerts) => {
   return new Map([
     [AppEventCode.ADD_CARD_SERVER_CONFIGURATION, alerts?.serverConfigurationAlert],
     [AppEventCode.ADD_CARD_DYNAMIC_REGISTRATION, alerts?.dynamicRegistrationErrorAlert],
-    [AppEventCode.INVALID_CLIENT_METADATA, alerts?.invalidClientMetadataAlert],
     [AppEventCode.ADD_CARD_TERMS_OF_USE, alerts?.termsOfUseErrorAlert],
     [AppEventCode.ADD_CARD_INCORRECT_OS, alerts?.incorrectOsAlert],
     [AppEventCode.ADD_CARD_PROVIDER, alerts?.addCardNotAvailableAlert],
@@ -110,13 +109,21 @@ export const iasErrorPolicy: ErrorHandlingPolicy = {
       return
     }
 
+    alert(error)
+  },
+}
+
+// Error policy for INVALID_CLIENT_METADATA — handles client metadata fetch failures with special case for unsupported OS versions
+export const invalidClientMetadataErrorPolicy: ErrorHandlingPolicy = {
+  matches: (error) => {
+    return error.appEvent === AppEventCode.INVALID_CLIENT_METADATA
+  },
+  handle: (error, context) => {
     if (error.technicalMessage?.toLowerCase().includes(UNSUPPORTED_OS_TECHNICAL_MESSAGE)) {
-      // Special case for unsupported OS
-      context.alerts.dynamicRegistrationErrorAlert(error)
-      return
+      return context.alerts.dynamicRegistrationErrorAlert(error)
     }
 
-    alert(error)
+    context.alerts.invalidClientMetadataAlert(error)
   },
 }
 
@@ -425,6 +432,7 @@ export const ClientErrorHandlingPolicies: ErrorHandlingPolicy[] = [
   invalidRegistrationRequestErrorPolicy,
   videoSessionErrorPolicy,
   attestationPollingErrorPolicy,
+  invalidClientMetadataErrorPolicy,
   iasErrorPolicy,
   // Specific polices listed above, followed by global policies
   globalAlertErrorPolicy,

--- a/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
@@ -66,7 +66,7 @@ export const BCSCApiClientProvider: React.FC<{ children: React.ReactNode }> = ({
       if (!policy) {
         logger.info('[BCSCApiClient] No error handling policy for:', {
           endpoint: context.endpoint,
-          appEvent: error.appEvent,
+          appEvent: error.cause.code,
         })
         return
       }

--- a/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
@@ -66,7 +66,7 @@ export const BCSCApiClientProvider: React.FC<{ children: React.ReactNode }> = ({
       if (!policy) {
         logger.info('[BCSCApiClient] No error handling policy for:', {
           endpoint: context.endpoint,
-          appEvent: error.cause.code,
+          appEvent: error.cause.code, // Bubble up original error code
         })
         return
       }

--- a/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
@@ -66,7 +66,8 @@ export const BCSCApiClientProvider: React.FC<{ children: React.ReactNode }> = ({
       if (!policy) {
         logger.info('[BCSCApiClient] No error handling policy for:', {
           endpoint: context.endpoint,
-          appEvent: error.cause.code, // Bubble up original error code
+          appEvent: error.appEvent,
+          errorCode: error.cause.code,
         })
         return
       }

--- a/app/src/errors/errorRegistry.ts
+++ b/app/src/errors/errorRegistry.ts
@@ -795,6 +795,13 @@ export const ErrorRegistry = {
     category: ErrorCategory.VERIFICATION,
     message: 'Service hours API returned a malformed time string — expected HH:MM format',
   },
+  INVALID_CLIENT_METADATA: {
+    statusCode: 2824,
+    appEvent: AppEventCode.INVALID_CLIENT_METADATA,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.GENERAL,
+    message: 'Client metadata is invalid — missing required fields or contains invalid values',
+  },
 
   // ============================================
   // Wallet/Agent Errors (2900-2999)

--- a/app/src/events/appEventCode.ts
+++ b/app/src/events/appEventCode.ts
@@ -146,6 +146,7 @@ export enum AppEventCode {
   NON_BCSC_WAS_DISABLED = 'non_bcsc_was_disabled',
   TOO_MANY_ACTIVE_ACCOUNTS = 'too_many_active_accounts',
   DEVICE_AUTHORIZATION_ERROR = 'device_authorization_error',
+  INVALID_CLIENT_METADATA = 'invalid_client_metadata',
   DEVICE_AUTHENTICATION_ERROR = 'device_authentication_error', // Non-IAS error code
   FATAL_UNRECOVERABLE_ERROR = 'fatal_unrecoverable_error', // Non-IAS error code
   UNKNOWN_ERROR_BOUNDARY_ERROR = 'unknown_error_boundary_error', // Non-IAS error code

--- a/app/src/hooks/useAlerts.test.tsx
+++ b/app/src/hooks/useAlerts.test.tsx
@@ -1405,8 +1405,8 @@ describe('useAlerts', () => {
         result.current.incorrectOsAlert()
 
         expect(mockEmitErrorModal).toHaveBeenCalledWith(
-          'Alerts.ProblemWithService.Title',
-          'Alerts.ProblemWithService.Description',
+          'Alerts.DynamicRegistrationError.Title',
+          'Alerts.DynamicRegistrationError.Description',
           expect.objectContaining({ appEvent: AppEventCode.ADD_CARD_INCORRECT_OS })
         )
       })

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -332,6 +332,7 @@ export const useAlerts = (navigation: NavigationProp<any>) => {
       loginRejected400Alert: _createProblemWithAccountErrorModal(AppEventCode.LOGIN_REJECTED_400, '400-1'),
       noTokensReturnedAlert: _createProblemWithAccountErrorModal(AppEventCode.NO_TOKENS_RETURNED, '214'),
       invalidTokenAlert: _createProblemWithAccountErrorModal(AppEventCode.INVALID_TOKEN, '215'),
+      invalidClientMetadataAlert: _createBasicErrorModal(AppEventCode.INVALID_CLIENT_METADATA, 'ProblemWithApp'),
       serverConfigurationAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_SERVER_CONFIGURATION, 'ProblemWithService', { errorCode: '201' }),
       dynamicRegistrationErrorAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_DYNAMIC_REGISTRATION, 'DynamicRegistrationError', { errorCode: '202' }),
       termsOfUseErrorAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_TERMS_OF_USE, 'ProblemWithService', { errorCode: '203' }),

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -332,7 +332,7 @@ export const useAlerts = (navigation: NavigationProp<any>) => {
       loginRejected400Alert: _createProblemWithAccountErrorModal(AppEventCode.LOGIN_REJECTED_400, '400-1'),
       noTokensReturnedAlert: _createProblemWithAccountErrorModal(AppEventCode.NO_TOKENS_RETURNED, '214'),
       invalidTokenAlert: _createProblemWithAccountErrorModal(AppEventCode.INVALID_TOKEN, '215'),
-      invalidClientMetadataAlert: _createBasicErrorModal(AppEventCode.INVALID_CLIENT_METADATA, 'ProblemWithApp'),
+      invalidClientMetadataAlert: _createBasicErrorModal(AppEventCode.INVALID_CLIENT_METADATA, 'ProblemWithApp', { errorCode: '222' }), // Note: Using 222 error code as placeholder
       serverConfigurationAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_SERVER_CONFIGURATION, 'ProblemWithService', { errorCode: '201' }),
       dynamicRegistrationErrorAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_DYNAMIC_REGISTRATION, 'DynamicRegistrationError', { errorCode: '202' }),
       termsOfUseErrorAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_TERMS_OF_USE, 'ProblemWithService', { errorCode: '203' }),

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -189,35 +189,6 @@ export const useAlerts = (navigation: NavigationProp<any>) => {
     })
   }, [emitAlert, logger, t, factoryReset])
 
-  // IAS error 202, 203, 204 — OK closes alert and returns to Start Setup
-  const _createProblemWithServiceReturnToSetupAlert = useCallback(
-    (event: AppEventCode, alertKey: string, params?: Record<string, unknown>) => {
-      return (error?: AppError | unknown) => {
-        emitErrorModal(
-          t(`Alerts.${alertKey}.Title`, params),
-          t(`Alerts.${alertKey}.Description`, params),
-          ensureAppError(error, event)
-          // FIXME: This won't reset the state of the application. Will need to use `useVerificationReset` hook.
-          // Additionally, will need to update `useVerificationHook` to remove the `useAlerts` dependency to prevent circular dep issue.
-          // {
-          //   action: {
-          //     text: t('Global.OK'),
-          //     onPress: () => {
-          //       navigation.dispatch(
-          //         CommonActions.reset({
-          //           index: 0,
-          //           routes: [{ name: BCSCScreens.SetupSteps }],
-          //         })
-          //       )
-          //     },
-          //   },
-          // }
-        )
-      }
-    },
-    [emitErrorModal, t]
-  )
-
   const liveCallFileUploadAlert = useCallback(() => {
     emitAlert(t('Alerts.LiveCallFileUploadError.Title'), t('Alerts.LiveCallFileUploadError.Description'), {
       event: AppEventCode.LIVE_CALL_FILE_UPLOAD_ERROR,
@@ -362,9 +333,9 @@ export const useAlerts = (navigation: NavigationProp<any>) => {
       noTokensReturnedAlert: _createProblemWithAccountErrorModal(AppEventCode.NO_TOKENS_RETURNED, '214'),
       invalidTokenAlert: _createProblemWithAccountErrorModal(AppEventCode.INVALID_TOKEN, '215'),
       serverConfigurationAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_SERVER_CONFIGURATION, 'ProblemWithService', { errorCode: '201' }),
-      dynamicRegistrationErrorAlert: _createProblemWithServiceReturnToSetupAlert(AppEventCode.ADD_CARD_DYNAMIC_REGISTRATION, 'DynamicRegistrationError'),
-      termsOfUseErrorAlert: _createProblemWithServiceReturnToSetupAlert(AppEventCode.ADD_CARD_TERMS_OF_USE, 'ProblemWithService', { errorCode: '203' }),
-      incorrectOsAlert: _createProblemWithServiceReturnToSetupAlert(AppEventCode.ADD_CARD_INCORRECT_OS, 'ProblemWithService', { errorCode: '204' }),
+      dynamicRegistrationErrorAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_DYNAMIC_REGISTRATION, 'DynamicRegistrationError', { errorCode: '202' }),
+      termsOfUseErrorAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_TERMS_OF_USE, 'ProblemWithService', { errorCode: '203' }),
+      incorrectOsAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_INCORRECT_OS, 'DynamicRegistrationError', { errorCode: '204' }),
       addCardNotAvailableAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_PROVIDER, 'AddCardNotAvailable'),
       missingJsonValuesAlert: _createBasicErrorModal(AppEventCode.ERR_206_MISSING_OR_NULL_VALUES_IN_JSON_RESPONSE, 'ProblemWithApp', { errorCode: '206' }),
       signClaimsErrorAlert: _createBasicErrorModal(AppEventCode.ERR_207_UNABLE_TO_SIGN_CLAIMS_SET, 'ProblemWithApp', { errorCode: '207' }),
@@ -392,7 +363,6 @@ export const useAlerts = (navigation: NavigationProp<any>) => {
       factoryResetErrorModal,
       _createBasicErrorModal,
       _createProblemWithAccountErrorModal,
-      _createProblemWithServiceReturnToSetupAlert,
     ]
   )
 }

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -1147,7 +1147,7 @@ const translation = {
     },
     "DynamicRegistrationError": {
       "Title": "Problem with Service",
-      "Description": "The OS on this device is not supported. Please update your device and make sure it's not a beta version. (error 202)"
+      "Description": "The OS on this device is not supported. Please update your device and make sure it's not a beta version. (error {{ errorCode }})"
     },
     "AddCardNotAvailable": {
       "Title": "Add Card Not Available",


### PR DESCRIPTION
# Summary of Changes

This PR refines the service errors language and adds support for "invalid_client_metadata".


# Testing Instructions

Wrong OS error modal "dynamic_registration_error"
1. Update the system version in `addDeviceInfoClaims` to be an invalid value. ie: "999.99.99"
https://github.com/bcgov/bc-wallet-mobile/blob/2ee6a5cae7b5cf45f4c1bc7fe23f85a0188aa350/packages/bcsc-core/ios/BcscCore.swift#L1388
2. Go through onboarding
3. Wrong OS error modal appears

Problem with app error modal "invalid_client_metadata"
1. Update system version to be a number
2. Problem with App error modal appears

# Acceptance Criteria

Error modals appear
# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
