### PR TITLE
feat: add version number to developer screen

### DIFF
--- a/app/src/screens/Developer.tsx
+++ b/app/src/screens/Developer.tsx
@@ -18,6 +18,7 @@ import { useNavigation } from '@react-navigation/native'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DeviceEventEmitter, Pressable, ScrollView, StyleSheet, Switch, Text, View } from 'react-native'
+import { getBuildNumber, getVersion } from 'react-native-device-info'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import ErrorAlertTest from './ErrorAlertTest'
 import IASEnvironment from './IASEnvironment'
@@ -584,6 +585,11 @@ const Developer: React.FC = () => {
             </SectionRow>
           </>
         ) : null}
+        <View style={styles.footer} testID={testIdWithKey('Version')}>
+          <Text
+            style={TextTheme.labelSubtitle}
+          >{`${t('Settings.Version')} ${getVersion()} (${getBuildNumber()})`}</Text>
+        </View>
       </ScrollView>
     </ScreenWrapper>
   )

--- a/app/src/screens/__snapshots__/Developer.test.tsx.snap
+++ b/app/src/screens/__snapshots__/Developer.test.tsx.snap
@@ -1524,6 +1524,28 @@ exports[`Developer Screen screen renders correctly 1`] = `
           }
         }
       />
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "marginVertical": 25,
+          }
+        }
+        testID="com.ariesbifold:id/Version"
+      >
+        <Text
+          style={
+            {
+              "color": "#313132",
+              "fontFamily": "BCSans-Regular",
+              "fontSize": 14,
+              "fontWeight": "normal",
+            }
+          }
+        >
+          Settings.Version 4.0.0 (142)
+        </Text>
+      </View>
     </View>
   </RCTScrollView>
 </RNCSafeAreaView>


### PR DESCRIPTION
# Summary of Changes

- Adds the app version and build number to the bottom of the Developer screen so Tier 1/2 support can identify the
  build users are running, even on pre-setup screens where the Settings screen isn't reachable.
- Uses `getVersion()` / `getBuildNumber()` from `react-native-device-info`, matching the pattern already in  
  `SettingsContent.tsx`.

# Testing Instructions

- [ ] Enable developer mode and confirm `Version X.Y.Z (build)` appears at the bottom of the Developer screen
- Snapshot test updated (Developer.test.tsx.snap)

# Acceptance Criteria

- Version and build number are visible at the bottom of the Developer screen
- Format matches `Version X.Y.Z (build)`
- Works on both BC Wallet and BCSC build targets

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A
