### PR TITLE
fix: invisible back button

### DIFF
--- a/app/src/bcsc-theme/navigators/AuthStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/AuthStack.test.tsx
@@ -1,0 +1,78 @@
+import * as Bifold from '@bifold/core'
+import { render } from '@testing-library/react-native'
+import React from 'react'
+import AuthStack from './AuthStack'
+
+jest.mock('@bifold/core')
+jest.mock('@react-navigation/stack', () => {
+  const Screen = ({ children }: any) => children
+  Screen.displayName = 'Screen'
+  const Navigator = ({ children }: any) => children
+  Navigator.displayName = 'Navigator'
+  return {
+    createStackNavigator: () => ({
+      Navigator,
+      Screen,
+    }),
+  }
+})
+jest.mock('../contexts/BCSCStackContext', () => ({
+  useBCSCStack: jest.fn(),
+}))
+jest.mock('../components/HeaderBackButton', () => ({
+  createHeaderBackButton: jest.fn(() => 'HeaderBackButton'),
+}))
+jest.mock('../components/HeaderWithBanner', () => ({
+  createHeaderWithoutBanner: jest.fn((props) => null),
+}))
+jest.mock('../components/SettingsHeaderButton', () => ({
+  createAuthSettingsHeaderButton: jest.fn(() => () => 'SettingsHeaderButton'),
+}))
+jest.mock('../../screens/Developer', () => 'Developer')
+jest.mock('../features/auth/AccountSelectorScreen', () => 'AccountSelector')
+jest.mock('../features/auth/ConfirmDeviceAuthInfoScreen', () => ({
+  ConfirmDeviceAuthInfoScreen: 'ConfirmDeviceAuthInfoScreen',
+}))
+jest.mock('../features/auth/DeviceAuthAppResetScreen', () => ({
+  DeviceAuthAppResetScreen: 'DeviceAuthAppResetScreen',
+}))
+jest.mock('../features/auth/EnterPINScreen', () => ({
+  EnterPINScreen: 'EnterPINScreen',
+}))
+jest.mock('../features/auth/LockoutScreen', () => ({
+  LockoutScreen: 'LockoutScreen',
+}))
+jest.mock('../features/modal/InternetDisconnected', () => ({
+  InternetDisconnected: 'InternetDisconnected',
+}))
+jest.mock('../features/modal/MandatoryUpdate', () => ({
+  MandatoryUpdate: 'MandatoryUpdate',
+}))
+jest.mock('../features/modal/ServiceOutage', () => ({
+  ServiceOutage: 'ServiceOutage',
+}))
+jest.mock('../features/settings/AuthPrivacyPolicyScreen', () => ({
+  AuthPrivacyPolicyScreen: 'AuthPrivacyPolicyScreen',
+}))
+jest.mock('../features/settings/AuthSettingsScreen', () => ({
+  AuthSettingsScreen: 'AuthSettingsScreen',
+}))
+jest.mock('../features/settings/ContactUsScreen', () => ({
+  ContactUsScreen: 'ContactUsScreen',
+}))
+jest.mock('../features/webview/WebViewScreen', () => ({
+  WebViewScreen: 'WebViewScreen',
+}))
+
+describe('AuthStack', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.mocked(Bifold.useDefaultStackOptions).mockReturnValue({} as any)
+    jest.mocked(Bifold.useTheme).mockReturnValue({} as any)
+  })
+
+  it('renders correctly', () => {
+    const { toJSON } = render(<AuthStack />)
+    expect(toJSON()).toMatchSnapshot()
+  })
+})

--- a/app/src/bcsc-theme/navigators/AuthStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/AuthStack.test.tsx
@@ -23,7 +23,7 @@ jest.mock('../components/HeaderBackButton', () => ({
   createHeaderBackButton: jest.fn(() => 'HeaderBackButton'),
 }))
 jest.mock('../components/HeaderWithBanner', () => ({
-  createHeaderWithoutBanner: jest.fn((props) => null),
+  createHeaderWithoutBanner: jest.fn(() => null),
 }))
 jest.mock('../components/SettingsHeaderButton', () => ({
   createAuthSettingsHeaderButton: jest.fn(() => () => 'SettingsHeaderButton'),

--- a/app/src/bcsc-theme/navigators/AuthStack.tsx
+++ b/app/src/bcsc-theme/navigators/AuthStack.tsx
@@ -2,6 +2,7 @@ import { useDefaultStackOptions, useTheme } from '@bifold/core'
 import { createStackNavigator } from '@react-navigation/stack'
 import { useTranslation } from 'react-i18next'
 import Developer from '../../screens/Developer'
+import { createHeaderBackButton } from '../components/HeaderBackButton'
 import { createHeaderWithoutBanner } from '../components/HeaderWithBanner'
 import { createAuthSettingsHeaderButton } from '../components/SettingsHeaderButton'
 import { useBCSCStack } from '../contexts/BCSCStackContext'
@@ -38,6 +39,7 @@ const AuthStack = (): React.ReactElement => {
       screenOptions={{
         ...defaultStackOptions,
         headerShadowVisible: false,
+        headerLeft: createHeaderBackButton,
         header: createHeaderWithoutBanner,
       }}
     >

--- a/app/src/bcsc-theme/navigators/__snapshots__/AuthStack.test.tsx.snap
+++ b/app/src/bcsc-theme/navigators/__snapshots__/AuthStack.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AuthStack renders correctly 1`] = `null`;


### PR DESCRIPTION
# Summary of Changes

There was a nearly invisible back button icon on the auth stack. It's like the others now. Getting test coverage of a single line of Stack Navigator config  was 99% of the work here

# Testing Instructions

In the authstack, open the settings menu, check the back button is visible

# Acceptance Criteria

Visible

# Screenshots, videos, or gifs

N/A

# Related Issues

#3652 