### PR TITLE
fix: removed fallback alerts

### DIFF
--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -88,10 +88,6 @@ const _getIasErrorAlertMap = (alerts?: AppAlerts) => {
     [AppEventCode.ERR_213_FAILED_CREATING_CLIENT_REGISTRATION, alerts?.creatingClientRegistrationFailedAlert],
     [AppEventCode.ERR_299_KEYS_OUT_OF_SYNC, alerts?.keysOutOfSyncAlert],
     [AppEventCode.ERR_300_EMPTY_RESPONSE, alerts?.emptyResponseAlert],
-
-    // Catch all for unknown and unregistered IAS errors
-    [AppEventCode.UNKNOWN_APP_ERROR, alerts?.unknownErrorModal],
-    [AppEventCode.UNKNOWN_SERVER_ERROR, alerts?.unknownErrorModal],
   ])
 }
 


### PR DESCRIPTION
# Summary of Changes

Removed the recently added fallback alerts. I think this will cause us more grief than benefit at this point. Quite a few of our API requests are expected to fail and not render alerts, this just restores the previous functionality.

# Testing Instructions

1. Add CSN
2. Add birthdate
3. No modal appears

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
