### PR TITLE
fix(registration): track build number and force update on v3→v4 upgrade

### DIFF
--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -69,7 +69,6 @@ class BCSCApiClient {
   tokens?: TokenResponse // this token will be used to interact and access data from IAS servers
   tokensPromise: Promise<TokenResponse> | null // to prevent multiple simultaneous token fetches
   onError?: BCSCClientOnErrorCallback
-  private requestCounter = 0
 
   constructor(baseURL: string, logger: RemoteLogger) {
     this.baseURL = baseURL
@@ -126,17 +125,7 @@ class BCSCApiClient {
 
     // Add interceptors
     this.client.interceptors.request.use(this.handleRequest.bind(this))
-    this.client.interceptors.response.use(
-      (response) => {
-        const reqId = (response.config as any).__reqId as number | undefined
-        const startTime = (response.config as any).__startTime as number | undefined
-        const elapsed = startTime ? `${Date.now() - startTime}ms` : '?ms'
-        this.logger.info(
-          `[DEBUG] [${new Date().toISOString()}] [req#${reqId}] RESPONSE ${response.status} ${String(response.config.url)} (${elapsed})`
-        )
-        return response
-      },
-      async (_error: unknown) => {
+    this.client.interceptors.response.use(undefined, async (_error: unknown) => {
       // Pass through errors that are already AppErrors (e.g. from request interceptor)
       if (_error instanceof AppError) {
         throw _error
@@ -149,13 +138,6 @@ class BCSCApiClient {
 
       // 1. Format the error - update error code and message properties from IAS response
       const error = formatIasAxiosResponseError(_error)
-
-      const reqId = (error.config as any)?.__reqId as number | undefined
-      const startTime = (error.config as any)?.__startTime as number | undefined
-      const elapsed = startTime ? `${Date.now() - startTime}ms` : '?ms'
-      this.logger.info(
-        `[DEBUG] [${new Date().toISOString()}] [req#${reqId}] ERROR ${error.response?.status ?? 'N/A'} ${String(error.config?.url)} (${elapsed})`
-      )
 
       // 2. Convert the axios error into an AppError
       const appError = getAppErrorFromAxiosError(error)
@@ -281,12 +263,7 @@ class BCSCApiClient {
   }
 
   private async handleRequest(config: InternalAxiosRequestConfig): Promise<InternalAxiosRequestConfig> {
-    const reqId = ++this.requestCounter
-    ;(config as any).__reqId = reqId
-    ;(config as any).__startTime = Date.now()
-    this.logger.info(
-      `[DEBUG] [${new Date().toISOString()}] [req#${reqId}] REQUEST ${config.method?.toUpperCase()} ${String(config.url)} skipAuth=${!!config.skipBearerAuth}`
-    )
+    this.logger.info(`[${config.method?.toUpperCase()}] ${String(config.url)}`)
 
     // skip processing if skipBearerAuth is set in the config
     if (config.skipBearerAuth) {

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -69,6 +69,7 @@ class BCSCApiClient {
   tokens?: TokenResponse // this token will be used to interact and access data from IAS servers
   tokensPromise: Promise<TokenResponse> | null // to prevent multiple simultaneous token fetches
   onError?: BCSCClientOnErrorCallback
+  private requestCounter = 0
 
   constructor(baseURL: string, logger: RemoteLogger) {
     this.baseURL = baseURL
@@ -125,7 +126,17 @@ class BCSCApiClient {
 
     // Add interceptors
     this.client.interceptors.request.use(this.handleRequest.bind(this))
-    this.client.interceptors.response.use(undefined, async (_error: unknown) => {
+    this.client.interceptors.response.use(
+      (response) => {
+        const reqId = (response.config as any).__reqId as number | undefined
+        const startTime = (response.config as any).__startTime as number | undefined
+        const elapsed = startTime ? `${Date.now() - startTime}ms` : '?ms'
+        this.logger.info(
+          `[DEBUG] [${new Date().toISOString()}] [req#${reqId}] RESPONSE ${response.status} ${String(response.config.url)} (${elapsed})`
+        )
+        return response
+      },
+      async (_error: unknown) => {
       // Pass through errors that are already AppErrors (e.g. from request interceptor)
       if (_error instanceof AppError) {
         throw _error
@@ -138,6 +149,13 @@ class BCSCApiClient {
 
       // 1. Format the error - update error code and message properties from IAS response
       const error = formatIasAxiosResponseError(_error)
+
+      const reqId = (error.config as any)?.__reqId as number | undefined
+      const startTime = (error.config as any)?.__startTime as number | undefined
+      const elapsed = startTime ? `${Date.now() - startTime}ms` : '?ms'
+      this.logger.info(
+        `[DEBUG] [${new Date().toISOString()}] [req#${reqId}] ERROR ${error.response?.status ?? 'N/A'} ${String(error.config?.url)} (${elapsed})`
+      )
 
       // 2. Convert the axios error into an AppError
       const appError = getAppErrorFromAxiosError(error)
@@ -263,7 +281,12 @@ class BCSCApiClient {
   }
 
   private async handleRequest(config: InternalAxiosRequestConfig): Promise<InternalAxiosRequestConfig> {
-    this.logger.info(`[${config.method?.toUpperCase()}] ${String(config.url)}`)
+    const reqId = ++this.requestCounter
+    ;(config as any).__reqId = reqId
+    ;(config as any).__startTime = Date.now()
+    this.logger.info(
+      `[DEBUG] [${new Date().toISOString()}] [req#${reqId}] REQUEST ${config.method?.toUpperCase()} ${String(config.url)} skipAuth=${!!config.skipBearerAuth}`
+    )
 
     // skip processing if skipBearerAuth is set in the config
     if (config.skipBearerAuth) {

--- a/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
+++ b/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
@@ -139,7 +139,14 @@ export const useCreateSystemChecks = (): UseGetSystemChecksReturn => {
 
     // Only run device registration update check for BCSC builds (ie: bundleId ca.bc.gov.id.servicescard)
     if (isBCServicesCardBundle) {
-      systemChecks.push(new UpdateDeviceRegistrationSystemCheck(store.bcsc.appVersion, updateRegistration, utils))
+      systemChecks.push(
+        new UpdateDeviceRegistrationSystemCheck(
+          store.bcsc.appVersion,
+          store.bcsc.appBuildNumber,
+          updateRegistration,
+          utils
+        )
+      )
     }
     return systemChecks
   }, [
@@ -153,6 +160,7 @@ export const useCreateSystemChecks = (): UseGetSystemChecksReturn => {
     store.bcscSecure.registrationAccessToken,
     store.bcsc.selectedNickname,
     store.bcsc.appVersion,
+    store.bcsc.appBuildNumber,
   ])
 
   return useMemo(() => {

--- a/app/src/services/system-checks/UpdateDeviceRegistrationSystemCheck.test.ts
+++ b/app/src/services/system-checks/UpdateDeviceRegistrationSystemCheck.test.ts
@@ -12,8 +12,7 @@ describe('UpdateDeviceRegistrationSystemCheck', () => {
     jest.useRealTimers()
   })
   describe('runCheck', () => {
-    it('should return true when app version is the same', async () => {
-      const mockAppVersion = '1.0.0'
+    it('should return true when app version and build number are the same', async () => {
       const mockUtils = {
         dispatch: jest.fn(),
         translation: jest.fn() as any,
@@ -21,18 +20,17 @@ describe('UpdateDeviceRegistrationSystemCheck', () => {
       }
       const updateRegistrationMock = jest.fn()
 
-      const mockGetVersion = jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('1.0.0')
+      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('1.0.0')
+      jest.spyOn(deviceInfo, 'getBuildNumber').mockReturnValue('100')
 
-      const systemCheck = new UpdateDeviceRegistrationSystemCheck(mockAppVersion, updateRegistrationMock, mockUtils)
+      const systemCheck = new UpdateDeviceRegistrationSystemCheck('1.0.0', '100', updateRegistrationMock, mockUtils)
 
       const result = systemCheck.runCheck()
 
-      expect(mockGetVersion).toHaveBeenCalled()
       expect(result).toBe(true)
     })
 
     it('should return false when app version is different', async () => {
-      const mockAppVersion = '1.0.0'
       const mockUtils = {
         dispatch: jest.fn(),
         translation: jest.fn() as any,
@@ -40,19 +38,72 @@ describe('UpdateDeviceRegistrationSystemCheck', () => {
       }
       const updateRegistrationMock = jest.fn()
 
-      const mockGetVersion = jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('1.0.1')
+      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('1.0.1')
+      jest.spyOn(deviceInfo, 'getBuildNumber').mockReturnValue('100')
 
-      const systemCheck = new UpdateDeviceRegistrationSystemCheck(mockAppVersion, updateRegistrationMock, mockUtils)
+      const systemCheck = new UpdateDeviceRegistrationSystemCheck('1.0.0', '100', updateRegistrationMock, mockUtils)
 
       const result = systemCheck.runCheck()
 
-      expect(mockGetVersion).toHaveBeenCalled()
+      expect(result).toBe(false)
+    })
+
+    it('should return false when build number is different', async () => {
+      const mockUtils = {
+        dispatch: jest.fn(),
+        translation: jest.fn() as any,
+        logger: new MockLogger(),
+      }
+      const updateRegistrationMock = jest.fn()
+
+      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('1.0.0')
+      jest.spyOn(deviceInfo, 'getBuildNumber').mockReturnValue('200')
+
+      const systemCheck = new UpdateDeviceRegistrationSystemCheck('1.0.0', '100', updateRegistrationMock, mockUtils)
+
+      const result = systemCheck.runCheck()
+
+      expect(result).toBe(false)
+    })
+
+    it('should return false when stored version is blank (v3→v4 upgrade)', async () => {
+      const mockUtils = {
+        dispatch: jest.fn(),
+        translation: jest.fn() as any,
+        logger: new MockLogger(),
+      }
+      const updateRegistrationMock = jest.fn()
+
+      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.0.0')
+      jest.spyOn(deviceInfo, 'getBuildNumber').mockReturnValue('5937')
+
+      const systemCheck = new UpdateDeviceRegistrationSystemCheck('', '', updateRegistrationMock, mockUtils)
+
+      const result = systemCheck.runCheck()
+
+      expect(result).toBe(false)
+    })
+
+    it('should return false when stored build number is blank', async () => {
+      const mockUtils = {
+        dispatch: jest.fn(),
+        translation: jest.fn() as any,
+        logger: new MockLogger(),
+      }
+      const updateRegistrationMock = jest.fn()
+
+      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('1.0.0')
+      jest.spyOn(deviceInfo, 'getBuildNumber').mockReturnValue('100')
+
+      const systemCheck = new UpdateDeviceRegistrationSystemCheck('1.0.0', '', updateRegistrationMock, mockUtils)
+
+      const result = systemCheck.runCheck()
+
       expect(result).toBe(false)
     })
   })
   describe('onFail', () => {
     it('should update registration and dispatch the new app version', async () => {
-      const mockAppVersion = '1.0.0'
       const mockUtils = {
         dispatch: jest.fn(),
         translation: jest.fn() as any,
@@ -60,7 +111,7 @@ describe('UpdateDeviceRegistrationSystemCheck', () => {
       }
       const updateRegistrationMock = jest.fn()
 
-      const systemCheck = new UpdateDeviceRegistrationSystemCheck(mockAppVersion, updateRegistrationMock, mockUtils)
+      const systemCheck = new UpdateDeviceRegistrationSystemCheck('1.0.0', '100', updateRegistrationMock, mockUtils)
 
       await systemCheck.onFail()
 
@@ -68,7 +119,6 @@ describe('UpdateDeviceRegistrationSystemCheck', () => {
       expect(updateRegistrationMock).toHaveBeenCalled()
     })
     it('should log an error if update registration fails', async () => {
-      const mockAppVersion = '1.0.0'
       const mockUtils = {
         dispatch: jest.fn(),
         translation: jest.fn() as any,
@@ -77,7 +127,7 @@ describe('UpdateDeviceRegistrationSystemCheck', () => {
       const error = new Error('Registration failed')
       const updateRegistrationMock = jest.fn().mockRejectedValue(error)
 
-      const systemCheck = new UpdateDeviceRegistrationSystemCheck(mockAppVersion, updateRegistrationMock, mockUtils)
+      const systemCheck = new UpdateDeviceRegistrationSystemCheck('1.0.0', '100', updateRegistrationMock, mockUtils)
 
       await systemCheck.onFail()
 

--- a/app/src/services/system-checks/UpdateDeviceRegistrationSystemCheck.test.ts
+++ b/app/src/services/system-checks/UpdateDeviceRegistrationSystemCheck.test.ts
@@ -10,6 +10,7 @@ describe('UpdateDeviceRegistrationSystemCheck', () => {
 
   afterEach(() => {
     jest.useRealTimers()
+    jest.restoreAllMocks()
   })
   describe('runCheck', () => {
     it('should return true when app version and build number are the same', async () => {

--- a/app/src/services/system-checks/UpdateDeviceRegistrationSystemCheck.ts
+++ b/app/src/services/system-checks/UpdateDeviceRegistrationSystemCheck.ts
@@ -43,9 +43,11 @@ export class UpdateDeviceRegistrationSystemCheck implements SystemCheckStrategy 
   }
 
   async onFail() {
-    this.utils.logger.info(
-      'UpdateDeviceRegistrationSystemCheck: Updating device registration due to version/build change'
-    )
+    const reason =
+      !this.lastAppVersion || !this.lastAppBuildNumber
+        ? 'missing stored version/build (first run or upgrade)'
+        : 'version/build change'
+    this.utils.logger.info(`UpdateDeviceRegistrationSystemCheck: Updating device registration due to ${reason}`)
 
     try {
       await this.updateRegistration()

--- a/app/src/services/system-checks/UpdateDeviceRegistrationSystemCheck.ts
+++ b/app/src/services/system-checks/UpdateDeviceRegistrationSystemCheck.ts
@@ -1,6 +1,6 @@
 import { RegistrationResponseData } from '@/bcsc-theme/api/hooks/useRegistrationApi'
 import { BCDispatchAction } from '@/store'
-import { getVersion } from 'react-native-device-info'
+import { getBuildNumber, getVersion } from 'react-native-device-info'
 import { SystemCheckStrategy, SystemCheckUtils } from './system-checks'
 
 type UpdateRegistrationFunction = () => Promise<RegistrationResponseData>
@@ -9,38 +9,48 @@ type UpdateRegistrationFunction = () => Promise<RegistrationResponseData>
  * Checks conditions to determine if the device registration needs to be updated.
  *
  * Currently supports:
- *    - App version mismatch (previously registered app version differs from current app version)
+ *    - App version or build number mismatch
+ *    - Blank stored values (v3→v4 upgrade or first run)
  *
  * @class UpdateDeviceRegistrationSystemCheck
  * @implements {SystemCheckStrategy}
  */
 export class UpdateDeviceRegistrationSystemCheck implements SystemCheckStrategy {
   private readonly lastAppVersion: string
+  private readonly lastAppBuildNumber: string
   private readonly updateRegistration: UpdateRegistrationFunction
   private readonly utils: SystemCheckUtils
 
-  constructor(lastAppVersion: string, updateRegistration: UpdateRegistrationFunction, utils: SystemCheckUtils) {
+  constructor(
+    lastAppVersion: string,
+    lastAppBuildNumber: string,
+    updateRegistration: UpdateRegistrationFunction,
+    utils: SystemCheckUtils
+  ) {
     this.lastAppVersion = lastAppVersion
+    this.lastAppBuildNumber = lastAppBuildNumber
     this.utils = utils
     this.updateRegistration = updateRegistration
   }
 
-  /**
-   * Runs the device registration update check to verify if the device registration needs to be updated.
-   *
-   * @returns {*} {boolean} - A boolean indicating if the device registration is up to date.
-   */
   runCheck() {
-    return this.lastAppVersion === getVersion()
+    const currentVersion = getVersion()
+    const currentBuild = getBuildNumber()
+
+    this.utils.logger.info(
+      `[DEBUG] UpdateDeviceRegistrationSystemCheck: stored=${this.lastAppVersion}(${this.lastAppBuildNumber}) current=${currentVersion}(${currentBuild})`
+    )
+
+    // Force update if stored values are blank (v3→v4 upgrade or first run)
+    if (!this.lastAppVersion || !this.lastAppBuildNumber) {
+      return false
+    }
+
+    return this.lastAppVersion === currentVersion && this.lastAppBuildNumber === currentBuild
   }
 
-  /**
-   * Handles the failure case where the device registration needs to be updated.
-   *
-   * @returns {*} {Promise<void>} - A promise that resolves when the device registration update process is complete.
-   */
   async onFail() {
-    this.utils.logger.info('UpdateDeviceRegistrationSystemCheck: Updating device registration due to version change')
+    this.utils.logger.info('UpdateDeviceRegistrationSystemCheck: Updating device registration due to version/build change')
 
     try {
       await this.updateRegistration()

--- a/app/src/services/system-checks/UpdateDeviceRegistrationSystemCheck.ts
+++ b/app/src/services/system-checks/UpdateDeviceRegistrationSystemCheck.ts
@@ -43,7 +43,9 @@ export class UpdateDeviceRegistrationSystemCheck implements SystemCheckStrategy 
   }
 
   async onFail() {
-    this.utils.logger.info('UpdateDeviceRegistrationSystemCheck: Updating device registration due to version/build change')
+    this.utils.logger.info(
+      'UpdateDeviceRegistrationSystemCheck: Updating device registration due to version/build change'
+    )
 
     try {
       await this.updateRegistration()

--- a/app/src/services/system-checks/UpdateDeviceRegistrationSystemCheck.ts
+++ b/app/src/services/system-checks/UpdateDeviceRegistrationSystemCheck.ts
@@ -34,19 +34,12 @@ export class UpdateDeviceRegistrationSystemCheck implements SystemCheckStrategy 
   }
 
   runCheck() {
-    const currentVersion = getVersion()
-    const currentBuild = getBuildNumber()
-
-    this.utils.logger.info(
-      `[DEBUG] UpdateDeviceRegistrationSystemCheck: stored=${this.lastAppVersion}(${this.lastAppBuildNumber}) current=${currentVersion}(${currentBuild})`
-    )
-
     // Force update if stored values are blank (v3→v4 upgrade or first run)
     if (!this.lastAppVersion || !this.lastAppBuildNumber) {
       return false
     }
 
-    return this.lastAppVersion === currentVersion && this.lastAppBuildNumber === currentBuild
+    return this.lastAppVersion === getVersion() && this.lastAppBuildNumber === getBuildNumber()
   }
 
   async onFail() {

--- a/app/src/store.test.ts
+++ b/app/src/store.test.ts
@@ -1,5 +1,5 @@
 import Config from 'react-native-config'
-import { getInitialEnvironment, IASEnvironment } from './store'
+import { getInitialEnvironment, IASEnvironment, reducer, initialState, BCDispatchAction } from './store'
 
 jest.mock('react-native-config', () => ({
   BUILD_TARGET: 'bcsc',
@@ -8,13 +8,15 @@ jest.mock('react-native-config', () => ({
 
 jest.mock('react-native-device-info', () => ({
   getVersion: jest.fn(() => '4.0.0'),
+  getBuildNumber: jest.fn(() => '100'),
 }))
 
 jest.mock('react-native-bcsc-core', () => ({}))
 jest.mock('@bifold/core', () => ({
   defaultState: { preferences: {}, tours: {}, onboarding: {}, loginAttempt: {}, migration: {} },
-  mergeReducers: jest.fn(),
+  mergeReducers: jest.fn((_base: any, custom: any) => custom),
   reducer: jest.fn(),
+  PersistentStorage: { storeValueForKey: jest.fn() },
 }))
 
 const configMock = Config as { DEFAULT_ENVIRONMENT: string; BUILD_TARGET: string }
@@ -83,5 +85,15 @@ describe('getInitialEnvironment', () => {
     configMock.DEFAULT_ENVIRONMENT = 'INVALID'
     configMock.BUILD_TARGET = 'bcwallet'
     expect(getInitialEnvironment()).toBe(IASEnvironment.PROD)
+  })
+})
+
+describe('reducer', () => {
+  it('UPDATE_APP_VERSION sets appVersion and appBuildNumber', () => {
+    const state = { ...initialState, bcsc: { ...initialState.bcsc, appVersion: '', appBuildNumber: '' } }
+    const result = reducer(state, { type: BCDispatchAction.UPDATE_APP_VERSION })
+
+    expect(result.bcsc.appVersion).toBe('4.0.0')
+    expect(result.bcsc.appBuildNumber).toBe('100')
   })
 })

--- a/app/src/store.test.ts
+++ b/app/src/store.test.ts
@@ -1,5 +1,5 @@
 import Config from 'react-native-config'
-import { getInitialEnvironment, IASEnvironment, reducer, initialState, BCDispatchAction } from './store'
+import { BCDispatchAction, getInitialEnvironment, IASEnvironment, initialState, reducer } from './store'
 
 jest.mock('react-native-config', () => ({
   BUILD_TARGET: 'bcsc',

--- a/app/src/store.tsx
+++ b/app/src/store.tsx
@@ -8,7 +8,7 @@ import {
 } from '@bifold/core'
 import { BCSCCardProcess, EvidenceMetadata } from 'react-native-bcsc-core'
 import Config from 'react-native-config'
-import { getVersion } from 'react-native-device-info'
+import { getBuildNumber, getVersion } from 'react-native-device-info'
 import { DeviceVerificationOption } from './bcsc-theme/api/hooks/useAuthorizationApi'
 import { VerificationPhotoUploadPayload, VerificationPrompt } from './bcsc-theme/api/hooks/useEvidenceApi'
 import { BCSCBannerMessage } from './bcsc-theme/components/AppBanner'
@@ -78,6 +78,7 @@ export interface NonBCSCUserMetadata {
 
 export interface BCSCState {
   appVersion: string
+  appBuildNumber: string
   hasAccount: boolean
   nicknames: string[]
   selectedNickname?: string
@@ -381,7 +382,8 @@ const dismissPersonCredentialOfferState: DismissPersonCredentialOffer = {
 }
 
 export const initialBCSCState: BCSCState = {
-  appVersion: getVersion(),
+  appVersion: '',
+  appBuildNumber: '',
   hasAccount: false,
   nicknames: [],
   selectedNickname: undefined,
@@ -489,7 +491,7 @@ const bcReducer = (state: BCState, action: ReducerAction<BCDispatchAction>): BCS
       return newState
     }
     case BCSCDispatchAction.UPDATE_APP_VERSION: {
-      const bcsc = { ...state.bcsc, appVersion: getVersion() }
+      const bcsc = { ...state.bcsc, appVersion: getVersion(), appBuildNumber: getBuildNumber() }
       const newState = { ...state, bcsc }
       PersistentStorage.storeValueForKey<BCSCState>(BCLocalStorageKeys.BCSC, bcsc)
       return newState


### PR DESCRIPTION
## Summary

Device registration was not being updated on app upgrades (v3→v4) or build-only changes.

The v3 native app stored both version and build number in a `DeviceInfo` object and compared all fields on launch — any change triggered a registration update PUT. The v4 rewrite only compared `getVersion()` (marketing version) and initialized it to the current value on store creation, so build-only bumps were invisible and v3→v4 upgrades never saw a mismatch.

Fix: track both version and build number in state, initialize as empty so the first run always triggers an update, and compare both on subsequent launches.

- Added `appBuildNumber` to `BCSCState`, initialized both version fields to empty strings
- Updated `UpdateDeviceRegistrationSystemCheck` to compare both and treat blanks as forced update
- Tests cover build mismatch, blank values (v3→v4 upgrade path)

## Test plan


You'll see the PUT (below) in the logs now when you update from 3 -> 4 or when the build updates. You can find missing build numbers, or know ones from the support tools.

```console
[PUT] https://idsit.gov.bc.ca/device/register/d3dc4721-017d-4149-b720-c31f3c7cfee32 
```
- [x] Run repeated times, no change to build number, no update (PUT missing from logs).
- [x] Upgrade from v3 -> v4, registration update triggered (PUT in logs)
- [x] Run, increment build number, run again update triggered (PUT in logs).

