### PR TITLE
feat: wire BCSC agent init via ViewModel + provider

### DIFF
--- a/app/src/bcsc-theme/features/agent/BCSCAgentProvider.test.tsx
+++ b/app/src/bcsc-theme/features/agent/BCSCAgentProvider.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react-native'
 import React from 'react'
 import { Text } from 'react-native'
 
-import BCSCAgentProvider from './BCSCAgentProvider'
+import BCSCAgentProvider, { useBCSCAgent } from './BCSCAgentProvider'
 import useAgentSetupViewModel from './useAgentSetupViewModel'
 
 jest.mock('react-i18next', () => ({
@@ -20,11 +20,25 @@ jest.mock('../../contexts/BCSCLoadingContext', () => {
     LoadingScreen: ({ message }: { message: string }) => <Text>{message}</Text>,
   }
 })
-jest.mock('@bifold/core', () => ({
-  AgentProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}))
+jest.mock('@bifold/core', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+  const { Text } = require('react-native')
+  return {
+    AgentProvider: ({ children }: { children: React.ReactNode }) => (
+      <>
+        <Text>bifold-agent-provider</Text>
+        {children}
+      </>
+    ),
+  }
+})
 
 const mockViewModel = useAgentSetupViewModel as jest.MockedFunction<typeof useAgentSetupViewModel>
+
+const StatusProbe: React.FC = () => {
+  const { status, agent, error } = useBCSCAgent()
+  return <Text>{`status=${status} hasAgent=${agent !== null} hasError=${error !== null}`}</Text>
+}
 
 describe('BCSCAgentProvider', () => {
   beforeEach(() => {
@@ -34,41 +48,49 @@ describe('BCSCAgentProvider', () => {
   it('renders LoadingScreen while initializing', () => {
     mockViewModel.mockReturnValue({ agent: null, status: 'initializing', error: null, retry: jest.fn() })
 
-    const { getByText } = render(
+    const { getByText, queryByText } = render(
       <BCSCAgentProvider>
         <Text>hidden</Text>
       </BCSCAgentProvider>
     )
 
     expect(getByText('Init.InitializingAgent')).toBeTruthy()
+    expect(queryByText('bifold-agent-provider')).toBeNull()
   })
 
-  it('renders children wrapped in AgentProvider when ready', () => {
+  it('wraps children in Bifold AgentProvider and exposes agent via BCSC context when ready', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const agent = {} as any
     mockViewModel.mockReturnValue({ agent, status: 'ready', error: null, retry: jest.fn() })
 
-    const { getByText, queryByText } = render(
+    const { getByText } = render(
       <BCSCAgentProvider>
-        <Text>home-screen</Text>
+        <StatusProbe />
       </BCSCAgentProvider>
     )
 
-    expect(getByText('home-screen')).toBeTruthy()
-    expect(queryByText('Init.InitializingAgent')).toBeNull()
+    expect(getByText('bifold-agent-provider')).toBeTruthy()
+    expect(getByText('status=ready hasAgent=true hasError=false')).toBeTruthy()
   })
 
-  it('renders children without AgentProvider when init fails (non-blocking)', () => {
+  it('renders children inside BCSC context but skips Bifold AgentProvider when init fails', () => {
     const error = AppError.fromErrorDefinition(ErrorRegistry.AGENT_INITIALIZATION_ERROR)
     mockViewModel.mockReturnValue({ agent: null, status: 'error', error, retry: jest.fn() })
 
     const { getByText, queryByText } = render(
       <BCSCAgentProvider>
-        <Text>home-screen</Text>
+        <StatusProbe />
       </BCSCAgentProvider>
     )
 
-    expect(getByText('home-screen')).toBeTruthy()
-    expect(queryByText('Init.InitializingAgent')).toBeNull()
+    expect(getByText('status=error hasAgent=false hasError=true')).toBeTruthy()
+    expect(queryByText('bifold-agent-provider')).toBeNull()
+  })
+
+  it('useBCSCAgent throws when called outside the provider', () => {
+    // suppress expected console.error from React rendering the throw
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => render(<StatusProbe />)).toThrow('useBCSCAgent must be used within a BCSCAgentProvider')
+    consoleSpy.mockRestore()
   })
 })

--- a/app/src/bcsc-theme/features/agent/BCSCAgentProvider.test.tsx
+++ b/app/src/bcsc-theme/features/agent/BCSCAgentProvider.test.tsx
@@ -1,0 +1,111 @@
+import * as ErrorAlertContext from '@/contexts/ErrorAlertContext'
+import { AppError, ErrorRegistry } from '@/errors'
+import { render, waitFor } from '@testing-library/react-native'
+import React from 'react'
+import { Text } from 'react-native'
+
+import BCSCAgentProvider from './BCSCAgentProvider'
+import useAgentSetupViewModel from './useAgentSetupViewModel'
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+jest.mock('./useAgentSetupViewModel', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+jest.mock('../../contexts/BCSCLoadingContext', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+  const { Text } = require('react-native')
+  return {
+    LoadingScreen: ({ message }: { message: string }) => <Text>{message}</Text>,
+  }
+})
+jest.mock('@bifold/core', () => ({
+  AgentProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+jest.mock('@/contexts/ErrorAlertContext', () => ({
+  useErrorAlert: jest.fn(),
+}))
+
+const mockViewModel = useAgentSetupViewModel as jest.MockedFunction<typeof useAgentSetupViewModel>
+
+describe('BCSCAgentProvider', () => {
+  const emitErrorModal = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(ErrorAlertContext, 'useErrorAlert').mockReturnValue({ emitErrorModal, emitAlert: jest.fn() })
+  })
+
+  it('renders LoadingScreen while initializing', () => {
+    mockViewModel.mockReturnValue({ agent: null, status: 'initializing', error: null, retry: jest.fn() })
+
+    const { getByText } = render(
+      <BCSCAgentProvider>
+        <Text>hidden</Text>
+      </BCSCAgentProvider>
+    )
+
+    expect(getByText('Init.InitializingAgent')).toBeTruthy()
+  })
+
+  it('renders children wrapped in AgentProvider when ready', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const agent = {} as any
+    mockViewModel.mockReturnValue({ agent, status: 'ready', error: null, retry: jest.fn() })
+
+    const { getByText, queryByText } = render(
+      <BCSCAgentProvider>
+        <Text>home-screen</Text>
+      </BCSCAgentProvider>
+    )
+
+    expect(getByText('home-screen')).toBeTruthy()
+    expect(queryByText('Init.InitializingAgent')).toBeNull()
+  })
+
+  it('calls emitErrorModal once per error transition with retry action', async () => {
+    const retry = jest.fn()
+    const error = AppError.fromErrorDefinition(ErrorRegistry.AGENT_INITIALIZATION_ERROR)
+    mockViewModel.mockReturnValue({ agent: null, status: 'error', error, retry })
+
+    const { rerender } = render(
+      <BCSCAgentProvider>
+        <Text>hidden</Text>
+      </BCSCAgentProvider>
+    )
+
+    await waitFor(() => expect(emitErrorModal).toHaveBeenCalledTimes(1))
+    expect(emitErrorModal).toHaveBeenCalledWith(
+      'Error.Title2901',
+      'Error.Message2901',
+      error,
+      expect.objectContaining({
+        action: expect.objectContaining({ text: 'Init.Retry', onPress: retry }),
+      })
+    )
+
+    // Re-render with same error — should not emit again
+    rerender(
+      <BCSCAgentProvider>
+        <Text>hidden</Text>
+      </BCSCAgentProvider>
+    )
+    expect(emitErrorModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits modal with 2902 strings when walletKey is missing', async () => {
+    const error = AppError.fromErrorDefinition(ErrorRegistry.WALLET_SECRET_NOT_FOUND)
+    mockViewModel.mockReturnValue({ agent: null, status: 'error', error, retry: jest.fn() })
+
+    render(
+      <BCSCAgentProvider>
+        <Text>hidden</Text>
+      </BCSCAgentProvider>
+    )
+
+    await waitFor(() => expect(emitErrorModal).toHaveBeenCalledTimes(1))
+    expect(emitErrorModal).toHaveBeenCalledWith('Error.Title2902', 'Error.Message2902', error, expect.anything())
+  })
+})

--- a/app/src/bcsc-theme/features/agent/BCSCAgentProvider.test.tsx
+++ b/app/src/bcsc-theme/features/agent/BCSCAgentProvider.test.tsx
@@ -1,6 +1,5 @@
-import * as ErrorAlertContext from '@/contexts/ErrorAlertContext'
 import { AppError, ErrorRegistry } from '@/errors'
-import { render, waitFor } from '@testing-library/react-native'
+import { render } from '@testing-library/react-native'
 import React from 'react'
 import { Text } from 'react-native'
 
@@ -24,18 +23,12 @@ jest.mock('../../contexts/BCSCLoadingContext', () => {
 jest.mock('@bifold/core', () => ({
   AgentProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
-jest.mock('@/contexts/ErrorAlertContext', () => ({
-  useErrorAlert: jest.fn(),
-}))
 
 const mockViewModel = useAgentSetupViewModel as jest.MockedFunction<typeof useAgentSetupViewModel>
 
 describe('BCSCAgentProvider', () => {
-  const emitErrorModal = jest.fn()
-
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.spyOn(ErrorAlertContext, 'useErrorAlert').mockReturnValue({ emitErrorModal, emitAlert: jest.fn() })
   })
 
   it('renders LoadingScreen while initializing', () => {
@@ -65,47 +58,17 @@ describe('BCSCAgentProvider', () => {
     expect(queryByText('Init.InitializingAgent')).toBeNull()
   })
 
-  it('calls emitErrorModal once per error transition with retry action', async () => {
-    const retry = jest.fn()
+  it('renders children without AgentProvider when init fails (non-blocking)', () => {
     const error = AppError.fromErrorDefinition(ErrorRegistry.AGENT_INITIALIZATION_ERROR)
-    mockViewModel.mockReturnValue({ agent: null, status: 'error', error, retry })
-
-    const { rerender } = render(
-      <BCSCAgentProvider>
-        <Text>hidden</Text>
-      </BCSCAgentProvider>
-    )
-
-    await waitFor(() => expect(emitErrorModal).toHaveBeenCalledTimes(1))
-    expect(emitErrorModal).toHaveBeenCalledWith(
-      'Error.Title2901',
-      'Error.Message2901',
-      error,
-      expect.objectContaining({
-        action: expect.objectContaining({ text: 'Init.Retry', onPress: retry }),
-      })
-    )
-
-    // Re-render with same error — should not emit again
-    rerender(
-      <BCSCAgentProvider>
-        <Text>hidden</Text>
-      </BCSCAgentProvider>
-    )
-    expect(emitErrorModal).toHaveBeenCalledTimes(1)
-  })
-
-  it('emits modal with 2902 strings when walletKey is missing', async () => {
-    const error = AppError.fromErrorDefinition(ErrorRegistry.WALLET_SECRET_NOT_FOUND)
     mockViewModel.mockReturnValue({ agent: null, status: 'error', error, retry: jest.fn() })
 
-    render(
+    const { getByText, queryByText } = render(
       <BCSCAgentProvider>
-        <Text>hidden</Text>
+        <Text>home-screen</Text>
       </BCSCAgentProvider>
     )
 
-    await waitFor(() => expect(emitErrorModal).toHaveBeenCalledTimes(1))
-    expect(emitErrorModal).toHaveBeenCalledWith('Error.Title2902', 'Error.Message2902', error, expect.anything())
+    expect(getByText('home-screen')).toBeTruthy()
+    expect(queryByText('Init.InitializingAgent')).toBeNull()
   })
 })

--- a/app/src/bcsc-theme/features/agent/BCSCAgentProvider.tsx
+++ b/app/src/bcsc-theme/features/agent/BCSCAgentProvider.tsx
@@ -1,41 +1,24 @@
-import { useErrorAlert } from '@/contexts/ErrorAlertContext'
 import { AgentProvider } from '@bifold/core'
-import React, { PropsWithChildren, useEffect, useRef } from 'react'
+import React, { PropsWithChildren } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { LoadingScreen } from '../../contexts/BCSCLoadingContext'
 
 import useAgentSetupViewModel from './useAgentSetupViewModel'
 
+// Non-blocking on error: init failures are logged by the ViewModel but we do
+// not surface a modal — children render without an active agent context, and
+// downstream credential features will surface their own errors when invoked.
 const BCSCAgentProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const { t } = useTranslation()
-  const { emitErrorModal } = useErrorAlert()
-  const { agent, status, error, retry } = useAgentSetupViewModel()
-  const lastErrorCodeRef = useRef<number | null>(null)
-
-  useEffect(() => {
-    if (status !== 'error' || !error) {
-      lastErrorCodeRef.current = null
-      return
-    }
-
-    if (lastErrorCodeRef.current === error.statusCode) {
-      return
-    }
-    lastErrorCodeRef.current = error.statusCode
-
-    const title = t(`Error.Title${error.statusCode}`)
-    const description = t(`Error.Message${error.statusCode}`)
-    emitErrorModal(title, description, error, {
-      action: {
-        text: t('Init.Retry'),
-        onPress: retry,
-      },
-    })
-  }, [status, error, emitErrorModal, retry, t])
+  const { agent, status } = useAgentSetupViewModel()
 
   if (status === 'ready' && agent) {
     return <AgentProvider agent={agent}>{children}</AgentProvider>
+  }
+
+  if (status === 'error') {
+    return <>{children}</>
   }
 
   return <LoadingScreen message={t('Init.InitializingAgent')} />

--- a/app/src/bcsc-theme/features/agent/BCSCAgentProvider.tsx
+++ b/app/src/bcsc-theme/features/agent/BCSCAgentProvider.tsx
@@ -1,24 +1,55 @@
 import { AgentProvider } from '@bifold/core'
-import React, { PropsWithChildren } from 'react'
+import { Agent } from '@credo-ts/core'
+import React, { createContext, PropsWithChildren, useContext, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+
+import { AppError } from '@/errors'
 
 import { LoadingScreen } from '../../contexts/BCSCLoadingContext'
 
-import useAgentSetupViewModel from './useAgentSetupViewModel'
+import useAgentSetupViewModel, { AgentSetupStatus } from './useAgentSetupViewModel'
+
+export interface BCSCAgentContextValue {
+  agent: Agent | null
+  status: AgentSetupStatus
+  error: AppError | null
+  retry: () => void
+}
+
+const BCSCAgentContext = createContext<BCSCAgentContextValue | null>(null)
+
+export const useBCSCAgent = (): BCSCAgentContextValue => {
+  const ctx = useContext(BCSCAgentContext)
+  if (!ctx) {
+    throw new Error('useBCSCAgent must be used within a BCSCAgentProvider')
+  }
+  return ctx
+}
 
 // Non-blocking on error: init failures are logged by the ViewModel but we do
-// not surface a modal — children render without an active agent context, and
-// downstream credential features will surface their own errors when invoked.
+// not surface a modal — children render inside the BCSC context (so they can
+// inspect status/error and react), but Bifold's AgentProvider is skipped on
+// error since it requires a live agent. Downstream credential features will
+// surface their own errors when invoked.
 const BCSCAgentProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const { t } = useTranslation()
-  const { agent, status } = useAgentSetupViewModel()
+  const { agent, status, error, retry } = useAgentSetupViewModel()
+
+  const value = useMemo<BCSCAgentContextValue>(
+    () => ({ agent, status, error, retry }),
+    [agent, status, error, retry]
+  )
 
   if (status === 'ready' && agent) {
-    return <AgentProvider agent={agent}>{children}</AgentProvider>
+    return (
+      <BCSCAgentContext.Provider value={value}>
+        <AgentProvider agent={agent}>{children}</AgentProvider>
+      </BCSCAgentContext.Provider>
+    )
   }
 
   if (status === 'error') {
-    return <>{children}</>
+    return <BCSCAgentContext.Provider value={value}>{children}</BCSCAgentContext.Provider>
   }
 
   return <LoadingScreen message={t('Init.InitializingAgent')} />

--- a/app/src/bcsc-theme/features/agent/BCSCAgentProvider.tsx
+++ b/app/src/bcsc-theme/features/agent/BCSCAgentProvider.tsx
@@ -1,0 +1,44 @@
+import { useErrorAlert } from '@/contexts/ErrorAlertContext'
+import { AgentProvider } from '@bifold/core'
+import React, { PropsWithChildren, useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { LoadingScreen } from '../../contexts/BCSCLoadingContext'
+
+import useAgentSetupViewModel from './useAgentSetupViewModel'
+
+const BCSCAgentProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const { t } = useTranslation()
+  const { emitErrorModal } = useErrorAlert()
+  const { agent, status, error, retry } = useAgentSetupViewModel()
+  const lastErrorCodeRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (status !== 'error' || !error) {
+      lastErrorCodeRef.current = null
+      return
+    }
+
+    if (lastErrorCodeRef.current === error.statusCode) {
+      return
+    }
+    lastErrorCodeRef.current = error.statusCode
+
+    const title = t(`Error.Title${error.statusCode}`)
+    const description = t(`Error.Message${error.statusCode}`)
+    emitErrorModal(title, description, error, {
+      action: {
+        text: t('Init.Retry'),
+        onPress: retry,
+      },
+    })
+  }, [status, error, emitErrorModal, retry, t])
+
+  if (status === 'ready' && agent) {
+    return <AgentProvider agent={agent}>{children}</AgentProvider>
+  }
+
+  return <LoadingScreen message={t('Init.InitializingAgent')} />
+}
+
+export default BCSCAgentProvider

--- a/app/src/bcsc-theme/features/agent/index.ts
+++ b/app/src/bcsc-theme/features/agent/index.ts
@@ -1,1 +1,3 @@
+export { default as BCSCAgentProvider, useBCSCAgent } from './BCSCAgentProvider'
+export type { BCSCAgentContextValue } from './BCSCAgentProvider'
 export * from './services/agent-service'

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
@@ -47,7 +47,6 @@ describe('useAgentSetupViewModel', () => {
     jest.mocked(Bifold.useServices).mockReturnValue([logger, [], attestationMonitor, [], []] as never)
     jest.mocked(Bifold.useStore).mockReturnValue(mockedStore() as never)
     jest.mocked(Bifold.createLinkSecretIfRequired).mockResolvedValue(undefined as never)
-    jest.mocked(Bifold.migrateToAskar).mockResolvedValue(undefined as never)
     jest.mocked(agentService.loadCachedLedgers).mockResolvedValue(undefined)
     jest.mocked(agentService.buildAgent).mockReturnValue(mockAgent())
     jest.mocked(agentService.restartAgent).mockResolvedValue(undefined)

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
@@ -1,0 +1,144 @@
+import { AppError, ErrorRegistry } from '@/errors'
+import { AppEventCode } from '@/events/appEventCode'
+import * as Bifold from '@bifold/core'
+import { act, renderHook, waitFor } from '@testing-library/react-native'
+
+import * as agentService from './services/agent-service'
+import useAgentSetupViewModel from './useAgentSetupViewModel'
+
+jest.mock('@bifold/core')
+jest.mock('@/utils/PushNotificationsHelper', () => ({ activate: jest.fn().mockResolvedValue(undefined) }))
+jest.mock('react-native-config', () => ({ Config: { INDY_VDR_PROXY_URL: '' } }))
+jest.mock('@credo-ts/core', () => {
+  const actual = jest.requireActual('@credo-ts/core')
+  return {
+    ...actual,
+    MediatorPickupStrategy: { PickUpV2LiveMode: 'PickUpV2LiveMode' },
+  }
+})
+jest.mock('./services/agent-service')
+
+const mockedStore = (overrides: Record<string, unknown> = {}) => {
+  const base = {
+    authentication: { didAuthenticate: true },
+    bcscSecure: { walletKey: 'wallet-key-hash' },
+    preferences: { selectedMediator: 'https://mediator.example', walletName: 'BC Wallet', usePushNotifications: false },
+    developer: { enableProxy: false },
+    migration: { didMigrateToAskar: true },
+    ...overrides,
+  }
+  return [base, jest.fn()]
+}
+
+const mockAgent = () =>
+  ({
+    mediationRecipient: { initiateMessagePickup: jest.fn().mockResolvedValue(undefined) },
+    initialize: jest.fn().mockResolvedValue(undefined),
+    shutdown: jest.fn().mockResolvedValue(undefined),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any
+
+const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), trace: jest.fn() }
+const attestationMonitor = { start: jest.fn(), stop: jest.fn() }
+
+describe('useAgentSetupViewModel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.mocked(Bifold.useServices).mockReturnValue([logger, [], attestationMonitor, [], []] as never)
+    jest.mocked(Bifold.useStore).mockReturnValue(mockedStore() as never)
+    jest.mocked(Bifold.createLinkSecretIfRequired).mockResolvedValue(undefined as never)
+    jest.mocked(Bifold.migrateToAskar).mockResolvedValue(undefined as never)
+    jest.mocked(agentService.loadCachedLedgers).mockResolvedValue(undefined)
+    jest.mocked(agentService.buildAgent).mockReturnValue(mockAgent())
+    jest.mocked(agentService.restartAgent).mockResolvedValue(undefined)
+    jest.mocked(agentService.warmCache).mockResolvedValue(undefined)
+    jest.mocked(agentService.shutdownAgent).mockResolvedValue(undefined)
+  })
+
+  it('happy path: builds agent and reaches ready status', async () => {
+    const { result } = renderHook(() => useAgentSetupViewModel())
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(result.current.agent).not.toBeNull()
+    expect(result.current.error).toBeNull()
+    expect(agentService.buildAgent).toHaveBeenCalled()
+    expect(agentService.warmCache).toHaveBeenCalled()
+  })
+
+  it('missing walletKey yields 2902 WALLET_SECRET_NOT_FOUND error', async () => {
+    jest.mocked(Bifold.useStore).mockReturnValue(mockedStore({ bcscSecure: { walletKey: undefined } }) as never)
+
+    const { result } = renderHook(() => useAgentSetupViewModel())
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    expect(result.current.error).toBeInstanceOf(AppError)
+    expect(result.current.error?.statusCode).toBe(2902)
+    expect(result.current.error?.appEvent).toBe(AppEventCode.WALLET_SECRET_NOT_FOUND)
+    expect(agentService.buildAgent).not.toHaveBeenCalled()
+  })
+
+  it('wraps non-AppError throws in 2901 AGENT_INITIALIZATION_ERROR', async () => {
+    jest.mocked(agentService.buildAgent).mockImplementationOnce(() => {
+      throw new Error('mediator unreachable')
+    })
+
+    const { result } = renderHook(() => useAgentSetupViewModel())
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    expect(result.current.error?.statusCode).toBe(2901)
+    expect(result.current.error?.appEvent).toBe(AppEventCode.AGENT_INITIALIZATION_ERROR)
+    expect(result.current.error?.cause).toBeInstanceOf(Error)
+  })
+
+  it('preserves AppError thrown by service (does not re-wrap)', async () => {
+    const thrownAppError = AppError.fromErrorDefinition(ErrorRegistry.AGENT_INITIALIZATION_ERROR, {
+      cause: new Error('Mediator URL is required to build agent'),
+    })
+    jest.mocked(agentService.buildAgent).mockImplementationOnce(() => {
+      throw thrownAppError
+    })
+
+    const { result } = renderHook(() => useAgentSetupViewModel())
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    expect(result.current.error).toBe(thrownAppError)
+  })
+
+  it('retry resets status to initializing and re-runs init', async () => {
+    jest.mocked(agentService.buildAgent).mockImplementationOnce(() => {
+      throw new Error('first attempt fails')
+    })
+
+    const { result } = renderHook(() => useAgentSetupViewModel())
+    await waitFor(() => expect(result.current.status).toBe('error'))
+
+    act(() => {
+      result.current.retry()
+    })
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(agentService.buildAgent).toHaveBeenCalledTimes(2)
+  })
+
+  it('shuts down agent when didAuthenticate flips to false', async () => {
+    const store: Record<string, unknown> = {
+      authentication: { didAuthenticate: true },
+      bcscSecure: { walletKey: 'wallet-key-hash' },
+      preferences: { selectedMediator: 'https://m', walletName: 'BC Wallet', usePushNotifications: false },
+      developer: { enableProxy: false },
+      migration: { didMigrateToAskar: true },
+    }
+    jest.mocked(Bifold.useStore).mockImplementation(() => [store as never, jest.fn()])
+
+    const { result, rerender } = renderHook(() => useAgentSetupViewModel())
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+
+    // Flip to unauthenticated
+    ;(store.authentication as Record<string, unknown>).didAuthenticate = false
+    rerender({})
+
+    await waitFor(() => expect(result.current.status).toBe('idle'))
+    expect(agentService.shutdownAgent).toHaveBeenCalled()
+    expect(result.current.agent).toBeNull()
+  })
+})

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
@@ -2,7 +2,7 @@ import { WALLET_ID } from '@/constants'
 import { AppError, ErrorRegistry } from '@/errors'
 import { BCState } from '@/store'
 import { activate } from '@/utils/PushNotificationsHelper'
-import { createLinkSecretIfRequired, DispatchAction, migrateToAskar, TOKENS, useServices, useStore } from '@bifold/core'
+import { createLinkSecretIfRequired, DispatchAction, TOKENS, useServices, useStore } from '@bifold/core'
 import { Agent, MediatorPickupStrategy } from '@credo-ts/core'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Config } from 'react-native-config'
@@ -111,8 +111,9 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
           logger,
         })
 
+        // BCSC v4.1 starts fresh on Askar — no legacy Indy wallet to migrate.
+        // Mark the flag so any downstream code that still checks it stays consistent.
         if (!didMigrateToAskar) {
-          await migrateToAskar(walletSecret.id, walletSecret.key, newAgent)
           dispatch({ type: DispatchAction.DID_MIGRATE_TO_ASKAR })
         }
 

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
@@ -2,7 +2,7 @@ import { WALLET_ID } from '@/constants'
 import { AppError, ErrorRegistry } from '@/errors'
 import { BCState } from '@/store'
 import { activate } from '@/utils/PushNotificationsHelper'
-import { createLinkSecretIfRequired, DispatchAction, TOKENS, useServices, useStore } from '@bifold/core'
+import { createLinkSecretIfRequired, TOKENS, useServices, useStore } from '@bifold/core'
 import { Agent, MediatorPickupStrategy } from '@credo-ts/core'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Config } from 'react-native-config'
@@ -19,7 +19,7 @@ export interface AgentSetupResult {
 }
 
 const useAgentSetupViewModel = (): AgentSetupResult => {
-  const [store, dispatch] = useStore<BCState>()
+  const [store] = useStore<BCState>()
   const [logger, indyLedgers, attestationMonitor, credDefs, schemas] = useServices([
     TOKENS.UTIL_LOGGER,
     TOKENS.UTIL_LEDGERS,
@@ -41,7 +41,6 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
   const walletLabel = store.preferences.walletName || 'BC Wallet'
   const enableProxy = store.developer.enableProxy
   const usePushNotifications = store.preferences.usePushNotifications
-  const didMigrateToAskar = store.migration.didMigrateToAskar
 
   const refreshAttestationMonitor = useCallback(
     (liveAgent: Agent) => {
@@ -111,12 +110,6 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
           logger,
         })
 
-        // BCSC v4.1 starts fresh on Askar — no legacy Indy wallet to migrate.
-        // Mark the flag so any downstream code that still checks it stays consistent.
-        if (!didMigrateToAskar) {
-          dispatch({ type: DispatchAction.DID_MIGRATE_TO_ASKAR })
-        }
-
         await newAgent.initialize()
         await newAgent.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
         await warmCache(newAgent, credDefs, schemas, cachedLedgers, logger)
@@ -152,14 +145,12 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
     walletLabel,
     enableProxy,
     usePushNotifications,
-    didMigrateToAskar,
     retryCount,
     status,
     logger,
     indyLedgers,
     credDefs,
     schemas,
-    dispatch,
     refreshAttestationMonitor,
   ])
 

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
@@ -1,0 +1,168 @@
+import { WALLET_ID } from '@/constants'
+import { AppError, ErrorRegistry } from '@/errors'
+import { BCState } from '@/store'
+import { activate } from '@/utils/PushNotificationsHelper'
+import { createLinkSecretIfRequired, DispatchAction, migrateToAskar, TOKENS, useServices, useStore } from '@bifold/core'
+import { Agent, MediatorPickupStrategy } from '@credo-ts/core'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Config } from 'react-native-config'
+
+import { buildAgent, loadCachedLedgers, restartAgent, shutdownAgent, warmCache } from './services/agent-service'
+
+export type AgentSetupStatus = 'idle' | 'initializing' | 'ready' | 'error'
+
+export interface AgentSetupResult {
+  agent: Agent | null
+  status: AgentSetupStatus
+  error: AppError | null
+  retry: () => void
+}
+
+const useAgentSetupViewModel = (): AgentSetupResult => {
+  const [store, dispatch] = useStore<BCState>()
+  const [logger, indyLedgers, attestationMonitor, credDefs, schemas] = useServices([
+    TOKENS.UTIL_LOGGER,
+    TOKENS.UTIL_LEDGERS,
+    TOKENS.UTIL_ATTESTATION_MONITOR,
+    TOKENS.CACHE_CRED_DEFS,
+    TOKENS.CACHE_SCHEMAS,
+  ])
+
+  const [status, setStatus] = useState<AgentSetupStatus>('idle')
+  const [agent, setAgent] = useState<Agent | null>(null)
+  const [error, setError] = useState<AppError | null>(null)
+  const [retryCount, setRetryCount] = useState(0)
+  const agentRef = useRef<Agent | null>(null)
+  const initializingRef = useRef(false)
+
+  const didAuthenticate = store.authentication.didAuthenticate
+  const walletKey = store.bcscSecure.walletKey
+  const mediatorUrl = store.preferences.selectedMediator
+  const walletLabel = store.preferences.walletName || 'BC Wallet'
+  const enableProxy = store.developer.enableProxy
+  const usePushNotifications = store.preferences.usePushNotifications
+  const didMigrateToAskar = store.migration.didMigrateToAskar
+
+  const refreshAttestationMonitor = useCallback(
+    (liveAgent: Agent) => {
+      attestationMonitor?.stop()
+      attestationMonitor?.start(liveAgent)
+    },
+    [attestationMonitor]
+  )
+
+  const retry = useCallback(() => {
+    setError(null)
+    setStatus('idle')
+    setRetryCount((c) => c + 1)
+  }, [])
+
+  useEffect(() => {
+    if (!didAuthenticate) {
+      if (agentRef.current) {
+        shutdownAgent(agentRef.current, logger)
+        agentRef.current = null
+        setAgent(null)
+      }
+      setStatus('idle')
+      setError(null)
+      initializingRef.current = false
+      return
+    }
+
+    if (initializingRef.current || status === 'ready' || status === 'error') {
+      return
+    }
+
+    initializingRef.current = true
+    setStatus('initializing')
+    setError(null)
+
+    const run = async (): Promise<void> => {
+      try {
+        if (!walletKey) {
+          throw AppError.fromErrorDefinition(ErrorRegistry.WALLET_SECRET_NOT_FOUND)
+        }
+
+        const walletSecret = { id: WALLET_ID, key: walletKey }
+
+        if (agentRef.current) {
+          const restarted = await restartAgent(agentRef.current, walletSecret, logger)
+          if (restarted) {
+            await restarted.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
+            refreshAttestationMonitor(restarted)
+            agentRef.current = restarted
+            setAgent(restarted)
+            setStatus('ready')
+            return
+          }
+        }
+
+        const cachedLedgers = await loadCachedLedgers()
+        const ledgers = cachedLedgers ?? indyLedgers
+
+        const newAgent = buildAgent({
+          ledgers,
+          walletSecret,
+          mediatorUrl,
+          walletLabel,
+          enableProxy,
+          proxyBaseUrl: Config.INDY_VDR_PROXY_URL,
+          logger,
+        })
+
+        if (!didMigrateToAskar) {
+          await migrateToAskar(walletSecret.id, walletSecret.key, newAgent)
+          dispatch({ type: DispatchAction.DID_MIGRATE_TO_ASKAR })
+        }
+
+        await newAgent.initialize()
+        await newAgent.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
+        await warmCache(newAgent, credDefs, schemas, cachedLedgers, logger)
+        await createLinkSecretIfRequired(newAgent)
+
+        if (usePushNotifications) {
+          activate(newAgent).catch((err) => logger.warn(`Push notification activation failed: ${err}`))
+        }
+
+        refreshAttestationMonitor(newAgent)
+
+        agentRef.current = newAgent
+        setAgent(newAgent)
+        setStatus('ready')
+      } catch (err) {
+        const appError =
+          err instanceof AppError
+            ? err
+            : AppError.fromErrorDefinition(ErrorRegistry.AGENT_INITIALIZATION_ERROR, { cause: err })
+        logger.error(`[${appError.appEvent}] Agent init failed: ${appError.message}`)
+        setError(appError)
+        setStatus('error')
+      } finally {
+        initializingRef.current = false
+      }
+    }
+
+    run()
+  }, [
+    didAuthenticate,
+    walletKey,
+    mediatorUrl,
+    walletLabel,
+    enableProxy,
+    usePushNotifications,
+    didMigrateToAskar,
+    retryCount,
+    status,
+    logger,
+    indyLedgers,
+    credDefs,
+    schemas,
+    dispatch,
+    refreshAttestationMonitor,
+  ])
+
+  return { agent, status, error, retry }
+}
+
+export default useAgentSetupViewModel

--- a/app/src/bcsc-theme/navigators/RootStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.test.tsx
@@ -59,6 +59,10 @@ jest.mock('../contexts/BCSCAccountContext', () => ({
 jest.mock('../contexts/BCSCIdTokenContext', () => ({
   BCSCIdTokenProvider: ({ children }: any) => children,
 }))
+jest.mock('../features/agent/BCSCAgentProvider', () => ({
+  __esModule: true,
+  default: ({ children }: any) => children,
+}))
 
 const mockStore = (overrides: Record<string, any> = {}) => ({
   stateLoaded: true,

--- a/app/src/bcsc-theme/navigators/RootStack.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.tsx
@@ -10,6 +10,7 @@ import useThirdPartyKeyboardWarning from '../api/hooks/useThirdPartyKeyboardWarn
 import { BCSCAccountProvider } from '../contexts/BCSCAccountContext'
 import { BCSCActivityProvider } from '../contexts/BCSCActivityContext'
 import { LoadingScreen } from '../contexts/BCSCLoadingContext'
+import BCSCAgentProvider from '../features/agent/BCSCAgentProvider'
 import { useFcmService } from '../features/fcm'
 import { useBCSCApiClientState } from '../hooks/useBCSCApiClient'
 import { SystemCheckScope, useSystemChecks } from '../hooks/useSystemChecks'
@@ -64,7 +65,23 @@ const BCSCRootStack: React.FC = () => {
     return <AuthStack />
   }
 
-  if (store.bcscSecure.verified === false && store.bcscSecure.verifiedStatus === VerificationStatus.IN_PROGRESS) {
+  return (
+    <BCSCAgentProvider>
+      <AuthenticatedStack
+        verified={store.bcscSecure.verified}
+        verifiedStatus={store.bcscSecure.verifiedStatus}
+      />
+    </BCSCAgentProvider>
+  )
+}
+
+interface AuthenticatedStackProps {
+  verified: boolean | undefined
+  verifiedStatus: VerificationStatus
+}
+
+const AuthenticatedStack: React.FC<AuthenticatedStackProps> = ({ verified, verifiedStatus }) => {
+  if (verified === false && verifiedStatus === VerificationStatus.IN_PROGRESS) {
     return (
       <BCSCActivityProvider>
         <VerifyStack />


### PR DESCRIPTION
Part of #3720 (PR 2 of 2, stacked on #3724). Activates the agent service from PR1 inside the BCSC shell via `useAgentSetupViewModel` + `BCSCAgentProvider`, mounted in `BCSCRootStack` between the `!didAuthenticate` and `!verified` branches so VerifyStack, MainStack, and any future credential-consuming feature run inside the live agent context.

On failure, the provider calls `emitErrorModal` (once per error transition) with 2901/2902 strings and a Retry action; the LoadingScreen stays mounted underneath. `isAppError`/`instanceof AppError` is used to preserve typed errors thrown by the service and wrap anything else as 2901 with the original as `cause`.