### PR TITLE
feat: login by pairing code

### DIFF
--- a/e2e/src/helpers/pairing-code.ts
+++ b/e2e/src/helpers/pairing-code.ts
@@ -174,7 +174,8 @@ async function readBodyOrThrow(step: string, response: Response): Promise<string
   const body = await response.text()
   if (!response.ok) {
     const snippet = body.slice(0, 200).replaceAll(/\s+/g, ' ').trim()
-    throw new Error(`${step} failed: HTTP ${response.status}${snippet ? ` — ${snippet}` : ''}`)
+    const detail = snippet ? ` — ${snippet}` : ''
+    throw new Error(`${step} failed: HTTP ${response.status}${detail}`)
   }
   return body
 }

--- a/e2e/src/helpers/pairing-code.ts
+++ b/e2e/src/helpers/pairing-code.ts
@@ -3,30 +3,39 @@
  * Node. Used by the login-from-computer spec so tests don't have to drive
  * an on-device browser.
  *
- * The flow targets the SIT (System Integration Testing) environment —
- * idsit.gov.bc.ca — and impersonates the "BC Parks Discover Camping"
- * demo relying party (clientId `urn:ca:bc:gov:demo:rp1`).
+ * Pinned to SIT (idsit.gov.bc.ca), same as every other automated BCSC
+ * helper in this repo — the test users in e2e/assets/USERS.md only exist
+ * there. `assertSitEnv` reads app/.env and throws early if the app under
+ * test is built for any other environment, so the failure shows up before
+ * we hit the pairing screen.
+ *
+ * Impersonates the "BC Parks Discover Camping" demo relying party
+ * (clientId `urn:ca:bc:gov:demo:rp1`).
  *
  * Captured from the real browser flow:
  *   1. GET  /demo/rp1/login         → scrape SAMLRequest + RelayState
- *   2. POST /login/saml2            → 302 sets cookie tied to the login session
- *   3. GET  /login/entry            → scrape cardtap transaction UUID from inline JS
+ *   2. POST /login/saml2            → 302, Location points at the login entry
+ *   3. GET  {Location}              → scrape cardtap transaction UUID
  *   4. POST /cardtap/v3/transactions/{uuid}?clientId=... → opens transaction
  *   5. PUT  /cardtap/v3/transactions/{uuid}/device       → returns `pairingCode`
- *
- * After step 5 the backend holds the code in `state: "pairing"` for a few
- * minutes, waiting for the mobile app to submit it via the normal pairing
- * API. The caller is expected to immediately type the returned code into
- * the app.
  */
+import { type CheerioAPI, load } from 'cheerio'
+import makeFetchCookie from 'fetch-cookie'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { CookieJar } from 'tough-cookie'
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
+const APP_ENV_PATH = path.resolve(SCRIPT_DIR, '../../../app/.env')
 
 const SIT_BASE = 'https://idsit.gov.bc.ca'
 const DEMO_RP_LOGIN = `${SIT_BASE}/demo/rp1/login`
 const SAML2_POST = `${SIT_BASE}/login/saml2`
-const LOGIN_ENTRY = `${SIT_BASE}/login/entry`
 const CLIENT_ID = 'urn:ca:bc:gov:demo:rp1'
 
 const USER_AGENT = 'bc-wallet-mobile-e2e/1.0 (+pairing-code-helper)'
+const DEFAULT_TIMEOUT_MS = 20_000
 
 export interface PairingSession {
   transactionId: string
@@ -34,160 +43,179 @@ export interface PairingSession {
   clientName: string
 }
 
-export async function fetchPairingCode(): Promise<PairingSession> {
-  const jar = new CookieJar()
+export interface FetchPairingCodeOptions {
+  timeoutMs?: number
+}
 
-  // 1. Demo RP login page — server returns an auto-submit SAML form.
-  const rpLoginRes = await fetch(DEMO_RP_LOGIN, {
-    redirect: 'manual',
-    headers: baseHeaders(jar),
-  })
-  jar.consume(rpLoginRes.headers)
-  const rpLoginHtml = await rpLoginRes.text()
-  const samlRequest = extractInputValue(rpLoginHtml, 'SAMLRequest')
-  const relayState = extractInputValue(rpLoginHtml, 'RelayState')
-  if (!samlRequest) {
-    throw new Error(`SAMLRequest input not found in ${DEMO_RP_LOGIN}`)
-  }
+export async function fetchPairingCode(options: FetchPairingCodeOptions = {}): Promise<PairingSession> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS } = options
+  assertSitEnv()
 
-  // 2. Post the SAML form. Expect 302 to /login/entry with a fresh session cookie.
-  const samlBody = new URLSearchParams({ SAMLRequest: samlRequest })
-  if (relayState) samlBody.append('RelayState', relayState)
-  const samlRes = await fetch(SAML2_POST, {
-    method: 'POST',
-    redirect: 'manual',
-    headers: {
-      ...baseHeaders(jar),
-      'Content-Type': 'application/x-www-form-urlencoded',
-      Origin: SIT_BASE,
-      Referer: DEMO_RP_LOGIN,
-    },
-    body: samlBody.toString(),
-  })
-  jar.consume(samlRes.headers)
-  if (samlRes.status !== 302) {
-    throw new Error(`POST /login/saml2 expected 302, got ${samlRes.status}`)
-  }
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
 
-  // 3. Follow redirect to /login/entry. Server embeds the cardtap transaction
-  //    UUID as a JS literal — scrape it.
-  const entryRes = await fetch(LOGIN_ENTRY, {
-    redirect: 'manual',
-    headers: {
-      ...baseHeaders(jar),
-      Referer: DEMO_RP_LOGIN,
-    },
-  })
-  jar.consume(entryRes.headers)
-  if (!entryRes.ok) {
-    throw new Error(`GET /login/entry failed: ${entryRes.status}`)
-  }
-  const entryHtml = await entryRes.text()
-  const txPattern = /var\s+transactionID\s*=\s*"([0-9a-fA-F-]+)"/
-  const txMatch = txPattern.exec(entryHtml)
-  if (!txMatch) {
-    throw new Error('transactionID literal not found in /login/entry HTML')
-  }
-  const transactionId = txMatch[1]
+  try {
+    const jar = new CookieJar()
+    const fetchWithCookies = makeFetchCookie(fetch, jar)
+    const { signal } = controller
 
-  // 4. Open the cardtap transaction. Response carries client metadata (name,
-  //    device options) — we only use clientName for log output.
-  const txUrl = `${SIT_BASE}/cardtap/v3/transactions/${transactionId}?clientId=${encodeURIComponent(CLIENT_ID)}`
-  const txRes = await fetch(txUrl, {
-    method: 'POST',
-    headers: {
-      ...baseHeaders(jar),
-      'Content-Type': 'application/json',
-      'X-Requested-With': 'XMLHttpRequest',
-      Origin: SIT_BASE,
-      Referer: LOGIN_ENTRY,
-    },
-  })
-  jar.consume(txRes.headers)
-  if (!txRes.ok) {
-    throw new Error(`POST cardtap transaction failed: ${txRes.status}`)
-  }
-  const txBody = (await txRes.json()) as { clientName?: string }
+    // 1. Demo RP login page — server returns an auto-submit SAML form.
+    const rpLoginRes = await fetchWithCookies(DEMO_RP_LOGIN, {
+      redirect: 'manual',
+      headers: baseHeaders(),
+      signal,
+    })
+    const rpLoginHtml = await readBodyOrThrow('GET /demo/rp1/login', rpLoginRes)
+    const $rpLogin = load(rpLoginHtml)
+    const samlRequest = inputValue($rpLogin, 'SAMLRequest')
+    const relayState = inputValue($rpLogin, 'RelayState')
+    if (!samlRequest) {
+      throw new Error(`SAMLRequest input not found in ${DEMO_RP_LOGIN}`)
+    }
 
-  // 5. Select BC Services Card app as the pairing device. Response body
-  //    carries the six-letter pairing code we type into the app.
-  const deviceUrl = `${SIT_BASE}/cardtap/v3/transactions/${transactionId}/device`
-  const deviceRes = await fetch(deviceUrl, {
-    method: 'PUT',
-    headers: {
-      ...baseHeaders(jar),
-      'Content-Type': 'application/json',
-      Accept: 'application/json, text/javascript, */*; q=0.01',
-      'X-Requested-With': 'XMLHttpRequest',
-      Origin: SIT_BASE,
-      Referer: LOGIN_ENTRY,
-    },
-    body: JSON.stringify({ deviceType: 'REMOTE_PAIRING_CODE', mobileSdkParams: null }),
-  })
-  if (!deviceRes.ok) {
-    throw new Error(`PUT cardtap device failed: ${deviceRes.status}`)
-  }
-  const deviceBody = (await deviceRes.json()) as { pairingCode?: string }
-  if (!deviceBody.pairingCode) {
-    throw new Error('pairingCode missing from cardtap device response')
-  }
+    // 2. Post the SAML form. Expect 302 with Location pointing at the login entry page.
+    const samlBody = new URLSearchParams({ SAMLRequest: samlRequest })
+    if (relayState) samlBody.append('RelayState', relayState)
+    const samlRes = await fetchWithCookies(SAML2_POST, {
+      method: 'POST',
+      redirect: 'manual',
+      headers: {
+        ...baseHeaders(),
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Origin: SIT_BASE,
+        Referer: DEMO_RP_LOGIN,
+      },
+      body: samlBody.toString(),
+      signal,
+    })
+    if (samlRes.status !== 302) {
+      throw new Error(`POST /login/saml2 expected 302, got ${samlRes.status}`)
+    }
+    const entryLocation = samlRes.headers.get('location')
+    if (!entryLocation) {
+      throw new Error('POST /login/saml2 returned 302 with no Location header')
+    }
+    const entryUrl = new URL(entryLocation, SIT_BASE).toString()
 
-  return {
-    transactionId,
-    pairingCode: deviceBody.pairingCode,
-    clientName: txBody.clientName ?? '',
+    // 3. Follow the 302 to the login entry page. Server embeds the cardtap
+    //    transaction UUID as a JS literal — scrape it.
+    const entryRes = await fetchWithCookies(entryUrl, {
+      redirect: 'manual',
+      headers: {
+        ...baseHeaders(),
+        Referer: DEMO_RP_LOGIN,
+      },
+      signal,
+    })
+    const entryHtml = await readBodyOrThrow(`GET ${entryUrl}`, entryRes)
+    const transactionId = extractTransactionId(entryHtml)
+    if (!transactionId) {
+      throw new Error(`transactionID not found in ${entryUrl}`)
+    }
+
+    // 4. Open the cardtap transaction. Response carries client metadata (name,
+    //    device options) — we only use clientName for log output.
+    const txUrl = `${SIT_BASE}/cardtap/v3/transactions/${transactionId}?clientId=${encodeURIComponent(CLIENT_ID)}`
+    const txRes = await fetchWithCookies(txUrl, {
+      method: 'POST',
+      headers: {
+        ...baseHeaders(),
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+        Origin: SIT_BASE,
+        Referer: entryUrl,
+      },
+      signal,
+    })
+    const txBodyRaw = await readBodyOrThrow('POST cardtap transaction', txRes)
+    const txBody = safeJson<{ clientName?: string }>(txBodyRaw)
+
+    // 5. Select BC Services Card app as the pairing device. Response body
+    //    carries the six-letter pairing code we type into the app.
+    const deviceUrl = `${SIT_BASE}/cardtap/v3/transactions/${transactionId}/device`
+    const deviceRes = await fetchWithCookies(deviceUrl, {
+      method: 'PUT',
+      headers: {
+        ...baseHeaders(),
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/javascript, */*; q=0.01',
+        'X-Requested-With': 'XMLHttpRequest',
+        Origin: SIT_BASE,
+        Referer: entryUrl,
+      },
+      body: JSON.stringify({ deviceType: 'REMOTE_PAIRING_CODE', mobileSdkParams: null }),
+      signal,
+    })
+    const deviceBodyRaw = await readBodyOrThrow('PUT cardtap device', deviceRes)
+    const deviceBody = safeJson<{ pairingCode?: string }>(deviceBodyRaw)
+    if (!deviceBody?.pairingCode) {
+      throw new Error(`pairingCode missing from cardtap device response: ${deviceBodyRaw.slice(0, 200)}`)
+    }
+
+    return {
+      transactionId,
+      pairingCode: deviceBody.pairingCode,
+      clientName: txBody?.clientName ?? '',
+    }
+  } finally {
+    clearTimeout(timeoutId)
   }
 }
 
-function baseHeaders(jar: CookieJar): Record<string, string> {
-  const headers: Record<string, string> = {
+function baseHeaders(): Record<string, string> {
+  return {
     'User-Agent': USER_AGENT,
     Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
     'Accept-Language': 'en-CA,en;q=0.9',
   }
-  const cookie = jar.cookieHeader()
-  if (cookie) headers.Cookie = cookie
-  return headers
 }
 
-function extractInputValue(html: string, name: string): string | null {
-  // Matches <input ... name="X" value="..."> in either attribute order.
-  const nameFirst = new RegExp(
-    String.raw`<input\b[^>]*\bname\s*=\s*['"]${name}['"][^>]*\bvalue\s*=\s*['"]([^'"]*)['"]`,
-    'i'
-  )
-  const valueFirst = new RegExp(
-    String.raw`<input\b[^>]*\bvalue\s*=\s*['"]([^'"]*)['"][^>]*\bname\s*=\s*['"]${name}['"]`,
-    'i'
-  )
-  const m = nameFirst.exec(html) ?? valueFirst.exec(html)
-  return m ? (m[1] ?? null) : null
-}
-
-class CookieJar {
-  private readonly store = new Map<string, string>()
-
-  consume(headers: Headers): void {
-    let raw: string[]
-    if (typeof headers.getSetCookie === 'function') {
-      raw = headers.getSetCookie()
-    } else {
-      const single = headers.get('set-cookie')
-      raw = single ? [single] : []
-    }
-    for (const line of raw) {
-      const first = line.split(';', 1)[0] ?? ''
-      const eq = first.indexOf('=')
-      if (eq < 0) continue
-      const name = first.slice(0, eq).trim()
-      const value = first.slice(eq + 1).trim()
-      if (name) this.store.set(name, value)
-    }
+async function readBodyOrThrow(step: string, response: Response): Promise<string> {
+  const body = await response.text()
+  if (!response.ok) {
+    const snippet = body.slice(0, 200).replaceAll(/\s+/g, ' ').trim()
+    throw new Error(`${step} failed: HTTP ${response.status}${snippet ? ` — ${snippet}` : ''}`)
   }
+  return body
+}
 
-  cookieHeader(): string {
-    return Array.from(this.store.entries())
-      .map(([k, v]) => `${k}=${v}`)
-      .join('; ')
+function inputValue($: CheerioAPI, name: string): string | null {
+  return $(`input[name="${name}"]`).first().attr('value') ?? null
+}
+
+function extractTransactionId(html: string): string | null {
+  // Server embeds `var transactionID = "<uuid>"` in an inline script. The regex
+  // tolerates single/double quotes and any declaration kind so a cosmetic
+  // server-side change doesn't silently break pairing tests.
+  const match = /\btransactionID\s*=\s*['"]([0-9a-fA-F-]+)['"]/.exec(html)
+  return match?.[1] ?? null
+}
+
+function safeJson<T>(raw: string): T | null {
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    return null
+  }
+}
+
+function assertSitEnv(): void {
+  // No app/.env — dev machine hasn't applied a variant yet; assume SIT
+  // (matches the rest of the e2e suite, which is also SIT-only).
+  let raw: string
+  try {
+    raw = readFileSync(APP_ENV_PATH, 'utf8')
+  } catch {
+    return
+  }
+  const match = /^DEFAULT_ENVIRONMENT\s*=\s*['"]?([^'"\r\n]+)/m.exec(raw)
+  if (!match) return
+  const env = match[1].trim().toUpperCase()
+  // bcsc-dev variant points at SIT too; anything else is a mismatch.
+  if (env !== 'SIT' && env !== 'DEV') {
+    throw new Error(
+      `pairing-code helper is pinned to SIT but app/.env DEFAULT_ENVIRONMENT=${env}. ` +
+        `Apply a SIT-targeted variant (e.g. yarn apply-variant bcsc-dev) before running this spec.`
+    )
   }
 }

--- a/e2e/src/helpers/pairing-code.ts
+++ b/e2e/src/helpers/pairing-code.ts
@@ -83,7 +83,8 @@ export async function fetchPairingCode(): Promise<PairingSession> {
     throw new Error(`GET /login/entry failed: ${entryRes.status}`)
   }
   const entryHtml = await entryRes.text()
-  const txMatch = entryHtml.match(/var\s+transactionID\s*=\s*"([0-9a-fA-F-]+)"/)
+  const txPattern = /var\s+transactionID\s*=\s*"([0-9a-fA-F-]+)"/
+  const txMatch = txPattern.exec(entryHtml)
   if (!txMatch) {
     throw new Error('transactionID literal not found in /login/entry HTML')
   }
@@ -152,14 +153,14 @@ function baseHeaders(jar: CookieJar): Record<string, string> {
 function extractInputValue(html: string, name: string): string | null {
   // Matches <input ... name="X" value="..."> in either attribute order.
   const nameFirst = new RegExp(
-    `<input\\b[^>]*\\bname\\s*=\\s*['"]${name}['"][^>]*\\bvalue\\s*=\\s*['"]([^'"]*)['"]`,
+    String.raw`<input\b[^>]*\bname\s*=\s*['"]${name}['"][^>]*\bvalue\s*=\s*['"]([^'"]*)['"]`,
     'i'
   )
   const valueFirst = new RegExp(
-    `<input\\b[^>]*\\bvalue\\s*=\\s*['"]([^'"]*)['"][^>]*\\bname\\s*=\\s*['"]${name}['"]`,
+    String.raw`<input\b[^>]*\bvalue\s*=\s*['"]([^'"]*)['"][^>]*\bname\s*=\s*['"]${name}['"]`,
     'i'
   )
-  const m = html.match(nameFirst) ?? html.match(valueFirst)
+  const m = nameFirst.exec(html) ?? valueFirst.exec(html)
   return m ? (m[1] ?? null) : null
 }
 
@@ -167,12 +168,13 @@ class CookieJar {
   private readonly store = new Map<string, string>()
 
   consume(headers: Headers): void {
-    const raw =
-      typeof headers.getSetCookie === 'function'
-        ? headers.getSetCookie()
-        : headers.get('set-cookie')
-          ? [headers.get('set-cookie') as string]
-          : []
+    let raw: string[]
+    if (typeof headers.getSetCookie === 'function') {
+      raw = headers.getSetCookie()
+    } else {
+      const single = headers.get('set-cookie')
+      raw = single ? [single] : []
+    }
     for (const line of raw) {
       const first = line.split(';', 1)[0] ?? ''
       const eq = first.indexOf('=')

--- a/e2e/src/helpers/pairing-code.ts
+++ b/e2e/src/helpers/pairing-code.ts
@@ -1,0 +1,191 @@
+/**
+ * Mints a BCSC login pairing code by replaying the web-browser flow from
+ * Node. Used by the login-from-computer spec so tests don't have to drive
+ * an on-device browser.
+ *
+ * The flow targets the SIT (System Integration Testing) environment —
+ * idsit.gov.bc.ca — and impersonates the "BC Parks Discover Camping"
+ * demo relying party (clientId `urn:ca:bc:gov:demo:rp1`).
+ *
+ * Captured from the real browser flow:
+ *   1. GET  /demo/rp1/login         → scrape SAMLRequest + RelayState
+ *   2. POST /login/saml2            → 302 sets cookie tied to the login session
+ *   3. GET  /login/entry            → scrape cardtap transaction UUID from inline JS
+ *   4. POST /cardtap/v3/transactions/{uuid}?clientId=... → opens transaction
+ *   5. PUT  /cardtap/v3/transactions/{uuid}/device       → returns `pairingCode`
+ *
+ * After step 5 the backend holds the code in `state: "pairing"` for a few
+ * minutes, waiting for the mobile app to submit it via the normal pairing
+ * API. The caller is expected to immediately type the returned code into
+ * the app.
+ */
+
+const SIT_BASE = 'https://idsit.gov.bc.ca'
+const DEMO_RP_LOGIN = `${SIT_BASE}/demo/rp1/login`
+const SAML2_POST = `${SIT_BASE}/login/saml2`
+const LOGIN_ENTRY = `${SIT_BASE}/login/entry`
+const CLIENT_ID = 'urn:ca:bc:gov:demo:rp1'
+
+const USER_AGENT = 'bc-wallet-mobile-e2e/1.0 (+pairing-code-helper)'
+
+export interface PairingSession {
+  transactionId: string
+  pairingCode: string
+  clientName: string
+}
+
+export async function fetchPairingCode(): Promise<PairingSession> {
+  const jar = new CookieJar()
+
+  // 1. Demo RP login page — server returns an auto-submit SAML form.
+  const rpLoginRes = await fetch(DEMO_RP_LOGIN, {
+    redirect: 'manual',
+    headers: baseHeaders(jar),
+  })
+  jar.consume(rpLoginRes.headers)
+  const rpLoginHtml = await rpLoginRes.text()
+  const samlRequest = extractInputValue(rpLoginHtml, 'SAMLRequest')
+  const relayState = extractInputValue(rpLoginHtml, 'RelayState')
+  if (!samlRequest) {
+    throw new Error(`SAMLRequest input not found in ${DEMO_RP_LOGIN}`)
+  }
+
+  // 2. Post the SAML form. Expect 302 to /login/entry with a fresh session cookie.
+  const samlBody = new URLSearchParams({ SAMLRequest: samlRequest })
+  if (relayState) samlBody.append('RelayState', relayState)
+  const samlRes = await fetch(SAML2_POST, {
+    method: 'POST',
+    redirect: 'manual',
+    headers: {
+      ...baseHeaders(jar),
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Origin: SIT_BASE,
+      Referer: DEMO_RP_LOGIN,
+    },
+    body: samlBody.toString(),
+  })
+  jar.consume(samlRes.headers)
+  if (samlRes.status !== 302) {
+    throw new Error(`POST /login/saml2 expected 302, got ${samlRes.status}`)
+  }
+
+  // 3. Follow redirect to /login/entry. Server embeds the cardtap transaction
+  //    UUID as a JS literal — scrape it.
+  const entryRes = await fetch(LOGIN_ENTRY, {
+    redirect: 'manual',
+    headers: {
+      ...baseHeaders(jar),
+      Referer: DEMO_RP_LOGIN,
+    },
+  })
+  jar.consume(entryRes.headers)
+  if (!entryRes.ok) {
+    throw new Error(`GET /login/entry failed: ${entryRes.status}`)
+  }
+  const entryHtml = await entryRes.text()
+  const txMatch = entryHtml.match(/var\s+transactionID\s*=\s*"([0-9a-fA-F-]+)"/)
+  if (!txMatch) {
+    throw new Error('transactionID literal not found in /login/entry HTML')
+  }
+  const transactionId = txMatch[1]
+
+  // 4. Open the cardtap transaction. Response carries client metadata (name,
+  //    device options) — we only use clientName for log output.
+  const txUrl = `${SIT_BASE}/cardtap/v3/transactions/${transactionId}?clientId=${encodeURIComponent(CLIENT_ID)}`
+  const txRes = await fetch(txUrl, {
+    method: 'POST',
+    headers: {
+      ...baseHeaders(jar),
+      'Content-Type': 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
+      Origin: SIT_BASE,
+      Referer: LOGIN_ENTRY,
+    },
+  })
+  jar.consume(txRes.headers)
+  if (!txRes.ok) {
+    throw new Error(`POST cardtap transaction failed: ${txRes.status}`)
+  }
+  const txBody = (await txRes.json()) as { clientName?: string }
+
+  // 5. Select BC Services Card app as the pairing device. Response body
+  //    carries the six-letter pairing code we type into the app.
+  const deviceUrl = `${SIT_BASE}/cardtap/v3/transactions/${transactionId}/device`
+  const deviceRes = await fetch(deviceUrl, {
+    method: 'PUT',
+    headers: {
+      ...baseHeaders(jar),
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/javascript, */*; q=0.01',
+      'X-Requested-With': 'XMLHttpRequest',
+      Origin: SIT_BASE,
+      Referer: LOGIN_ENTRY,
+    },
+    body: JSON.stringify({ deviceType: 'REMOTE_PAIRING_CODE', mobileSdkParams: null }),
+  })
+  if (!deviceRes.ok) {
+    throw new Error(`PUT cardtap device failed: ${deviceRes.status}`)
+  }
+  const deviceBody = (await deviceRes.json()) as { pairingCode?: string }
+  if (!deviceBody.pairingCode) {
+    throw new Error('pairingCode missing from cardtap device response')
+  }
+
+  return {
+    transactionId,
+    pairingCode: deviceBody.pairingCode,
+    clientName: txBody.clientName ?? '',
+  }
+}
+
+function baseHeaders(jar: CookieJar): Record<string, string> {
+  const headers: Record<string, string> = {
+    'User-Agent': USER_AGENT,
+    Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'Accept-Language': 'en-CA,en;q=0.9',
+  }
+  const cookie = jar.cookieHeader()
+  if (cookie) headers.Cookie = cookie
+  return headers
+}
+
+function extractInputValue(html: string, name: string): string | null {
+  // Matches <input ... name="X" value="..."> in either attribute order.
+  const nameFirst = new RegExp(
+    `<input\\b[^>]*\\bname\\s*=\\s*['"]${name}['"][^>]*\\bvalue\\s*=\\s*['"]([^'"]*)['"]`,
+    'i'
+  )
+  const valueFirst = new RegExp(
+    `<input\\b[^>]*\\bvalue\\s*=\\s*['"]([^'"]*)['"][^>]*\\bname\\s*=\\s*['"]${name}['"]`,
+    'i'
+  )
+  const m = html.match(nameFirst) ?? html.match(valueFirst)
+  return m ? (m[1] ?? null) : null
+}
+
+class CookieJar {
+  private readonly store = new Map<string, string>()
+
+  consume(headers: Headers): void {
+    const raw =
+      typeof headers.getSetCookie === 'function'
+        ? headers.getSetCookie()
+        : headers.get('set-cookie')
+          ? [headers.get('set-cookie') as string]
+          : []
+    for (const line of raw) {
+      const first = line.split(';', 1)[0] ?? ''
+      const eq = first.indexOf('=')
+      if (eq < 0) continue
+      const name = first.slice(0, eq).trim()
+      const value = first.slice(eq + 1).trim()
+      if (name) this.store.set(name, value)
+    }
+  }
+
+  cookieHeader(): string {
+    return Array.from(this.store.entries())
+      .map(([k, v]) => `${k}=${v}`)
+      .join('; ')
+  }
+}

--- a/e2e/test/bcsc/main/login-from-computer.spec.ts
+++ b/e2e/test/bcsc/main/login-from-computer.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * Login-from-computer e2e: mint a pairing code via a Node-side replay of
+ * the BC Parks demo web flow (idsit.gov.bc.ca), then type it into BCSC and
+ * verify PairingConfirmation renders.
+ *
+ * Covers ticket AC #3: Home → LogInFromComputer → ManualPairingCode →
+ * enter code → Submit → PairingConfirmation.
+ *
+ * Preconditions: app is onboarded and resting on the Home tab. Spec is not
+ * imported by full-regression.spec.ts yet — run standalone with --spec
+ * while we validate the Node-fetch path.
+ */
+import { Timeouts } from '../../../src/constants.js'
+import { fetchPairingCode } from '../../../src/helpers/pairing-code.js'
+import { BaseScreen } from '../../../src/screens/BaseScreen.js'
+import { BCSC_TestIDs } from '../../../src/testIDs.js'
+
+const Home = new BaseScreen(BCSC_TestIDs.Home)
+const ManualPairing = new BaseScreen(BCSC_TestIDs.ManualPairingCode)
+const PairingConfirmation = new BaseScreen(BCSC_TestIDs.PairingConfirmation)
+
+describe('Login From Computer — pairing code minted in Node', () => {
+  let pairingCode = ''
+
+  before(async () => {
+    await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
+    const session = await fetchPairingCode()
+    pairingCode = session.pairingCode
+    console.log(
+      `[login-from-computer] minted pairing code ${pairingCode} for "${session.clientName}" (tx ${session.transactionId})`
+    )
+  })
+
+  it('navigates from Home to ManualPairingCode via Log In From Computer', async () => {
+    await Home.tap('LogInFromComputer')
+    await ManualPairing.waitFor('PairingCodeInput')
+  })
+
+  it('submits the pairing code and verifies PairingConfirmation renders', async () => {
+    await ManualPairing.type('PairingCodeInput', pairingCode, {
+      tapFirst: true,
+      characterByCharacter: true,
+    })
+    await ManualPairing.dismissKeyboard()
+    await ManualPairing.tap('Submit')
+    await PairingConfirmation.waitFor('Close', Timeouts.screenTransition)
+  })
+
+  it('closes the PairingConfirmation screen', async () => {
+    await PairingConfirmation.tap('Close')
+    await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
+  })
+})

--- a/e2e/test/bcsc/main/login-from-computer.spec.ts
+++ b/e2e/test/bcsc/main/login-from-computer.spec.ts
@@ -26,8 +26,11 @@ describe('Login From Computer — pairing code minted in Node', () => {
     await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
     const session = await fetchPairingCode()
     pairingCode = session.pairingCode
+    // Pairing codes are short-lived but live credentials — only log a masked
+    // suffix so CI archives don't retain an active code.
+    const redactedPairingCode = `***${pairingCode.slice(-2)}`
     console.log(
-      `[login-from-computer] minted pairing code ${pairingCode} for "${session.clientName}" (tx ${session.transactionId})`
+      `[login-from-computer] minted pairing code ${redactedPairingCode} for "${session.clientName}" (tx ${session.transactionId})`
     )
   })
 


### PR DESCRIPTION
# Summary of Changes

Add e2e coverage for the Log-In-From-Computer flow.

- `e2e/src/helpers/pairing-code.ts` — Node-side helper that mints a real pairing code by replaying the BC Parks demo web flow at `idsit.gov.bc.ca` (5 HTTP calls, no external deps)
- `e2e/test/bcsc/main/login-from-computer.spec.ts` — spec that drives Home → ManualPairingCode, types the minted code, and verifies PairingConfirmation renders and closes back to Home

Skips driving an on-device browser entirely, so the same path runs on iOS and Android without context-switching or parallel sessions.

# Testing Instructions

Preconditions: app is onboarded and resting on Home (e.g. run with `NO_RESET=true` after a full-regression pass).

```sh
cd e2e && yarn test:android:local --spec test/bcsc/main/login-from-computer.spec.ts
cd e2e && yarn test:ios:local     --spec test/bcsc/main/login-from-computer.spec.ts
```

# Acceptance Criteria

- Home → LogInFromComputer navigates to ManualPairingCode
- Pairing code minted from `idsit.gov.bc.ca` submits successfully, landing on PairingConfirmation
- Close returns the user to Home

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A
