### PR TITLE
fix(nickname): navigate before updating registration

### DIFF
--- a/app/src/bcsc-theme/features/account/NicknameAccountScreen.test.tsx
+++ b/app/src/bcsc-theme/features/account/NicknameAccountScreen.test.tsx
@@ -47,7 +47,10 @@ describe('NicknameAccount', () => {
     const dispatchMock = jest.fn()
     const updateRegistrationMock = jest.fn().mockResolvedValue(undefined)
     mockUseRegistrationService.mockReturnValue({ updateRegistration: updateRegistrationMock } as any)
-    mockUseStore.mockReturnValue([{ ...initialState, bcscSecure: { registrationAccessToken: 'test-token' } }, dispatchMock] as any)
+    mockUseStore.mockReturnValue([
+      { ...initialState, bcscSecure: { registrationAccessToken: 'test-token' } },
+      dispatchMock,
+    ] as any)
 
     const { getByTestId } = render(
       <BasicAppContext>
@@ -68,7 +71,10 @@ describe('NicknameAccount', () => {
     const dispatchMock = jest.fn()
     const updateRegistrationMock = jest.fn().mockResolvedValue(undefined)
     mockUseRegistrationService.mockReturnValue({ updateRegistration: updateRegistrationMock } as any)
-    mockUseStore.mockReturnValue([{ ...initialState, bcscSecure: { registrationAccessToken: 'test-token' } }, dispatchMock] as any)
+    mockUseStore.mockReturnValue([
+      { ...initialState, bcscSecure: { registrationAccessToken: 'test-token' } },
+      dispatchMock,
+    ] as any)
     const navigation = useNavigation()
 
     const { getByTestId } = render(
@@ -94,7 +100,10 @@ describe('NicknameAccount', () => {
     const apiError = new Error('API failure')
     const updateRegistrationMock = jest.fn().mockRejectedValue(apiError)
     mockUseRegistrationService.mockReturnValue({ updateRegistration: updateRegistrationMock } as any)
-    mockUseStore.mockReturnValue([{ ...initialState, bcscSecure: { registrationAccessToken: 'test-token' } }, dispatchMock] as any)
+    mockUseStore.mockReturnValue([
+      { ...initialState, bcscSecure: { registrationAccessToken: 'test-token' } },
+      dispatchMock,
+    ] as any)
     mockUseServices.mockReturnValue([{ ...defaultLogger, error: errorMock }] as any)
 
     const { getByTestId } = render(

--- a/app/src/bcsc-theme/features/account/NicknameAccountScreen.test.tsx
+++ b/app/src/bcsc-theme/features/account/NicknameAccountScreen.test.tsx
@@ -1,4 +1,5 @@
 import { useRegistrationService } from '@/bcsc-theme/services/hooks/useRegistrationService'
+import { BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { BCDispatchAction, initialState } from '@/store'
 import { useServices, useStore } from '@bifold/core'
 import { BasicAppContext } from '@mocks/helpers/app'
@@ -90,7 +91,7 @@ describe('NicknameAccount', () => {
       expect(updateRegistrationMock).toHaveBeenCalledWith('test-token', 'MyAccount')
     })
     expect(navigation.dispatch).toHaveBeenCalledWith(
-      CommonActions.reset({ index: 0, routes: [{ name: 'Setup Steps' }] })
+      CommonActions.reset({ index: 0, routes: [{ name: BCSCScreens.SetupSteps }] })
     )
   })
 

--- a/app/src/bcsc-theme/features/account/NicknameAccountScreen.test.tsx
+++ b/app/src/bcsc-theme/features/account/NicknameAccountScreen.test.tsx
@@ -1,16 +1,36 @@
+import { useRegistrationService } from '@/bcsc-theme/services/hooks/useRegistrationService'
+import { BCDispatchAction, initialState } from '@/store'
+import { useServices, useStore } from '@bifold/core'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { render } from '@testing-library/react-native'
+import { CommonActions, useNavigation } from '@react-navigation/native'
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import NicknameAccountScreen from './NicknameAccountScreen'
+
+jest.mock('@/bcsc-theme/services/hooks/useRegistrationService', () => ({
+  useRegistrationService: jest.fn(),
+}))
+
+jest.mock('@bifold/core', () => ({
+  ...jest.requireActual('@bifold/core'),
+  useStore: jest.fn(),
+  useServices: jest.fn(),
+}))
+
+const mockUseStore = useStore as jest.Mock
+const mockUseServices = useServices as jest.Mock
+const mockUseRegistrationService = useRegistrationService as jest.Mock
+
+const defaultLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn(), trace: jest.fn() }
 
 describe('NicknameAccount', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.useFakeTimers()
-  })
-
-  afterEach(() => {
-    jest.useRealTimers()
+    mockUseStore.mockReturnValue([initialState, jest.fn()] as any)
+    mockUseServices.mockReturnValue([defaultLogger] as any)
+    mockUseRegistrationService.mockReturnValue({
+      updateRegistration: jest.fn().mockResolvedValue(undefined),
+    } as any)
   })
 
   it('renders correctly', () => {
@@ -21,5 +41,74 @@ describe('NicknameAccount', () => {
     )
 
     expect(tree).toMatchSnapshot()
+  })
+
+  it('should dispatch ADD_NICKNAME and SELECT_ACCOUNT on submit', async () => {
+    const dispatchMock = jest.fn()
+    const updateRegistrationMock = jest.fn().mockResolvedValue(undefined)
+    mockUseRegistrationService.mockReturnValue({ updateRegistration: updateRegistrationMock } as any)
+    mockUseStore.mockReturnValue([{ ...initialState, bcscSecure: { registrationAccessToken: 'test-token' } }, dispatchMock] as any)
+
+    const { getByTestId } = render(
+      <BasicAppContext>
+        <NicknameAccountScreen />
+      </BasicAppContext>
+    )
+
+    fireEvent.changeText(getByTestId('com.ariesbifold:id/accountNickname-input'), 'MyAccount')
+    fireEvent.press(getByTestId('com.ariesbifold:id/SaveAndContinue'))
+
+    await waitFor(() => {
+      expect(dispatchMock).toHaveBeenCalledWith({ type: BCDispatchAction.ADD_NICKNAME, payload: ['MyAccount'] })
+      expect(dispatchMock).toHaveBeenCalledWith({ type: BCDispatchAction.SELECT_ACCOUNT, payload: ['MyAccount'] })
+    })
+  })
+
+  it('should call updateRegistration and navigate on submit', async () => {
+    const dispatchMock = jest.fn()
+    const updateRegistrationMock = jest.fn().mockResolvedValue(undefined)
+    mockUseRegistrationService.mockReturnValue({ updateRegistration: updateRegistrationMock } as any)
+    mockUseStore.mockReturnValue([{ ...initialState, bcscSecure: { registrationAccessToken: 'test-token' } }, dispatchMock] as any)
+    const navigation = useNavigation()
+
+    const { getByTestId } = render(
+      <BasicAppContext>
+        <NicknameAccountScreen />
+      </BasicAppContext>
+    )
+
+    fireEvent.changeText(getByTestId('com.ariesbifold:id/accountNickname-input'), 'MyAccount')
+    fireEvent.press(getByTestId('com.ariesbifold:id/SaveAndContinue'))
+
+    await waitFor(() => {
+      expect(updateRegistrationMock).toHaveBeenCalledWith('test-token', 'MyAccount')
+    })
+    expect(navigation.dispatch).toHaveBeenCalledWith(
+      CommonActions.reset({ index: 0, routes: [{ name: 'Setup Steps' }] })
+    )
+  })
+
+  it('should log error when updateRegistration fails', async () => {
+    const dispatchMock = jest.fn()
+    const errorMock = jest.fn()
+    const apiError = new Error('API failure')
+    const updateRegistrationMock = jest.fn().mockRejectedValue(apiError)
+    mockUseRegistrationService.mockReturnValue({ updateRegistration: updateRegistrationMock } as any)
+    mockUseStore.mockReturnValue([{ ...initialState, bcscSecure: { registrationAccessToken: 'test-token' } }, dispatchMock] as any)
+    mockUseServices.mockReturnValue([{ ...defaultLogger, error: errorMock }] as any)
+
+    const { getByTestId } = render(
+      <BasicAppContext>
+        <NicknameAccountScreen />
+      </BasicAppContext>
+    )
+
+    fireEvent.changeText(getByTestId('com.ariesbifold:id/accountNickname-input'), 'MyAccount')
+    fireEvent.press(getByTestId('com.ariesbifold:id/SaveAndContinue'))
+
+    await waitFor(() => {
+      expect(updateRegistrationMock).toHaveBeenCalled()
+      expect(errorMock).toHaveBeenCalledWith('Failed to update registration', apiError)
+    })
   })
 })

--- a/app/src/bcsc-theme/features/account/NicknameAccountScreen.tsx
+++ b/app/src/bcsc-theme/features/account/NicknameAccountScreen.tsx
@@ -17,14 +17,13 @@ const NicknameAccountScreen: React.FC = () => {
       dispatch({ type: BCDispatchAction.ADD_NICKNAME, payload: [trimmedNickname] })
       dispatch({ type: BCDispatchAction.SELECT_ACCOUNT, payload: [trimmedNickname] })
 
-      navigation.dispatch(CommonActions.reset({ index: 0, routes: [{ name: BCSCScreens.SetupSteps }] }))
-
-      try {
-        await registration.updateRegistration(store.bcscSecure.registrationAccessToken, trimmedNickname)
-      } catch (apiError) {
-        // Note: Updating nickname in registration is non-critical
+      // Fire-and-forget: Updating nickname is non-critical
+      // Intentionally not awaiting this to prevent state updates on an unmounted component
+      registration.updateRegistration(store.bcscSecure.registrationAccessToken, trimmedNickname).catch((apiError) => {
         logger.error('Failed to update registration', apiError as Error)
-      }
+      })
+
+      navigation.dispatch(CommonActions.reset({ index: 0, routes: [{ name: BCSCScreens.SetupSteps }] }))
     },
     [dispatch, navigation, logger, registration, store.bcscSecure.registrationAccessToken]
   )

--- a/app/src/bcsc-theme/features/account/NicknameAccountScreen.tsx
+++ b/app/src/bcsc-theme/features/account/NicknameAccountScreen.tsx
@@ -13,7 +13,7 @@ const NicknameAccountScreen: React.FC = () => {
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
 
   const handleSubmit = useCallback(
-    async (trimmedNickname: string) => {
+    (trimmedNickname: string) => {
       dispatch({ type: BCDispatchAction.ADD_NICKNAME, payload: [trimmedNickname] })
       dispatch({ type: BCDispatchAction.SELECT_ACCOUNT, payload: [trimmedNickname] })
 

--- a/app/src/bcsc-theme/features/account/NicknameAccountScreen.tsx
+++ b/app/src/bcsc-theme/features/account/NicknameAccountScreen.tsx
@@ -16,13 +16,15 @@ const NicknameAccountScreen: React.FC = () => {
     async (trimmedNickname: string) => {
       dispatch({ type: BCDispatchAction.ADD_NICKNAME, payload: [trimmedNickname] })
       dispatch({ type: BCDispatchAction.SELECT_ACCOUNT, payload: [trimmedNickname] })
+
+      navigation.dispatch(CommonActions.reset({ index: 0, routes: [{ name: BCSCScreens.SetupSteps }] }))
+
       try {
         await registration.updateRegistration(store.bcscSecure.registrationAccessToken, trimmedNickname)
       } catch (apiError) {
-        // Don't throw error to allow navigation to proceed even if API call fails (nickname in registration is not critical)
+        // Note: Updating nickname in registration is non-critical
         logger.error('Failed to update registration', apiError as Error)
       }
-      navigation.dispatch(CommonActions.reset({ index: 0, routes: [{ name: BCSCScreens.SetupSteps }] }))
     },
     [dispatch, navigation, logger, registration, store.bcscSecure.registrationAccessToken]
   )


### PR DESCRIPTION
# Summary of Changes

This PR updates the nickname step in SetupSteps to navigate before updating the registration. Enhances the user experience by not having to wait for the request to finish.

# Testing Instructions

Replace this text with detailed instructions on how to test the changes included in this PR.

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs


https://github.com/user-attachments/assets/f45db77c-9613-4852-9d60-35321a1acb74


https://github.com/user-attachments/assets/26c0dabe-8bd5-4978-9686-d54f5dfb9583


# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
