### PR TITLE
fix: upgrade dep versions

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -92,7 +92,7 @@
     "@react-navigation/native": "~6.0.16",
     "@react-navigation/stack": "~6.3.29",
     "@snowplow/react-native-tracker": "^4.6.8",
-    "axios": "1.13.6",
+    "axios": "1.15.0",
     "base-64": "~1.0.0",
     "buffer": "~6.0.3",
     "credo-ts-indy-vdr-proxy-client": "0.2.4",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -18,7 +18,8 @@
     "test:sauce": "npm run test:android:sauce && npm run test:ios:sauce"
   },
   "resolutions": {
-    "form-data": "^4.0.4"
+    "form-data": "^4.0.4",
+    "basic-ftp": "5.3.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.0.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -20,7 +20,8 @@
   "resolutions": {
     "form-data": "^4.0.4",
     "basic-ftp": "5.3.0",
-    "protobufjs": "7.5.5"
+    "protobufjs": "7.5.5",
+    "axios": "1.15.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.0.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -19,7 +19,8 @@
   },
   "resolutions": {
     "form-data": "^4.0.4",
-    "basic-ftp": "5.3.0"
+    "basic-ftp": "5.3.0",
+    "protobufjs": "7.5.5"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.0.0",

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -2894,10 +2894,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"basic-ftp@npm:^5.0.2":
-  version: 5.2.0
-  resolution: "basic-ftp@npm:5.2.0"
-  checksum: 10c0/a0f85c01deae0723021f9bf4a7be29378186fa8bba41e74ea11832fe74c187ce90c3599c3cc5ec936581cfd150020e79f4a9ed0ee9fb20b2308e69b045f3a059
+"basic-ftp@npm:5.3.0":
+  version: 5.3.0
+  resolution: "basic-ftp@npm:5.3.0"
+  checksum: 10c0/307ebc0635d06e671729d348e45e6eaec5f926713f93de535b268e17ae675942cd6903a84196cece948b54e04b24591431be3df79b2824551a0d5ed150555fb2
   languageName: node
   linkType: hard
 

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -7239,9 +7239,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.2.5":
-  version: 7.5.4
-  resolution: "protobufjs@npm:7.5.4"
+"protobufjs@npm:7.5.5":
+  version: 7.5.5
+  resolution: "protobufjs@npm:7.5.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -7255,7 +7255,7 @@ __metadata:
     "@protobufjs/utf8": "npm:^1.1.0"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
+  checksum: 10c0/3d48896a916761e3e60b52f80027eb4fba3f5a6e3f8461e04939db18812db2cb0db4c73d03e1134a960e99525ae1d236f076a0bc01273016f573b76f33ffbd47
   languageName: node
   linkType: hard
 

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -2750,25 +2750,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.9.0":
-  version: 1.9.0
-  resolution: "axios@npm:1.9.0"
-  dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.0"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/9371a56886c2e43e4ff5647b5c2c3c046ed0a3d13482ef1d0135b994a628c41fbad459796f101c655e62f0c161d03883454474d2e435b2e021b1924d9f24994c
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.4.0, axios@npm:^1.6.5, axios@npm:^1.6.7, axios@npm:^1.7.4, axios@npm:^1.x":
-  version: 1.13.6
-  resolution: "axios@npm:1.13.6"
+"axios@npm:1.15.0":
+  version: 1.15.0
+  resolution: "axios@npm:1.15.0"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/51fb5af055c3b85662fa97df17d986ae2c37d13bf86d50b6bb36b6b3a2dec6966a1d3a14ab3774b71707b155ae3597ed9b7babdf1a1a863d1a31840cb8e7ec71
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
   languageName: node
   linkType: hard
 
@@ -4758,7 +4747,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.11, follow-redirects@npm:^1.15.6":
+"follow-redirects@npm:^1.15.11":
   version: 1.15.11
   resolution: "follow-redirects@npm:1.15.11"
   peerDependenciesMeta:
@@ -7289,6 +7278,13 @@ __metadata:
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
   checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: 10c0/ed01729fd4d094eab619cd7e17ce3698b3413b31eb102c4904f9875e677cd207392795d5b4adee9cec359dfd31c44d5ad7595a3a3ad51c40250e141512281c58
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "react-native-fs@npm:~2.20.0": "patch:react-native-fs@npm%3A2.20.0#~/.yarn/patches/react-native-fs-npm-2.20.0-a38fe24051.patch",
     "handlebars": "4.7.9",
     "basic-ftp": "5.3.0",
-    "protobufjs": "7.5.5"
+    "protobufjs": "7.5.5",
+    "axios": "1.15.0"
   },
   "dependencies": {
     "react-native-bcsc-core": "workspace:*"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "@animo-id/pex@npm:4.1.1-alpha.0": "patch:@animo-id/pex@npm%3A4.1.1-alpha.0#~/.yarn/patches/@animo-id-pex-npm-4.1.1-alpha.0-f29edfffa2.patch",
     "@sphereon/pex@npm:5.0.0-unstable.24": "patch:@sphereon/pex@npm%3A5.0.0-unstable.24#~/.yarn/patches/@sphereon-pex-npm-5.0.0-unstable.24-921df3a8ac.patch",
     "react-native-fs@npm:~2.20.0": "patch:react-native-fs@npm%3A2.20.0#~/.yarn/patches/react-native-fs-npm-2.20.0-a38fe24051.patch",
-    "handlebars": "4.7.9"
+    "handlebars": "4.7.9",
+    "basic-ftp": "5.3.0"
   },
   "dependencies": {
     "react-native-bcsc-core": "workspace:*"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "@sphereon/pex@npm:5.0.0-unstable.24": "patch:@sphereon/pex@npm%3A5.0.0-unstable.24#~/.yarn/patches/@sphereon-pex-npm-5.0.0-unstable.24-921df3a8ac.patch",
     "react-native-fs@npm:~2.20.0": "patch:react-native-fs@npm%3A2.20.0#~/.yarn/patches/react-native-fs-npm-2.20.0-a38fe24051.patch",
     "handlebars": "4.7.9",
-    "basic-ftp": "5.3.0"
+    "basic-ftp": "5.3.0",
+    "protobufjs": "7.5.5"
   },
   "dependencies": {
     "react-native-bcsc-core": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8054,10 +8054,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"basic-ftp@npm:^5.0.2":
-  version: 5.2.0
-  resolution: "basic-ftp@npm:5.2.0"
-  checksum: 10c0/a0f85c01deae0723021f9bf4a7be29378186fa8bba41e74ea11832fe74c187ce90c3599c3cc5ec936581cfd150020e79f4a9ed0ee9fb20b2308e69b045f3a059
+"basic-ftp@npm:5.3.0":
+  version: 5.3.0
+  resolution: "basic-ftp@npm:5.3.0"
+  checksum: 10c0/307ebc0635d06e671729d348e45e6eaec5f926713f93de535b268e17ae675942cd6903a84196cece948b54e04b24591431be3df79b2824551a0d5ed150555fb2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7789,14 +7789,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.13.6, axios@npm:~1.13.2":
-  version: 1.13.6
-  resolution: "axios@npm:1.13.6"
+"axios@npm:1.15.0":
+  version: 1.15.0
+  resolution: "axios@npm:1.15.0"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/51fb5af055c3b85662fa97df17d986ae2c37d13bf86d50b6bb36b6b3a2dec6966a1d3a14ab3774b71707b155ae3597ed9b7babdf1a1a863d1a31840cb8e7ec71
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
   languageName: node
   linkType: hard
 
@@ -8127,7 +8127,7 @@ __metadata:
     "@types/react-native-vector-icons": "npm:~6.4.18"
     "@typescript-eslint/eslint-plugin": "npm:~7.18.0"
     "@typescript-eslint/parser": "npm:~7.18.0"
-    axios: "npm:1.13.6"
+    axios: "npm:1.15.0"
     babel-jest: "npm:~29.7.0"
     babel-plugin-module-resolver: "npm:~5.0.2"
     base-64: "npm:~1.0.0"
@@ -16454,6 +16454,13 @@ __metadata:
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
   checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: 10c0/ed01729fd4d094eab619cd7e17ce3698b3413b31eb102c4904f9875e677cd207392795d5b4adee9cec359dfd31c44d5ad7595a3a3ad51c40250e141512281c58
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16397,9 +16397,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.2.5":
-  version: 7.5.4
-  resolution: "protobufjs@npm:7.5.4"
+"protobufjs@npm:7.5.5":
+  version: 7.5.5
+  resolution: "protobufjs@npm:7.5.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -16413,7 +16413,7 @@ __metadata:
     "@protobufjs/utf8": "npm:^1.1.0"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
+  checksum: 10c0/3d48896a916761e3e60b52f80027eb4fba3f5a6e3f8461e04939db18812db2cb0db4c73d03e1134a960e99525ae1d236f076a0bc01273016f573b76f33ffbd47
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary of Changes

- Bump basic-ftp version: 5.3.0
- Bump protobufjs version: 7.5.5
- Bump axios version: 1.15.0


# Testing Instructions

- [ ] Run `yarn install` at the repo root and confirm it completes without errors
- [ ] Run `yarn install` in `e2e/` and confirm it completes without errors
- [ ] Verify the following resolved versions appear in both `yarn.lock` and `e2e/yarn.lock` (no older versions remain):
  - `basic-ftp@npm:5.3.0`
  - `protobufjs@npm:7.5.5`
  - `axios@npm:1.15.0`
- [ ] Run `yarn check` at the repo root (typecheck + lint + format:check + tests) and confirm all pass
- [ ] Smoke-test the E2E setup in `e2e/` (e.g. `yarn setup`) to confirm WebDriver tooling still resolves correctly

# Acceptance Criteria

- No Dependabot alerts remain for `basic-ftp`, `protobufjs`, or `axios` after merge
- Both `yarn.lock` files resolve `basic-ftp` to `5.3.0`, `protobufjs` to `7.5.5`, and `axios` to `1.15.0`
- No regressions in app build, unit tests, or E2E tooling setup


# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
