### PR TITLE
feat: deep linking e2e test

### DIFF
--- a/e2e/src/helpers/deep-link.ts
+++ b/e2e/src/helpers/deep-link.ts
@@ -1,0 +1,41 @@
+/**
+ * Helpers for dispatching `<scheme>://...` deep links to the app under test.
+ *
+ * Both iOS XCUITest and Android UiAutomator2 expose Appium's `mobile: deepLink`
+ * command, but with platform-specific arg names (`bundleId` vs `package`).
+ * This module wraps that and the matching app-id lookup so spec code can stay
+ * platform-agnostic.
+ */
+import type { DeepLinkPlatform } from './pairing-code.js'
+
+/** Platform string the WDIO driver is currently bound to. */
+export function currentPlatform(): DeepLinkPlatform {
+  return driver.isIOS ? 'ios' : 'android'
+}
+
+/**
+ * Capture the package (Android) or bundle id (iOS) of the currently running
+ * app. Must be invoked while the app under test is in the foreground so the
+ * driver query resolves to the right process.
+ */
+export async function getCurrentAppId(): Promise<string> {
+  if (driver.isIOS) {
+    const info = (await driver.execute('mobile: activeAppInfo')) as { bundleId?: string }
+    if (!info?.bundleId) {
+      throw new Error('Unable to resolve iOS bundle id from mobile: activeAppInfo')
+    }
+    return info.bundleId
+  }
+  return driver.getCurrentPackage()
+}
+
+/**
+ * Dispatch a deep-link URL to the named app. Mirrors how the OS would
+ * resolve a tap on a `<scheme>://...` link in a mobile browser — Appium
+ * routes through Safari (iOS) or `am start -a VIEW` (Android), and the
+ * registered URL scheme handler in the variant manifests catches it.
+ */
+export async function dispatchDeepLink(url: string, appId: string): Promise<void> {
+  const params = driver.isIOS ? { url, bundleId: appId } : { url, package: appId }
+  await driver.execute('mobile: deepLink', params)
+}

--- a/e2e/src/helpers/gestures.ts
+++ b/e2e/src/helpers/gestures.ts
@@ -34,6 +34,23 @@ export async function swipeDownBy(fraction = 0.25, durationMs = 500): Promise<vo
 }
 
 /**
+ * Pop the top stack frame using the platform's native "back" affordance:
+ * an edge-swipe-from-left on iOS (XCUITest's `interactivePopGestureRecognizer`),
+ * or the system back button on Android (`driver.back()`).
+ *
+ * Useful for screens that intentionally omit an in-app back/close control —
+ * e.g. PairingConfirmation in the iOS app-switch flow, where the user is
+ * expected to leave via the OS back-to-Safari shortcut.
+ */
+export async function navigateBack(): Promise<void> {
+  if (driver.isIOS) {
+    await swipeIosFromTo({ x: 0, y: 0.5 }, { x: 0.85, y: 0.5 }, 300)
+  } else {
+    await driver.back()
+  }
+}
+
+/**
  * Tap at window-relative coordinates (0–1 fractions of width/height). Uses the same
  * primitives as dismiss-keyboard taps — good for camera tap-to-focus without a test id.
  */

--- a/e2e/src/helpers/pairing-code.ts
+++ b/e2e/src/helpers/pairing-code.ts
@@ -1,7 +1,13 @@
 /**
- * Mints a BCSC login pairing code by replaying the web-browser flow from
- * Node. Used by the login-from-computer spec so tests don't have to drive
- * an on-device browser.
+ * Mints BCSC login pairing artifacts by replaying the web-browser flow from
+ * Node. Two variants share the same SAML/cardtap setup and only differ in
+ * the final PUT to /device:
+ *
+ *   - `fetchPairingCode()` returns the six-letter manual pairing code, used
+ *     by the login-from-computer spec.
+ *   - `fetchPairingDeepLink()` returns a fully-formed `<scheme>://pair/...`
+ *     URL, used by the deep-link spec to invoke the app via Appium
+ *     `mobile: deepLink`.
  *
  * Pinned to SIT (idsit.gov.bc.ca), same as every other automated BCSC
  * helper in this repo — the test users in e2e/assets/USERS.md only exist
@@ -16,8 +22,14 @@
  *   1. GET  /demo/rp1/login         → scrape SAMLRequest + RelayState
  *   2. POST /login/saml2            → 302, Location points at the login entry
  *   3. GET  {Location}              → scrape cardtap transaction UUID
- *   4. POST /cardtap/v3/transactions/{uuid}?clientId=... → opens transaction
- *   5. PUT  /cardtap/v3/transactions/{uuid}/device       → returns `pairingCode`
+ *   4. POST /cardtap/v3/transactions/{uuid}?clientId=...   → opens transaction
+ *   5. PUT  /cardtap/v3/transactions/{uuid}/device         → returns pairing artifacts
+ *
+ * The deep-link variant additionally appends `&maxTouchPoints=1` to step 4
+ * and sends `{"deviceType":"LOCAL_APP_SWITCH"}` in step 5 with a
+ * mobile-Safari User-Agent — that combination causes the demo site to
+ * select the LOCAL_APP_SWITCH device path and embed a `handlerURI` in the
+ * response.
  */
 import { type CheerioAPI, load } from 'cheerio'
 import makeFetchCookie from 'fetch-cookie'
@@ -35,7 +47,18 @@ const SAML2_POST = `${SIT_BASE}/login/saml2`
 const CLIENT_ID = 'urn:ca:bc:gov:demo:rp1'
 
 const USER_AGENT = 'bc-wallet-mobile-e2e/1.0 (+pairing-code-helper)'
+// Mobile UAs picked so the demo site (a) chooses LOCAL_APP_SWITCH (with a
+// `handlerURI`) over the desktop remote-pairing-code flow and (b) embeds
+// the platform-matching custom URL scheme — iPhone UA → iOS bcsc-dev
+// scheme `ca.bc.gov.iddev.servicescard`; Pixel UA → Android bcsc-dev
+// scheme `ca.bc.gov.id.servicescard.dev`.
+const IOS_USER_AGENT =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 Safari/604.1'
+const ANDROID_USER_AGENT =
+  'Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Mobile Safari/537.36'
 const DEFAULT_TIMEOUT_MS = 20_000
+
+export type DeepLinkPlatform = 'ios' | 'android'
 
 export interface PairingSession {
   transactionId: string
@@ -43,128 +66,257 @@ export interface PairingSession {
   clientName: string
 }
 
+export interface PairingDeepLinkSession extends PairingSession {
+  /** Fully-formed deep link, ready to dispatch via Appium `mobile: deepLink`. */
+  deepLink: string
+  /** URL scheme (without `://`) the demo site selected for this UA, e.g. `ca.bc.gov.iddev.servicescard`. */
+  scheme: string
+}
+
 export interface FetchPairingCodeOptions {
   timeoutMs?: number
 }
 
+export interface FetchPairingDeepLinkOptions extends FetchPairingCodeOptions {
+  /**
+   * Mobile platform UA to send. The demo site picks the matching custom URL
+   * scheme based on this — must align with the device the deep link will
+   * be dispatched to or the OS will refuse to resolve it.
+   */
+  platform: DeepLinkPlatform
+}
+
+interface CardtapTransactionContext {
+  transactionId: string
+  entryUrl: string
+  clientName: string
+  fetchWithCookies: typeof fetch
+  signal: AbortSignal
+  userAgent: string
+}
+
 export async function fetchPairingCode(options: FetchPairingCodeOptions = {}): Promise<PairingSession> {
   const { timeoutMs = DEFAULT_TIMEOUT_MS } = options
-  assertSitEnv()
-
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
 
   try {
-    const jar = new CookieJar()
-    const fetchWithCookies = makeFetchCookie(fetch, jar)
-    const { signal } = controller
+    const tx = await mintCardtapTransaction({ userAgent: USER_AGENT, signal: controller.signal })
 
-    // 1. Demo RP login page — server returns an auto-submit SAML form.
-    const rpLoginRes = await fetchWithCookies(DEMO_RP_LOGIN, {
-      redirect: 'manual',
-      headers: baseHeaders(),
-      signal,
+    // Select BC Services Card app as the pairing device. Response body
+    // carries the six-letter pairing code we type into the app.
+    const deviceBody = await putCardtapDevice<{ pairingCode?: string }>(tx, {
+      deviceType: 'REMOTE_PAIRING_CODE',
+      mobileSdkParams: null,
     })
-    const rpLoginHtml = await readBodyOrThrow('GET /demo/rp1/login', rpLoginRes)
-    const $rpLogin = load(rpLoginHtml)
-    const samlRequest = inputValue($rpLogin, 'SAMLRequest')
-    const relayState = inputValue($rpLogin, 'RelayState')
-    if (!samlRequest) {
-      throw new Error(`SAMLRequest input not found in ${DEMO_RP_LOGIN}`)
-    }
-
-    // 2. Post the SAML form. Expect 302 with Location pointing at the login entry page.
-    const samlBody = new URLSearchParams({ SAMLRequest: samlRequest })
-    if (relayState) samlBody.append('RelayState', relayState)
-    const samlRes = await fetchWithCookies(SAML2_POST, {
-      method: 'POST',
-      redirect: 'manual',
-      headers: {
-        ...baseHeaders(),
-        'Content-Type': 'application/x-www-form-urlencoded',
-        Origin: SIT_BASE,
-        Referer: DEMO_RP_LOGIN,
-      },
-      body: samlBody.toString(),
-      signal,
-    })
-    if (samlRes.status !== 302) {
-      throw new Error(`POST /login/saml2 expected 302, got ${samlRes.status}`)
-    }
-    const entryLocation = samlRes.headers.get('location')
-    if (!entryLocation) {
-      throw new Error('POST /login/saml2 returned 302 with no Location header')
-    }
-    const entryUrl = new URL(entryLocation, SIT_BASE).toString()
-
-    // 3. Follow the 302 to the login entry page. Server embeds the cardtap
-    //    transaction UUID as a JS literal — scrape it.
-    const entryRes = await fetchWithCookies(entryUrl, {
-      redirect: 'manual',
-      headers: {
-        ...baseHeaders(),
-        Referer: DEMO_RP_LOGIN,
-      },
-      signal,
-    })
-    const entryHtml = await readBodyOrThrow(`GET ${entryUrl}`, entryRes)
-    const transactionId = extractTransactionId(entryHtml)
-    if (!transactionId) {
-      throw new Error(`transactionID not found in ${entryUrl}`)
-    }
-
-    // 4. Open the cardtap transaction. Response carries client metadata (name,
-    //    device options) — we only use clientName for log output.
-    const txUrl = `${SIT_BASE}/cardtap/v3/transactions/${transactionId}?clientId=${encodeURIComponent(CLIENT_ID)}`
-    const txRes = await fetchWithCookies(txUrl, {
-      method: 'POST',
-      headers: {
-        ...baseHeaders(),
-        'Content-Type': 'application/json',
-        'X-Requested-With': 'XMLHttpRequest',
-        Origin: SIT_BASE,
-        Referer: entryUrl,
-      },
-      signal,
-    })
-    const txBodyRaw = await readBodyOrThrow('POST cardtap transaction', txRes)
-    const txBody = safeJson<{ clientName?: string }>(txBodyRaw)
-
-    // 5. Select BC Services Card app as the pairing device. Response body
-    //    carries the six-letter pairing code we type into the app.
-    const deviceUrl = `${SIT_BASE}/cardtap/v3/transactions/${transactionId}/device`
-    const deviceRes = await fetchWithCookies(deviceUrl, {
-      method: 'PUT',
-      headers: {
-        ...baseHeaders(),
-        'Content-Type': 'application/json',
-        Accept: 'application/json, text/javascript, */*; q=0.01',
-        'X-Requested-With': 'XMLHttpRequest',
-        Origin: SIT_BASE,
-        Referer: entryUrl,
-      },
-      body: JSON.stringify({ deviceType: 'REMOTE_PAIRING_CODE', mobileSdkParams: null }),
-      signal,
-    })
-    const deviceBodyRaw = await readBodyOrThrow('PUT cardtap device', deviceRes)
-    const deviceBody = safeJson<{ pairingCode?: string }>(deviceBodyRaw)
-    if (!deviceBody?.pairingCode) {
-      throw new Error(`pairingCode missing from cardtap device response: ${deviceBodyRaw.slice(0, 200)}`)
+    if (!deviceBody.parsed?.pairingCode) {
+      throw new Error(`pairingCode missing from cardtap device response: ${deviceBody.raw.slice(0, 200)}`)
     }
 
     return {
-      transactionId,
-      pairingCode: deviceBody.pairingCode,
-      clientName: txBody?.clientName ?? '',
+      transactionId: tx.transactionId,
+      pairingCode: deviceBody.parsed.pairingCode,
+      clientName: tx.clientName,
     }
   } finally {
     clearTimeout(timeoutId)
   }
 }
 
-function baseHeaders(): Record<string, string> {
+/**
+ * Mints a `<scheme>://pair/...` deep link by replaying the mobile-browser
+ * demo flow. The PUT response embeds a `selectedDevice.handlerURI` of the
+ * form `<scheme>://pair/<URL-encoded HTTPS path>/<service title>/`;
+ * concatenating the returned `pairingCode` produces the full link the
+ * device should resolve.
+ *
+ * The server picks the custom URL scheme by UA — pass `platform: 'ios'` to
+ * get `ca.bc.gov.iddev.servicescard`, `'android'` for
+ * `ca.bc.gov.id.servicescard.dev`. Both match the bcsc-dev variant.env
+ * declarations in `variants/bcsc-dev/variant.env`.
+ */
+export async function fetchPairingDeepLink(options: FetchPairingDeepLinkOptions): Promise<PairingDeepLinkSession> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, platform } = options
+  const userAgent = platform === 'ios' ? IOS_USER_AGENT : ANDROID_USER_AGENT
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    const tx = await mintCardtapTransaction({
+      userAgent,
+      signal: controller.signal,
+      // The live mobile flow always sends maxTouchPoints — the cardtap UI
+      // uses it to decide whether to surface the LOCAL_APP_SWITCH tile.
+      cardtapQueryExtras: { maxTouchPoints: '1' },
+    })
+
+    const deviceBody = await putCardtapDevice<{
+      pairingCode?: string
+      selectedDevice?: { handlerURI?: string }
+    }>(tx, { deviceType: 'LOCAL_APP_SWITCH' })
+
+    const pairingCode = deviceBody.parsed?.pairingCode
+    const handlerUri = deviceBody.parsed?.selectedDevice?.handlerURI
+    if (!pairingCode || !handlerUri) {
+      throw new Error(
+        `pairingCode or selectedDevice.handlerURI missing from cardtap device response: ${deviceBody.raw.slice(0, 200)}`
+      )
+    }
+
+    // handlerURI ends in `/`, e.g. `ca.bc.gov.iddev.servicescard://pair/https%3A%2F%2F.../device/BC+Parks+Discover+Camping/`
+    const deepLink = `${handlerUri}${pairingCode}`
+    const schemeMatch = /^([^:]+):\/\//.exec(handlerUri)
+    if (!schemeMatch) {
+      throw new Error(`Unable to parse scheme from handlerURI: ${handlerUri}`)
+    }
+
+    return {
+      transactionId: tx.transactionId,
+      pairingCode,
+      clientName: tx.clientName,
+      deepLink,
+      scheme: schemeMatch[1],
+    }
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+interface MintTransactionOptions {
+  userAgent: string
+  signal: AbortSignal
+  /** Extra query string params appended to the POST cardtap transaction call. */
+  cardtapQueryExtras?: Record<string, string>
+}
+
+/**
+ * Walks the SAML/login-entry/cardtap-open sequence and returns the live
+ * transaction context. Shared between the manual-pairing-code and
+ * deep-link variants — they only diverge at the final PUT to /device.
+ */
+async function mintCardtapTransaction({
+  userAgent,
+  signal,
+  cardtapQueryExtras,
+}: MintTransactionOptions): Promise<CardtapTransactionContext> {
+  assertSitEnv()
+  const jar = new CookieJar()
+  const fetchWithCookies = makeFetchCookie(fetch, jar)
+  const headers = baseHeaders(userAgent)
+
+  // 1. Demo RP login page — server returns an auto-submit SAML form.
+  const rpLoginRes = await fetchWithCookies(DEMO_RP_LOGIN, {
+    redirect: 'manual',
+    headers,
+    signal,
+  })
+  const rpLoginHtml = await readBodyOrThrow('GET /demo/rp1/login', rpLoginRes)
+  const $rpLogin = load(rpLoginHtml)
+  const samlRequest = inputValue($rpLogin, 'SAMLRequest')
+  const relayState = inputValue($rpLogin, 'RelayState')
+  if (!samlRequest) {
+    throw new Error(`SAMLRequest input not found in ${DEMO_RP_LOGIN}`)
+  }
+
+  // 2. Post the SAML form. Expect 302 with Location pointing at the login entry page.
+  const samlBody = new URLSearchParams({ SAMLRequest: samlRequest })
+  if (relayState) samlBody.append('RelayState', relayState)
+  const samlRes = await fetchWithCookies(SAML2_POST, {
+    method: 'POST',
+    redirect: 'manual',
+    headers: {
+      ...headers,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Origin: SIT_BASE,
+      Referer: DEMO_RP_LOGIN,
+    },
+    body: samlBody.toString(),
+    signal,
+  })
+  if (samlRes.status !== 302) {
+    throw new Error(`POST /login/saml2 expected 302, got ${samlRes.status}`)
+  }
+  const entryLocation = samlRes.headers.get('location')
+  if (!entryLocation) {
+    throw new Error('POST /login/saml2 returned 302 with no Location header')
+  }
+  const entryUrl = new URL(entryLocation, SIT_BASE).toString()
+
+  // 3. Follow the 302 to the login entry page. Server embeds the cardtap
+  //    transaction UUID as a JS literal — scrape it.
+  const entryRes = await fetchWithCookies(entryUrl, {
+    redirect: 'manual',
+    headers: {
+      ...headers,
+      Referer: DEMO_RP_LOGIN,
+    },
+    signal,
+  })
+  const entryHtml = await readBodyOrThrow(`GET ${entryUrl}`, entryRes)
+  const transactionId = extractTransactionId(entryHtml)
+  if (!transactionId) {
+    throw new Error(`transactionID not found in ${entryUrl}`)
+  }
+
+  // 4. Open the cardtap transaction. Response carries client metadata
+  //    (name, device options); callers may use clientName for log output.
+  const extraQuery = cardtapQueryExtras
+    ? Object.entries(cardtapQueryExtras)
+        .map(([k, v]) => `&${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+        .join('')
+    : ''
+  const txUrl = `${SIT_BASE}/cardtap/v3/transactions/${transactionId}?clientId=${encodeURIComponent(
+    CLIENT_ID
+  )}${extraQuery}`
+  const txRes = await fetchWithCookies(txUrl, {
+    method: 'POST',
+    headers: {
+      ...headers,
+      'Content-Type': 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
+      Origin: SIT_BASE,
+      Referer: entryUrl,
+    },
+    signal,
+  })
+  const txBodyRaw = await readBodyOrThrow('POST cardtap transaction', txRes)
+  const txBody = safeJson<{ clientName?: string }>(txBodyRaw)
+
   return {
-    'User-Agent': USER_AGENT,
+    transactionId,
+    entryUrl,
+    clientName: txBody?.clientName ?? '',
+    fetchWithCookies,
+    signal,
+    userAgent,
+  }
+}
+
+async function putCardtapDevice<T>(
+  tx: CardtapTransactionContext,
+  body: Record<string, unknown>
+): Promise<{ raw: string; parsed: T | null }> {
+  const deviceUrl = `${SIT_BASE}/cardtap/v3/transactions/${tx.transactionId}/device`
+  const deviceRes = await tx.fetchWithCookies(deviceUrl, {
+    method: 'PUT',
+    headers: {
+      ...baseHeaders(tx.userAgent),
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/javascript, */*; q=0.01',
+      'X-Requested-With': 'XMLHttpRequest',
+      Origin: SIT_BASE,
+      Referer: tx.entryUrl,
+    },
+    body: JSON.stringify(body),
+    signal: tx.signal,
+  })
+  const raw = await readBodyOrThrow('PUT cardtap device', deviceRes)
+  return { raw, parsed: safeJson<T>(raw) }
+}
+
+function baseHeaders(userAgent: string): Record<string, string> {
+  return {
+    'User-Agent': userAgent,
     Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
     'Accept-Language': 'en-CA,en;q=0.9',
   }

--- a/e2e/test/bcsc/full-regression/verified.spec.ts
+++ b/e2e/test/bcsc/full-regression/verified.spec.ts
@@ -27,4 +27,8 @@ import '../verify/in-person-verification.spec.js'
 import '../main/main.spec.js'
 
 // Phase 2: Specs that start from the verified home screen
+
+import '../main/login-from-deep-link.spec.js'
+import '../main/login-from-computer.spec.js'
+
 import '../settings/settings.spec.js'

--- a/e2e/test/bcsc/main/login-from-deep-link.spec.ts
+++ b/e2e/test/bcsc/main/login-from-deep-link.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * Deep-link login e2e — two sibling suites:
+ *
+ *  - Warm start (AC #2): app already running on Home; dispatch deep link via
+ *    Appium `mobile: deepLink`, walk the happy path through ServiceLoginScreen
+ *    and PairingConfirmation, and unwind back to Home with two back gestures.
+ *    PairingConfirmation in the iOS app-switch flow has no Close control
+ *    (the screen guides the user to the OS back-to-Safari shortcut), so we
+ *    pop the stack instead of tapping Cancel/Close.
+ *
+ *  - Cold start (AC #1): terminate the app, dispatch the deep link to
+ *    re-launch it, re-authenticate, and confirm ServiceLoginScreen renders
+ *    seeded with the deep-link params. Relies on MainStack consuming the
+ *    buffered pending pairing on mount (see MainStack.tsx:57) and using
+ *    ServiceLogin as initialRouteName.
+ *
+ * Both suites mint a fresh deep link in their `before` hook — pairing codes
+ * are short-lived and the cold-start suite can't reuse the warm-start link.
+ *
+ * Preconditions for both: app is onboarded and resting on the Home tab.
+ * Spec is not imported by full-regression.spec.ts yet — run standalone
+ * with --spec while we validate Appium deep-link behaviour on Sauce RDC.
+ */
+import { TEST_PIN, Timeouts } from '../../../src/constants.js'
+import { currentPlatform, dispatchDeepLink, getCurrentAppId } from '../../../src/helpers/deep-link.js'
+import { navigateBack } from '../../../src/helpers/gestures.js'
+import { fetchPairingDeepLink } from '../../../src/helpers/pairing-code.js'
+import { BaseScreen } from '../../../src/screens/BaseScreen.js'
+import { BCSC_TestIDs } from '../../../src/testIDs.js'
+
+const Home = new BaseScreen(BCSC_TestIDs.Home)
+const ServiceLogin = new BaseScreen(BCSC_TestIDs.ServiceLogin)
+const PairingConfirmation = new BaseScreen(BCSC_TestIDs.PairingConfirmation)
+const EnterPIN = new BaseScreen(BCSC_TestIDs.EnterPIN)
+
+/** Pause after `terminateApp` to let the OS settle before re-launching via deep link. */
+const TERMINATE_SETTLE_MS = 500
+
+/**
+ * Tap the AccountSelector card if it appears post-cold-launch. Mirrors the
+ * recovery branch in settings.spec.ts — on single-account devices the app
+ * may skip straight to PIN entry, so the absence of a card is not an error.
+ */
+async function tapAccountCardIfPresent(): Promise<void> {
+  const selector = driver.isIOS
+    ? '-ios predicate string:name BEGINSWITH "com.ariesbifold:id/CardButton-"'
+    : 'android=new UiSelector().resourceIdMatches(".*CardButton-.*")'
+  try {
+    const card = await $(selector)
+    await card.waitForDisplayed({ timeout: 5000 })
+    await card.click()
+  } catch {
+    // No card surfaced within the window — assume PIN screen is next.
+  }
+}
+
+describe('Login From Deep Link — warm start', () => {
+  let appId = ''
+  let deepLink = ''
+
+  before(async () => {
+    await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
+    appId = await getCurrentAppId()
+    const session = await fetchPairingDeepLink({ platform: currentPlatform() })
+    deepLink = session.deepLink
+    // Pairing codes are short-lived but live credentials — only log a masked
+    // suffix so CI archives don't retain an active code.
+    const masked = `***${session.pairingCode.slice(-2)}`
+    console.log(
+      `[deep-link] minted ${session.scheme}://...${masked} for "${session.clientName}" (tx ${session.transactionId})`
+    )
+  })
+
+  it('routes the deep link to ServiceLoginScreen', async () => {
+    await dispatchDeepLink(deepLink, appId)
+    await ServiceLogin.waitFor('ServiceLoginCancel', Timeouts.screenTransition)
+  })
+
+  it('continues to the PairingConfirmation screen', async () => {
+    await ServiceLogin.waitFor('ServiceLoginContinue', Timeouts.screenTransition)
+    await ServiceLogin.tap('ServiceLoginContinue')
+  })
+
+  it('saves bookmark for the logged-in service', async () => {
+    await PairingConfirmation.waitFor('ToggleBookmark', Timeouts.screenTransition)
+    await PairingConfirmation.tap('ToggleBookmark')
+  })
+
+  it('returns to the Home tab via two back gestures', async () => {
+    // PairingConfirmation hides its Close button on iOS app-switch flows
+    // (see PairingConfirmation.tsx:53). Two back gestures pop the stack:
+    // PairingConfirmation → ServiceLogin → Home.
+    await navigateBack()
+    await navigateBack()
+    await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
+  })
+})
+
+describe('Login From Deep Link — cold start', () => {
+  let appId = ''
+  let deepLink = ''
+
+  before(async () => {
+    await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
+    appId = await getCurrentAppId()
+    const session = await fetchPairingDeepLink({ platform: currentPlatform() })
+    deepLink = session.deepLink
+    const masked = `***${session.pairingCode.slice(-2)}`
+    console.log(
+      `[deep-link cold-start] minted ${session.scheme}://...${masked} for "${session.clientName}" (tx ${session.transactionId})`
+    )
+  })
+
+  it('terminates the app, dispatches the deep link, and re-authenticates into ServiceLoginScreen', async () => {
+    await driver.terminateApp(appId)
+    await driver.pause(TERMINATE_SETTLE_MS)
+    await dispatchDeepLink(deepLink, appId)
+
+    // Cold-launch sequence: AccountSelector (multi-account devices only) →
+    // EnterPIN → MainStack mounts and consumes the buffered pending pairing
+    // → ServiceLogin is the initial route.
+    await tapAccountCardIfPresent()
+    await EnterPIN.waitFor('PINInput', Timeouts.appLaunch)
+    await EnterPIN.type('PINInput', TEST_PIN)
+    await EnterPIN.tap('Continue')
+
+    await ServiceLogin.waitFor('ServiceLoginCancel', Timeouts.appLaunch)
+  })
+
+  it('cancels back to the Home tab', async () => {
+    // ServiceLogin onCancel falls through to navigate(Tab, Home) when the
+    // screen was the initial route (see ServiceLoginScreen.tsx:469-485).
+    await ServiceLogin.tap('ServiceLoginCancel')
+    await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
+  })
+})

--- a/e2e/test/bcsc/main/login-from-deep-link.spec.ts
+++ b/e2e/test/bcsc/main/login-from-deep-link.spec.ts
@@ -54,21 +54,28 @@ async function tapAccountCardIfPresent(): Promise<void> {
   }
 }
 
+/**
+ * Shared setup for both deep-link suites: wait for Home, capture the app id,
+ * mint a fresh pairing deep link, and log a masked suffix so CI archives
+ * don't retain an active pairing code.
+ */
+async function prepareDeepLinkSession(logTag: string): Promise<{ appId: string; deepLink: string }> {
+  await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
+  const appId = await getCurrentAppId()
+  const session = await fetchPairingDeepLink({ platform: currentPlatform() })
+  const masked = `***${session.pairingCode.slice(-2)}`
+  console.log(
+    `[${logTag}] minted ${session.scheme}://...${masked} for "${session.clientName}" (tx ${session.transactionId})`
+  )
+  return { appId, deepLink: session.deepLink }
+}
+
 describe('Login From Deep Link — warm start', () => {
   let appId = ''
   let deepLink = ''
 
   before(async () => {
-    await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
-    appId = await getCurrentAppId()
-    const session = await fetchPairingDeepLink({ platform: currentPlatform() })
-    deepLink = session.deepLink
-    // Pairing codes are short-lived but live credentials — only log a masked
-    // suffix so CI archives don't retain an active code.
-    const masked = `***${session.pairingCode.slice(-2)}`
-    console.log(
-      `[deep-link] minted ${session.scheme}://...${masked} for "${session.clientName}" (tx ${session.transactionId})`
-    )
+    ;({ appId, deepLink } = await prepareDeepLinkSession('deep-link'))
   })
 
   it('routes the deep link to ServiceLoginScreen', async () => {
@@ -101,14 +108,7 @@ describe('Login From Deep Link — cold start', () => {
   let deepLink = ''
 
   before(async () => {
-    await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
-    appId = await getCurrentAppId()
-    const session = await fetchPairingDeepLink({ platform: currentPlatform() })
-    deepLink = session.deepLink
-    const masked = `***${session.pairingCode.slice(-2)}`
-    console.log(
-      `[deep-link cold-start] minted ${session.scheme}://...${masked} for "${session.clientName}" (tx ${session.transactionId})`
-    )
+    ;({ appId, deepLink } = await prepareDeepLinkSession('deep-link cold-start'))
   })
 
   it('terminates the app, dispatches the deep link, and re-authenticates into ServiceLoginScreen', async () => {

--- a/e2e/test/bcsc/main/login-from-deep-link.spec.ts
+++ b/e2e/test/bcsc/main/login-from-deep-link.spec.ts
@@ -1,25 +1,15 @@
 /**
- * Deep-link login e2e — two sibling suites:
+ * Deep-link login e2e — two suites:
  *
- *  - Warm start (AC #2): app already running on Home; dispatch deep link via
- *    Appium `mobile: deepLink`, walk the happy path through ServiceLoginScreen
- *    and PairingConfirmation, and unwind back to Home with two back gestures.
- *    PairingConfirmation in the iOS app-switch flow has no Close control
- *    (the screen guides the user to the OS back-to-Safari shortcut), so we
- *    pop the stack instead of tapping Cancel/Close.
+ *  - Warm start: dispatch a deep link from Home, walk through
+ *    ServiceLoginScreen and PairingConfirmation, return to Home.
  *
- *  - Cold start (AC #1): terminate the app, dispatch the deep link to
- *    re-launch it, re-authenticate, and confirm ServiceLoginScreen renders
- *    seeded with the deep-link params. Relies on MainStack consuming the
- *    buffered pending pairing on mount (see MainStack.tsx:57) and using
- *    ServiceLogin as initialRouteName.
+ *  - Cold start: terminate the app, dispatch the deep link to re-launch,
+ *    re-authenticate, and confirm ServiceLoginScreen renders seeded with
+ *    the deep-link params.
  *
- * Both suites mint a fresh deep link in their `before` hook — pairing codes
- * are short-lived and the cold-start suite can't reuse the warm-start link.
- *
- * Preconditions for both: app is onboarded and resting on the Home tab.
- * Spec is not imported by full-regression.spec.ts yet — run standalone
- * with --spec while we validate Appium deep-link behaviour on Sauce RDC.
+ * Both suites mint a fresh deep link in their `before` hook.
+ * Preconditions: app is onboarded and resting on the Home tab.
  */
 import { TEST_PIN, Timeouts } from '../../../src/constants.js'
 import { currentPlatform, dispatchDeepLink, getCurrentAppId } from '../../../src/helpers/deep-link.js'
@@ -36,11 +26,7 @@ const EnterPIN = new BaseScreen(BCSC_TestIDs.EnterPIN)
 /** Pause after `terminateApp` to let the OS settle before re-launching via deep link. */
 const TERMINATE_SETTLE_MS = 500
 
-/**
- * Tap the AccountSelector card if it appears post-cold-launch. Mirrors the
- * recovery branch in settings.spec.ts — on single-account devices the app
- * may skip straight to PIN entry, so the absence of a card is not an error.
- */
+/** Tap the AccountSelector card if it appears; single-account devices skip it. */
 async function tapAccountCardIfPresent(): Promise<void> {
   const selector = driver.isIOS
     ? '-ios predicate string:name BEGINSWITH "com.ariesbifold:id/CardButton-"'
@@ -55,9 +41,8 @@ async function tapAccountCardIfPresent(): Promise<void> {
 }
 
 /**
- * Shared setup for both deep-link suites: wait for Home, capture the app id,
- * mint a fresh pairing deep link, and log a masked suffix so CI archives
- * don't retain an active pairing code.
+ * Wait for Home, capture the app id, mint a fresh pairing deep link, and
+ * log a masked suffix so CI archives don't retain an active pairing code.
  */
 async function prepareDeepLinkSession(logTag: string): Promise<{ appId: string; deepLink: string }> {
   await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
@@ -91,12 +76,11 @@ describe('Login From Deep Link — warm start', () => {
   it('saves bookmark for the logged-in service', async () => {
     await PairingConfirmation.waitFor('ToggleBookmark', Timeouts.screenTransition)
     await PairingConfirmation.tap('ToggleBookmark')
+    await PairingConfirmation.tap('ToggleBookmark')
   })
 
   it('returns to the Home tab via two back gestures', async () => {
-    // PairingConfirmation hides its Close button on iOS app-switch flows
-    // (see PairingConfirmation.tsx:53). Two back gestures pop the stack:
-    // PairingConfirmation → ServiceLogin → Home.
+    // Two back gestures pop the stack: PairingConfirmation → ServiceLogin → Home.
     await navigateBack()
     await navigateBack()
     await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
@@ -117,8 +101,7 @@ describe('Login From Deep Link — cold start', () => {
     await dispatchDeepLink(deepLink, appId)
 
     // Cold-launch sequence: AccountSelector (multi-account devices only) →
-    // EnterPIN → MainStack mounts and consumes the buffered pending pairing
-    // → ServiceLogin is the initial route.
+    // EnterPIN → ServiceLogin.
     await tapAccountCardIfPresent()
     await EnterPIN.waitFor('PINInput', Timeouts.appLaunch)
     await EnterPIN.type('PINInput', TEST_PIN)
@@ -128,8 +111,7 @@ describe('Login From Deep Link — cold start', () => {
   })
 
   it('cancels back to the Home tab', async () => {
-    // ServiceLogin onCancel falls through to navigate(Tab, Home) when the
-    // screen was the initial route (see ServiceLoginScreen.tsx:469-485).
+    // ServiceLogin onCancel navigates to Home when the screen was the initial route.
     await ServiceLogin.tap('ServiceLoginCancel')
     await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
   })


### PR DESCRIPTION
# Summary of Changes

Adds e2e coverage for BCSC deep-link login:

- Warm start: app on Home, dispatch deep link, walk through ServiceLogin → PairingConfirmation → Home.
- Cold start: terminate app, dispatch deep link, re-authenticate, land on ServiceLogin.
- New helpers: `deep-link.ts` (mint + dispatch via Appium `mobile: deepLink`) and `gestures.ts` (cross-platform back).
- Extends `pairing-code.ts` to mint a fresh pairing deep link per run.

# Testing Instructions

- Run `login-from-deep-link.spec.ts` standalone on iOS simulator.
- Run on Android emulator.
- Validate on Sauce RDC before wiring into `full-regression.spec.ts`.

# Acceptance Criteria

- Cold start: deep link launches the app and routes to ServiceLoginScreen after PIN entry.
- Warm start: deep link routes the running app to ServiceLoginScreen.
- Both suites unwind back to the Home tab cleanly.

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A
