### PR TITLE
feat: restrict languages based on build target

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -48,7 +48,8 @@ import Toast from 'react-native-toast-message'
 import { container } from 'tsyringe'
 import { AppContainer } from './container-imp'
 
-initLanguages(localization)
+// Only english in BCSC, all three languages in BC Wallet
+initLanguages(Config.BUILD_TARGET === Mode.BCSC ? { en: localization.en } : localization)
 initIssuer(appLogger)
 
 // Module-level singletons - constructors are pure (no RN bridge calls)


### PR DESCRIPTION
# Summary of Changes

BCSC - only english
BC Wallet - same as before

# Testing Instructions

Change your device language to french, open the BCSC app from a fresh install, don't see any French

# Acceptance Criteria

Above works

# Screenshots, videos, or gifs

https://github.com/user-attachments/assets/292046a0-dd92-4c01-b183-3e9b13d45663

# Related Issues

#3612 
