### PR TITLE
fix: hide device limit banner on account selector

### DIFF
--- a/app/src/bcsc-theme/components/HeaderWithBanner.tsx
+++ b/app/src/bcsc-theme/components/HeaderWithBanner.tsx
@@ -15,7 +15,11 @@ interface HeaderWithBannerProps extends StackHeaderProps {
  * @param {HeaderWithBannerProps} props - The properties for the header component.
  * @returns {*} {React.ReactElement} The header component with an optional notification banner.
  */
-const HeaderWithBanner = ({ onManageDevices, bannerMessages, ...headerProps }: HeaderWithBannerProps): React.ReactElement => {
+const HeaderWithBanner = ({
+  onManageDevices,
+  bannerMessages,
+  ...headerProps
+}: HeaderWithBannerProps): React.ReactElement => {
   return (
     <View>
       <Header {...headerProps} />

--- a/app/src/bcsc-theme/components/HeaderWithBanner.tsx
+++ b/app/src/bcsc-theme/components/HeaderWithBanner.tsx
@@ -1,10 +1,12 @@
 import { Header, StackHeaderProps } from '@react-navigation/stack'
 import React from 'react'
 import { View } from 'react-native'
+import { BCSCBannerMessage } from './AppBanner'
 import { NotificationBannerContainer } from './NotificationBannerContainer'
 
 interface HeaderWithBannerProps extends StackHeaderProps {
   onManageDevices: () => void
+  bannerMessages: BCSCBannerMessage[]
 }
 
 /**
@@ -13,11 +15,11 @@ interface HeaderWithBannerProps extends StackHeaderProps {
  * @param {HeaderWithBannerProps} props - The properties for the header component.
  * @returns {*} {React.ReactElement} The header component with an optional notification banner.
  */
-const HeaderWithBanner = ({ onManageDevices, ...headerProps }: HeaderWithBannerProps): React.ReactElement => {
+const HeaderWithBanner = ({ onManageDevices, bannerMessages, ...headerProps }: HeaderWithBannerProps): React.ReactElement => {
   return (
     <View>
       <Header {...headerProps} />
-      <NotificationBannerContainer onManageDevices={onManageDevices} />
+      <NotificationBannerContainer onManageDevices={onManageDevices} bannerMessages={bannerMessages} />
     </View>
   )
 }
@@ -26,11 +28,12 @@ const HeaderWithBanner = ({ onManageDevices, ...headerProps }: HeaderWithBannerP
  * Creates a header with banner component that includes navigation callback for device management.
  *
  * @param {() => void} onManageDevices - Callback function for managing devices navigation
+ * @param {BCSCBannerMessage[]} bannerMessages - Banner messages to display below the header
  * @returns {(props: StackHeaderProps) => React.ReactElement} A header component with banner
  */
-export const createHeaderWithBanner = (onManageDevices: () => void) => {
+export const createHeaderWithBanner = (onManageDevices: () => void, bannerMessages: BCSCBannerMessage[]) => {
   const HeaderWithBannerComponent = (props: StackHeaderProps) => (
-    <HeaderWithBanner {...props} onManageDevices={onManageDevices} />
+    <HeaderWithBanner {...props} onManageDevices={onManageDevices} bannerMessages={bannerMessages} />
   )
   return HeaderWithBannerComponent
 }

--- a/app/src/bcsc-theme/components/NotificationBannerContainer.test.tsx
+++ b/app/src/bcsc-theme/components/NotificationBannerContainer.test.tsx
@@ -1,0 +1,78 @@
+import { BasicAppContext } from '@mocks/helpers/app'
+import { fireEvent, render } from '@testing-library/react-native'
+import React from 'react'
+import { BCSCBanner, BCSCBannerMessage } from './AppBanner'
+import { NotificationBannerContainer } from './NotificationBannerContainer'
+
+const deviceLimitBanner: BCSCBannerMessage = {
+  id: BCSCBanner.DEVICE_LIMIT_EXCEEDED,
+  title: 'Device limit reached',
+  type: 'warning',
+  dismissible: false,
+}
+
+const serverNotificationBanner: BCSCBannerMessage = {
+  id: BCSCBanner.IAS_SERVER_NOTIFICATION,
+  title: 'Server notification',
+  type: 'info',
+  dismissible: true,
+}
+
+describe('NotificationBannerContainer', () => {
+  const onManageDevices = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders all banners when excludeBanners is not provided', () => {
+    const tree = render(
+      <BasicAppContext
+        initialStateOverride={{ bcsc: { bannerMessages: [deviceLimitBanner, serverNotificationBanner] } as any }}
+      >
+        <NotificationBannerContainer onManageDevices={onManageDevices} />
+      </BasicAppContext>
+    )
+
+    expect(tree.getByText('Device limit reached')).toBeTruthy()
+    expect(tree.getByText('Server notification')).toBeTruthy()
+  })
+
+  it('filters out banners whose ids are in excludeBanners', () => {
+    const tree = render(
+      <BasicAppContext
+        initialStateOverride={{ bcsc: { bannerMessages: [deviceLimitBanner, serverNotificationBanner] } as any }}
+      >
+        <NotificationBannerContainer
+          onManageDevices={onManageDevices}
+          excludeBanners={[BCSCBanner.DEVICE_LIMIT_EXCEEDED]}
+        />
+      </BasicAppContext>
+    )
+
+    expect(tree.queryByText('Device limit reached')).toBeNull()
+    expect(tree.getByText('Server notification')).toBeTruthy()
+  })
+
+  it('treats an empty excludeBanners array as no-op', () => {
+    const tree = render(
+      <BasicAppContext initialStateOverride={{ bcsc: { bannerMessages: [serverNotificationBanner] } as any }}>
+        <NotificationBannerContainer onManageDevices={onManageDevices} excludeBanners={[]} />
+      </BasicAppContext>
+    )
+
+    expect(tree.getByText('Server notification')).toBeTruthy()
+  })
+
+  it('invokes the banner press handler when a banner is tapped', () => {
+    const tree = render(
+      <BasicAppContext initialStateOverride={{ bcsc: { bannerMessages: [serverNotificationBanner] } as any }}>
+        <NotificationBannerContainer onManageDevices={onManageDevices} />
+      </BasicAppContext>
+    )
+
+    fireEvent.press(tree.getByText('Server notification'))
+    // Dismissible banner should be removed from the visible tree after press.
+    expect(tree.queryByText('Server notification')).toBeNull()
+  })
+})

--- a/app/src/bcsc-theme/components/NotificationBannerContainer.test.tsx
+++ b/app/src/bcsc-theme/components/NotificationBannerContainer.test.tsx
@@ -25,12 +25,13 @@ describe('NotificationBannerContainer', () => {
     jest.clearAllMocks()
   })
 
-  it('renders all banners when excludeBanners is not provided', () => {
+  it('renders the banners passed via bannerMessages', () => {
     const tree = render(
-      <BasicAppContext
-        initialStateOverride={{ bcsc: { bannerMessages: [deviceLimitBanner, serverNotificationBanner] } as any }}
-      >
-        <NotificationBannerContainer onManageDevices={onManageDevices} />
+      <BasicAppContext>
+        <NotificationBannerContainer
+          onManageDevices={onManageDevices}
+          bannerMessages={[deviceLimitBanner, serverNotificationBanner]}
+        />
       </BasicAppContext>
     )
 
@@ -38,15 +39,21 @@ describe('NotificationBannerContainer', () => {
     expect(tree.getByText('Server notification')).toBeTruthy()
   })
 
-  it('filters out banners whose ids are in excludeBanners', () => {
+  it('renders nothing when bannerMessages is empty', () => {
     const tree = render(
-      <BasicAppContext
-        initialStateOverride={{ bcsc: { bannerMessages: [deviceLimitBanner, serverNotificationBanner] } as any }}
-      >
-        <NotificationBannerContainer
-          onManageDevices={onManageDevices}
-          excludeBanners={[BCSCBanner.DEVICE_LIMIT_EXCEEDED]}
-        />
+      <BasicAppContext>
+        <NotificationBannerContainer onManageDevices={onManageDevices} bannerMessages={[]} />
+      </BasicAppContext>
+    )
+
+    expect(tree.queryByText('Device limit reached')).toBeNull()
+    expect(tree.queryByText('Server notification')).toBeNull()
+  })
+
+  it('only renders banners the caller provides', () => {
+    const tree = render(
+      <BasicAppContext>
+        <NotificationBannerContainer onManageDevices={onManageDevices} bannerMessages={[serverNotificationBanner]} />
       </BasicAppContext>
     )
 
@@ -54,25 +61,14 @@ describe('NotificationBannerContainer', () => {
     expect(tree.getByText('Server notification')).toBeTruthy()
   })
 
-  it('treats an empty excludeBanners array as no-op', () => {
+  it('hides a dismissible banner after it is pressed', () => {
     const tree = render(
-      <BasicAppContext initialStateOverride={{ bcsc: { bannerMessages: [serverNotificationBanner] } as any }}>
-        <NotificationBannerContainer onManageDevices={onManageDevices} excludeBanners={[]} />
-      </BasicAppContext>
-    )
-
-    expect(tree.getByText('Server notification')).toBeTruthy()
-  })
-
-  it('invokes the banner press handler when a banner is tapped', () => {
-    const tree = render(
-      <BasicAppContext initialStateOverride={{ bcsc: { bannerMessages: [serverNotificationBanner] } as any }}>
-        <NotificationBannerContainer onManageDevices={onManageDevices} />
+      <BasicAppContext>
+        <NotificationBannerContainer onManageDevices={onManageDevices} bannerMessages={[serverNotificationBanner]} />
       </BasicAppContext>
     )
 
     fireEvent.press(tree.getByText('Server notification'))
-    // Dismissible banner should be removed from the visible tree after press.
     expect(tree.queryByText('Server notification')).toBeNull()
   })
 })

--- a/app/src/bcsc-theme/components/NotificationBannerContainer.tsx
+++ b/app/src/bcsc-theme/components/NotificationBannerContainer.tsx
@@ -11,7 +11,8 @@ import { BCSCMainStackParams, BCSCScreens } from '../types/navigators'
 import { AppBanner, BCSCBanner, BCSCBannerMessage } from './AppBanner'
 
 interface NotificationBannerContainerProps {
-  onManageDevices: () => void
+  onManageDevices?: () => void
+  excludeBanners?: BCSCBanner[]
 }
 
 /**
@@ -20,7 +21,7 @@ interface NotificationBannerContainerProps {
  * @param {NotificationBannerContainerProps} props - The properties for the NotificationBannerContainer component.
  * @returns {*} {React.ReactElement} The NotificationBannerContainer component.
  */
-export const NotificationBannerContainer = ({ onManageDevices }: NotificationBannerContainerProps) => {
+export const NotificationBannerContainer = ({ onManageDevices, excludeBanners }: NotificationBannerContainerProps) => {
   const [store, dispatch] = useStore<BCState>()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const [devicesModalVisible, setDevicesModalVisible] = useState(false)
@@ -81,19 +82,21 @@ export const NotificationBannerContainer = ({ onManageDevices }: NotificationBan
           maxDevices={3}
           handleClose={() => handleCloseDevicesModal({ shouldAnimate: true })}
           handleDelete={handleDeleteDeviceCountMessage}
-          onManageDevices={onManageDevices}
+          onManageDevices={() => onManageDevices?.()}
         />
       </SafeAreaModal>
 
       <AppBanner
-        messages={store.bcsc.bannerMessages.map((banner) => ({
-          id: banner.id,
-          title: banner.title,
-          description: banner.description,
-          type: banner.type,
-          dismissible: banner.dismissible,
-          onPress: () => handleBannerPress(banner),
-        }))}
+        messages={store.bcsc.bannerMessages
+          .filter((banner) => !excludeBanners?.includes(banner.id))
+          .map((banner) => ({
+            id: banner.id,
+            title: banner.title,
+            description: banner.description,
+            type: banner.type,
+            dismissible: banner.dismissible,
+            onPress: () => handleBannerPress(banner),
+          }))}
       />
     </View>
   )

--- a/app/src/bcsc-theme/components/NotificationBannerContainer.tsx
+++ b/app/src/bcsc-theme/components/NotificationBannerContainer.tsx
@@ -11,7 +11,7 @@ import { BCSCMainStackParams, BCSCScreens } from '../types/navigators'
 import { AppBanner, BCSCBanner, BCSCBannerMessage } from './AppBanner'
 
 interface NotificationBannerContainerProps {
-  onManageDevices?: () => void
+  onManageDevices: () => void
   excludeBanners?: BCSCBanner[]
 }
 
@@ -82,7 +82,7 @@ export const NotificationBannerContainer = ({ onManageDevices, excludeBanners }:
           maxDevices={3}
           handleClose={() => handleCloseDevicesModal({ shouldAnimate: true })}
           handleDelete={handleDeleteDeviceCountMessage}
-          onManageDevices={onManageDevices ?? (() => {})}
+          onManageDevices={onManageDevices}
         />
       </SafeAreaModal>
 

--- a/app/src/bcsc-theme/components/NotificationBannerContainer.tsx
+++ b/app/src/bcsc-theme/components/NotificationBannerContainer.tsx
@@ -82,7 +82,7 @@ export const NotificationBannerContainer = ({ onManageDevices, excludeBanners }:
           maxDevices={3}
           handleClose={() => handleCloseDevicesModal({ shouldAnimate: true })}
           handleDelete={handleDeleteDeviceCountMessage}
-          onManageDevices={() => onManageDevices?.()}
+          onManageDevices={onManageDevices ?? (() => {})}
         />
       </SafeAreaModal>
 

--- a/app/src/bcsc-theme/components/NotificationBannerContainer.tsx
+++ b/app/src/bcsc-theme/components/NotificationBannerContainer.tsx
@@ -12,7 +12,7 @@ import { AppBanner, BCSCBanner, BCSCBannerMessage } from './AppBanner'
 
 interface NotificationBannerContainerProps {
   onManageDevices: () => void
-  excludeBanners?: BCSCBanner[]
+  bannerMessages: BCSCBannerMessage[]
 }
 
 /**
@@ -21,7 +21,7 @@ interface NotificationBannerContainerProps {
  * @param {NotificationBannerContainerProps} props - The properties for the NotificationBannerContainer component.
  * @returns {*} {React.ReactElement} The NotificationBannerContainer component.
  */
-export const NotificationBannerContainer = ({ onManageDevices, excludeBanners }: NotificationBannerContainerProps) => {
+export const NotificationBannerContainer = ({ onManageDevices, bannerMessages }: NotificationBannerContainerProps) => {
   const [store, dispatch] = useStore<BCState>()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const [devicesModalVisible, setDevicesModalVisible] = useState(false)
@@ -87,16 +87,14 @@ export const NotificationBannerContainer = ({ onManageDevices, excludeBanners }:
       </SafeAreaModal>
 
       <AppBanner
-        messages={store.bcsc.bannerMessages
-          .filter((banner) => !excludeBanners?.includes(banner.id))
-          .map((banner) => ({
-            id: banner.id,
-            title: banner.title,
-            description: banner.description,
-            type: banner.type,
-            dismissible: banner.dismissible,
-            onPress: () => handleBannerPress(banner),
-          }))}
+        messages={bannerMessages.map((banner) => ({
+          id: banner.id,
+          title: banner.title,
+          description: banner.description,
+          type: banner.type,
+          dismissible: banner.dismissible,
+          onPress: () => handleBannerPress(banner),
+        }))}
       />
     </View>
   )

--- a/app/src/bcsc-theme/features/auth/AccountSelectorScreen.test.tsx
+++ b/app/src/bcsc-theme/features/auth/AccountSelectorScreen.test.tsx
@@ -1,3 +1,4 @@
+import { BCSCBanner, BCSCBannerMessage } from '@/bcsc-theme/components/AppBanner'
 import { useNavigation } from '@mocks/@react-navigation/native'
 import { BasicAppContext } from '@mocks/helpers/app'
 import { fireEvent, render } from '@testing-library/react-native'
@@ -77,6 +78,45 @@ describe('AccountSetup', () => {
       fireEvent.press(continueButton)
 
       expect(mockUnlockApp).toHaveBeenCalled()
+    })
+  })
+
+  describe('banner filtering (issue #3717)', () => {
+    const deviceLimitBanner: BCSCBannerMessage = {
+      id: BCSCBanner.DEVICE_LIMIT_EXCEEDED,
+      title: 'Device limit reached',
+      type: 'warning',
+      dismissible: false,
+    }
+
+    const serverNotificationBanner: BCSCBannerMessage = {
+      id: BCSCBanner.IAS_SERVER_NOTIFICATION,
+      title: 'Server notification',
+      type: 'info',
+      dismissible: true,
+    }
+
+    it('does not render the device limit banner', () => {
+      const tree = render(
+        <BasicAppContext initialStateOverride={{ bcsc: { bannerMessages: [deviceLimitBanner] } as any }}>
+          <AccountSelectorScreen navigation={mockNavigation as never} />
+        </BasicAppContext>
+      )
+
+      expect(tree.queryByText('Device limit reached')).toBeNull()
+    })
+
+    it('still renders other banners', () => {
+      const tree = render(
+        <BasicAppContext
+          initialStateOverride={{ bcsc: { bannerMessages: [deviceLimitBanner, serverNotificationBanner] } as any }}
+        >
+          <AccountSelectorScreen navigation={mockNavigation as never} />
+        </BasicAppContext>
+      )
+
+      expect(tree.queryByText('Device limit reached')).toBeNull()
+      expect(tree.getByText('Server notification')).toBeTruthy()
     })
   })
 })

--- a/app/src/bcsc-theme/features/auth/AccountSelectorScreen.tsx
+++ b/app/src/bcsc-theme/features/auth/AccountSelectorScreen.tsx
@@ -1,3 +1,4 @@
+import { BCSCBanner } from '@/bcsc-theme/components/AppBanner'
 import { CardButton } from '@/bcsc-theme/components/CardButton'
 import GenericCardImage from '@/bcsc-theme/components/GenericCardImage'
 import { NotificationBannerContainer } from '@/bcsc-theme/components/NotificationBannerContainer'
@@ -59,7 +60,7 @@ const AccountSelectorScreen = ({ navigation }: AccountSelectorScreenProps) => {
 
   return (
     <>
-      <NotificationBannerContainer onManageDevices={() => {}} />
+      <NotificationBannerContainer excludeBanners={[BCSCBanner.DEVICE_LIMIT_EXCEEDED]} />
       <ScreenWrapper scrollable scrollViewContainerStyle={styles.contentContainer} controls={controls}>
         <GenericCardImage />
         <ThemedText variant={'headingFour'} style={{ textAlign: 'center' }}>

--- a/app/src/bcsc-theme/features/auth/AccountSelectorScreen.tsx
+++ b/app/src/bcsc-theme/features/auth/AccountSelectorScreen.tsx
@@ -60,7 +60,7 @@ const AccountSelectorScreen = ({ navigation }: AccountSelectorScreenProps) => {
 
   return (
     <>
-      {/* noop handler: DEVICE_LIMIT_EXCEEDED is the only banner that invokes it and is excluded above */}
+      {/* noop handler: DEVICE_LIMIT_EXCEEDED is the only banner that invokes it and is excluded via `excludeBanners` here */}
       <NotificationBannerContainer onManageDevices={() => {}} excludeBanners={[BCSCBanner.DEVICE_LIMIT_EXCEEDED]} />
       <ScreenWrapper scrollable scrollViewContainerStyle={styles.contentContainer} controls={controls}>
         <GenericCardImage />

--- a/app/src/bcsc-theme/features/auth/AccountSelectorScreen.tsx
+++ b/app/src/bcsc-theme/features/auth/AccountSelectorScreen.tsx
@@ -60,8 +60,11 @@ const AccountSelectorScreen = ({ navigation }: AccountSelectorScreenProps) => {
 
   return (
     <>
-      {/* noop handler: DEVICE_LIMIT_EXCEEDED is the only banner that invokes it and is excluded via `excludeBanners` here */}
-      <NotificationBannerContainer onManageDevices={() => {}} excludeBanners={[BCSCBanner.DEVICE_LIMIT_EXCEEDED]} />
+      {/* noop handler: DEVICE_LIMIT_EXCEEDED is the only banner that invokes it and is filtered out below */}
+      <NotificationBannerContainer
+        onManageDevices={() => {}}
+        bannerMessages={store.bcsc.bannerMessages.filter((b) => b.id !== BCSCBanner.DEVICE_LIMIT_EXCEEDED)}
+      />
       <ScreenWrapper scrollable scrollViewContainerStyle={styles.contentContainer} controls={controls}>
         <GenericCardImage />
         <ThemedText variant={'headingFour'} style={{ textAlign: 'center' }}>

--- a/app/src/bcsc-theme/features/auth/AccountSelectorScreen.tsx
+++ b/app/src/bcsc-theme/features/auth/AccountSelectorScreen.tsx
@@ -60,7 +60,8 @@ const AccountSelectorScreen = ({ navigation }: AccountSelectorScreenProps) => {
 
   return (
     <>
-      <NotificationBannerContainer excludeBanners={[BCSCBanner.DEVICE_LIMIT_EXCEEDED]} />
+      {/* noop handler: DEVICE_LIMIT_EXCEEDED is the only banner that invokes it and is excluded above */}
+      <NotificationBannerContainer onManageDevices={() => {}} excludeBanners={[BCSCBanner.DEVICE_LIMIT_EXCEEDED]} />
       <ScreenWrapper scrollable scrollViewContainerStyle={styles.contentContainer} controls={controls}>
         <GenericCardImage />
         <ThemedText variant={'headingFour'} style={{ textAlign: 'center' }}>

--- a/app/src/bcsc-theme/features/home/Home.tsx
+++ b/app/src/bcsc-theme/features/home/Home.tsx
@@ -56,7 +56,7 @@ const Home: React.FC<HomeProps> = ({ navigation }) => {
 
   return (
     <>
-      <NotificationBannerContainer onManageDevices={handleManageDevices} />
+      <NotificationBannerContainer onManageDevices={handleManageDevices} bannerMessages={store.bcsc.bannerMessages} />
       <TabScreenWrapper>
         <HomeHeader name={account.fullname_formatted} cardSize={GENERIC_CARD_SIZE_SMALL} />
         <View style={styles.buttonsContainer}>


### PR DESCRIPTION
On v4 the "Device limit reached" banner was showing up on the Account Selector screen (pre-auth), where tapping it opened a dialog that tried to navigate to Manage Devices — but since the user isn't authenticated yet, the button had nowhere to go. Per v3, this banner is only meant to appear post-auth on Home.

The fix is small: add an optional `excludeBanners` prop to `NotificationBannerContainer` and pass `[DEVICE_LIMIT_EXCEEDED]` from the Account Selector. Global banner state is left alone so Home still renders it correctly once the user authenticates. Other banners (server notifications, account expiry, etc.) continue to appear on the Account Selector as before.


https://github.com/user-attachments/assets/a8fa0da1-552a-4144-9390-0e605ea32bab


## Test plan

- [x] \`yarn typecheck\` and \`yarn lint\` pass
- [x] \`AccountSelectorScreen.test.tsx\` — 2 new unit tests cover the filter
- [x] Trigger device limit, confirm banner shows on Home
- [x] Lock app, confirm banner is absent on Account Selector
- [x] Verify a non-excluded banner still appears on Account Selector