### PR TITLE
fix: remove photo placeholder when picture doesn't exist

### DIFF
--- a/app/src/bcsc-theme/features/account/Account.tsx
+++ b/app/src/bcsc-theme/features/account/Account.tsx
@@ -114,9 +114,9 @@ const Account: React.FC = () => {
     photoAndNameContainer: {
       flexDirection: 'row',
       alignItems: 'center',
+      gap: Spacing.sm,
     },
     name: {
-      marginLeft: Spacing.sm,
       flexShrink: 1,
       flexWrap: 'wrap',
     },
@@ -137,8 +137,7 @@ const Account: React.FC = () => {
     <TabScreenWrapper>
       <View style={styles.container} testID={testIdWithKey('AccountScreen')}>
         <View style={styles.photoAndNameContainer}>
-          {/*TODO (MD): fallback for when this is undefined (silhouette) */}
-          <AccountPhoto photoUri={account.picture} />
+          {account.picture ? <AccountPhoto photoUri={account.picture} /> : null}
           <ThemedText variant={'headingTwo'} style={styles.name}>
             {account.fullname_formatted}
           </ThemedText>

--- a/app/src/bcsc-theme/features/account/__snapshots__/Account.test.tsx.snap
+++ b/app/src/bcsc-theme/features/account/__snapshots__/Account.test.tsx.snap
@@ -39,22 +39,10 @@ exports[`Account renders full name when both given_name and family_name are pres
             {
               "alignItems": "center",
               "flexDirection": "row",
+              "gap": 8,
             }
           }
         >
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#D3D3D3",
-                "height": 180,
-                "justifyContent": "center",
-                "marginBottom": 16,
-                "overflow": "hidden",
-                "width": 130,
-              }
-            }
-          />
           <Text
             maxFontSizeMultiplier={2}
             style={
@@ -68,7 +56,6 @@ exports[`Account renders full name when both given_name and family_name are pres
                 {
                   "flexShrink": 1,
                   "flexWrap": "wrap",
-                  "marginLeft": 8,
                 },
               ]
             }
@@ -633,22 +620,10 @@ exports[`Account renders only family_name when given_name is empty string (monon
             {
               "alignItems": "center",
               "flexDirection": "row",
+              "gap": 8,
             }
           }
         >
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#D3D3D3",
-                "height": 180,
-                "justifyContent": "center",
-                "marginBottom": 16,
-                "overflow": "hidden",
-                "width": 130,
-              }
-            }
-          />
           <Text
             maxFontSizeMultiplier={2}
             style={
@@ -662,7 +637,6 @@ exports[`Account renders only family_name when given_name is empty string (monon
                 {
                   "flexShrink": 1,
                   "flexWrap": "wrap",
-                  "marginLeft": 8,
                 },
               ]
             }
@@ -1227,22 +1201,10 @@ exports[`Account renders only family_name when given_name is undefined (mononym)
             {
               "alignItems": "center",
               "flexDirection": "row",
+              "gap": 8,
             }
           }
         >
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#D3D3D3",
-                "height": 180,
-                "justifyContent": "center",
-                "marginBottom": 16,
-                "overflow": "hidden",
-                "width": 130,
-              }
-            }
-          />
           <Text
             maxFontSizeMultiplier={2}
             style={
@@ -1256,7 +1218,6 @@ exports[`Account renders only family_name when given_name is undefined (mononym)
                 {
                   "flexShrink": 1,
                   "flexWrap": "wrap",
-                  "marginLeft": 8,
                 },
               ]
             }
@@ -1821,22 +1782,10 @@ exports[`Account renders only given_name when family_name is undefined 1`] = `
             {
               "alignItems": "center",
               "flexDirection": "row",
+              "gap": 8,
             }
           }
         >
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#D3D3D3",
-                "height": 180,
-                "justifyContent": "center",
-                "marginBottom": 16,
-                "overflow": "hidden",
-                "width": 130,
-              }
-            }
-          />
           <Text
             maxFontSizeMultiplier={2}
             style={
@@ -1850,7 +1799,6 @@ exports[`Account renders only given_name when family_name is undefined 1`] = `
                 {
                   "flexShrink": 1,
                   "flexWrap": "wrap",
-                  "marginLeft": 8,
                 },
               ]
             }

--- a/app/src/bcsc-theme/features/account/components/AccountPhoto.test.tsx
+++ b/app/src/bcsc-theme/features/account/components/AccountPhoto.test.tsx
@@ -1,0 +1,35 @@
+import { BasicAppContext } from '@mocks/helpers/app'
+import { render } from '@testing-library/react-native'
+import React from 'react'
+import AccountPhoto from './AccountPhoto'
+
+describe('AccountPhoto', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('renders correctly with no photo', () => {
+    const tree = render(
+      <BasicAppContext>
+        <AccountPhoto photoUri={null} />
+      </BasicAppContext>
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders correctly with a photo', () => {
+    const tree = render(
+      <BasicAppContext>
+        <AccountPhoto photoUri="https://example.com/photo.jpg" />
+      </BasicAppContext>
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/app/src/bcsc-theme/features/account/components/__snapshots__/AccountPhoto.test.tsx.snap
+++ b/app/src/bcsc-theme/features/account/components/__snapshots__/AccountPhoto.test.tsx.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AccountPhoto renders correctly with a photo 1`] = `
+<View
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "#D3D3D3",
+      "height": 180,
+      "justifyContent": "center",
+      "marginBottom": 16,
+      "overflow": "hidden",
+      "width": 130,
+    }
+  }
+>
+  <Image
+    source={
+      {
+        "uri": "https://example.com/photo.jpg",
+      }
+    }
+    style={
+      {
+        "height": "100%",
+        "resizeMode": "cover",
+        "width": "100%",
+      }
+    }
+  />
+</View>
+`;
+
+exports[`AccountPhoto renders correctly with no photo 1`] = `
+<View
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "#D3D3D3",
+      "height": 180,
+      "justifyContent": "center",
+      "marginBottom": 16,
+      "overflow": "hidden",
+      "width": 130,
+    }
+  }
+/>
+`;


### PR DESCRIPTION
# Summary of Changes

Removes placeholder grey box when picture isn't available:

See screenshots

# Testing Instructions

Look at account screen

# Acceptance Criteria

No picture, no grey box

# Screenshots, videos, or gifs

<img width="284" height="614" alt="with_picture" src="https://github.com/user-attachments/assets/afd50916-8a62-4357-9222-e39d5bc19c30" />
<img width="284" height="614" alt="without_picture" src="https://github.com/user-attachments/assets/0895bb95-adcd-4c4e-8e48-73715ebbe5fc" />

# Related Issues

#3663 