### PR TITLE
fix: account transfer bugs

### DIFF
--- a/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
@@ -273,14 +273,9 @@ describe('clientErrorPolicies', () => {
       it('should call no tokens returned alert', () => {
         const error = newError('no_tokens_returned')
         const alertMock = jest.fn()
-        const navigationMock = jest.fn()
-        const translateMock = jest.fn()
         const context = {
           alerts: { noTokensReturnedAlert: alertMock },
-          translate: translateMock,
-          navigation: { navigate: navigationMock },
         }
-        translateMock.mockReturnValue('close')
         noTokensReturnedErrorPolicy.handle(error, context as any)
 
         expect(alertMock).toHaveBeenCalled()
@@ -350,15 +345,9 @@ describe('clientErrorPolicies', () => {
       it('should call app update required alert', () => {
         const error = newError('ios_app_update_required')
         const mockAlert = jest.fn()
-        const translateMock = jest.fn()
-        const openURLMock = jest.fn()
-        const linkingMock = { openURL: openURLMock }
         const context = {
           alerts: { appUpdateRequiredAlert: mockAlert },
-          translate: translateMock,
-          linking: linkingMock,
         }
-        translateMock.mockReturnValue('Go to App Store')
         updateRequiredErrorPolicy.handle(error, context as any)
 
         expect(mockAlert).toHaveBeenCalled()
@@ -616,6 +605,18 @@ describe('clientErrorPolicies', () => {
         expect(attestationPollingErrorPolicy.matches(error, context as any)).toBeFalsy()
       })
 
+      it('should match 400 on attestation endpoint', () => {
+        const error = newError('unknown_server_error')
+        const context = {
+          statusCode: 400,
+          endpoint: '/api/attestation/some-jwt-id',
+          apiEndpoints: {
+            attestation: '/api/attestation',
+          },
+        }
+        expect(attestationPollingErrorPolicy.matches(error, context as any)).toBeTruthy()
+      })
+
       it('should NOT match other status codes on attestation endpoint', () => {
         const error = newError('unknown_server_error')
         const context = {
@@ -637,7 +638,7 @@ describe('clientErrorPolicies', () => {
         attestationPollingErrorPolicy.handle(error, context as any)
 
         expect(loggerMock.info).toHaveBeenCalledWith(
-          '[AttestationPollingErrorPolicy] 404 expected during polling — attestation not yet consumed'
+          '[AttestationPollingErrorPolicy] 400 or 404 expected during polling — attestation not yet consumed or already consumed'
         )
       })
     })

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -232,12 +232,18 @@ export const videoSessionErrorPolicy: ErrorHandlingPolicy = {
 
 // Error policy for attestation status polling — 404 is expected while the attestation
 // has not yet been created or consumed by another device's verifyAttestation call.
+// 400 is expected when the JTI has expired or been rotated before the transfer device scanned the QR code.
 export const attestationPollingErrorPolicy: ErrorHandlingPolicy = {
   matches: (_, context) => {
-    return context.statusCode === 404 && context.endpoint.includes(context.apiEndpoints.attestation)
+    return (
+      (context.statusCode === 404 || context.statusCode === 400) &&
+      context.endpoint.includes(context.apiEndpoints.attestation)
+    )
   },
   handle: (_error, context) => {
-    context.logger.info('[AttestationPollingErrorPolicy] 404 expected during polling — attestation not yet consumed')
+    context.logger.info(
+      '[AttestationPollingErrorPolicy] 400 or 404 expected during polling — attestation not yet consumed or already consumed'
+    )
   },
 }
 

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -231,8 +231,9 @@ export const videoSessionErrorPolicy: ErrorHandlingPolicy = {
 }
 
 // Error policy for attestation status polling — 404 is expected while the attestation
-// has not yet been created or consumed by another device's verifyAttestation call.
-// 400 is expected when the JTI has expired or been rotated before the transfer device scanned the QR code.
+// has not yet been created by another device's verifyAttestation call.
+// 400 is expected when the JTI has already been consumed but the polling happens
+// additional times before the 2xx response is processed
 export const attestationPollingErrorPolicy: ErrorHandlingPolicy = {
   matches: (_, context) => {
     return (

--- a/app/src/bcsc-theme/api/hooks/useDeviceAttestationApi.test.ts
+++ b/app/src/bcsc-theme/api/hooks/useDeviceAttestationApi.test.ts
@@ -114,12 +114,39 @@ describe('useDeviceAttestationApi', () => {
       const response = await result.current.checkAttestationStatus(mockJwtID)
 
       expect(mockApiClient.get).toHaveBeenCalledWith('/attestation/mock_jwt_id_123', {
-        suppressStatusCodeLogs: [404],
+        suppressStatusCodeLogs: [400, 404],
       })
       expect(response).toBe(true)
     })
 
-    it('should return undefined for non-200 status responses', async () => {
+    it('should return true for any 2xx status response', async () => {
+      const mockJwtID = 'mock_jwt_id_123'
+      const createdResponse = {
+        ...mockAxiosResponse,
+        status: 201,
+        statusText: 'Created',
+      }
+
+      mockApiClient.get.mockResolvedValue(createdResponse)
+
+      const { result } = renderHook(() => useDeviceAttestationApi(mockApiClient))
+      const response = await result.current.checkAttestationStatus(mockJwtID)
+
+      expect(response).toBe(true)
+    })
+
+    it('should propagate errors from the API client', async () => {
+      const mockJwtID = 'mock_jwt_id_123'
+      const error = new Error('Network error')
+
+      mockApiClient.get.mockRejectedValue(error)
+
+      const { result } = renderHook(() => useDeviceAttestationApi(mockApiClient))
+
+      await expect(result.current.checkAttestationStatus(mockJwtID)).rejects.toThrow('Network error')
+    })
+
+    it('should return false for non-2xx status responses', async () => {
       const mockJwtID = 'mock_jwt_id_123'
       const notFoundResponse = {
         ...mockAxiosResponse,
@@ -132,7 +159,7 @@ describe('useDeviceAttestationApi', () => {
       const { result } = renderHook(() => useDeviceAttestationApi(mockApiClient))
       const response = await result.current.checkAttestationStatus(mockJwtID)
 
-      expect(response).toBeFalsy()
+      expect(response).toBe(false)
     })
 
     it('should throw error when BCSC client is not ready', async () => {

--- a/app/src/bcsc-theme/api/hooks/useDeviceAttestationApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useDeviceAttestationApi.tsx
@@ -61,8 +61,8 @@ const useDeviceAttestationApi = (apiClient: BCSCApiClient | null) => {
    * @returns {Promise<boolean | undefined>} Returns status of the attestation request for a given jwtID.
    *                                         True is returned if attestation is complete false if response code of 401, 404 or others are returned.
    *                                         Response Codes:
-   *                                            200: the attestation request is valid
-   *                                            401: the request is authorized, most likely an issue with the tokens
+   *                                            200/201: the attestation request has been consumed and is valid
+   *                                            401: the request is unauthorized, most likely an issue with the tokens
    *                                            404: the attestation has yet to be consumed/ processed by `verifyAttestation`
    *
    * @throws {Error} When BCSC client is not ready
@@ -74,11 +74,11 @@ const useDeviceAttestationApi = (apiClient: BCSCApiClient | null) => {
       }
 
       const response = await apiClient.get(`${apiClient.endpoints.attestation}/${jwtID}`, {
-        suppressStatusCodeLogs: [404],
+        suppressStatusCodeLogs: [400, 404],
       })
 
-      // 200 response means that the attestation request has been consumed and is valid
-      if (response.status == 200) {
+      // Any 2xx response means the attestation has been consumed and is valid.
+      if (response.status >= 200 && response.status < 300) {
         return true
       }
 

--- a/app/src/bcsc-theme/features/account-transfer/transferee/TransferInstructionsScreen.test.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/TransferInstructionsScreen.test.tsx
@@ -1,10 +1,16 @@
+import { testIdWithKey } from '@bifold/core'
+import { useNavigation } from '@mocks/@react-navigation/native'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { render } from '@testing-library/react-native'
+import { act, fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
+import { BCSCScreens } from '../../../types/navigators'
 import TransferInstructionsScreen from './TransferInstructionsScreen'
 
-describe('TransferInstructions', () => {
+describe('TransferInstructionsScreen', () => {
+  let mockNavigation: any
+
   beforeEach(() => {
+    mockNavigation = useNavigation()
     jest.clearAllMocks()
     jest.useFakeTimers()
   })
@@ -21,5 +27,19 @@ describe('TransferInstructions', () => {
     )
 
     expect(tree).toMatchSnapshot()
+  })
+
+  it('navigates to QR scan screen when Scan QR Code button is pressed', () => {
+    const { getByTestId } = render(
+      <BasicAppContext>
+        <TransferInstructionsScreen />
+      </BasicAppContext>
+    )
+
+    const scanButton = getByTestId(testIdWithKey('ScanQRCode'))
+    act(() => {
+      fireEvent.press(scanButton)
+    })
+    expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.TransferAccountQRScan)
   })
 })

--- a/app/src/bcsc-theme/features/account-transfer/transferee/TransferInstructionsScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/TransferInstructionsScreen.tsx
@@ -2,7 +2,7 @@ import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigator
 import QRCodePhone from '@assets/img/qr-code-phone.png'
 import QRScan from '@assets/img/qr-code-scan.png'
 import TabNavigator from '@assets/img/tab-navigator-account.png'
-import { Button, ButtonType, ContentGradient, ScreenWrapper, ThemedText, useTheme } from '@bifold/core'
+import { Button, ButtonType, ContentGradient, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React from 'react'
@@ -25,6 +25,8 @@ const TransferInstructionsScreen: React.FC = () => {
       <Button
         buttonType={ButtonType.Primary}
         title={t('BCSC.TransferInstructions.ScanQRCode')}
+        accessibilityLabel={t('BCSC.TransferInstructions.ScanQRCode')}
+        testID={testIdWithKey('ScanQRCode')}
         onPress={() => {
           navigation.navigate(BCSCScreens.TransferAccountQRScan)
         }}

--- a/app/src/bcsc-theme/features/account-transfer/transferee/TransferInstructionsScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/TransferInstructionsScreen.tsx
@@ -2,7 +2,7 @@ import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigator
 import QRCodePhone from '@assets/img/qr-code-phone.png'
 import QRScan from '@assets/img/qr-code-scan.png'
 import TabNavigator from '@assets/img/tab-navigator-account.png'
-import { Button, ButtonType, ScreenWrapper, ThemedText, useTheme } from '@bifold/core'
+import { Button, ButtonType, ContentGradient, ScreenWrapper, ThemedText, useTheme } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React from 'react'
@@ -14,19 +14,22 @@ const QR_CODE_PHONE = Image.resolveAssetSource(QRCodePhone)
 const QR_SCAN = Image.resolveAssetSource(QRScan)
 
 const TransferInstructionsScreen: React.FC = () => {
-  const { Spacing } = useTheme()
+  const { Spacing, ColorPalette } = useTheme()
   const { t } = useTranslation()
 
   const navigation = useNavigation<StackNavigationProp<BCSCVerifyStackParams>>()
 
   const controls = (
-    <Button
-      buttonType={ButtonType.Primary}
-      title={t('BCSC.TransferInstructions.ScanQRCode')}
-      onPress={() => {
-        navigation.navigate(BCSCScreens.TransferAccountQRScan)
-      }}
-    />
+    <>
+      <ContentGradient backgroundColor={ColorPalette.brand.primaryBackground} />
+      <Button
+        buttonType={ButtonType.Primary}
+        title={t('BCSC.TransferInstructions.ScanQRCode')}
+        onPress={() => {
+          navigation.navigate(BCSCScreens.TransferAccountQRScan)
+        }}
+      />
+    </>
   )
 
   return (

--- a/app/src/bcsc-theme/features/account-transfer/transferee/__snapshots__/TransferInstructionsScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/__snapshots__/TransferInstructionsScreen.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TransferInstructions renders correctly 1`] = `
+exports[`TransferInstructionsScreen renders correctly 1`] = `
 <RNCSafeAreaView
   edges={
     {
@@ -253,6 +253,7 @@ exports[`TransferInstructions renders correctly 1`] = `
       </RNSVGSvgView>
     </View>
     <View
+      accessibilityLabel="BCSC.TransferInstructions.ScanQRCode"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -289,6 +290,7 @@ exports[`TransferInstructions renders correctly 1`] = `
           "padding": 16,
         }
       }
+      testID="com.ariesbifold:id/ScanQRCode"
     >
       <View
         style={

--- a/app/src/bcsc-theme/features/account-transfer/transferee/__snapshots__/TransferInstructionsScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/__snapshots__/TransferInstructionsScreen.test.tsx.snap
@@ -169,6 +169,90 @@ exports[`TransferInstructions renders correctly 1`] = `
     }
   >
     <View
+      style={
+        {
+          "height": 30,
+          "position": "absolute",
+          "top": -30,
+          "width": "100%",
+        }
+      }
+    >
+      <RNSVGSvgView
+        bbHeight="30"
+        bbWidth="100%"
+        focusable={false}
+        height="30"
+        style={
+          [
+            {
+              "backgroundColor": "transparent",
+              "borderWidth": 0,
+            },
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "flex": 0,
+              "height": 30,
+              "width": "100%",
+            },
+          ]
+        }
+        width="100%"
+      >
+        <RNSVGGroup
+          fill={
+            {
+              "payload": 4278190080,
+              "type": 0,
+            }
+          }
+        >
+          <RNSVGDefs>
+            <RNSVGLinearGradient
+              gradient={
+                [
+                  0,
+                  15921906,
+                  1,
+                  -855310,
+                ]
+              }
+              gradientTransform={null}
+              gradientUnits={0}
+              name="gradient"
+              x1="0%"
+              x2="0%"
+              y1="0%"
+              y2="100%"
+            />
+          </RNSVGDefs>
+          <RNSVGRect
+            fill={
+              {
+                "brushRef": "gradient",
+                "type": 1,
+              }
+            }
+            height="30"
+            propList={
+              [
+                "fill",
+              ]
+            }
+            width="100%"
+            x={0}
+            y={0}
+          />
+        </RNSVGGroup>
+      </RNSVGSvgView>
+    </View>
+    <View
       accessibilityRole="button"
       accessibilityState={
         {

--- a/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.test.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.test.tsx
@@ -1,20 +1,49 @@
+import { useNavigation } from '@mocks/@react-navigation/native'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { render, waitFor } from '@testing-library/react-native'
+import { act, render, waitFor } from '@testing-library/react-native'
+import { jwtDecode } from 'jwt-decode'
 import React from 'react'
-import { getAccount } from 'react-native-bcsc-core'
+import { createDeviceSignedJWT, getAccount } from 'react-native-bcsc-core'
+import { BCSCScreens } from '../../../types/navigators'
 import TransferQRDisplayScreen from './TransferQRDisplayScreen'
 
+jest.mock('jwt-decode', () => ({
+  jwtDecode: jest.fn(),
+}))
+
+const mockCheckAttestationStatus = jest.fn()
 const mockAccountNotFoundAlert = jest.fn()
+
 jest.mock('@/hooks/useAlerts', () => ({
   useAlerts: () => ({
     accountNotFoundAlert: mockAccountNotFoundAlert,
   }),
 }))
 
-describe('TransferQRDisplay', () => {
+jest.mock('@/bcsc-theme/api/hooks/useApi', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    deviceAttestation: {
+      checkAttestationStatus: mockCheckAttestationStatus,
+    },
+  })),
+}))
+
+const mockAccount = {
+  id: 'mock-account-id',
+  issuer: 'https://idsit.gov.bc.ca/device/',
+  clientID: 'mock-client-id',
+}
+
+describe('TransferQRDisplayScreen', () => {
+  let mockNavigation: any
+
   beforeEach(() => {
+    mockNavigation = useNavigation()
     jest.clearAllMocks()
     jest.useFakeTimers()
+    ;(jwtDecode as jest.Mock).mockReturnValue({ jti: 'decoded-jti' })
+    mockCheckAttestationStatus.mockResolvedValue(false)
   })
 
   afterEach(() => {
@@ -42,6 +71,116 @@ describe('TransferQRDisplay', () => {
 
     await waitFor(() => {
       expect(mockAccountNotFoundAlert).toHaveBeenCalled()
+    })
+  })
+
+  describe('createToken', () => {
+    it('creates a signed JWT and displays a QR code when account is found', async () => {
+      jest.mocked(getAccount).mockResolvedValueOnce(mockAccount)
+
+      render(
+        <BasicAppContext>
+          <TransferQRDisplayScreen />
+        </BasicAppContext>
+      )
+
+      await waitFor(() => {
+        expect(createDeviceSignedJWT).toHaveBeenCalledWith(
+          expect.objectContaining({
+            aud: mockAccount.issuer,
+            iss: mockAccount.clientID,
+            sub: mockAccount.clientID,
+          })
+        )
+      })
+    })
+
+    it('decodes the signed JWT to extract the actual jti', async () => {
+      jest.mocked(getAccount).mockResolvedValueOnce(mockAccount)
+
+      render(
+        <BasicAppContext>
+          <TransferQRDisplayScreen />
+        </BasicAppContext>
+      )
+
+      await waitFor(() => {
+        expect(jwtDecode).toHaveBeenCalledWith('mock-jwt')
+      })
+    })
+
+    it('starts polling for attestation status after QR code is created', async () => {
+      jest.mocked(getAccount).mockResolvedValueOnce(mockAccount)
+
+      render(
+        <BasicAppContext>
+          <TransferQRDisplayScreen />
+        </BasicAppContext>
+      )
+
+      await waitFor(() => {
+        expect(mockCheckAttestationStatus).toHaveBeenCalledWith('decoded-jti')
+      })
+    })
+
+    it('navigates to success when attestation status returns true', async () => {
+      jest.mocked(getAccount).mockResolvedValueOnce(mockAccount)
+      mockCheckAttestationStatus.mockResolvedValueOnce(true)
+
+      render(
+        <BasicAppContext>
+          <TransferQRDisplayScreen />
+        </BasicAppContext>
+      )
+
+      await waitFor(() => {
+        expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.TransferAccountSuccess)
+      })
+    })
+
+    it('refreshes the QR code after the refresh interval', async () => {
+      jest.mocked(getAccount).mockResolvedValue(mockAccount)
+
+      render(
+        <BasicAppContext>
+          <TransferQRDisplayScreen />
+        </BasicAppContext>
+      )
+
+      await waitFor(() => {
+        expect(createDeviceSignedJWT).toHaveBeenCalledTimes(1)
+      })
+
+      // Advance past the 50 second refresh interval
+      await act(async () => {
+        jest.advanceTimersByTime(50000)
+      })
+
+      await waitFor(() => {
+        expect(createDeviceSignedJWT).toHaveBeenCalledTimes(2)
+      })
+    })
+
+    it('falls back to the locally generated jti when jwtDecode returns no jti', async () => {
+      jest.mocked(getAccount).mockResolvedValueOnce(mockAccount)
+      ;(jwtDecode as jest.Mock).mockReturnValue({}) // no jti in decoded token
+
+      render(
+        <BasicAppContext>
+          <TransferQRDisplayScreen />
+        </BasicAppContext>
+      )
+
+      await waitFor(() => {
+        // Should still poll — using the locally generated UUID as fallback
+        expect(mockCheckAttestationStatus).toHaveBeenCalled()
+      })
+
+      // The jti used should be a UUID string, not undefined
+      const calledWithJti = mockCheckAttestationStatus.mock.calls[0][0]
+      expect(calledWithJti).toBeDefined()
+      expect(typeof calledWithJti).toBe('string')
+      expect(calledWithJti.length).toBeGreaterThan(0)
     })
   })
 })

--- a/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
@@ -72,7 +72,7 @@ const TransferQRDisplayScreen: React.FC = () => {
       jti: newJti,
     })
 
-    // Ensure we are using the correct JTI incase the createDeviceSignedJWT method
+    // Ensure we are using the correct JTI in case the createDeviceSignedJWT method
     // uses a fallback JTI instead of our provided one or mutates it in-place
     const decoded = jwtDecode<{ jti?: string }>(jwt)
     jtiRef.current = decoded.jti ?? newJti

--- a/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
@@ -16,6 +16,7 @@ import {
 } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
+import { jwtDecode } from 'jwt-decode'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, StyleSheet, View } from 'react-native'
@@ -71,7 +72,10 @@ const TransferQRDisplayScreen: React.FC = () => {
       jti: newJti,
     })
 
-    jtiRef.current = newJti
+    // Ensure we are using the correct JTI incase the createDeviceSignedJWT method
+    // uses a fallback JTI instead of our provided one or mutates it in-place
+    const decoded = jwtDecode<{ jti?: string }>(jwt)
+    jtiRef.current = decoded.jti ?? newJti
     const url = `${store.developer.environment.iasApiBaseUrl}/static/selfsetup.html?${jwt}`
     setQRValue(url)
     setIsLoading(false)
@@ -124,9 +128,13 @@ const TransferQRDisplayScreen: React.FC = () => {
     if (!qrValue) {
       return
     }
-    checkAttestation(jtiRef.current)
+    // Snapshot the JTI at the time this effect runs. Reading jtiRef.current live inside the
+    // setInterval closure would mean a QR rotation (createToken mutating jtiRef.current) silently
+    // switches all in-flight polls to the new JTI, abandoning the consumed one before the 200 is seen.
+    const jtiSnapshot = jtiRef.current
+    checkAttestation(jtiSnapshot)
     const interval = setInterval(() => {
-      checkAttestation(jtiRef.current)
+      checkAttestation(jtiSnapshot)
     }, attestationPollInterval)
     return () => clearInterval(interval)
   }, [checkAttestation, qrValue])

--- a/app/src/bcsc-theme/features/account-transfer/transferer/__snapshots__/TransferQRDisplayScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/account-transfer/transferer/__snapshots__/TransferQRDisplayScreen.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TransferQRDisplay renders correctly 1`] = `
+exports[`TransferQRDisplayScreen renders correctly 1`] = `
 <ActivityIndicator
   size="large"
   style={

--- a/app/src/bcsc-theme/features/verify/VerificationSuccessScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/VerificationSuccessScreen.tsx
@@ -1,14 +1,14 @@
 import StatusDetails from '@/bcsc-theme/components/StatusDetails'
-import { Button, ButtonType, ScreenWrapper, testIdWithKey, useTheme } from '@bifold/core'
+import { Button, ButtonType, ScreenWrapper, testIdWithKey, useAnimatedComponents } from '@bifold/core'
 import { useFocusEffect } from '@react-navigation/native'
 import { useTranslation } from 'react-i18next'
-import { ActivityIndicator, BackHandler, StyleSheet } from 'react-native'
+import { BackHandler, StyleSheet } from 'react-native'
 import useVerificationResponseViewModel from './_models/useVerificationResponseViewModel'
 
 const VerificationSuccessScreen = () => {
   const { t } = useTranslation()
-  const { ColorPalette } = useTheme()
   const { isSettingUpAccount, handleAccountSetup } = useVerificationResponseViewModel()
+  const { ButtonLoading } = useAnimatedComponents()
 
   const styles = StyleSheet.create({
     contentContainer: {
@@ -34,7 +34,7 @@ const VerificationSuccessScreen = () => {
       }}
       disabled={isSettingUpAccount}
     >
-      {isSettingUpAccount && <ActivityIndicator color={ColorPalette.brand.text} />}
+      {isSettingUpAccount && <ButtonLoading />}
     </Button>
   )
   return (


### PR DESCRIPTION
# Summary of Changes

This PR:
- expands attestation check success handling range to any 2xx (sometimes gets 201's)
- logs attestation check 400's but doesn't bubble them into QR scanner errors
- adds content gradient on lengthy instructions screen to indicate more content is available and scrollable
- uses proper ButtonLoading rather than ActivityIndicator so there is space between indicator and text content

# Testing Instructions

Do account transfer

# Acceptance Criteria

Works, no unexpected errors

# Screenshots, videos, or gifs

N/A

# Related Issues

#3647 
#3648 