### PR TITLE
fix: removed plain url

### DIFF
--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.test.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.test.tsx
@@ -128,6 +128,21 @@ describe('ServiceLogin', () => {
       expect(getByTestId(testIdWithKey('ServiceClientLink'))).toBeTruthy()
     })
 
+    it('renders Unavailable view (quick login unavailable) without service client URI', () => {
+      mockedUseServiceLoginState.mockReturnValue({
+        state: {
+          serviceTitle: 'Test Service',
+          serviceClientUri: undefined,
+        },
+        isLoading: false,
+        serviceHydrated: true,
+      })
+
+      const { queryByTestId } = renderScreen(mockNavigation)
+
+      expect(queryByTestId(testIdWithKey('ServiceClientLink'))).toBeNull()
+    })
+
     it('opens service client URI when ServiceClientLink is pressed', () => {
       mockedUseServiceLoginState.mockReturnValue({
         state: {

--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.test.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.test.tsx
@@ -128,6 +128,25 @@ describe('ServiceLogin', () => {
       expect(getByTestId(testIdWithKey('ServiceClientLink'))).toBeTruthy()
     })
 
+    it('opens service client URI when ServiceClientLink is pressed', () => {
+      mockedUseServiceLoginState.mockReturnValue({
+        state: {
+          serviceTitle: 'Test Service',
+          serviceClientUri: SERVICE_CLIENT_URI,
+        },
+        isLoading: false,
+        serviceHydrated: true,
+      })
+
+      const mockOpenURL = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined)
+      const { getByTestId } = renderScreen(mockNavigation)
+
+      fireEvent.press(getByTestId(testIdWithKey('ServiceClientLink')))
+
+      expect(mockOpenURL).toHaveBeenCalledWith(SERVICE_CLIENT_URI)
+      mockOpenURL.mockRestore()
+    })
+
     it('renders Default view with privacy policy card when privacyPolicyUri is set', () => {
       mockedUseServiceLoginState.mockReturnValue({
         state: {

--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.test.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.test.tsx
@@ -107,9 +107,9 @@ describe('ServiceLogin', () => {
         serviceHydrated: true,
       })
 
-      const { getByText, queryByTestId } = renderScreen(mockNavigation)
+      const { getByTestId, queryByTestId } = renderScreen(mockNavigation)
 
-      expect(getByText(SERVICE_CLIENT_URI)).toBeTruthy()
+      expect(getByTestId(testIdWithKey('ReportSuspiciousLink'))).toBeTruthy()
       expect(queryByTestId(testIdWithKey('ServiceClientLink'))).toBeNull()
     })
 
@@ -140,10 +140,10 @@ describe('ServiceLogin', () => {
         serviceHydrated: true,
       })
 
-      const { getByTestId, queryByTestId } = renderScreen(mockNavigation)
+      const { getByTestId } = renderScreen(mockNavigation)
 
       expect(getByTestId(testIdWithKey('ReadPrivacyPolicy'))).toBeTruthy()
-      expect(queryByTestId(testIdWithKey('ReportSuspiciousLink'))).toBeNull()
+      expect(getByTestId(testIdWithKey('ReportSuspiciousLink'))).toBeTruthy()
     })
 
     it('renders Default view with report suspicious link when no privacyPolicyUri', () => {

--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
@@ -68,7 +68,6 @@ type DevicePreferenceURLViewProps = {
   ColorPalette: ReturnType<typeof useTheme>['ColorPalette']
   t: (key: string, options?: Record<string, unknown>) => string
   Spacing: ReturnType<typeof useTheme>['Spacing']
-  isQuickLogin: boolean
 }
 
 const DevicePreferenceURLView: React.FC<DevicePreferenceURLViewProps> = ({
@@ -76,7 +75,6 @@ const DevicePreferenceURLView: React.FC<DevicePreferenceURLViewProps> = ({
   ColorPalette,
   t,
   Spacing,
-  isQuickLogin,
 }: DevicePreferenceURLViewProps) =>
   serviceClientUri ? (
     <View style={{ marginTop: Spacing.lg }}>
@@ -91,17 +89,13 @@ const DevicePreferenceURLView: React.FC<DevicePreferenceURLViewProps> = ({
         {t('BCSC.Services.PreferOtherDevice')}
       </ThemedText>
       <ThemedText style={{ textAlign: 'center' }}>{t('BCSC.Services.Goto')}</ThemedText>
-      <ThemedText style={{ textAlign: 'center' }}>
-        {isQuickLogin ? (
-          serviceClientUri
-        ) : (
-          <Link
-            style={{ textAlign: 'center' }}
-            linkText={serviceClientUri}
-            testID={testIdWithKey('ServiceClientLink')}
-            onPress={() => Linking.openURL(serviceClientUri)}
-          />
-        )}
+      <ThemedText selectable={true} style={{ textAlign: 'center' }}>
+        <Link
+          style={{ textAlign: 'center' }}
+          linkText={serviceClientUri}
+          testID={testIdWithKey('ServiceClientLink')}
+          onPress={() => Linking.openURL(serviceClientUri)}
+        />
       </ThemedText>
     </View>
   ) : null
@@ -174,7 +168,6 @@ const ServiceLoginUnavailableView = ({
           ColorPalette={ColorPalette}
           t={t}
           Spacing={Spacing}
-          isQuickLogin={false}
         />
       </View>
     </ScrollView>
@@ -274,17 +267,7 @@ const ServiceLoginDefaultView = ({
             onPress={onCancel}
           />
         </View>
-        {state.privacyPolicyUri ? (
-          <DevicePreferenceURLView
-            serviceClientUri={state.serviceClientUri}
-            ColorPalette={ColorPalette}
-            t={t}
-            Spacing={Spacing}
-            isQuickLogin={true}
-          />
-        ) : (
-          <ReportSuspiciousLink t={t} testID={testIdWithKey('ReportSuspiciousLink')} Spacing={Spacing} />
-        )}
+        <ReportSuspiciousLink t={t} Spacing={Spacing} testID={testIdWithKey('ReportSuspiciousLink')} />
       </ScrollView>
     </SafeAreaView>
   )


### PR DESCRIPTION
# Summary of Changes

- removed plain URL link from the bottom of service login screen
- replaced it with "Not you? Report suspicious activity" link

# Testing Instructions

- verify an account
- login via push notification/ deep link
- see no url at the bottom of the screen
- see "Not you? Report..." link

###
- Select "government Gateway OIDC" from service list
- see no url at the bottom of the screen
- see "Not you? Report..." link

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs
<img width="396" height="808" alt="Screenshot 2026-04-09 at 2 00 16 PM" src="https://github.com/user-attachments/assets/2e41d5f0-4aa9-46d3-9002-20c4518bc0ca" />



# Related Issues

[BC-Wallet-Mobile: 3457](https://github.com/bcgov/bc-wallet-mobile/issues/3457)
