### PR TITLE
feat: e2e cidc upgrade

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,89 @@
+# E2E Nightly Full Regression
+#
+# Runs the full-regression E2E suite against the latest successful main
+# build's SauceLabs artifacts, followed by biometric tests (non-blocking).
+#
+# Default device matrix: 3 iOS + 3 Android OS versions (moderate coverage).
+#
+# Two trigger modes:
+#   schedule         — runs every night at midnight PT (7 AM UTC)
+#   workflow_dispatch — manual trigger for ad-hoc regression runs
+#
+# The workflow resolves the latest successful main build number via the
+# GitHub API, so no build_number input is needed.
+#
+# NOTE: Nightly schedule is disabled until SauceLabs IPs are whitelisted.
+# To re-enable, uncomment the schedule trigger below.
+name: E2E Nightly
+
+on:
+  # schedule:
+  #   - cron: '0 7 * * *'
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: 'Test suite to run'
+        type: choice
+        options:
+          - full-regression
+          - happy-path
+          - smoke
+        default: full-regression
+      device_matrix:
+        description: 'JSON array of {platform, device, os_version} objects'
+        type: string
+        default: '[{"platform":"iOS","device":"iPhone.*","os_version":"18"},{"platform":"iOS","device":"iPhone.*","os_version":"17"},{"platform":"iOS","device":"iPhone.*","os_version":"16"},{"platform":"Android","device":"Google.*","os_version":"15"},{"platform":"Android","device":"Google.*","os_version":"14"},{"platform":"Android","device":"Google.*","os_version":"13"}]'
+      include_biometrics:
+        description: 'Include biometric tests (non-blocking)'
+        type: boolean
+        default: true
+
+jobs:
+  resolve-build:
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+    outputs:
+      build_number: ${{ steps.find.outputs.build_number }}
+    steps:
+      - name: Find latest successful main build
+        id: find
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BUILD_NUMBER=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/main.yaml/runs?branch=main&status=success&per_page=1" \
+            --jq '.workflow_runs[0].run_number')
+          if [ -z "$BUILD_NUMBER" ] || [ "$BUILD_NUMBER" = "null" ]; then
+            echo "::error::No successful main build found"
+            exit 1
+          fi
+          echo "build_number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "Latest successful main build: #${BUILD_NUMBER}"
+
+  e2e:
+    needs: [resolve-build]
+    uses: ./.github/workflows/e2e.yml
+    with:
+      suite: ${{ inputs.suite || 'full-regression' }}
+      build_number: ${{ needs.resolve-build.outputs.build_number }}
+      device_matrix: ${{ inputs.device_matrix || '[{"platform":"iOS","device":"iPhone.*","os_version":"18"},{"platform":"iOS","device":"iPhone.*","os_version":"17"},{"platform":"iOS","device":"iPhone.*","os_version":"16"},{"platform":"Android","device":"Google.*","os_version":"15"},{"platform":"Android","device":"Google.*","os_version":"14"},{"platform":"Android","device":"Google.*","os_version":"13"}]' }}
+    secrets:
+      SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+      CARD_SERIAL: ${{ secrets.CARD_SERIAL }}
+      BIRTH_DATE: ${{ secrets.BIRTH_DATE }}
+
+  e2e-biometrics:
+    needs: [resolve-build]
+    if: github.event_name != 'workflow_dispatch' || inputs.include_biometrics
+    uses: ./.github/workflows/e2e.yml
+    with:
+      suite: biometrics
+      build_number: ${{ needs.resolve-build.outputs.build_number }}
+      device_matrix: ${{ inputs.device_matrix || '[{"platform":"iOS","device":"iPhone.*","os_version":"18"},{"platform":"Android","device":"Google.*","os_version":"15"}]' }}
+    secrets:
+      SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+      CARD_SERIAL: ${{ secrets.CARD_SERIAL }}
+      BIRTH_DATE: ${{ secrets.BIRTH_DATE }}

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -5,9 +5,13 @@
 #
 # Default device matrix: 3 iOS + 3 Android OS versions (moderate coverage).
 #
-# Two trigger modes:
+# Trigger modes:
 #   schedule         — runs every night at midnight PT (7 AM UTC)
 #   workflow_dispatch — manual trigger for ad-hoc regression runs
+#
+# Merge-gated: on schedule, the workflow first checks whether any commits
+# landed on main in the last 24 hours. If nothing changed, it skips the
+# run to avoid burning SauceLabs device time. Manual dispatches always run.
 #
 # The workflow resolves the latest successful main build number via the
 # GitHub API, so no build_number input is needed.
@@ -43,10 +47,41 @@ on:
         default: true
 
 jobs:
-  resolve-build:
+  # ─── Gate: skip scheduled runs when nothing merged to main ──────
+  check-for-merges:
     runs-on: ubuntu-22.04
-    permissions:
-      actions: read
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Check for commits on main in the last 24 hours
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch — always run"
+            exit 0
+          fi
+
+          SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+              || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ)
+          COUNT=$(gh api \
+            "repos/${{ github.repository }}/commits?sha=main&since=${SINCE}&per_page=1" \
+            --jq 'length')
+
+          if [ "$COUNT" -gt 0 ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "Commits found on main since ${SINCE} — running regression"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "No commits on main since ${SINCE} — skipping"
+          fi
+
+  resolve-build:
+    needs: [check-for-merges]
+    if: needs.check-for-merges.outputs.should_run == 'true'
+    runs-on: ubuntu-22.04
     outputs:
       build_number: ${{ steps.find.outputs.build_number }}
     steps:
@@ -66,7 +101,8 @@ jobs:
           echo "Latest successful main build: #${BUILD_NUMBER}"
 
   e2e:
-    needs: [resolve-build]
+    needs: [check-for-merges, resolve-build]
+    if: needs.check-for-merges.outputs.should_run == 'true'
     uses: ./.github/workflows/e2e.yml
     with:
       suite: ${{ inputs.suite || 'full-regression' }}
@@ -79,8 +115,10 @@ jobs:
       BIRTH_DATE: ${{ secrets.BIRTH_DATE }}
 
   e2e-biometrics:
-    needs: [resolve-build]
-    if: github.event_name != 'workflow_dispatch' || inputs.include_biometrics
+    needs: [check-for-merges, resolve-build]
+    if: >-
+      needs.check-for-merges.outputs.should_run == 'true' &&
+      (github.event_name != 'workflow_dispatch' || inputs.include_biometrics)
     uses: ./.github/workflows/e2e.yml
     with:
       suite: biometrics

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -16,6 +16,10 @@
 # To re-enable, uncomment the schedule trigger below.
 name: E2E Nightly
 
+permissions:
+  contents: read
+  actions: read
+
 on:
   # schedule:
   #   - cron: '0 7 * * *'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ on:
   workflow_call:
     inputs:
       suite:
-        description: 'Test suite (smoke, happy-path, full-regression, biometrics)'
+        description: 'Test suite (smoke, happy-path, full-regression, verified, biometrics)'
         type: string
         required: true
       build_number:
@@ -60,6 +60,7 @@ on:
           - smoke
           - happy-path
           - full-regression
+          - verified
           - biometrics
         default: smoke
       build_number:
@@ -74,7 +75,7 @@ on:
 jobs:
   e2e-tests:
     name: '${{ inputs.suite }} - ${{ matrix.device.platform }} ${{ matrix.device.os_version }}'
-    if: inputs.suite != 'biometrics'
+    if: inputs.suite != 'biometrics' && inputs.suite != 'verified'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -133,6 +134,70 @@ jobs:
           else
             ANDROID_APP_FILENAME="${SAUCE_LABS_PREFIX}-${BUILD_NUMBER}.aab" \
               yarn wdio configs/sauce/wdio.android.sauce.rdc.conf.ts --suite "${SUITE}"
+          fi
+
+  # ─── E2E Verified ──────────────────────────────────────────────────
+  # Runs the verified-state suite sequentially with app state persisted
+  # across sessions (noReset=true / fullReset=false). The first spec
+  # runs the full onboarding + verification flow; subsequent specs start
+  # from the verified home screen without re-verifying.
+  # Non-blocking: failures are reported but do not gate the pipeline.
+  e2e-verified:
+    name: 'Verified - ${{ matrix.platform }}'
+    if: inputs.suite == 'verified'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    timeout-minutes: 45
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [iOS, Android]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load variant config
+        uses: ./.github/workflows/actions/load-variant-config
+        with:
+          variant: bcsc-dev
+
+      - name: Setup NodeJS
+        uses: ./.github/workflows/actions/setup-node
+
+      - name: Cache E2E dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            e2e/.yarn/cache
+            e2e/node_modules
+          key: e2e-deps-${{ hashFiles('e2e/yarn.lock') }}
+          restore-keys: e2e-deps-
+
+      - name: Install E2E dependencies
+        working-directory: e2e
+        run: yarn install --immutable
+
+      - name: Run verified-state tests
+        working-directory: e2e
+        env:
+          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+          SAUCE_REGION: us
+          VARIANT: bcsc-dev
+          PLATFORM: ${{ matrix.platform }}
+          BUILD_NUMBER: ${{ inputs.build_number }}
+          BUILD_NAME: 'build-${{ inputs.build_number }}'
+          TEST_NAME: 'E2E Verified - bcsc-dev ${{ matrix.platform }}'
+          CARD_SERIAL: ${{ secrets.CARD_SERIAL }}
+          BIRTH_DATE: ${{ secrets.BIRTH_DATE }}
+        run: |
+          if [ "$PLATFORM" = "iOS" ]; then
+            IOS_APP_FILENAME="${SAUCE_LABS_PREFIX}-${BUILD_NUMBER}.ipa" \
+              yarn wdio configs/sauce/verified/wdio.ios.verified.sauce.rdc.conf.ts --suite verified
+          else
+            ANDROID_APP_FILENAME="${SAUCE_LABS_PREFIX}-${BUILD_NUMBER}.aab" \
+              yarn wdio configs/sauce/verified/wdio.android.verified.sauce.rdc.conf.ts --suite verified
           fi
 
   # ─── E2E Biometrics ────────────────────────────────────────────────

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,7 @@
 #   happy-path      — onboarding → verify → main (straight-through)
 #   full-regression — onboarding → verify → main (with detours)
 #   biometrics      — onboarding with biometric auth (Sauce RDC only)
+#   verified        — verified-state flows (noReset, sequential phases; Sauce RDC only)
 #
 # Device matrix:
 #   Callers pass a device_matrix JSON array of {platform, device, os_version}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,13 +9,12 @@
 #   full-regression — onboarding → verify → main (with detours)
 #   biometrics      — onboarding with biometric auth (Sauce RDC only)
 #
-# Each suite is mutually exclusive: selecting "biometrics" runs only the
-# biometric auth job; all other suites run the standard E2E job.
-#
 # Device matrix:
 #   Callers pass a device_matrix JSON array of {platform, device, os_version}
 #   objects. Each entry spawns a separate SauceLabs session.
 #   Example: [{"platform":"iOS","device":"iPhone.*","os_version":"18"}]
+#   For suites that don't need specific devices (verified, biometrics), pass
+#   a minimal matrix: [{"platform":"iOS"},{"platform":"Android"}]
 #
 # Trigger modes:
 #   workflow_call  — called from main.yaml after builds (PR smoke tests)
@@ -73,13 +72,22 @@ on:
         default: '[{"platform":"iOS","device":"iPhone.*","os_version":""},{"platform":"Android","device":"Google.*","os_version":""}]'
 
 jobs:
+  # ─── E2E Tests ─────────────────────────────────────────────────────
+  # Single unified job for all suites. Config file paths are selected at
+  # runtime via a case statement on $SUITE:
+  #   smoke / happy-path / full-regression → configs/sauce/
+  #   verified                             → configs/sauce/verified/
+  #   biometrics                           → configs/sauce/biometrics/
+  #
+  # Non-blocking suites (verified, biometrics): failures are reported but
+  # do not gate the pipeline.
   e2e-tests:
     name: '${{ inputs.suite }} - ${{ matrix.device.platform }} ${{ matrix.device.os_version }}'
-    if: inputs.suite != 'biometrics' && inputs.suite != 'verified'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-    timeout-minutes: 30
+    timeout-minutes: 45
+    continue-on-error: ${{ inputs.suite == 'verified' || inputs.suite == 'biometrics' }}
     strategy:
       max-parallel: 2
       fail-fast: false
@@ -128,137 +136,24 @@ jobs:
           CARD_SERIAL: ${{ secrets.CARD_SERIAL }}
           BIRTH_DATE: ${{ secrets.BIRTH_DATE }}
         run: |
+          case "$SUITE" in
+            verified)
+              IOS_CONF="configs/sauce/verified/wdio.ios.verified.sauce.rdc.conf.ts"
+              ANDROID_CONF="configs/sauce/verified/wdio.android.verified.sauce.rdc.conf.ts"
+              ;;
+            biometrics)
+              IOS_CONF="configs/sauce/biometrics/wdio.ios.bio.sauce.rdc.conf.ts"
+              ANDROID_CONF="configs/sauce/biometrics/wdio.android.bio.sauce.rdc.conf.ts"
+              ;;
+            *)
+              IOS_CONF="configs/sauce/wdio.ios.sauce.rdc.conf.ts"
+              ANDROID_CONF="configs/sauce/wdio.android.sauce.rdc.conf.ts"
+              ;;
+          esac
           if [ "$PLATFORM" = "iOS" ]; then
             IOS_APP_FILENAME="${SAUCE_LABS_PREFIX}-${BUILD_NUMBER}.ipa" \
-              yarn wdio configs/sauce/wdio.ios.sauce.rdc.conf.ts --suite "${SUITE}"
+              yarn wdio "$IOS_CONF" --suite "${SUITE}"
           else
             ANDROID_APP_FILENAME="${SAUCE_LABS_PREFIX}-${BUILD_NUMBER}.aab" \
-              yarn wdio configs/sauce/wdio.android.sauce.rdc.conf.ts --suite "${SUITE}"
-          fi
-
-  # ─── E2E Verified ──────────────────────────────────────────────────
-  # Runs the verified-state suite sequentially with app state persisted
-  # across sessions (noReset=true / fullReset=false). The first spec
-  # runs the full onboarding + verification flow; subsequent specs start
-  # from the verified home screen without re-verifying.
-  # Non-blocking: failures are reported but do not gate the pipeline.
-  e2e-verified:
-    name: 'Verified - ${{ matrix.platform }}'
-    if: inputs.suite == 'verified'
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-    timeout-minutes: 45
-    continue-on-error: true
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [iOS, Android]
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Load variant config
-        uses: ./.github/workflows/actions/load-variant-config
-        with:
-          variant: bcsc-dev
-
-      - name: Setup NodeJS
-        uses: ./.github/workflows/actions/setup-node
-
-      - name: Cache E2E dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            e2e/.yarn/cache
-            e2e/node_modules
-          key: e2e-deps-${{ hashFiles('e2e/yarn.lock') }}
-          restore-keys: e2e-deps-
-
-      - name: Install E2E dependencies
-        working-directory: e2e
-        run: yarn install --immutable
-
-      - name: Run verified-state tests
-        working-directory: e2e
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-          SAUCE_REGION: us
-          VARIANT: bcsc-dev
-          PLATFORM: ${{ matrix.platform }}
-          BUILD_NUMBER: ${{ inputs.build_number }}
-          BUILD_NAME: 'build-${{ inputs.build_number }}'
-          TEST_NAME: 'E2E Verified - bcsc-dev ${{ matrix.platform }}'
-          CARD_SERIAL: ${{ secrets.CARD_SERIAL }}
-          BIRTH_DATE: ${{ secrets.BIRTH_DATE }}
-        run: |
-          if [ "$PLATFORM" = "iOS" ]; then
-            IOS_APP_FILENAME="${SAUCE_LABS_PREFIX}-${BUILD_NUMBER}.ipa" \
-              yarn wdio configs/sauce/verified/wdio.ios.verified.sauce.rdc.conf.ts --suite verified
-          else
-            ANDROID_APP_FILENAME="${SAUCE_LABS_PREFIX}-${BUILD_NUMBER}.aab" \
-              yarn wdio configs/sauce/verified/wdio.android.verified.sauce.rdc.conf.ts --suite verified
-          fi
-
-  # ─── E2E Biometrics ────────────────────────────────────────────────
-  # Runs biometric auth tests on Sauce Labs RDC with allowTouchIdEnroll.
-  # Separated from the main E2E job because iOS biometrics are flaky on
-  # certain Sauce RDC devices.
-  # Non-blocking: failures are reported but do not gate the pipeline.
-  e2e-biometrics:
-    name: 'Bio - ${{ matrix.platform }}'
-    if: inputs.suite == 'biometrics'
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-    timeout-minutes: 15
-    continue-on-error: true
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [iOS, Android]
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Load variant config
-        uses: ./.github/workflows/actions/load-variant-config
-        with:
-          variant: bcsc-dev
-
-      - name: Setup NodeJS
-        uses: ./.github/workflows/actions/setup-node
-
-      - name: Cache E2E dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            e2e/.yarn/cache
-            e2e/node_modules
-          key: e2e-deps-${{ hashFiles('e2e/yarn.lock') }}
-          restore-keys: e2e-deps-
-
-      - name: Install E2E dependencies
-        working-directory: e2e
-        run: yarn install --immutable
-
-      - name: Run biometric tests
-        working-directory: e2e
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-          SAUCE_REGION: us
-          VARIANT: bcsc-dev
-          PLATFORM: ${{ matrix.platform }}
-          BUILD_NUMBER: ${{ inputs.build_number }}
-          BUILD_NAME: 'build-${{ inputs.build_number }}'
-          TEST_NAME: 'E2E Bio - bcsc-dev ${{ matrix.platform }}'
-          CARD_SERIAL: ${{ secrets.CARD_SERIAL }}
-          BIRTH_DATE: ${{ secrets.BIRTH_DATE }}
-        run: |
-          if [ "$PLATFORM" = "iOS" ]; then
-            IOS_APP_FILENAME="${SAUCE_LABS_PREFIX}-${BUILD_NUMBER}.ipa" \
-              yarn wdio configs/sauce/biometrics/wdio.ios.bio.sauce.rdc.conf.ts --suite biometrics
-          else
-            ANDROID_APP_FILENAME="${SAUCE_LABS_PREFIX}-${BUILD_NUMBER}.aab" \
-              yarn wdio configs/sauce/biometrics/wdio.android.bio.sauce.rdc.conf.ts --suite biometrics
+              yarn wdio "$ANDROID_CONF" --suite "${SUITE}"
           fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,11 @@
 #   full-regression — onboarding → verify → main (with detours)
 #   biometrics      — onboarding with biometric auth (Sauce RDC only)
 #
+# Device matrix:
+#   Callers pass a device_matrix JSON array of {platform, device, os_version}
+#   objects. Each entry spawns a separate SauceLabs session.
+#   Example: [{"platform":"iOS","device":"iPhone.*","os_version":"18"}]
+#
 # Trigger modes:
 #   workflow_call  — called from main.yaml after builds (PR smoke tests)
 #   workflow_dispatch — manual runs from the Actions UI
@@ -29,6 +34,10 @@ on:
         required: true
       variants:
         description: 'JSON array of variants to test'
+        type: string
+        required: true
+      device_matrix:
+        description: 'JSON array of {platform, device, os_version} objects'
         type: string
         required: true
       include_biometrics:
@@ -62,6 +71,10 @@ on:
         description: 'JSON array of variants to test'
         type: string
         default: '["bcsc-dev"]'
+      device_matrix:
+        description: 'JSON array of {platform, device, os_version} objects'
+        type: string
+        default: '[{"platform":"iOS","device":"iPhone.*","os_version":"18"},{"platform":"Android","device":"Google.*","os_version":"15"}]'
       include_biometrics:
         description: 'Run biometric tests (non-blocking)'
         type: boolean
@@ -69,7 +82,7 @@ on:
 
 jobs:
   e2e-tests:
-    name: '${{ inputs.suite }} - ${{ matrix.variant }} ${{ matrix.platform }}'
+    name: '${{ inputs.suite }} - ${{ matrix.variant }} ${{ matrix.device.platform }} ${{ matrix.device.os_version }}'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -78,7 +91,7 @@ jobs:
       max-parallel: 2
       fail-fast: false
       matrix:
-        platform: [iOS, Android]
+        device: ${{ fromJSON(inputs.device_matrix) }}
         variant: ${{ fromJSON(inputs.variants) }}
     steps:
       - uses: actions/checkout@v6
@@ -111,11 +124,15 @@ jobs:
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
           SAUCE_REGION: us
           VARIANT: ${{ matrix.variant }}
-          PLATFORM: ${{ matrix.platform }}
+          PLATFORM: ${{ matrix.device.platform }}
+          IOS_DEVICE_NAME: ${{ matrix.device.platform == 'iOS' && matrix.device.device || '' }}
+          IOS_PLATFORM_VERSION: ${{ matrix.device.platform == 'iOS' && matrix.device.os_version || '' }}
+          ANDROID_DEVICE_NAME: ${{ matrix.device.platform == 'Android' && matrix.device.device || '' }}
+          ANDROID_PLATFORM_VERSION: ${{ matrix.device.platform == 'Android' && matrix.device.os_version || '' }}
           BUILD_NUMBER: ${{ inputs.build_number }}
           SUITE: ${{ inputs.suite }}
           BUILD_NAME: 'build-${{ inputs.build_number }}'
-          TEST_NAME: 'E2E ${{ inputs.suite }} - ${{ matrix.variant }} ${{ matrix.platform }}'
+          TEST_NAME: 'E2E ${{ inputs.suite }} - ${{ matrix.variant }} ${{ matrix.device.platform }} ${{ matrix.device.os_version }}'
           CARD_SERIAL: ${{ secrets.CARD_SERIAL }}
           BIRTH_DATE: ${{ secrets.BIRTH_DATE }}
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,9 @@
 # Constraint: max-parallel=2 (SauceLabs concurrent-session limit).
 name: E2E Tests
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,9 @@
 #   full-regression — onboarding → verify → main (with detours)
 #   biometrics      — onboarding with biometric auth (Sauce RDC only)
 #
+# Each suite is mutually exclusive: selecting "biometrics" runs only the
+# biometric auth job; all other suites run the standard E2E job.
+#
 # Device matrix:
 #   Callers pass a device_matrix JSON array of {platform, device, os_version}
 #   objects. Each entry spawns a separate SauceLabs session.
@@ -25,25 +28,17 @@ on:
   workflow_call:
     inputs:
       suite:
-        description: 'Test suite (smoke, happy-path, full-regression)'
+        description: 'Test suite (smoke, happy-path, full-regression, biometrics)'
         type: string
         required: true
       build_number:
         description: 'Build number for SauceLabs artifact lookup'
         type: string
         required: true
-      variants:
-        description: 'JSON array of variants to test'
-        type: string
-        required: true
       device_matrix:
         description: 'JSON array of {platform, device, os_version} objects'
         type: string
         required: true
-      include_biometrics:
-        description: 'Run biometric tests (non-blocking)'
-        type: boolean
-        default: false
     secrets:
       SAUCE_USERNAME:
         required: true
@@ -62,27 +57,21 @@ on:
           - smoke
           - happy-path
           - full-regression
+          - biometrics
         default: smoke
       build_number:
         description: 'Build number (run_number from the build workflow)'
         type: string
         required: true
-      variants:
-        description: 'JSON array of variants to test'
-        type: string
-        default: '["bcsc-dev"]'
       device_matrix:
         description: 'JSON array of {platform, device, os_version} objects'
         type: string
-        default: '[{"platform":"iOS","device":"iPhone.*","os_version":"18"},{"platform":"Android","device":"Google.*","os_version":"15"}]'
-      include_biometrics:
-        description: 'Run biometric tests (non-blocking)'
-        type: boolean
-        default: false
+        default: '[{"platform":"iOS","device":"iPhone.*","os_version":""},{"platform":"Android","device":"Google.*","os_version":""}]'
 
 jobs:
   e2e-tests:
-    name: '${{ inputs.suite }} - ${{ matrix.variant }} ${{ matrix.device.platform }} ${{ matrix.device.os_version }}'
+    name: '${{ inputs.suite }} - ${{ matrix.device.platform }} ${{ matrix.device.os_version }}'
+    if: inputs.suite != 'biometrics'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -92,14 +81,13 @@ jobs:
       fail-fast: false
       matrix:
         device: ${{ fromJSON(inputs.device_matrix) }}
-        variant: ${{ fromJSON(inputs.variants) }}
     steps:
       - uses: actions/checkout@v6
 
       - name: Load variant config
         uses: ./.github/workflows/actions/load-variant-config
         with:
-          variant: ${{ matrix.variant }}
+          variant: bcsc-dev
 
       - name: Setup NodeJS
         uses: ./.github/workflows/actions/setup-node
@@ -123,7 +111,7 @@ jobs:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
           SAUCE_REGION: us
-          VARIANT: ${{ matrix.variant }}
+          VARIANT: bcsc-dev
           PLATFORM: ${{ matrix.device.platform }}
           IOS_DEVICE_NAME: ${{ matrix.device.platform == 'iOS' && matrix.device.device || '' }}
           IOS_PLATFORM_VERSION: ${{ matrix.device.platform == 'iOS' && matrix.device.os_version || '' }}
@@ -132,7 +120,7 @@ jobs:
           BUILD_NUMBER: ${{ inputs.build_number }}
           SUITE: ${{ inputs.suite }}
           BUILD_NAME: 'build-${{ inputs.build_number }}'
-          TEST_NAME: 'E2E ${{ inputs.suite }} - ${{ matrix.variant }} ${{ matrix.device.platform }} ${{ matrix.device.os_version }}'
+          TEST_NAME: 'E2E ${{ inputs.suite }} - ${{ matrix.device.platform }} ${{ matrix.device.os_version }}'
           CARD_SERIAL: ${{ secrets.CARD_SERIAL }}
           BIRTH_DATE: ${{ secrets.BIRTH_DATE }}
         run: |
@@ -151,8 +139,7 @@ jobs:
   # Non-blocking: failures are reported but do not gate the pipeline.
   e2e-biometrics:
     name: 'Bio - ${{ matrix.platform }}'
-    needs: [e2e-tests]
-    if: ${{ always() && !cancelled() && inputs.include_biometrics }}
+    if: inputs.suite == 'biometrics'
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1150,15 +1150,10 @@ jobs:
   # ─── E2E Tests ──────────────────────────────────────────────────────
   # Delegated to .github/workflows/e2e.yml (reusable workflow).
   # PR: smoke tests on 1 iOS + 1 Android device (fast feedback).
-  # Main: full-regression on 3 iOS + 3 Android OS versions.
-  # Nightly: full device coverage + biometrics via e2e-nightly.yml.
-  #
-  # ── IP Whitelisting (required before enabling e2e-regression) ──
-  # GH Actions runner IPs must be whitelisted with BC Gov ID Check.
-  #  Whitelist GitHub's published ranges (api.github.com/meta → actions)
-  #
-  # TODO: Uncomment e2e-regression below once GH Actions runner IPs
-  # are whitelisted via one of the above approaches.
+  # Main: full-regression is deferred to the nightly workflow
+  #       (e2e-nightly.yml) which checks for merges in the last 24h
+  #       before running. This keeps SauceLabs devices free during the
+  #       day when multiple PRs merge.
   e2e:
     needs: [ship-to-saucelabs]
     if: >-
@@ -1175,28 +1170,3 @@ jobs:
       SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
       CARD_SERIAL: ${{ secrets.CARD_SERIAL }}
       BIRTH_DATE: ${{ secrets.BIRTH_DATE }}
-
-  # Full regression on merge to main (3 iOS + 3 Android OS versions):
-  # e2e-regression:
-  #   needs: [ship-to-saucelabs]
-  #   if: >-
-  #     always() && !cancelled() &&
-  #     github.ref_name == 'main'
-  #   uses: ./.github/workflows/e2e.yml
-  #   with:
-  #     suite: full-regression
-  #     build_number: ${{ github.run_number }}
-  #     device_matrix: >-
-  #       [
-  #         {"platform":"iOS","device":"iPhone.*","os_version":"18"},
-  #         {"platform":"iOS","device":"iPhone.*","os_version":"17"},
-  #         {"platform":"iOS","device":"iPhone.*","os_version":"16"},
-  #         {"platform":"Android","device":"Google.*","os_version":"15"},
-  #         {"platform":"Android","device":"Google.*","os_version":"14"},
-  #         {"platform":"Android","device":"Google.*","os_version":"13"}
-  #       ]
-  #   secrets:
-  #     SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-  #     SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-  #     CARD_SERIAL: ${{ secrets.CARD_SERIAL }}
-  #     BIRTH_DATE: ${{ secrets.BIRTH_DATE }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1156,6 +1156,8 @@ jobs:
   #       day when multiple PRs merge.
   e2e:
     needs: [ship-to-saucelabs]
+    permissions:
+      contents: read
     if: >-
       always() && !cancelled() &&
       github.event_name == 'pull_request' &&

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1151,7 +1151,7 @@ jobs:
   # Delegated to .github/workflows/e2e.yml (reusable workflow).
   # PR: smoke tests on 1 iOS + 1 Android device (fast feedback).
   # Main: full-regression on 3 iOS + 3 Android OS versions.
-  # Nightly: full variant × device coverage via e2e-nightly.yml.
+  # Nightly: full device coverage + biometrics via e2e-nightly.yml.
   #
   # ── IP Whitelisting (required before enabling e2e-regression) ──
   # GH Actions runner IPs must be whitelisted with BC Gov ID Check.
@@ -1160,7 +1160,7 @@ jobs:
   # TODO: Uncomment e2e-regression below once GH Actions runner IPs
   # are whitelisted via one of the above approaches.
   e2e:
-    needs: [ship-to-saucelabs, compute-variants]
+    needs: [ship-to-saucelabs]
     if: >-
       always() && !cancelled() &&
       github.event_name == 'pull_request' &&
@@ -1169,18 +1169,16 @@ jobs:
     with:
       suite: smoke
       build_number: ${{ github.run_number }}
-      variants: ${{ needs.compute-variants.outputs.variants }}
       device_matrix: '[{"platform":"iOS","device":"iPhone.*","os_version":""},{"platform":"Android","device":"Google.*","os_version":""}]'
-      include_biometrics: false
     secrets:
       SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
       SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
       CARD_SERIAL: ${{ secrets.CARD_SERIAL }}
       BIRTH_DATE: ${{ secrets.BIRTH_DATE }}
 
-  # Full regression + biometrics on merge to main (3 iOS + 3 Android OS versions):
+  # Full regression on merge to main (3 iOS + 3 Android OS versions):
   # e2e-regression:
-  #   needs: [ship-to-saucelabs, compute-variants]
+  #   needs: [ship-to-saucelabs]
   #   if: >-
   #     always() && !cancelled() &&
   #     github.ref_name == 'main'
@@ -1188,7 +1186,6 @@ jobs:
   #   with:
   #     suite: full-regression
   #     build_number: ${{ github.run_number }}
-  #     variants: ${{ needs.compute-variants.outputs.variants }}
   #     device_matrix: >-
   #       [
   #         {"platform":"iOS","device":"iPhone.*","os_version":"18"},
@@ -1198,7 +1195,6 @@ jobs:
   #         {"platform":"Android","device":"Google.*","os_version":"14"},
   #         {"platform":"Android","device":"Google.*","os_version":"13"}
   #       ]
-  #     include_biometrics: true
   #   secrets:
   #     SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
   #     SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1149,11 +1149,16 @@ jobs:
 
   # ─── E2E Tests ──────────────────────────────────────────────────────
   # Delegated to .github/workflows/e2e.yml (reusable workflow).
-  # PR: smoke tests for fast feedback.
-  # Main: use e2e-nightly.yml (schedule/manual) for full-regression.
+  # PR: smoke tests on 1 iOS + 1 Android device (fast feedback).
+  # Main: full-regression on 3 iOS + 3 Android OS versions.
+  # Nightly: full variant × device coverage via e2e-nightly.yml.
+  #
+  # ── IP Whitelisting (required before enabling e2e-regression) ──
+  # GH Actions runner IPs must be whitelisted with BC Gov ID Check.
+  #  Whitelist GitHub's published ranges (api.github.com/meta → actions)
   #
   # TODO: Uncomment e2e-regression below once GH Actions runner IPs
-  # are whitelisted, to run full-regression on every merge to main.
+  # are whitelisted via one of the above approaches.
   e2e:
     needs: [ship-to-saucelabs, compute-variants]
     if: >-
@@ -1165,6 +1170,7 @@ jobs:
       suite: smoke
       build_number: ${{ github.run_number }}
       variants: ${{ needs.compute-variants.outputs.variants }}
+      device_matrix: '[{"platform":"iOS","device":"iPhone.*","os_version":""},{"platform":"Android","device":"Google.*","os_version":""}]'
       include_biometrics: false
     secrets:
       SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
@@ -1172,7 +1178,7 @@ jobs:
       CARD_SERIAL: ${{ secrets.CARD_SERIAL }}
       BIRTH_DATE: ${{ secrets.BIRTH_DATE }}
 
-  # Full regression + biometrics on merge to main:
+  # Full regression + biometrics on merge to main (3 iOS + 3 Android OS versions):
   # e2e-regression:
   #   needs: [ship-to-saucelabs, compute-variants]
   #   if: >-
@@ -1183,6 +1189,15 @@ jobs:
   #     suite: full-regression
   #     build_number: ${{ github.run_number }}
   #     variants: ${{ needs.compute-variants.outputs.variants }}
+  #     device_matrix: >-
+  #       [
+  #         {"platform":"iOS","device":"iPhone.*","os_version":"18"},
+  #         {"platform":"iOS","device":"iPhone.*","os_version":"17"},
+  #         {"platform":"iOS","device":"iPhone.*","os_version":"16"},
+  #         {"platform":"Android","device":"Google.*","os_version":"15"},
+  #         {"platform":"Android","device":"Google.*","os_version":"14"},
+  #         {"platform":"Android","device":"Google.*","os_version":"13"}
+  #       ]
   #     include_biometrics: true
   #   secrets:
   #     SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}

--- a/e2e/.env.saucelabs.example
+++ b/e2e/.env.saucelabs.example
@@ -14,6 +14,14 @@ SAUCE_REGION=us
 ANDROID_APP_FILENAME=BCSC-Dev-latest.aab
 IOS_APP_FILENAME=BCSC-Dev-latest.ipa
 
+# --- iOS device targeting (optional) ---
+# IOS_DEVICE_NAME=iPhone 15.*
+# IOS_PLATFORM_VERSION=18
+
+# --- Android device targeting (optional) ---
+# ANDROID_DEVICE_NAME=Google Pixel 8.*
+# ANDROID_PLATFORM_VERSION=15
+
 # --- SauceLabs test metadata ---
 BUILD_NAME=local-manual
 TEST_NAME=E2E Tests (local)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -30,12 +30,15 @@ _Tests are organized into named suites. Use the_ `--suite` _flag to select which
 | `happy-path`      | _Full flow: straight-through onboarding (PIN auth), combined-card verification, main navigation_ |
 | `full-regression` | _Full flow: card scanning + send video verification (two orchestrated specs via directory glob)_ |
 | `biometrics`      | _Onboarding with biometric auth (Sauce Labs RDC only, requires_ `allowTouchIdEnroll`_)_          |
+| `verified`        | _Verified-state flows: setup (phase 1) then credential checks (phase 2). Sauce RDC only._        |
 
 ```bash
 # Run by suite name
 yarn wdio configs/local/wdio.ios.local.sim.conf.ts --suite smoke
 yarn wdio configs/local/wdio.ios.local.sim.conf.ts --suite happy-path
 yarn wdio configs/local/wdio.ios.local.sim.conf.ts --suite full-regression
+# verified runs against Sauce RDC (noReset=true); use the sauce config
+yarn wdio configs/sauce/verified/wdio.ios.verified.sauce.rdc.conf.ts --suite verified
 ```
 
 _Without_ `--suite`_, the default spec is_ `smoke.spec.ts`_._
@@ -345,17 +348,16 @@ _For local testing, camera injection is not available — use a test-mode flag i
 
 _Tests run automatically in GitHub Actions via a device matrix that controls which OS versions are tested:_
 
-| _Trigger_            | _Suite_           | _Device Matrix_                     | _Variants_        | _Biometrics_ |
-| -------------------- | ----------------- | ----------------------------------- | ----------------- | ------------ |
-| _PR_                 | `smoke`           | _1 iOS (18) + 1 Android (15)_       | _PR variants (2)_ | _No_         |
-| `main` _merge_       | `full-regression` | _3 iOS (16–18) + 3 Android (13–15)_ | _All 5 variants_  | _Yes_        |
-| _Nightly (schedule)_ | `full-regression` | _3 iOS (16–18) + 3 Android (13–15)_ | _All 5 variants_  | _Yes_        |
+| _Trigger_            | _Suite_           | _Device Matrix_                     | _Variant_  | _Biometrics_ |
+| -------------------- | ----------------- | ----------------------------------- | ---------- | ------------ |
+| _PR_                 | `smoke`           | _1 iOS (18) + 1 Android (15)_       | `bcsc-dev` | _No_         |
+| _Nightly (schedule)_ | `full-regression` | _3 iOS (16–18) + 3 Android (13–15)_ | `bcsc-dev` | _Yes_        |
 
 _The device matrix is passed as a JSON array of_ `{platform, device, os_version}` _objects to_ `e2e.yml`_. Each entry spawns a separate SauceLabs session with its own logs and pass/fail status. Biometric tests run as a separate non-blocking job after the main E2E tests._
 
 _**Note:** The_ `main` _merge E2E regression job is commented out pending GitHub Actions runner IP whitelisting with the BC Gov ID Check portal. See the IP whitelisting options documented in_ `main.yaml`_. Until resolved, nightly runs provide full regression coverage._
 
-_**Concurrency:** SauceLabs sessions are limited to_ `max-parallel: 2`_. For PRs (2 devices × 2 variants = 4 jobs) this means 2 rounds. Nightly runs with the full matrix queue longer._
+_**Concurrency:** SauceLabs sessions are limited to_ `max-parallel: 2`_. For PRs (2 devices = 2 jobs) this fits within a single round. Nightly runs with the full device matrix queue longer._
 
 ## _Local App Binaries_
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -28,7 +28,7 @@ _Tests are organized into named suites. Use the_ `--suite` _flag to select which
 | ----------------- | ------------------------------------------------------------------------------------------------ |
 | `smoke`           | _App launch + initial navigation (fast sanity check)_                                            |
 | `happy-path`      | _Full flow: straight-through onboarding (PIN auth), combined-card verification, main navigation_ |
-| `full-regression` | _Full flow: card scanning + send video verification (two orchestrated specs via directory glob)_  |
+| `full-regression` | _Full flow: card scanning + send video verification (two orchestrated specs via directory glob)_ |
 | `biometrics`      | _Onboarding with biometric auth (Sauce Labs RDC only, requires_ `allowTouchIdEnroll`_)_          |
 
 ```bash
@@ -196,17 +196,19 @@ _Three env files split general e2e config, SauceLabs credentials, and SiteMinder
 
 ### _SauceLabs (`.env.saucelabs`)_
 
-| _Variable_             | _Default_               | _Description_                                                                    |
-| ---------------------- | ----------------------- | -------------------------------------------------------------------------------- |
-| `SAUCE_USERNAME`       | _—_                     | _SauceLabs username_                                                             |
-| `SAUCE_ACCESS_KEY`     | _—_                     | _SauceLabs access key_                                                           |
-| `SAUCE_REGION`         | `us`                    | _SauceLabs data center region (_`us` _or_ `eu`_)_                                |
-| `ANDROID_APP_FILENAME` | `BCSC-Dev-latest.aab`   | _Android app filename in SauceLabs storage_                                      |
-| `IOS_APP_FILENAME`     | `BCSC-Dev-latest.ipa`   | _iOS app filename in SauceLabs storage_                                          |
-| `PLATFORM_VERSION`     | _unset_                 | _Pin Sauce RDC OS version (e.g._ `18`_,_ `15`_). Unset = Sauce picks any match._ |
-| `DEVICE_NAME`          | `iPhone.*` / `Google.*` | _Sauce RDC device name regex. Overrides the default per-platform pattern._       |
-| `BUILD_NAME`           | `local-<timestamp>`     | _SauceLabs build name_                                                           |
-| `TEST_NAME`            | `E2E Tests`             | _SauceLabs test name_                                                            |
+| _Variable_                 | _Default_             | _Description_                                                                 |
+| -------------------------- | --------------------- | ----------------------------------------------------------------------------- |
+| `SAUCE_USERNAME`           | _—_                   | _SauceLabs username_                                                          |
+| `SAUCE_ACCESS_KEY`         | _—_                   | _SauceLabs access key_                                                        |
+| `SAUCE_REGION`             | `us`                  | _SauceLabs data center region (_`us` _or_ `eu`_)_                             |
+| `ANDROID_APP_FILENAME`     | `BCSC-Dev-latest.aab` | _Android app filename in SauceLabs storage_                                   |
+| `IOS_APP_FILENAME`         | `BCSC-Dev-latest.ipa` | _iOS app filename in SauceLabs storage_                                       |
+| `IOS_DEVICE_NAME`          | `iPhone.*`            | _iOS device name regex for Sauce RDC allocation_                              |
+| `IOS_PLATFORM_VERSION`     | _unset_               | _Pin iOS version (e.g._ `18`_). Unset = Sauce picks any available match._     |
+| `ANDROID_DEVICE_NAME`      | `Google.*`            | _Android device name regex for Sauce RDC allocation_                          |
+| `ANDROID_PLATFORM_VERSION` | _unset_               | _Pin Android version (e.g._ `15`_). Unset = Sauce picks any available match._ |
+| `BUILD_NAME`               | `local-<timestamp>`   | _SauceLabs build name_                                                        |
+| `TEST_NAME`                | `E2E Tests`           | _SauceLabs test name_                                                         |
 
 ### _SiteMinder (`local.env`)_
 
@@ -241,7 +243,7 @@ wdio.shared.conf.ts                         ← base (specs, suites, framework, 
       └── sauce/wdio.ios.sauce.rdc.conf.ts         ← + iOS real device caps
 ```
 
-_Each leaf config only contains **capabilities** (device name, platform version, app path). Everything else is inherited. Sauce configs read_ `DEVICE_NAME` _and_ `PLATFORM_VERSION` _from the environment to allow CI to control device targeting without config changes._
+_Each leaf config only contains **capabilities** (device name, platform version, app path). Everything else is inherited. Each platform config reads its own env vars (_`IOS_DEVICE_NAME`_,_ `IOS_PLATFORM_VERSION`_,_ `ANDROID_DEVICE_NAME`_,_ `ANDROID_PLATFORM_VERSION`_) to allow CI to control device targeting without config changes._
 
 ## _Writing Tests_
 
@@ -343,11 +345,11 @@ _For local testing, camera injection is not available — use a test-mode flag i
 
 _Tests run automatically in GitHub Actions via a device matrix that controls which OS versions are tested:_
 
-| _Trigger_            | _Suite_           | _Device Matrix_                     | _Variants_                  | _Biometrics_ |
-| -------------------- | ----------------- | ----------------------------------- | --------------------------- | ------------ |
-| _PR_                 | `smoke`           | _1 iOS (18) + 1 Android (15)_       | _PR variants (2)_           | _No_         |
-| `main` _merge_       | `full-regression` | _3 iOS (16–18) + 3 Android (13–15)_ | _All 5 variants_            | _Yes_        |
-| _Nightly (schedule)_ | `full-regression` | _3 iOS (16–18) + 3 Android (13–15)_ | _All 5 variants_            | _Yes_        |
+| _Trigger_            | _Suite_           | _Device Matrix_                     | _Variants_        | _Biometrics_ |
+| -------------------- | ----------------- | ----------------------------------- | ----------------- | ------------ |
+| _PR_                 | `smoke`           | _1 iOS (18) + 1 Android (15)_       | _PR variants (2)_ | _No_         |
+| `main` _merge_       | `full-regression` | _3 iOS (16–18) + 3 Android (13–15)_ | _All 5 variants_  | _Yes_        |
+| _Nightly (schedule)_ | `full-regression` | _3 iOS (16–18) + 3 Android (13–15)_ | _All 5 variants_  | _Yes_        |
 
 _The device matrix is passed as a JSON array of_ `{platform, device, os_version}` _objects to_ `e2e.yml`_. Each entry spawns a separate SauceLabs session with its own logs and pass/fail status. Biometric tests run as a separate non-blocking job after the main E2E tests._
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -28,7 +28,8 @@ _Tests are organized into named suites. Use the_ `--suite` _flag to select which
 | ----------------- | ------------------------------------------------------------------------------------------------ |
 | `smoke`           | _App launch + initial navigation (fast sanity check)_                                            |
 | `happy-path`      | _Full flow: straight-through onboarding (PIN auth), combined-card verification, main navigation_ |
-| `full-regression` | _Full flow: onboarding with transfer/setup/help detours, non-photo card with additional ID_      |
+| `full-regression` | _Full flow: card scanning + send video verification (two orchestrated specs via directory glob)_  |
+| `biometrics`      | _Onboarding with biometric auth (Sauce Labs RDC only, requires_ `allowTouchIdEnroll`_)_          |
 
 ```bash
 # Run by suite name
@@ -114,7 +115,7 @@ Appium installs **WebDriverAgentRunner** on the device to drive automation. It m
 
 1. **Device:** Trust the computer (USB prompt), enable **Developer Mode** (iOS 16+: Settings → Privacy & Security), and **trust your developer certificate** (Settings → General → VPN & Device Management → your team → Trust).
 2. **WDA signing:** Follow [Appium's real device preparation](https://appium.github.io/appium-xcuitest-driver/latest/preparation/real-device-config/). Easiest is [Basic Automatic Configuration](https://appium.github.io/appium-xcuitest-driver/latest/preparation/prov-profile-basic-auto/) (paid Apple Developer account). If that fails, use one of the manual approaches (e.g. open WDA in Xcode: `appium driver run xcuitest open-wda` from the e2e folder, then sign the WebDriverAgent target with your team).
-3. **Logs:** The device config sets `showXcodeLog: true` so Appium logs show the actual xcodebuild error; check `e2e/logs/` after a run.
+3. **Logs:** Set `SHOW_XCODE_LOG=true` (in `.env.e2e` or inline) to print full xcodebuild output when WDA fails; check `e2e/logs/` after a run.
 
 ### _Local — Android Real Device_
 
@@ -195,15 +196,17 @@ _Three env files split general e2e config, SauceLabs credentials, and SiteMinder
 
 ### _SauceLabs (`.env.saucelabs`)_
 
-| _Variable_             | _Default_             | _Description_                                     |
-| ---------------------- | --------------------- | ------------------------------------------------- |
-| `SAUCE_USERNAME`       | _—_                   | _SauceLabs username_                              |
-| `SAUCE_ACCESS_KEY`     | _—_                   | _SauceLabs access key_                            |
-| `SAUCE_REGION`         | `us`                  | _SauceLabs data center region (_`us` _or_ `eu`_)_ |
-| `ANDROID_APP_FILENAME` | `BCSC-Dev-latest.aab` | _Android app filename in SauceLabs storage_       |
-| `IOS_APP_FILENAME`     | `BCSC-Dev-latest.ipa` | _iOS app filename in SauceLabs storage_           |
-| `BUILD_NAME`           | `local-<timestamp>`   | _SauceLabs build name_                            |
-| `TEST_NAME`            | `E2E Tests`           | _SauceLabs test name_                             |
+| _Variable_             | _Default_               | _Description_                                                                    |
+| ---------------------- | ----------------------- | -------------------------------------------------------------------------------- |
+| `SAUCE_USERNAME`       | _—_                     | _SauceLabs username_                                                             |
+| `SAUCE_ACCESS_KEY`     | _—_                     | _SauceLabs access key_                                                           |
+| `SAUCE_REGION`         | `us`                    | _SauceLabs data center region (_`us` _or_ `eu`_)_                                |
+| `ANDROID_APP_FILENAME` | `BCSC-Dev-latest.aab`   | _Android app filename in SauceLabs storage_                                      |
+| `IOS_APP_FILENAME`     | `BCSC-Dev-latest.ipa`   | _iOS app filename in SauceLabs storage_                                          |
+| `PLATFORM_VERSION`     | _unset_                 | _Pin Sauce RDC OS version (e.g._ `18`_,_ `15`_). Unset = Sauce picks any match._ |
+| `DEVICE_NAME`          | `iPhone.*` / `Google.*` | _Sauce RDC device name regex. Overrides the default per-platform pattern._       |
+| `BUILD_NAME`           | `local-<timestamp>`     | _SauceLabs build name_                                                           |
+| `TEST_NAME`            | `E2E Tests`             | _SauceLabs test name_                                                            |
 
 ### _SiteMinder (`local.env`)_
 
@@ -238,7 +241,7 @@ wdio.shared.conf.ts                         ← base (specs, suites, framework, 
       └── sauce/wdio.ios.sauce.rdc.conf.ts         ← + iOS real device caps
 ```
 
-_Each leaf config only contains **capabilities** (device name, platform version, app path). Everything else is inherited._
+_Each leaf config only contains **capabilities** (device name, platform version, app path). Everything else is inherited. Sauce configs read_ `DEVICE_NAME` _and_ `PLATFORM_VERSION` _from the environment to allow CI to control device targeting without config changes._
 
 ## _Writing Tests_
 
@@ -282,10 +285,10 @@ _Specs are small, focused files that each test a single action or feature. Suite
 | `E2E_FLOW=simple ... --spec test/bcsc/e2e.spec.ts`   | `--suite happy-path`      |
 | `E2E_FLOW=advanced ... --spec test/bcsc/e2e.spec.ts` | `--suite full-regression` |
 
-_Each suite's orchestrator imports composable specs in order, preserving a single Mocha session for stateful flows. Adding a new permutation (e.g. biometric + combined card) is just a new orchestrator with different imports:_
+_Orchestrator files import composable specs in order, preserving a single Mocha session for stateful flows. Adding a new permutation (e.g. biometric + combined card) is just a new orchestrator with different imports:_
 
 ```typescript
-// test/bcsc/happy-path.spec.ts
+// test/bcsc/happy-path.spec.ts — used by --suite happy-path
 import './onboarding/app-launch.spec.js'
 import './onboarding/add-account.spec.js'
 import './onboarding/consent.spec.js'
@@ -298,62 +301,59 @@ import './verify/in-person-verification.spec.js'
 import './main/main.spec.js'
 ```
 
+_The_ `full-regression` _suite uses a **directory glob** (`full-regression/*.spec.ts`) rather than a single orchestrator. Each file in the_ `full-regression/` _directory is an independent orchestrated flow (e.g. card scanning, send video). The standalone_ `full-regression.spec.ts` _orchestrator still exists for running the full non-photo-card flow via_ `--spec`_:_
+
 ```typescript
-// test/bcsc/full-regression.spec.ts
-import './onboarding/app-launch.spec.js'
-import './onboarding/transfer-detour.spec.js'
-import './onboarding/add-account.spec.js'
-import './onboarding/setup-type-interaction.spec.js'
-import './onboarding/consent.spec.js'
-import './onboarding/notifications-help.spec.js'
-import './onboarding/notifications.spec.js'
-import './onboarding/secure-app-help.spec.js'
-import './onboarding/pin-auth.spec.js'
-import './verify/card-type/config-non-photo-card.js'
-import './verify/nickname.spec.js'
-import './verify/card-csn.spec.js'
-import './verify/additional-id-passport.spec.js'
-import './verify/in-person-verification.spec.js'
-import './main/main.spec.js'
+// test/bcsc/full-regression/card-csn-scanning.spec.ts — card scanning flow
+import '../onboarding/app-launch.spec.js'
+import '../onboarding/add-account.spec.js'
+import '../onboarding/consent.spec.js'
+import '../onboarding/notifications.spec.js'
+import '../onboarding/pin-auth.spec.js'
+import '../verify/card-type/config-combined-card.js'
+import '../verify/nickname.spec.js'
+import '../verify/card-scan.spec.js'
 ```
 
 _Shared state (e.g. test user data) flows between specs via_ `verify/card-type/card-context.ts`_. Card-type config modules (e.g._ `config-combined-card.ts`_) set_ `verifyContext.testUser` _and_ `verifyContext.cardTypeButton` _at module evaluation time; downstream specs like_ `card-csn.spec.ts` _and_ `in-person-verification.spec.ts` _read them lazily inside_ `it` _blocks._
 
-### _Camera & Video Injection_
+### _Camera Image Injection_
 
-_The_ `camera` _and_ `video` _helpers simulate camera input on Sauce Labs RDC. Both use Sauce Labs' image injection under the hood — still images for photo capture / QR scanning, and the same mechanism for video frames (Sauce feeds the injected image into_ `AVCaptureVideoDataOutput` _on iOS and_ `camera2` _on Android)._
+_The_ `camera` _helper simulates camera input on Sauce Labs RDC via image injection. The injected image replaces the live camera feed for both still capture and video frame output, so the same call works for photo capture, QR/barcode scanning, and video recording._
 
-_Place test images in_ `e2e/assets/` _(see_ [`assets/README.md`](assets/README.md)_). Helpers resolve relative filenames from that directory automatically._
+_Place test images in_ `e2e/assets/images/` _(see_ [`assets/README.md`](assets/README.md)_). Helpers resolve relative filenames from the_ `assets/` _directory automatically._
+
+_The_ `injectPhoto` _function takes a path and a padding object. Padding (in pixels) repositions the image within the injected camera frame — useful for aligning barcodes with the app's scanning target area:_
 
 ```typescript
-import { injectQRCode, injectPhoto } from '../../src/helpers/camera.js'
-import { injectVideoFrame, sustainedFrameInjection } from '../../src/helpers/video.js'
+import { injectPhoto } from '../../src/helpers/camera.js'
+import { CARD_SCAN_PADDING } from '../../src/constants.js'
 
-// Inject a QR code before the scanner screen opens
-await injectQRCode('qr-invite.png')
-await SerialInstructions.tap('ScanBarcode')
+// Inject a driver's licence photo for card barcode scanning (with padding)
+await injectPhoto('images/dl_velma.jpg', CARD_SCAN_PADDING)
 
-// Inject an ID photo for evidence capture
-await injectPhoto('id-drivers-license.jpg')
-await EvidenceCapture.tap('TakePhoto')
-
-// Inject a face image as video frames while recording
-await injectVideoFrame('selfie-liveness.png')
-await TakeVideo.tap('StartRecordingButton')
-// Keep re-injecting during the recording duration
-await sustainedFrameInjection('selfie-liveness.png', { durationMs: 8_000 })
+// Inject a selfie for evidence capture (no padding needed)
+await injectPhoto('images/id_shaggy.jpg', { top: 0, right: 0, bottom: 0, left: 0 })
+await TakePhoto.tap('TakePhoto')
 ```
 
 _For local testing, camera injection is not available — use a test-mode flag in the app instead._
 
 ## _CI/CD_
 
-_Tests run automatically in GitHub Actions:_
+_Tests run automatically in GitHub Actions via a device matrix that controls which OS versions are tested:_
 
-| _Trigger_      | _Scope_                                        | _Devices_                   |
-| -------------- | ---------------------------------------------- | --------------------------- |
-| _PR_           | `--suite smoke` _only_                         | _1 Android RDC + 1 iOS RDC_ |
-| `main` _merge_ | _Temporarily disabled (re-enable when stable)_ | _—_                         |
+| _Trigger_            | _Suite_           | _Device Matrix_                     | _Variants_                  | _Biometrics_ |
+| -------------------- | ----------------- | ----------------------------------- | --------------------------- | ------------ |
+| _PR_                 | `smoke`           | _1 iOS (18) + 1 Android (15)_       | _PR variants (2)_           | _No_         |
+| `main` _merge_       | `full-regression` | _3 iOS (16–18) + 3 Android (13–15)_ | _All 5 variants_            | _Yes_        |
+| _Nightly (schedule)_ | `full-regression` | _3 iOS (16–18) + 3 Android (13–15)_ | _All 5 variants_            | _Yes_        |
+
+_The device matrix is passed as a JSON array of_ `{platform, device, os_version}` _objects to_ `e2e.yml`_. Each entry spawns a separate SauceLabs session with its own logs and pass/fail status. Biometric tests run as a separate non-blocking job after the main E2E tests._
+
+_**Note:** The_ `main` _merge E2E regression job is commented out pending GitHub Actions runner IP whitelisting with the BC Gov ID Check portal. See the IP whitelisting options documented in_ `main.yaml`_. Until resolved, nightly runs provide full regression coverage._
+
+_**Concurrency:** SauceLabs sessions are limited to_ `max-parallel: 2`_. For PRs (2 devices × 2 variants = 4 jobs) this means 2 rounds. Nightly runs with the full matrix queue longer._
 
 ## _Local App Binaries_
 
@@ -372,6 +372,7 @@ _Place local builds in_ `e2e/apps/` _for local testing. See_ [`apps/README.md`](
 e2e/
 ├── package.json                             # workspace package with WDIO + Appium deps
 ├── tsconfig.json                            # TypeScript config (strict, ESNext modules)
+├── eslint.config.mjs                        # ESLint flat config
 ├── .env.e2e.example                         # general e2e config template (copy to .env.e2e)
 ├── .env.saucelabs.example                   # SauceLabs credentials template (copy to .env.saucelabs)
 │
@@ -391,7 +392,10 @@ e2e/
 │   └── sauce/
 │       ├── wdio.shared.sauce.conf.ts        # SauceLabs auth, region, sauce service
 │       ├── wdio.android.sauce.rdc.conf.ts   # Android real device (SauceLabs)
-│       └── wdio.ios.sauce.rdc.conf.ts       # iOS real device (SauceLabs)
+│       ├── wdio.ios.sauce.rdc.conf.ts       # iOS real device (SauceLabs)
+│       └── biometrics/
+│           ├── wdio.android.bio.sauce.rdc.conf.ts # Android + allowTouchIdEnroll
+│           └── wdio.ios.bio.sauce.rdc.conf.ts     # iOS + allowTouchIdEnroll
 │
 ├── src/
 │   ├── constants.ts                         # timeouts, TestUsers, and shared values
@@ -399,13 +403,11 @@ e2e/
 │   ├── testIDs.ts                           # central registry of accessibility / resource IDs
 │   │
 │   ├── helpers/
+│   │   ├── alerts.ts                        # iOS system alert acceptance (permissions, dialogs)
 │   │   ├── approval.ts                      # in-person verification approval via SiteMinder
-│   │   ├── biometrics.ts                    # biometric simulation (local + SauceLabs)
-│   │   ├── camera.ts                        # camera image injection (QR codes, photos)
-│   │   ├── video.ts                         # video frame injection + device file push
-│   │   ├── gestures.ts                      # swipe, scroll, long-press wrappers
-│   │   ├── iosPermissions.ts                # iOS local-network permission dialog handling
-│   │   ├── notifications.ts                 # notification permission dialog handling (iOS + Android)
+│   │   ├── biometrics.ts                    # biometric simulation (Sauce Labs RDC)
+│   │   ├── camera.ts                        # camera image injection + padding (photos, QR, video)
+│   │   ├── gestures.ts                      # swipe, scroll, tap-at-coordinate wrappers
 │   │   └── sauce.ts                         # SauceLabs-specific utilities (detection, annotations)
 │   │
 │   └── screens/                             # screen objects — generic base + BCSC_TestIDs registry
@@ -418,35 +420,48 @@ e2e/
 │   └── bcsc/                                # BCSC variant test suite
 │       ├── smoke.spec.ts                    # app launch + initial navigation (default spec)
 │       ├── happy-path.spec.ts               # suite orchestrator: onboarding → combined card → main
-│       ├── full-regression.spec.ts          # suite orchestrator: full onboarding → non-photo + passport → main
+│       ├── full-regression.spec.ts          # orchestrator: full onboarding → non-photo + passport → main
+│       ├── biometrics.spec.ts               # orchestrator: onboarding with biometric auth
+│       ├── full-regression/                 # full-regression suite (glob: *.spec.ts)
+│       │   ├── card-csn-scanning.spec.ts    # card scanning flow (onboarding → scan → verify)
+│       │   └── send-image-video.spec.ts     # send video flow (onboarding → photo/video capture)
 │       ├── onboarding/
 │       │   ├── app-launch.spec.ts           # app launch + first screen
 │       │   ├── add-account.spec.ts          # add account flow
+│       │   ├── biometric-auth.spec.ts       # biometric auth setup (biometrics suite)
 │       │   ├── consent.spec.ts              # consent screen
 │       │   ├── notifications.spec.ts        # notification permission
-│       │   ├── notifications-help.spec.ts   # notification help detour (full-regression)
+│       │   ├── notifications-help.spec.ts   # notification help detour
 │       │   ├── pin-auth.spec.ts             # PIN creation
-│       │   ├── secure-app-help.spec.ts      # secure app help detour (full-regression)
-│       │   ├── setup-type-interaction.spec.ts # setup type selection detour (full-regression)
-│       │   └── transfer-detour.spec.ts      # transfer detour (full-regression)
+│       │   ├── secure-app-help.spec.ts      # secure app help detour
+│       │   ├── setup-type-interaction.spec.ts # setup type selection detour
+│       │   └── transfer-detour.spec.ts      # transfer detour
 │       ├── verify/
 │       │   ├── card-csn.spec.ts             # card serial + birthdate entry
+│       │   ├── card-scan.spec.ts            # card barcode scanning via camera injection
 │       │   ├── nickname.spec.ts             # nickname entry
-│       │   ├── additional-id-passport.spec.ts # passport evidence capture (full-regression)
+│       │   ├── additional-id-passport.spec.ts # passport evidence capture
 │       │   ├── in-person-verification.spec.ts # in-person verification method
+│       │   ├── send-video-verification.spec.ts # photo + video evidence capture
 │       │   └── card-type/
 │       │       ├── card-context.ts          # shared mutable verify context (testUser, cardType)
 │       │       ├── config-combined-card.ts  # sets context for combined card (happy-path)
-│       │       └── config-non-photo-card.ts # sets context for non-photo card (full-regression)
+│       │       └── config-non-photo-card.ts # sets context for non-photo card
 │       └── main/
 │           └── main.spec.ts                 # tab navigation, settings, account tests
 │
-├── assets/                                  # test images for camera/video injection
+├── assets/                                  # test images for camera injection
 │   ├── README.md
 │   ├── USERS.md                             # test account reference (Scooby-Doo themed)
-│   └── images/                              # ID and passport photos for evidence capture
-│       ├── id-1.jpg .. id-4.jpg
-│       └── passport.jpg
+│   └── images/                              # ID, driver's licence, and passport photos
+│       ├── dl_daphne.jpg                    # driver's licence — Daphne (non-photo card)
+│       ├── dl_shaggy.jpg                    # driver's licence — Shaggy (photo card)
+│       ├── dl_velma.jpg                     # driver's licence — Velma (combo card)
+│       ├── id_daphne.jpg                    # ID selfie — Daphne
+│       ├── id_fred.jpg                      # ID selfie — Fred
+│       ├── id_shaggy.jpg                    # ID selfie — Shaggy
+│       ├── id_velma.jpg                     # ID selfie — Velma
+│       └── passport.jpg                     # passport photo
 │
 ├── logs/                                    # Appium logs (gitignored)
 │

--- a/e2e/apps/README.md
+++ b/e2e/apps/README.md
@@ -65,5 +65,5 @@ The WDIO configs look for these filenames by default (override via env vars):
 | Target                  | Default filename | Env var override |
 | ----------------------- | ---------------- | ---------------- |
 | iOS Simulator           | `BCWallet.app`   | `IOS_APP`        |
-| iOS Real Device         | `BCWallet.ipa`   | `IOS_APP`        |
+| iOS Real Device         | `BCWallet.ipa`   | `IOS_APP_DEVICE` |
 | Android (emu or device) | `BCWallet.apk`   | `ANDROID_APP`    |

--- a/e2e/assets/README.md
+++ b/e2e/assets/README.md
@@ -1,34 +1,29 @@
 # E2E Test Assets
 
-Static image and video files used by camera/video injection helpers during E2E tests.
+Static image files used by camera injection helpers during E2E tests.
 
 ## Conventions
 
-| File           | Purpose                                      | Format             |
-| -------------- | -------------------------------------------- | ------------------ |
-| `qr-*.png`     | QR code images for scanner tests             | PNG, ≤ 5 MB        |
-| `id-*.jpg`     | ID card / evidence photos                    | JPG or PNG, ≤ 5 MB |
-| `selfie-*.png` | Selfie / face images for liveness            | PNG, ≤ 5 MB        |
-| `*.mp4`        | Pre-recorded videos for gallery upload flows | MP4                |
+| File           | Purpose                      | Format             |
+| -------------- | ---------------------------- | ------------------ |
+| `dl_*.jpg`     | Driver's licence photos      | JPG or PNG, ≤ 5 MB |
+| `id_*.jpg`     | BC Services Card / ID photos | JPG or PNG, ≤ 5 MB |
+| `passport.jpg` | Passport photo               | JPG or PNG, ≤ 5 MB |
 
 ## Image Requirements (Sauce Labs)
 
 - **Format:** JPG, JPEG, or PNG
 - **Max size:** 5 MB
-- **QR codes:** Add whitespace padding around the code if the app's scanner defines a small target area — Sauce Labs scales images linearly to fit the camera resolution
 
 ## Usage
 
 ```typescript
-import { injectQRCode, injectPhoto } from '../src/helpers/camera.js'
-import { injectVideoFrame, sustainedFrameInjection } from '../src/helpers/video.js'
+import { injectPhoto } from '../src/helpers/camera.js'
+import { CARD_SCAN_PADDING } from '../src/constants.js'
 
-// QR code scanning — resolves to e2e/assets/qr-invite.png
-await injectQRCode('qr-invite.png')
+// Driver's licence capture — resolves to e2e/assets/images/dl_velma.jpg
+await injectPhoto('images/dl_velma.jpg', CARD_SCAN_PADDING)
 
-// ID photo capture — resolves to e2e/assets/id-drivers-license.jpg
-await injectPhoto('id-drivers-license.jpg')
-
-// Video recording — inject face image as video frames for 8 seconds
-await sustainedFrameInjection('selfie-liveness.png', { durationMs: 8_000 })
+// ID card capture — resolves to e2e/assets/images/id_shaggy.jpg
+await injectPhoto('images/id_shaggy.jpg', { top: 0, right: 0, bottom: 0, left: 0 })
 ```

--- a/e2e/assets/USERS.md
+++ b/e2e/assets/USERS.md
@@ -1,31 +1,30 @@
 # BC Services Card — E2E test accounts
 
-Reference for **Create a Test Account** in the test portal. Use generated or placeholder values where the portal allows; align with your environment’s rules for serials, PHN, and document IDs.
+Test accounts created in the **SIT** environment. All values below (serials, PHNs, ICBC IDs) are fake. Card serial numbers match the barcodes embedded in the corresponding `dl_*.jpg` asset images.
 
 ## Test users (Scooby-Doo themed)
 
-One persona per **card type**. **Shared conventions (replace with env-specific values):**
+One persona per **card type**.
 
-- **Password:** use one team-wide test secret (not committed), e.g. vault-stored `E2E_BCSC_TEST_PASSWORD`.
-- **Serials / PHN / ICBC / doc IDs:** use unique, obviously fake values unless your portal supplies generators.
-- **Email domain:** use your org’s disposable test domain if required.
+- **Serials / PHN / ICBC / doc IDs:** unique, obviously fake values.
+- **Email domain:** use your org's disposable test domain if required.
 
-| Card type        | Username     | PASSWORD   | Surname | Given 1 | DOB        | Documented sex |
-| ---------------- | ------------ | ---------- | ------- | ------- | ---------- | -------------- |
-| Standalone photo | `e2e_shaggy` | `password` | Rogers  | Shaggy  | 1969-09-13 | Male           |
-| Combo            | `e2e_velma`  | `password` | Dinkley | Velma   | 1995-12-17 | Female         |
-| Non-Photo        | `e2e_daphne` | `password` | Blake   | Daphne  | 1980-09-22 | Female         |
-| N/A              | `e2e_fred`   | `password` | Jones   | Fred    | 1968-09-18 | Male           |
+| Card type        | Username     | Surname | Given 1 | DOB        | Documented sex |
+| ---------------- | ------------ | ------- | ------- | ---------- | -------------- |
+| Standalone photo | `e2e_shaggy` | Rogers  | Shaggy  | 1969-09-13 | Male           |
+| Combo            | `e2e_velma`  | Dinkley | Velma   | 1995-12-17 | Female         |
+| Non-Photo        | `e2e_daphne` | Blake   | Daphne  | 1980-09-22 | Female         |
+| N/A              | `e2e_fred`   | Jones   | Fred    | 1968-09-18 | Male           |
 
 ---
 
-## Example fake IDs (optional pattern)
+## Fake IDs
 
-Use only if your portal accepts arbitrary test digits; **do not** use real PHNs or real card data.
+All values are fabricated for testing — **do not** use real PHNs or real card data.
 
-| Username     | Example card serial | Card issue date | Card Expiry Date | DOB          | Example PHN (fake) | Example ICBC ID (fake) |
-| ------------ | ------------------- | --------------- | ---------------- | ------------ | ------------------ | ---------------------- |
-| `e2e_shaggy` | `C74455103`         | `2022-09-13`    | `2026-09-13`     | `1969-09-13` | `5171963054`       | `793501815`            |
-| `e2e_velma`  | `C82643367`         | `2026-03-24`    | `2031-03-23`     | `1995-12-17` | `5892454574`       | `111442027`            |
-| `e2e_daphne` | `C26444539`         | `2026-03-24`    | `2031-03-23`     | `1980-09-22` | `6270487024`       | `774425241`            |
-| `e2e_fred`   | `N/A`               | `N/A`           | `N/A`            | `1968-09-18` | `N/A`              | `N/A`                  |
+| Username     | Card serial | Card issue date | Card expiry date | DOB          | PHN (fake)   | ICBC ID (fake) |
+| ------------ | ----------- | --------------- | ---------------- | ------------ | ------------ | -------------- |
+| `e2e_shaggy` | `C74455103` | `2022-09-13`    | `2026-09-13`     | `1969-09-13` | `5171963054` | `793501815`    |
+| `e2e_velma`  | `C82643367` | `2026-03-24`    | `2031-03-23`     | `1995-12-17` | `5892454574` | `111442027`    |
+| `e2e_daphne` | `C26444539` | `2026-03-24`    | `2031-03-23`     | `1980-09-22` | `6270487024` | `774425241`    |
+| `e2e_fred`   | `N/A`       | `N/A`           | `N/A`            | `1968-09-18` | `N/A`        | `N/A`          |

--- a/e2e/configs/sauce/verified/wdio.android.verified.sauce.rdc.conf.ts
+++ b/e2e/configs/sauce/verified/wdio.android.verified.sauce.rdc.conf.ts
@@ -1,0 +1,19 @@
+// sauce/verified/wdio.android.verified.sauce.rdc.conf.ts
+import { config as sauceConfig } from '../wdio.android.sauce.rdc.conf.js'
+import { sauceRdcOptions } from '../wdio.shared.sauce.conf.js'
+
+const config = { ...sauceConfig }
+
+// Sequential: specs share persisted app state across sessions
+config.maxInstances = 1
+
+config.capabilities = [
+  {
+    ...sauceConfig.capabilities[0],
+    'appium:noReset': true,
+    'appium:fullReset': false,
+    'sauce:options': sauceRdcOptions,
+  },
+]
+
+export { config }

--- a/e2e/configs/sauce/verified/wdio.ios.verified.sauce.rdc.conf.ts
+++ b/e2e/configs/sauce/verified/wdio.ios.verified.sauce.rdc.conf.ts
@@ -1,0 +1,19 @@
+// sauce/verified/wdio.ios.verified.sauce.rdc.conf.ts
+import { config as sauceConfig } from '../wdio.ios.sauce.rdc.conf.js'
+import { sauceRdcOptions } from '../wdio.shared.sauce.conf.js'
+
+const config = { ...sauceConfig }
+
+// Sequential: specs share persisted app state across sessions
+config.maxInstances = 1
+
+config.capabilities = [
+  {
+    ...sauceConfig.capabilities[0],
+    'appium:noReset': true,
+    'appium:fullReset': false,
+    'sauce:options': sauceRdcOptions,
+  },
+]
+
+export { config }

--- a/e2e/configs/sauce/wdio.android.sauce.rdc.conf.ts
+++ b/e2e/configs/sauce/wdio.android.sauce.rdc.conf.ts
@@ -8,13 +8,16 @@ const config = { ...sauceConfig }
 config.capabilities = [
   {
     platformName: 'Android',
-    'appium:deviceName': 'Google.*',
+    'appium:deviceName': process.env.ANDROID_DEVICE_NAME || 'Google.*',
     'appium:automationName': 'UiAutomator2',
     'appium:app': `storage:filename=${appFilename}`,
     'appium:noReset': false,
     'appium:fullReset': true,
     'appium:newCommandTimeout': 180,
     'appium:autoGrantPermissions': true,
+    ...(process.env.ANDROID_PLATFORM_VERSION && {
+      'appium:platformVersion': process.env.ANDROID_PLATFORM_VERSION,
+    }),
     'sauce:options': sauceRdcOptions,
   },
 ]

--- a/e2e/configs/sauce/wdio.ios.sauce.rdc.conf.ts
+++ b/e2e/configs/sauce/wdio.ios.sauce.rdc.conf.ts
@@ -8,13 +8,16 @@ const config = { ...sauceConfig }
 config.capabilities = [
   {
     platformName: 'iOS',
-    'appium:deviceName': 'iPhone.*',
+    'appium:deviceName': process.env.IOS_DEVICE_NAME || 'iPhone.*',
     'appium:automationName': 'XCUITest',
     'appium:app': `storage:filename=${appFilename}`,
     'appium:noReset': false,
     'appium:fullReset': true,
     'appium:newCommandTimeout': 180,
     'appium:autoAcceptAlerts': false,
+    ...(process.env.IOS_PLATFORM_VERSION && {
+      'appium:platformVersion': process.env.IOS_PLATFORM_VERSION,
+    }),
     'sauce:options': sauceRdcOptions,
   },
 ]

--- a/e2e/configs/wdio.shared.conf.ts
+++ b/e2e/configs/wdio.shared.conf.ts
@@ -19,6 +19,7 @@ export const config: WebdriverIO.Config = {
     'happy-path': [resolve(__dirname, `../test/${variant}/happy-path.spec.ts`)],
     'full-regression': [resolve(__dirname, `../test/${variant}/full-regression/*.spec.ts`)],
     biometrics: [resolve(__dirname, `../test/${variant}/biometrics.spec.ts`)],
+    verified: [resolve(__dirname, `../test/${variant}/verified/*.spec.ts`)],
   },
   exclude: [],
   capabilities: [],

--- a/e2e/configs/wdio.shared.conf.ts
+++ b/e2e/configs/wdio.shared.conf.ts
@@ -19,7 +19,7 @@ export const config: WebdriverIO.Config = {
     'happy-path': [resolve(__dirname, `../test/${variant}/happy-path.spec.ts`)],
     'full-regression': [resolve(__dirname, `../test/${variant}/full-regression/*.spec.ts`)],
     biometrics: [resolve(__dirname, `../test/${variant}/biometrics.spec.ts`)],
-    verified: [resolve(__dirname, `../test/${variant}/verified/*.spec.ts`)],
+    verified: [resolve(__dirname, `../test/${variant}/verified.spec.ts`)],
   },
   exclude: [],
   capabilities: [],

--- a/e2e/test/bcsc/verified.spec.ts
+++ b/e2e/test/bcsc/verified.spec.ts
@@ -1,0 +1,9 @@
+// organize-imports-ignore — import order defines test run order
+/**
+ * Verified BCSC E2E flow: straight-through onboarding (PIN auth, no detours),
+ *
+ * Run with: yarn wdio ... --suite verified
+ */
+
+// Note: `./verified/01-setup.spec.js` must be imported before any other `./verified/*.spec.js` imports to ensure proper test setup.
+import './verified/01-setup.spec.js'

--- a/e2e/test/bcsc/verified/01-setup.spec.ts
+++ b/e2e/test/bcsc/verified/01-setup.spec.ts
@@ -1,0 +1,31 @@
+// organize-imports-ignore — import order defines test run order
+/**
+ * Verified-state BCSC E2E suite: specs run sequentially with app state
+ * preserved between sessions (noReset=true / fullReset=false).
+ *
+ * Phase 1 — establishes verified state:
+ *   Full onboarding + verification flow, leaving the app at the home screen
+ *   with a verified account.
+ *
+ * Phase 2 — runs from verified home state:
+ *   Each subsequent spec starts a new session and finds the app already
+ *   verified, so it can skip onboarding entirely.
+ *
+ * Run with: yarn wdio configs/sauce/verified/wdio.<platform>.verified.sauce.rdc.conf.ts --suite verified
+ */
+
+// Phase 1: Onboarding + verification (runs once to establish verified state)
+import '../onboarding/app-launch.spec.js'
+import '../onboarding/add-account.spec.js'
+import '../onboarding/consent.spec.js'
+import '../onboarding/notifications.spec.js'
+import '../onboarding/pin-auth.spec.js'
+// Verify: Import `verify/card-type/config-*.js` before any `./verify/*.spec.js` imports.
+import '../verify/card-type/config-combined-card.js'
+import '../verify/nickname.spec.js'
+import '../verify/card-csn.spec.js'
+import '../verify/in-person-verification.spec.js'
+import '../main/main.spec.js'
+
+// Phase 2: Specs that start from the verified home screen
+// (add new specs here as they are created)


### PR DESCRIPTION
# Summary of Changes

Configure SauceLabs infrastructure so E2E tests run reliably in CI/CD pipelines.

### PR smoke tests (active)

- Every PR triggers a `smoke` suite on 1 iOS + 1 Android device via the reusable `e2e.yml` workflow (called from `main.yaml`).

### Nightly full regression + biometrics (blocked on IP whitelisting)

- Full regression is **not** run inline on merge to main — this keeps SauceLabs devices free during the day when multiple PRs merge.
- Instead, `e2e-nightly.yml` runs at midnight PT and checks whether any commits landed on main in the last 24 hours. If merges happened, it runs `full-regression` on 3 iOS (18/17/16) + 3 Android (15/14/13) OS versions, plus non-blocking biometric tests. If nothing merged, it skips entirely.
- Manual dispatches via the Actions UI always run regardless of the merge check.
- The nightly schedule is currently disabled pending IP whitelisting.

### Verified-state suite (scaffolded)

- A new `verified` suite runs specs sequentially with app state **persisted across sessions** (`noReset=true` / `fullReset=false`). The first spec runs the full onboarding + verification flow to reach the verified home screen; subsequent specs skip re-verification entirely.
- Dedicated config files (`configs/sauce/verified/wdio.{ios,android}.verified.sauce.rdc.conf.ts`) mirror the biometrics pattern — capability overrides are isolated, keeping the shared configs clean. `maxInstances: 1` is enforced at the config level to guarantee sequential execution.
- Wired into `e2e.yml` as a non-blocking `e2e-verified` job (like biometrics), and available as a `workflow_dispatch` option. The suite entry in `wdio.shared.conf.ts` is registered and ready; post-verified specs are added by importing under the Phase 2 comment in `verified.spec.ts`.

### Reusable E2E workflow

- `e2e.yml` accepts a `device_matrix` JSON array, `suite` name, and `build_number`. Each matrix entry spawns a separate SauceLabs RDC session (max-parallel: 2). Supports `smoke`, `happy-path`, `full-regression`, `biometrics`, and `verified` suites.

### Still in progress

- GitHub Actions runner IP whitelisting with BC Gov ID Check. Once complete, the nightly schedule can be enabled.

# Testing Instructions

1. Open a PR against `main` — verify the `e2e` / smoke job triggers after `ship-to-saucelabs` completes and runs on 1 iOS + 1 Android device.
2. Manually dispatch `e2e.yml` from the Actions UI with a known `build_number` and confirm tests execute on SauceLabs.
3. Manually dispatch `e2e-nightly.yml` — verify it resolves the latest main build number and runs the full device matrix (manual dispatches bypass the merge check).
4. Once IPs are whitelisted: uncomment the nightly schedule in `e2e-nightly.yml` and confirm it fires at midnight PT, only running when commits landed on main that day.
5. Manually dispatch `e2e.yml` with `suite: verified` — confirm the `e2e-verified` job runs on both iOS and Android, that phase 1 completes verification, and that any phase 2 specs start from the verified home screen without re-onboarding.

# Acceptance Criteria

- [x] CI/CD pipeline runs E2E smoke tests on at least 1 iOS and 1 Android device per PR
- [ ] GitHub Actions runner IPs are whitelisted for the verification process
- [ ] Nightly runs E2E full-regression on multiple devices and OS versions when merges land on main (uncomment schedule after whitelisting)
- [x] Pipeline configuration is documented (`e2e/README.md`, workflow comments, `.env.saucelabs.example`)
- [x] `verified` suite scaffolded — config files, suite aggregator, and CI job ready; post-verified specs added as they are written

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A
