### PR TITLE
fix: error info card styles and accordian behaviour

### DIFF
--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'react-native',
+  maxWorkers: '50%',
   testTimeout: 10000,
   setupFiles: ['<rootDir>/jestSetup.js'],
   setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect', '<rootDir>/jestSetupAfterEnv.js'],

--- a/app/src/errors/components/ErrorInfoCard.test.tsx
+++ b/app/src/errors/components/ErrorInfoCard.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
-import { ErrorInfoCard, ErrorInfoCardColors, ErrorInfoCardProps, fallbackColors } from './ErrorInfoCard'
+import { ErrorInfoCard, ErrorInfoCardProps, colors as errorInfoCardColors } from './ErrorInfoCard'
 
 jest.mock('react-native-device-info', () => ({
   getVersion: () => '1.0.0',
@@ -79,6 +79,18 @@ describe('ErrorInfoCard', () => {
       expect(getByTestId('com.aries.bifold:id/DetailsText')).toBeTruthy()
     })
 
+    it('should hide details text when toggle is pressed again', () => {
+      const { getByTestId, queryByTestId } = render(
+        <ErrorInfoCard {...defaultProps} message="Technical details" code={2800} />
+      )
+
+      fireEvent.press(getByTestId('com.aries.bifold:id/ShowDetails'))
+      expect(getByTestId('com.aries.bifold:id/DetailsText')).toBeTruthy()
+
+      fireEvent.press(getByTestId('com.aries.bifold:id/ShowDetails'))
+      expect(queryByTestId('com.aries.bifold:id/DetailsText')).toBeNull()
+    })
+
     it('should format details with error code and message', () => {
       const { getByTestId, getByText } = render(
         <ErrorInfoCard {...defaultProps} message="Technical details" code={2800} />
@@ -97,12 +109,29 @@ describe('ErrorInfoCard', () => {
       expect(getByText('Error.ErrorCode 0 - Tech msg')).toBeTruthy()
     })
 
-    it('should hide toggle after revealing details', () => {
-      const { getByTestId, queryByTestId } = render(<ErrorInfoCard {...defaultProps} message="Tech msg" />)
+    it('should keep toggle visible after revealing details', () => {
+      const { getByTestId } = render(<ErrorInfoCard {...defaultProps} message="Tech msg" />)
 
       fireEvent.press(getByTestId('com.aries.bifold:id/ShowDetails'))
 
-      expect(queryByTestId('com.aries.bifold:id/ShowDetails')).toBeNull()
+      expect(getByTestId('com.aries.bifold:id/ShowDetails')).toBeTruthy()
+    })
+
+    it('should show "Hide details" text when details are visible', () => {
+      const { getByTestId, getByText } = render(<ErrorInfoCard {...defaultProps} message="Tech msg" />)
+
+      fireEvent.press(getByTestId('com.aries.bifold:id/ShowDetails'))
+
+      expect(getByText('Global.HideDetails')).toBeTruthy()
+    })
+
+    it('should show "Show details" text after hiding details again', () => {
+      const { getByTestId, getByText } = render(<ErrorInfoCard {...defaultProps} message="Tech msg" />)
+
+      fireEvent.press(getByTestId('com.aries.bifold:id/ShowDetails'))
+      fireEvent.press(getByTestId('com.aries.bifold:id/ShowDetails'))
+
+      expect(getByText('Global.ShowDetails')).toBeTruthy()
     })
   })
 
@@ -199,7 +228,7 @@ describe('ErrorInfoCard', () => {
         ? Object.assign({}, ...button.props.style)
         : button.props.style
 
-      expect(buttonStyle.backgroundColor).toBe(fallbackColors.destructiveButton)
+      expect(buttonStyle.backgroundColor).toBe(errorInfoCardColors.destructiveButton)
     })
 
     it('should apply secondary style when action.style is not destructive', () => {
@@ -211,7 +240,7 @@ describe('ErrorInfoCard', () => {
         ? Object.assign({}, ...button.props.style)
         : button.props.style
 
-      expect(buttonStyle.backgroundColor).toBe(fallbackColors.secondaryButtonBackground)
+      expect(buttonStyle.backgroundColor).toBe(errorInfoCardColors.secondaryButtonBackground)
     })
 
     it('should not render action button when action is not provided', () => {
@@ -221,23 +250,21 @@ describe('ErrorInfoCard', () => {
     })
   })
 
-  describe('colors', () => {
-    it('should use fallback colors by default', () => {
-      const { getByTestId } = render(<ErrorInfoCard {...defaultProps} />)
+  describe('snapshots', () => {
+    it('should match snapshot with default props', () => {
+      const tree = render(<ErrorInfoCard {...defaultProps} />)
 
-      expect(getByTestId('com.aries.bifold:id/HeaderText')).toBeTruthy()
+      expect(tree.toJSON()).toMatchSnapshot()
     })
 
-    it('should accept custom colors', () => {
-      const customColors: ErrorInfoCardColors = {
-        ...fallbackColors,
-        text: '#FF0000',
-        cardBackground: '#000000',
-      }
+    it('should match snapshot with details expanded', () => {
+      const tree = render(
+        <ErrorInfoCard {...defaultProps} message="Technical details" code={2800} enableReport onReport={mockOnReport} />
+      )
 
-      const { getByTestId } = render(<ErrorInfoCard {...defaultProps} colors={customColors} />)
+      fireEvent.press(tree.getByTestId('com.aries.bifold:id/ShowDetails'))
 
-      expect(getByTestId('com.aries.bifold:id/HeaderText')).toBeTruthy()
+      expect(tree.toJSON()).toMatchSnapshot()
     })
   })
 })

--- a/app/src/errors/components/ErrorInfoCard.test.tsx
+++ b/app/src/errors/components/ErrorInfoCard.test.tsx
@@ -8,6 +8,7 @@ jest.mock('react-native-device-info', () => ({
 }))
 
 jest.mock('react-native-vector-icons/MaterialIcons', () => 'Icon')
+jest.mock('react-native-vector-icons/MaterialCommunityIcons', () => 'CommunityIcon')
 
 jest.mock('@bifold/core', () => ({
   testIdWithKey: (key: string) => `com.aries.bifold:id/${key}`,

--- a/app/src/errors/components/ErrorInfoCard.tsx
+++ b/app/src/errors/components/ErrorInfoCard.tsx
@@ -102,6 +102,7 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
             <TouchableOpacity
               accessibilityLabel={showDetails ? t('Global.HideDetails') : t('Global.ShowDetails')}
               accessibilityRole="button"
+              accessibilityState={{ expanded: showDetails }}
               testID={testIdWithKey('ShowDetails')}
               style={styles.showDetailsTouchable}
               onPress={() => setShowDetails((prev) => !prev)}

--- a/app/src/errors/components/ErrorInfoCard.tsx
+++ b/app/src/errors/components/ErrorInfoCard.tsx
@@ -5,30 +5,31 @@ import React, { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native'
 import { getBuildNumber, getVersion } from 'react-native-device-info'
+import CommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import { ErrorModalAction } from './ErrorModal'
 
-export const fallbackColors = {
+// This component is used outside the theme provider in many cases and has style requirements
+// that the current theme doesn't support well, so we define the colours here
+export const colors = {
   cardBackground: '#FFFFFF',
   cardBorder: '#D3D3D3',
   shadow: '#000000',
   icon: '#313132',
   text: '#313132',
   textSecondary: '#606060',
-  link: '#FCBA19',
-  primaryButton: '#FCBA19',
+  link: '#003366',
+  primaryButton: '#003366',
   primaryButtonDisabled: '#757575',
-  primaryButtonText: '#01264C',
+  primaryButtonText: '#FFFFFF',
   primaryButtonTextDisabled: '#FFFFFF',
   successIcon: '#89CE00',
   secondaryButtonBackground: '#FFFFFF',
-  secondaryButtonBorder: '#313132',
-  secondaryButtonText: '#313132',
+  secondaryButtonBorder: '#003366',
+  secondaryButtonText: '#003366',
   destructiveButton: '#D8292F',
   destructiveButtonText: '#FFFFFF',
 }
-
-export type ErrorInfoCardColors = typeof fallbackColors
 
 export interface ErrorInfoCardProps {
   title: string
@@ -38,7 +39,6 @@ export interface ErrorInfoCardProps {
   onDismiss: () => void
   onReport?: () => void
   enableReport?: boolean
-  colors?: ErrorInfoCardColors
   action?: ErrorModalAction
 }
 
@@ -51,7 +51,6 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
   onReport,
   action,
   enableReport = false,
-  colors = fallbackColors,
 }) => {
   const { t } = useTranslation()
   const { width } = useWindowDimensions()
@@ -59,15 +58,22 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
   const [reported, setReported] = useState(false)
 
   const formattedDetails = message ? `${t('Error.ErrorCode')} ${code ?? 0} - ${message}` : ''
-  const styles = useMemo(() => createCardStyles(width, colors), [width, colors])
 
   const handleReport = () => {
     setReported(true)
     onReport?.()
   }
 
+  const containerStyle = useMemo(
+    () => ({
+      minWidth: width - 50,
+      maxWidth: width - 50,
+    }),
+    [width]
+  )
+
   return (
-    <View style={styles.container}>
+    <View style={containerStyle}>
       <View style={styles.card}>
         <View style={styles.header}>
           <Icon name="error" size={30} color={colors.icon} style={styles.icon} />
@@ -92,26 +98,28 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
             {description}
           </Text>
 
+          {message && (
+            <TouchableOpacity
+              accessibilityLabel={showDetails ? t('Global.HideDetails') : t('Global.ShowDetails')}
+              accessibilityRole="button"
+              testID={testIdWithKey('ShowDetails')}
+              style={styles.showDetailsTouchable}
+              onPress={() => setShowDetails((prev) => !prev)}
+              activeOpacity={0.7}
+            >
+              <View style={styles.showDetailsRow}>
+                <Text style={styles.showDetailsText}>
+                  {showDetails ? t('Global.HideDetails') : t('Global.ShowDetails')}{' '}
+                </Text>
+                <CommunityIcon name={showDetails ? 'chevron-up' : 'chevron-down'} size={30} color={colors.link} />
+              </View>
+            </TouchableOpacity>
+          )}
+
           {message && showDetails && (
             <Text style={styles.detailsText} testID={testIdWithKey('DetailsText')}>
               {formattedDetails}
             </Text>
-          )}
-
-          {message && !showDetails && (
-            <TouchableOpacity
-              accessibilityLabel={t('Global.ShowDetails')}
-              accessibilityRole="button"
-              testID={testIdWithKey('ShowDetails')}
-              style={styles.showDetailsTouchable}
-              onPress={() => setShowDetails(true)}
-              activeOpacity={0.7}
-            >
-              <View style={styles.showDetailsRow}>
-                <Text style={styles.showDetailsText}>{t('Global.ShowDetails')} </Text>
-                <Icon name="chevron-right" size={30} color={colors.link} />
-              </View>
-            </TouchableOpacity>
           )}
 
           <View style={styles.buttons}>
@@ -166,139 +174,133 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
   )
 }
 
-const createCardStyles = (width: number, colors: ErrorInfoCardColors) =>
-  StyleSheet.create({
-    container: {
-      minWidth: width - 50,
-      maxWidth: width - 50,
-    },
-    card: {
-      backgroundColor: colors.cardBackground,
-      borderRadius: 8,
-      borderWidth: 1,
-      borderColor: colors.cardBorder,
-      padding: 16,
-      shadowColor: colors.shadow,
-      shadowOffset: { width: 0, height: 2 },
-      shadowOpacity: 0.1,
-      shadowRadius: 8,
-      elevation: 4,
-    },
-    header: {
-      flexDirection: 'row',
-      paddingHorizontal: 4,
-      paddingTop: 4,
-    },
-    icon: {
-      marginRight: 10,
-      alignSelf: 'center',
-    },
-    headerTextContainer: {
-      flex: 1,
-      alignSelf: 'center',
-    },
-    titleText: {
-      fontSize: 18,
-      fontWeight: '700',
-      color: colors.text,
-    },
-    body: {
-      marginTop: 8,
-      paddingHorizontal: 4,
-      paddingBottom: 8,
-    },
-    bodyText: {
-      fontSize: 16,
-      color: colors.text,
-      marginVertical: 12,
-      lineHeight: 24,
-    },
-    detailsText: {
-      fontSize: 14,
-      color: colors.textSecondary,
-      marginTop: 8,
-      marginBottom: 4,
-      lineHeight: 20,
-    },
-    showDetailsTouchable: {
-      marginVertical: 14,
-    },
-    showDetailsRow: {
-      flexDirection: 'row',
-      alignItems: 'center',
-    },
-    showDetailsText: {
-      fontSize: 16,
-      fontWeight: '500',
-      color: colors.link,
-    },
-    buttons: {
-      paddingTop: 16,
-      paddingHorizontal: 4,
-      gap: 8,
-    },
-    primaryButton: {
-      backgroundColor: colors.primaryButton,
-      borderRadius: 8,
-      paddingVertical: 14,
-      paddingHorizontal: 24,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    primaryButtonDisabled: {
-      backgroundColor: colors.primaryButtonDisabled,
-    },
-    primaryButtonContent: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    reportIcon: {
-      marginRight: 8,
-    },
-    primaryButtonText: {
-      fontSize: 16,
-      fontWeight: '600',
-      color: colors.primaryButtonText,
-    },
-    primaryButtonTextDisabled: {
-      fontSize: 16,
-      fontWeight: '600',
-      color: colors.primaryButtonTextDisabled,
-    },
-    secondaryButton: {
-      backgroundColor: colors.secondaryButtonBackground,
-      borderRadius: 8,
-      borderWidth: 1.5,
-      borderColor: colors.secondaryButtonBorder,
-      paddingVertical: 14,
-      paddingHorizontal: 24,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    secondaryButtonText: {
-      fontSize: 16,
-      fontWeight: '600',
-      color: colors.secondaryButtonText,
-    },
-    destructiveButton: {
-      backgroundColor: colors.destructiveButton,
-      borderRadius: 8,
-      paddingVertical: 14,
-      paddingHorizontal: 24,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    destructiveButtonText: {
-      fontSize: 16,
-      fontWeight: '600',
-      color: colors.destructiveButtonText,
-    },
-    footer: {
-      marginTop: 16,
-      paddingTop: 8,
-      alignSelf: 'center',
-      fontSize: 12,
-      color: colors.textSecondary,
-    },
-  })
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.cardBackground,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.cardBorder,
+    padding: 16,
+    shadowColor: colors.shadow,
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 8,
+    elevation: 4,
+  },
+  header: {
+    flexDirection: 'row',
+    paddingHorizontal: 4,
+    paddingTop: 4,
+  },
+  icon: {
+    marginRight: 10,
+    alignSelf: 'center',
+  },
+  headerTextContainer: {
+    flex: 1,
+    alignSelf: 'center',
+  },
+  titleText: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  body: {
+    marginTop: 8,
+    paddingHorizontal: 4,
+    paddingBottom: 8,
+  },
+  bodyText: {
+    fontSize: 16,
+    color: colors.text,
+    marginVertical: 8,
+    lineHeight: 24,
+  },
+  detailsText: {
+    fontSize: 14,
+    color: colors.textSecondary,
+    marginBottom: 4,
+    lineHeight: 20,
+  },
+  showDetailsTouchable: {
+    marginVertical: 8,
+  },
+  showDetailsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  showDetailsText: {
+    fontSize: 16,
+    fontWeight: '500',
+    color: colors.link,
+  },
+  buttons: {
+    paddingTop: 16,
+    paddingHorizontal: 4,
+    gap: 8,
+  },
+  primaryButton: {
+    backgroundColor: colors.primaryButton,
+    borderRadius: 8,
+    paddingVertical: 14,
+    paddingHorizontal: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  primaryButtonDisabled: {
+    backgroundColor: colors.primaryButtonDisabled,
+  },
+  primaryButtonContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  reportIcon: {
+    marginRight: 8,
+  },
+  primaryButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.primaryButtonText,
+  },
+  primaryButtonTextDisabled: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.primaryButtonTextDisabled,
+  },
+  secondaryButton: {
+    backgroundColor: colors.secondaryButtonBackground,
+    borderRadius: 8,
+    borderWidth: 1.5,
+    borderColor: colors.secondaryButtonBorder,
+    paddingVertical: 14,
+    paddingHorizontal: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  secondaryButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.secondaryButtonText,
+  },
+  destructiveButton: {
+    backgroundColor: colors.destructiveButton,
+    borderRadius: 8,
+    paddingVertical: 14,
+    paddingHorizontal: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  destructiveButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.destructiveButtonText,
+  },
+  footer: {
+    marginTop: 16,
+    paddingTop: 8,
+    alignSelf: 'center',
+    fontSize: 12,
+    color: colors.textSecondary,
+  },
+})

--- a/app/src/errors/components/ErrorModal.tsx
+++ b/app/src/errors/components/ErrorModal.tsx
@@ -4,7 +4,7 @@ import { appLogger } from '@/utils/logger'
 import { BifoldError, useTheme } from '@bifold/core'
 import React, { useCallback, useMemo } from 'react'
 import { Modal, Pressable, StyleSheet } from 'react-native'
-import { ErrorInfoCard, ErrorInfoCardColors } from './ErrorInfoCard'
+import { ErrorInfoCard } from './ErrorInfoCard'
 
 const ANALYTICS_REPORT_THIS_PROBLEM_LABEL = 'Report this problem'
 
@@ -23,26 +23,6 @@ export interface ErrorModalPayload {
   cause?: unknown
   stack?: string
 }
-
-const mapThemeToCardColors = (palette: ReturnType<typeof useTheme>['ColorPalette']): ErrorInfoCardColors => ({
-  cardBackground: palette.grayscale.white,
-  cardBorder: palette.grayscale.lightGrey,
-  shadow: palette.grayscale.black,
-  icon: palette.grayscale.darkGrey,
-  text: palette.grayscale.darkGrey,
-  textSecondary: palette.grayscale.mediumGrey,
-  link: palette.brand.link,
-  primaryButton: palette.brand.modalPrimary,
-  primaryButtonDisabled: palette.brand.primaryDisabled,
-  primaryButtonText: palette.brand.text,
-  primaryButtonTextDisabled: palette.grayscale.white,
-  successIcon: palette.semantic.success,
-  secondaryButtonBackground: palette.grayscale.white,
-  secondaryButtonBorder: palette.grayscale.darkGrey,
-  secondaryButtonText: palette.grayscale.darkGrey,
-  destructiveButton: palette.semantic.error,
-  destructiveButtonText: palette.grayscale.white,
-})
 
 export interface BCSCErrorModalProps {
   error: ErrorModalPayload | null
@@ -88,8 +68,6 @@ export const BCSCErrorModal: React.FC<BCSCErrorModalProps> = ({
     appLogger.report(reportError)
   }, [error])
 
-  const cardColors = useMemo(() => mapThemeToCardColors(ColorPalette), [ColorPalette])
-
   const overlayStyle = useMemo(
     () =>
       StyleSheet.create({
@@ -123,7 +101,6 @@ export const BCSCErrorModal: React.FC<BCSCErrorModalProps> = ({
             onReport={handleReport}
             action={action}
             enableReport={enableReport}
-            colors={cardColors}
           />
         </Pressable>
       </Pressable>

--- a/app/src/errors/components/__snapshots__/ErrorInfoCard.test.tsx.snap
+++ b/app/src/errors/components/__snapshots__/ErrorInfoCard.test.tsx.snap
@@ -326,7 +326,7 @@ exports[`ErrorInfoCard snapshots should match snapshot with details expanded 1`]
               "busy": undefined,
               "checked": undefined,
               "disabled": undefined,
-              "expanded": undefined,
+              "expanded": true,
               "selected": undefined,
             }
           }
@@ -376,27 +376,11 @@ exports[`ErrorInfoCard snapshots should match snapshot with details expanded 1`]
               Global.HideDetails
                
             </Text>
-            <Text
-              allowFontScaling={false}
-              selectable={false}
-              style={
-                [
-                  {
-                    "color": "#003366",
-                    "fontSize": 30,
-                  },
-                  undefined,
-                  {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  {},
-                ]
-              }
-            >
-              󰅃
-            </Text>
+            <CommunityIcon
+              color="#003366"
+              name="chevron-up"
+              size={30}
+            />
           </View>
         </View>
         <Text

--- a/app/src/errors/components/__snapshots__/ErrorInfoCard.test.tsx.snap
+++ b/app/src/errors/components/__snapshots__/ErrorInfoCard.test.tsx.snap
@@ -1,0 +1,513 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ErrorInfoCard snapshots should match snapshot with default props 1`] = `
+<View
+  style={
+    {
+      "maxWidth": 700,
+      "minWidth": 700,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "backgroundColor": "#FFFFFF",
+        "borderColor": "#D3D3D3",
+        "borderRadius": 8,
+        "borderWidth": 1,
+        "elevation": 4,
+        "padding": 16,
+        "shadowColor": "#000000",
+        "shadowOffset": {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.1,
+        "shadowRadius": 8,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "paddingHorizontal": 4,
+          "paddingTop": 4,
+        }
+      }
+    >
+      <Icon
+        color="#313132"
+        name="error"
+        size={30}
+        style={
+          {
+            "alignSelf": "center",
+            "marginRight": 10,
+          }
+        }
+      />
+      <View
+        style={
+          {
+            "alignSelf": "center",
+            "flex": 1,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#313132",
+              "fontSize": 18,
+              "fontWeight": "700",
+            }
+          }
+          testID="com.aries.bifold:id/HeaderText"
+        >
+          Test Error
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="Global.Close"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        hitSlop={
+          {
+            "bottom": 44,
+            "left": 44,
+            "right": 44,
+            "top": 44,
+          }
+        }
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        testID="com.aries.bifold:id/CloseButton"
+      >
+        <Icon
+          color="#313132"
+          name="close"
+          size={24}
+        />
+      </View>
+    </View>
+    <RCTScrollView
+      showsVerticalScrollIndicator={false}
+      style={
+        {
+          "marginTop": 8,
+          "paddingBottom": 8,
+          "paddingHorizontal": 4,
+        }
+      }
+    >
+      <View>
+        <Text
+          style={
+            {
+              "color": "#313132",
+              "fontSize": 16,
+              "lineHeight": 24,
+              "marginVertical": 8,
+            }
+          }
+          testID="com.aries.bifold:id/BodyText"
+        >
+          Something went wrong.
+        </Text>
+        <View
+          style={
+            {
+              "gap": 8,
+              "paddingHorizontal": 4,
+              "paddingTop": 16,
+            }
+          }
+        />
+        <Text
+          style={
+            {
+              "alignSelf": "center",
+              "color": "#606060",
+              "fontSize": 12,
+              "marginTop": 16,
+              "paddingTop": 8,
+            }
+          }
+          testID="com.aries.bifold:id/VersionNumber"
+        >
+          Settings.Version
+           
+          1.0.0
+           (
+          42
+          )
+        </Text>
+      </View>
+    </RCTScrollView>
+  </View>
+</View>
+`;
+
+exports[`ErrorInfoCard snapshots should match snapshot with details expanded 1`] = `
+<View
+  style={
+    {
+      "maxWidth": 700,
+      "minWidth": 700,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "backgroundColor": "#FFFFFF",
+        "borderColor": "#D3D3D3",
+        "borderRadius": 8,
+        "borderWidth": 1,
+        "elevation": 4,
+        "padding": 16,
+        "shadowColor": "#000000",
+        "shadowOffset": {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.1,
+        "shadowRadius": 8,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "paddingHorizontal": 4,
+          "paddingTop": 4,
+        }
+      }
+    >
+      <Icon
+        color="#313132"
+        name="error"
+        size={30}
+        style={
+          {
+            "alignSelf": "center",
+            "marginRight": 10,
+          }
+        }
+      />
+      <View
+        style={
+          {
+            "alignSelf": "center",
+            "flex": 1,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#313132",
+              "fontSize": 18,
+              "fontWeight": "700",
+            }
+          }
+          testID="com.aries.bifold:id/HeaderText"
+        >
+          Test Error
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="Global.Close"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        hitSlop={
+          {
+            "bottom": 44,
+            "left": 44,
+            "right": 44,
+            "top": 44,
+          }
+        }
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        testID="com.aries.bifold:id/CloseButton"
+      >
+        <Icon
+          color="#313132"
+          name="close"
+          size={24}
+        />
+      </View>
+    </View>
+    <RCTScrollView
+      showsVerticalScrollIndicator={false}
+      style={
+        {
+          "marginTop": 8,
+          "paddingBottom": 8,
+          "paddingHorizontal": 4,
+        }
+      }
+    >
+      <View>
+        <Text
+          style={
+            {
+              "color": "#313132",
+              "fontSize": 16,
+              "lineHeight": 24,
+              "marginVertical": 8,
+            }
+          }
+          testID="com.aries.bifold:id/BodyText"
+        >
+          Something went wrong.
+        </Text>
+        <View
+          accessibilityLabel="Global.HideDetails"
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "marginVertical": 8,
+              "opacity": 1,
+            }
+          }
+          testID="com.aries.bifold:id/ShowDetails"
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#003366",
+                  "fontSize": 16,
+                  "fontWeight": "500",
+                }
+              }
+            >
+              Global.HideDetails
+               
+            </Text>
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#003366",
+                    "fontSize": 30,
+                  },
+                  undefined,
+                  {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              󰅃
+            </Text>
+          </View>
+        </View>
+        <Text
+          style={
+            {
+              "color": "#606060",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 4,
+            }
+          }
+          testID="com.aries.bifold:id/DetailsText"
+        >
+          Error.ErrorCode 2800 - Technical details
+        </Text>
+        <View
+          style={
+            {
+              "gap": 8,
+              "paddingHorizontal": 4,
+              "paddingTop": 16,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Error.ReportThisProblem"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "backgroundColor": "#003366",
+                "borderRadius": 8,
+                "justifyContent": "center",
+                "opacity": 1,
+                "paddingHorizontal": 24,
+                "paddingVertical": 14,
+              }
+            }
+            testID="com.aries.bifold:id/ReportThisProblem"
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <Text
+                style={
+                  {
+                    "color": "#FFFFFF",
+                    "fontSize": 16,
+                    "fontWeight": "600",
+                  }
+                }
+              >
+                Error.ReportThisProblem
+              </Text>
+            </View>
+          </View>
+        </View>
+        <Text
+          style={
+            {
+              "alignSelf": "center",
+              "color": "#606060",
+              "fontSize": 12,
+              "marginTop": 16,
+              "paddingTop": 8,
+            }
+          }
+          testID="com.aries.bifold:id/VersionNumber"
+        >
+          Settings.Version
+           
+          1.0.0
+           (
+          42
+          )
+        </Text>
+      </View>
+    </RCTScrollView>
+  </View>
+</View>
+`;

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -10,6 +10,7 @@ const translation = {
     "Loading": "Loading...",
     "Close": "Close",
     "ShowDetails": "Show Details",
+    "HideDetails": "Hide Details",
     "Dismiss": "Dismiss",
     "GetHelp": "Get help",
     "ContinueSetup": "Continue setup",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -10,6 +10,7 @@ const translation = {
     "Loading": "Chargement...",
     "Close": "Close (FR)",
     "ShowDetails": "Afficher les détails",
+    "HideDetails": "Masquer les détails",
     "Dismiss": "Fermer",
     "GetHelp": "Get help (FR)",
     "ContinueSetup": "Continue setup (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -10,6 +10,7 @@ const translation = {
     "Loading": "Carregando...",
     "Close": "Close (PT-BR)",
     "ShowDetails": "Mostrar detalhes",
+    "HideDetails": "Ocultar detalhes",
     "Dismiss": "Dispensar",
     "GetHelp": "Get help (PT-BR)",
     "ContinueSetup": "Continue setup (PT-BR)",


### PR DESCRIPTION
# Summary of Changes

Changes colouring and accordian behaviour of ErrorInfoCard component, simplifies styling

# Testing Instructions

Throw a random error, see what it looks like. No functional changes

# Acceptance Criteria

No functional changes, colours are correct

# Screenshots, videos, or gifs

This is what it looks like now:

https://github.com/user-attachments/assets/d9390b2e-e5d6-4304-a484-9b6149e2fb1f


Here are some quick wireframes Jer put together for this (it used to be yellow Show details text and the details could not be hidden once revealed):
<img width="594" height="241" alt="Screenshot 2026-04-07 at 2 16 06 PM" src="https://github.com/user-attachments/assets/08fab9f4-08d0-439d-be1e-3f2c7fa606cb" />

# Related Issues

#3605 