### PR TITLE
feat: e2e transfer account

### DIFF
--- a/app/src/bcsc-theme/features/onboarding/OnboardingOptInAnalyticsScreen.test.tsx
+++ b/app/src/bcsc-theme/features/onboarding/OnboardingOptInAnalyticsScreen.test.tsx
@@ -37,7 +37,7 @@ describe('OnboardingOptInAnalytics', () => {
       </BasicAppContext>
     )
 
-    const learnMoreButton = getByTestId(testIdWithKey('CardButton-BCSC.Onboarding.LearnMore'))
+    const learnMoreButton = getByTestId(testIdWithKey('LearnMore'))
     fireEvent.press(learnMoreButton)
 
     expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.OnboardingWebView, {

--- a/app/src/bcsc-theme/features/onboarding/__snapshots__/OnboardingOptInAnalyticsScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/onboarding/__snapshots__/OnboardingOptInAnalyticsScreen.test.tsx.snap
@@ -159,7 +159,7 @@ exports[`OnboardingOptInAnalytics renders correctly 1`] = `
             undefined,
           ]
         }
-        testID="com.ariesbifold:id/CardButton-BCSC.Onboarding.LearnMore"
+        testID="com.ariesbifold:id/LearnMore"
       >
         <View
           style={

--- a/app/src/bcsc-theme/features/onboarding/components/OnboardingOptInAnalyticsContent.tsx
+++ b/app/src/bcsc-theme/features/onboarding/components/OnboardingOptInAnalyticsContent.tsx
@@ -105,7 +105,12 @@ export const OnboardingOptInAnalyticsContent: React.FC<OnboardingOptInAnalyticsC
       <ThemedText variant="headingThree">{t('BCSC.Onboarding.AnalyticsHeader')}</ThemedText>
       <ThemedText>{t('BCSC.Onboarding.AnalyticsContent')}</ThemedText>
       <ThemedText>{t('BCSC.Onboarding.AnalyticsAnonymousInfo')}</ThemedText>
-      <CardButton title={t('BCSC.Onboarding.LearnMore')} onPress={onLearnMore} endIcon="open-in-new" />
+      <CardButton
+        title={t('BCSC.Onboarding.LearnMore')}
+        testID={testIdWithKey('LearnMore')}
+        onPress={onLearnMore}
+        endIcon="open-in-new"
+      />
     </ScreenWrapper>
   )
 }

--- a/e2e/src/constants.ts
+++ b/e2e/src/constants.ts
@@ -7,21 +7,13 @@ export const UPDATED_TEST_PIN = '555555'
 
 export enum Timeouts {
   /** Default wait for an element to appear on screen */
-  elementVisible = 5_000,
+  ELEMENT_VISIBLE = 5_000,
   /** Wait for a screen transition to complete */
-  screenTransition = 20_000,
+  SCREEN_TRANSITION = 20_000,
   /** Initial app launch — generous for cold starts on real devices */
-  appLaunch = 30_000,
+  APP_LAUNCH = 30_000,
   /** Per-test timeout (Mocha) */
-  testTimeout = 300_000,
-  /** WDIO waitforTimeout */
-  waitFor = 20_000,
-  /** Appium new command timeout */
-  newCommand = 180,
-  /** WDIO connection retry timeout */
-  connectionRetry = 180_000,
-  /** swipe duration */
-  swipeDuration = 800,
+  TEST_TIMEOUT = 300_000,
   /** Browser handoff pause (ms) */
   BROWSER_HANDOFF_PAUSE_MS = 1_000,
 }

--- a/e2e/src/constants.ts
+++ b/e2e/src/constants.ts
@@ -23,7 +23,7 @@ export enum Timeouts {
   /** swipe duration */
   swipeDuration = 800,
   /** Browser handoff pause (ms) */
-  BROWSER_HANDOFF_PAUSE_MS = 2_000,
+  BROWSER_HANDOFF_PAUSE_MS = 1_000,
 }
 
 export const TestUsers = {

--- a/e2e/src/constants.ts
+++ b/e2e/src/constants.ts
@@ -5,24 +5,26 @@ export const TEST_PIN = '222222'
  *  enter a PIN after the settings suite should use this value. */
 export const UPDATED_TEST_PIN = '555555'
 
-export const Timeouts = {
+export enum Timeouts {
   /** Default wait for an element to appear on screen */
-  elementVisible: 5_000,
+  elementVisible = 5_000,
   /** Wait for a screen transition to complete */
-  screenTransition: 20_000,
+  screenTransition = 20_000,
   /** Initial app launch — generous for cold starts on real devices */
-  appLaunch: 30_000,
+  appLaunch = 30_000,
   /** Per-test timeout (Mocha) */
-  testTimeout: 300_000,
+  testTimeout = 300_000,
   /** WDIO waitforTimeout */
-  waitFor: 20_000,
+  waitFor = 20_000,
   /** Appium new command timeout */
-  newCommand: 180,
+  newCommand = 180,
   /** WDIO connection retry timeout */
-  connectionRetry: 180_000,
+  connectionRetry = 180_000,
   /** swipe duration */
-  swipeDuration: 800,
-} as const
+  swipeDuration = 800,
+  /** Browser handoff pause (ms) */
+  BROWSER_HANDOFF_PAUSE_MS = 2_000,
+}
 
 export const TestUsers = {
   photo: {

--- a/e2e/src/screens/BaseScreen.ts
+++ b/e2e/src/screens/BaseScreen.ts
@@ -82,7 +82,7 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
    * @param testId - test ID of the element to wait for
    * @returns void
    */
-  async waitForDisplayed(testId: string, timeout: number = Timeouts.elementVisible) {
+  async waitForDisplayed(testId: string, timeout: number = Timeouts.ELEMENT_VISIBLE) {
     const el = await this.findByTestId(testId)
     try {
       await el.waitForDisplayed({ timeout })
@@ -98,7 +98,7 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
    * On iOS, falls back to the `label` attribute when `getText()` returns empty
    * (common for styled ThemedText / accessibility-labelled elements).
    */
-  public async getTextByTestId(testId: string, timeout: number = Timeouts.elementVisible): Promise<string> {
+  public async getTextByTestId(testId: string, timeout: number = Timeouts.ELEMENT_VISIBLE): Promise<string> {
     const el = await this.findByTestId(testId)
     await el.waitForDisplayed({ timeout })
     const text = await el.getText()
@@ -162,7 +162,7 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
    * @param testId - test ID of the element
    * @param timeout - max time to wait for the element to become enabled (default 20s)
    */
-  public async waitForEnabledAndTap(testId: string, timeout: number = Timeouts.screenTransition) {
+  public async waitForEnabledAndTap(testId: string, timeout: number = Timeouts.SCREEN_TRANSITION) {
     const el = await this.findByTestId(testId)
     await el.waitForDisplayed({ timeout })
     await el.waitForEnabled({ timeout })
@@ -192,11 +192,11 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
   public async enterText(testId: string, text: string, options?: EnterTextOptions) {
     const el = await this.findByTestId(testId)
     try {
-      await el.waitForDisplayed({ timeout: Timeouts.screenTransition })
+      await el.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     } catch {
-      console.warn(`Element "${testId}" not visible after ${Timeouts.screenTransition}ms; scrolling then retrying`)
+      console.warn(`Element "${testId}" not visible after ${Timeouts.SCREEN_TRANSITION}ms; scrolling then retrying`)
       await this.scrollToTestId(testId, 4, 'both')
-      await el.waitForDisplayed({ timeout: Timeouts.screenTransition })
+      await el.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     }
 
     if (options?.tapFirst) {

--- a/e2e/src/testIDs.ts
+++ b/e2e/src/testIDs.ts
@@ -354,9 +354,11 @@ export const BCSC_TestIDs = {
   TransferAccountQRInformation: {
     GetQRCodeButton: 'com.ariesbifold:id/GetQRCodeButton',
     LearnMoreButton: 'com.ariesbifold:id/LearnMoreButton',
+    Back: 'com.ariesbifold:id/Back',
   },
   TransferAccountQRDisplay: {
     GetNewQRCode: 'com.ariesbifold:id/GetNewQRCode',
+    Back: 'com.ariesbifold:id/Back',
   },
   TransferAccountSuccess: {
     TransferSuccessButton: 'com.ariesbifold:id/TransferSuccessButton',

--- a/e2e/src/testIDs.ts
+++ b/e2e/src/testIDs.ts
@@ -35,6 +35,7 @@ export const BCSC_TestIDs = {
     Accept: 'com.ariesbifold:id/Accept',
     Decline: 'com.ariesbifold:id/Decline',
     Back: 'com.ariesbifold:id/Back',
+    LearnMore: 'com.ariesbifold:id/LearnMore',
   },
   Notifications: {
     Continue: 'com.ariesbifold:id/Continue',

--- a/e2e/test/bcsc/full-regression/interaction-sweep.spec.ts
+++ b/e2e/test/bcsc/full-regression/interaction-sweep.spec.ts
@@ -7,4 +7,12 @@
  *
  * Run with: yarn wdio ... --spec e2e/test/bcsc/full-regression/interaction-sweep.spec.ts
  */
+import '../onboarding/transferee-flow.spec.js'
+
 import '../onboarding/onboarding-interaction-sweep.spec.js'
+
+// import '../verify/verify-interaction-sweep.spec.js'
+
+// import '../main/main-interaction-sweep.spec.js'
+
+// import '../main/transferer-flow.spec.js'

--- a/e2e/test/bcsc/full-regression/interaction-sweep.spec.ts
+++ b/e2e/test/bcsc/full-regression/interaction-sweep.spec.ts
@@ -1,9 +1,10 @@
 // organize-imports-ignore — import order defines test run order
 /**
  * Full-regression Interaction Sweep: composes the stack-level interaction
- * sweeps (onboarding, verify, main). Only the onboarding stack is
- * implemented today; verify and main sweeps will be imported below as they
- * land.
+ * sweeps (onboarding, verify, main). Imports the transferee flow
+ * (account-transfer detour + notifications deny path) and the onboarding
+ * interaction sweep. Verify and main sweeps, and the transferer flow
+ * (needs verified-state composition), will be imported below as they land.
  *
  * Run with: yarn wdio ... --spec e2e/test/bcsc/full-regression/interaction-sweep.spec.ts
  */

--- a/e2e/test/bcsc/main/login-from-computer.spec.ts
+++ b/e2e/test/bcsc/main/login-from-computer.spec.ts
@@ -23,7 +23,7 @@ describe('Login From Computer — pairing code minted in Node', () => {
   let pairingCode = ''
 
   before(async () => {
-    await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
+    await Home.waitFor('SettingsMenuButton', Timeouts.SCREEN_TRANSITION)
     const session = await fetchPairingCode()
     pairingCode = session.pairingCode
     // Pairing codes are short-lived but live credentials — only log a masked
@@ -46,11 +46,11 @@ describe('Login From Computer — pairing code minted in Node', () => {
     })
     await ManualPairing.dismissKeyboard()
     await ManualPairing.tap('Submit')
-    await PairingConfirmation.waitFor('Close', Timeouts.screenTransition)
+    await PairingConfirmation.waitFor('Close', Timeouts.SCREEN_TRANSITION)
   })
 
   it('closes the PairingConfirmation screen', async () => {
     await PairingConfirmation.tap('Close')
-    await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
+    await Home.waitFor('SettingsMenuButton', Timeouts.SCREEN_TRANSITION)
   })
 })

--- a/e2e/test/bcsc/main/login-from-deep-link.spec.ts
+++ b/e2e/test/bcsc/main/login-from-deep-link.spec.ts
@@ -45,7 +45,7 @@ async function tapAccountCardIfPresent(): Promise<void> {
  * log a masked suffix so CI archives don't retain an active pairing code.
  */
 async function prepareDeepLinkSession(logTag: string): Promise<{ appId: string; deepLink: string }> {
-  await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
+  await Home.waitFor('SettingsMenuButton', Timeouts.SCREEN_TRANSITION)
   const appId = await getCurrentAppId()
   const session = await fetchPairingDeepLink({ platform: currentPlatform() })
   const masked = `***${session.pairingCode.slice(-2)}`
@@ -65,16 +65,16 @@ describe('Login From Deep Link — warm start', () => {
 
   it('routes the deep link to ServiceLoginScreen', async () => {
     await dispatchDeepLink(deepLink, appId)
-    await ServiceLogin.waitFor('ServiceLoginCancel', Timeouts.screenTransition)
+    await ServiceLogin.waitFor('ServiceLoginCancel', Timeouts.SCREEN_TRANSITION)
   })
 
   it('continues to the PairingConfirmation screen', async () => {
-    await ServiceLogin.waitFor('ServiceLoginContinue', Timeouts.screenTransition)
+    await ServiceLogin.waitFor('ServiceLoginContinue', Timeouts.SCREEN_TRANSITION)
     await ServiceLogin.tap('ServiceLoginContinue')
   })
 
   it('saves bookmark for the logged-in service', async () => {
-    await PairingConfirmation.waitFor('ToggleBookmark', Timeouts.screenTransition)
+    await PairingConfirmation.waitFor('ToggleBookmark', Timeouts.SCREEN_TRANSITION)
     await PairingConfirmation.tap('ToggleBookmark')
     await PairingConfirmation.tap('ToggleBookmark')
   })
@@ -83,7 +83,7 @@ describe('Login From Deep Link — warm start', () => {
     // Two back gestures pop the stack: PairingConfirmation → ServiceLogin → Home.
     await navigateBack()
     await navigateBack()
-    await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
+    await Home.waitFor('SettingsMenuButton', Timeouts.SCREEN_TRANSITION)
   })
 })
 
@@ -103,16 +103,16 @@ describe('Login From Deep Link — cold start', () => {
     // Cold-launch sequence: AccountSelector (multi-account devices only) →
     // EnterPIN → ServiceLogin.
     await tapAccountCardIfPresent()
-    await EnterPIN.waitFor('PINInput', Timeouts.appLaunch)
+    await EnterPIN.waitFor('PINInput', Timeouts.APP_LAUNCH)
     await EnterPIN.type('PINInput', TEST_PIN)
     await EnterPIN.tap('Continue')
 
-    await ServiceLogin.waitFor('ServiceLoginCancel', Timeouts.appLaunch)
+    await ServiceLogin.waitFor('ServiceLoginCancel', Timeouts.APP_LAUNCH)
   })
 
   it('cancels back to the Home tab', async () => {
     // ServiceLogin onCancel navigates to Home when the screen was the initial route.
     await ServiceLogin.tap('ServiceLoginCancel')
-    await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
+    await Home.waitFor('SettingsMenuButton', Timeouts.SCREEN_TRANSITION)
   })
 })

--- a/e2e/test/bcsc/main/settings/settings.spec.ts
+++ b/e2e/test/bcsc/main/settings/settings.spec.ts
@@ -81,7 +81,7 @@ async function tapAccountCard(nickname: string): Promise<void> {
   const testId = `com.ariesbifold:id/CardButton-${nickname}`
   const selector = driver.isIOS ? `~${testId}` : `android=new UiSelector().resourceId("${testId}")`
   const card = await $(selector)
-  await card.waitForDisplayed({ timeout: Timeouts.elementVisible })
+  await card.waitForDisplayed({ timeout: Timeouts.ELEMENT_VISIBLE })
   await card.click()
 }
 
@@ -146,7 +146,7 @@ describe('Settings', () => {
     // value on iOS.
     await Settings.tap('EditNickname')
     const nicknameText = await EditNickname.findByText(newNickname)
-    await nicknameText.waitForDisplayed({ timeout: Timeouts.elementVisible })
+    await nicknameText.waitForDisplayed({ timeout: Timeouts.ELEMENT_VISIBLE })
     await EditNickname.tap('BackButton')
     await Settings.waitFor('EditNickname')
   })
@@ -183,7 +183,7 @@ describe('Settings', () => {
     // `createAuthSettingsHeaderButton`) rather than the localized
     // "Continue as:" heading — testID-based, not text-based, so copy
     // changes can't silently break the test.
-    await AccountSelector.waitFor('SettingsMenuButton', Timeouts.screenTransition)
+    await AccountSelector.waitFor('SettingsMenuButton', Timeouts.SCREEN_TRANSITION)
     await tapAccountCard(newNickname)
     await EnterPIN.waitFor('PINInput')
     await EnterPIN.type('PINInput', currentPin)
@@ -201,7 +201,7 @@ describe('Settings', () => {
 
     // The current-method indicator box should show "PIN".
     const pinLabel = await MainAppSecurity.findByText('PIN')
-    await pinLabel.waitForDisplayed({ timeout: Timeouts.elementVisible })
+    await pinLabel.waitForDisplayed({ timeout: Timeouts.ELEMENT_VISIBLE })
 
     // Button-state assertions fork on whether biometrics are available:
     // `SecurityMethodSelector` has two render branches. When device auth
@@ -213,7 +213,7 @@ describe('Settings', () => {
     // ChangePIN) and LearnMoreButton — ChooseDeviceAuthButton is not in
     // the tree at all. Probe for the device-auth button to pick a branch.
     const pinButton = await MainAppSecurity.findByTestId(MainAppSecurity.ids.ChoosePINButton)
-    await pinButton.waitForDisplayed({ timeout: Timeouts.elementVisible })
+    await pinButton.waitForDisplayed({ timeout: Timeouts.ELEMENT_VISIBLE })
     const deviceAuthButton = await MainAppSecurity.findByTestId(MainAppSecurity.ids.ChooseDeviceAuthButton)
     const deviceAuthAvailable = await deviceAuthButton.isDisplayed().catch(() => false)
 
@@ -249,7 +249,7 @@ describe('Settings', () => {
     await ChangePIN.tap('ChangePIN')
 
     const mismatchError = await ChangePIN.findByText('PIN does not match')
-    await mismatchError.waitForDisplayed({ timeout: Timeouts.elementVisible })
+    await mismatchError.waitForDisplayed({ timeout: Timeouts.ELEMENT_VISIBLE })
 
     // Uncheck BEFORE correcting the confirm PIN — typing the 6th digit
     // triggers handleConfirmPINComplete which auto-validates. If the
@@ -262,7 +262,7 @@ describe('Settings', () => {
 
     // Verify the button is disabled without the checkbox.
     const changePINButton = await ChangePIN.findByTestId(ChangePIN.ids.ChangePIN)
-    await changePINButton.waitForDisplayed({ timeout: Timeouts.elementVisible })
+    await changePINButton.waitForDisplayed({ timeout: Timeouts.ELEMENT_VISIBLE })
     const enabledWhenUnchecked = await changePINButton.isEnabled()
     if (enabledWhenUnchecked) throw new Error('Expected Change PIN button to be disabled without checkbox')
 
@@ -292,7 +292,7 @@ describe('Settings', () => {
     // and not individually queryable via findByText.
     if (driver.isAndroid) {
       const adornment3 = await Settings.findByText('3 min')
-      await adornment3.waitForDisplayed({ timeout: Timeouts.elementVisible })
+      await adornment3.waitForDisplayed({ timeout: Timeouts.ELEMENT_VISIBLE })
     }
   })
 
@@ -304,7 +304,7 @@ describe('Settings', () => {
     await Settings.waitFor('EditNickname')
     if (driver.isAndroid) {
       const adornment5 = await Settings.findByText('5 min')
-      await adornment5.waitForDisplayed({ timeout: Timeouts.elementVisible })
+      await adornment5.waitForDisplayed({ timeout: Timeouts.ELEMENT_VISIBLE })
     }
   })
 
@@ -316,7 +316,7 @@ describe('Settings', () => {
     await Settings.waitFor('EditNickname')
     if (driver.isAndroid) {
       const adornment1 = await Settings.findByText('1 min')
-      await adornment1.waitForDisplayed({ timeout: Timeouts.elementVisible })
+      await adornment1.waitForDisplayed({ timeout: Timeouts.ELEMENT_VISIBLE })
     }
 
     // Wait for the 1-minute inactivity timer to fire. BCSCActivityContext
@@ -324,7 +324,7 @@ describe('Settings', () => {
     // timer precision and navigation transition time.
     await driver.pause(70_000)
 
-    await AccountSelector.waitFor('SettingsMenuButton', Timeouts.screenTransition)
+    await AccountSelector.waitFor('SettingsMenuButton', Timeouts.SCREEN_TRANSITION)
     await tapAccountCard(newNickname)
     await EnterPIN.waitFor('PINInput')
     await EnterPIN.type('PINInput', currentPin)
@@ -357,7 +357,7 @@ describe('Settings', () => {
       }
     } else {
       const successHeading = await Forget.findByText('Success')
-      await successHeading.waitForDisplayed({ timeout: Timeouts.screenTransition })
+      await successHeading.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
       const okButton = await Forget.findByText('OK')
       await okButton.click()
     }
@@ -376,7 +376,7 @@ describe('Settings', () => {
       await Settings.tap('AnalyticsOptIn')
       const expectedAfter = isCurrentlyOn ? 'OFF' : 'ON'
       const after = await Settings.findByText(expectedAfter)
-      await after.waitForDisplayed({ timeout: Timeouts.elementVisible })
+      await after.waitForDisplayed({ timeout: Timeouts.ELEMENT_VISIBLE })
     } else {
       // On iOS just verify the tap doesn't error.
       await Settings.tap('AnalyticsOptIn')
@@ -403,7 +403,7 @@ describe('Settings', () => {
       }
     } else {
       const heading = await Settings.findByText('Are you sure?')
-      await heading.waitForDisplayed({ timeout: Timeouts.elementVisible })
+      await heading.waitForDisplayed({ timeout: Timeouts.ELEMENT_VISIBLE })
       // Android Material upper-cases AlertDialog button labels.
       const cancelButton = await Settings.findByText('CANCEL')
       await cancelButton.click()
@@ -420,7 +420,7 @@ describe('Settings', () => {
     await Settings.tap('Help')
     await WebView.waitFor('Back')
     const supportGuide = await WebView.findByText('Support guide')
-    await supportGuide.waitForDisplayed({ timeout: Timeouts.screenTransition })
+    await supportGuide.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     await WebView.tap('Back')
     await Settings.waitFor('EditNickname')
   })
@@ -439,7 +439,7 @@ describe('Settings', () => {
     // text (`BCSC.ContactUs.Title` = "Service BC Help Desk") which is
     // rendered as a plain ThemedText at the top of the screen.
     const heading = await MainContactUs.findByText('Service BC Help Desk')
-    await heading.waitForDisplayed({ timeout: Timeouts.elementVisible })
+    await heading.waitForDisplayed({ timeout: Timeouts.ELEMENT_VISIBLE })
     await MainContactUs.tap('BackButton')
     await Settings.waitFor('EditNickname')
   })
@@ -469,7 +469,7 @@ describe('Settings', () => {
     await tapResetAppConfirm()
     // `factoryReset()` tears down secure storage and navigation state;
     // the app lands back on the AccountSetup onboarding screen. Use the
-    // generous `appLaunch` timeout to absorb the reset work.
-    await AccountSetup.waitFor('AddAccount', Timeouts.appLaunch)
+    // generous `APP_LAUNCH` timeout to absorb the reset work.
+    await AccountSetup.waitFor('AddAccount', Timeouts.APP_LAUNCH)
   })
 })

--- a/e2e/test/bcsc/main/transferer-flow.spec.ts
+++ b/e2e/test/bcsc/main/transferer-flow.spec.ts
@@ -1,0 +1,56 @@
+import { Timeouts } from '../../../src/constants.js'
+import { BaseScreen } from '../../../src/screens/BaseScreen.js'
+import { BCSC_TestIDs } from '../../../src/testIDs.js'
+
+const TabBar = new BaseScreen(BCSC_TestIDs.TabBar)
+const Home = new BaseScreen(BCSC_TestIDs.Home)
+const Account = new BaseScreen(BCSC_TestIDs.Account)
+const TransferAccountQRInformation = new BaseScreen(BCSC_TestIDs.TransferAccountQRInformation)
+const WebView = new BaseScreen(BCSC_TestIDs.WebView)
+const TransferAccountQRDisplay = new BaseScreen(BCSC_TestIDs.TransferAccountQRDisplay)
+
+describe('Transfer Flow', () => {
+  it('should navigate through the Home tab and to the Account tab', async () => {
+    await TabBar.waitFor('Home')
+    await Home.waitFor('SettingsMenuButton')
+    await TabBar.tap('Account')
+  })
+
+  it('should navigate through the Account tab and click the transfer account button', async () => {
+    await Account.waitFor('TransferAccount')
+    await Account.tap('TransferAccount')
+  })
+
+  it('should navigate to the learn more screen and return', async () => {
+    await TransferAccountQRInformation.waitFor('LearnMoreButton')
+    await TransferAccountQRInformation.tap('LearnMoreButton')
+    await driver.pause(Timeouts.BROWSER_HANDOFF_PAUSE_MS)
+    await WebView.waitFor('Back')
+    await WebView.tap('Back')
+  })
+
+  it('should navigate to the QR code screen', async () => {
+    await TransferAccountQRInformation.waitFor('GetQRCodeButton')
+    await TransferAccountQRInformation.tap('GetQRCodeButton')
+  })
+
+  it('should display the QR code and click the new QR code button', async () => {
+    await TransferAccountQRDisplay.waitFor('GetNewQRCode')
+    await TransferAccountQRDisplay.tap('GetNewQRCode')
+
+    await TransferAccountQRDisplay.waitFor('GetNewQRCode')
+    await TransferAccountQRDisplay.tap('GetNewQRCode')
+  })
+
+  it('should navigate back to the home screen', async () => {
+    await TransferAccountQRDisplay.waitFor('Back')
+    await TransferAccountQRDisplay.tap('Back')
+
+    await TransferAccountQRInformation.waitFor('Back')
+    await TransferAccountQRInformation.tap('Back')
+
+    await TabBar.waitFor('Home')
+    await TabBar.tap('Home')
+    await Home.waitFor('LogInFromComputer')
+  })
+})

--- a/e2e/test/bcsc/migration/v3-onboarding.spec.ts
+++ b/e2e/test/bcsc/migration/v3-onboarding.spec.ts
@@ -102,8 +102,8 @@ describe('V3 Add Card', () => {
   it('should tap the Add Card / Setup button', async () => {
     await annotate('Migration: V3 onboarding')
     const addCard = await V3.Initial.addCard()
-    await addCard.waitForDisplayed({ timeout: Timeouts.screenTransition })
-    await addCard.waitForEnabled({ timeout: Timeouts.screenTransition })
+    await addCard.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+    await addCard.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     console.log('tapping add card...')
     await addCard.click()
     console.log('tapped add card...')
@@ -128,9 +128,9 @@ describe('V3 Add Card', () => {
   // this is the one that it gets stuck on
   it('should advance past the "New setup" intro page', async () => {
     const continueBtn = await V3.NewSetup.continue()
-    await continueBtn.waitForDisplayed({ timeout: Timeouts.screenTransition })
+    await continueBtn.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     console.log('tapping continue on New setup intro page...')
-    await continueBtn.waitForEnabled({ timeout: Timeouts.screenTransition })
+    await continueBtn.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await continueBtn.click()
     console.log('tapped continue on New setup intro page...')
   })
@@ -138,8 +138,8 @@ describe('V3 Add Card', () => {
   it('should enable notifications', async () => {
     if (driver.isIOS) {
       const enableBtn = await V3.Notifications.continue()
-      await enableBtn.waitForDisplayed({ timeout: Timeouts.screenTransition })
-      await enableBtn.waitForEnabled({ timeout: Timeouts.screenTransition })
+      await enableBtn.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+      await enableBtn.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
       await enableBtn.click()
     } else {
       // Android doesn't show a notifications screen
@@ -148,29 +148,29 @@ describe('V3 Add Card', () => {
 
   it('should tap Step 1', async () => {
     const step1 = await V3.SetupSteps.step1()
-    await step1.waitForDisplayed({ timeout: Timeouts.screenTransition })
-    await step1.waitForEnabled({ timeout: Timeouts.screenTransition })
+    await step1.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+    await step1.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await step1.click()
   })
 
   it('should accept the privacy policy', async () => {
     const continueBtn = await V3.Privacy.continue()
-    await continueBtn.waitForDisplayed({ timeout: Timeouts.screenTransition })
-    await continueBtn.waitForEnabled({ timeout: Timeouts.screenTransition })
+    await continueBtn.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+    await continueBtn.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await continueBtn.click()
   })
 
   it('should accept terms of use', async () => {
     const acceptBtn = await V3.Terms.acceptAndContinue()
-    await acceptBtn.waitForDisplayed({ timeout: Timeouts.screenTransition })
-    await acceptBtn.waitForEnabled({ timeout: Timeouts.screenTransition })
+    await acceptBtn.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+    await acceptBtn.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await acceptBtn.click()
   })
 
   it('should enter an account nickname', async () => {
     if (driver.isAndroid) {
       const nicknameInput = await V3.Nickname.nicknameInput()
-      await nicknameInput.waitForDisplayed({ timeout: Timeouts.screenTransition })
+      await nicknameInput.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
       await nicknameInput.click()
       await nicknameInput.setValue(testUser.username)
 
@@ -180,7 +180,7 @@ describe('V3 Add Card', () => {
       await saveBtn.click()
     } else {
       const nicknameField = await $('-ios class chain:**/XCUIElementTypeTextField')
-      await nicknameField.waitForDisplayed({ timeout: Timeouts.screenTransition })
+      await nicknameField.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
       await nicknameField.click()
       await nicknameField.setValue(testUser.username)
 
@@ -195,8 +195,8 @@ describe('V3 Add Card', () => {
 
   it('should tap Choose a PIN', async () => {
     const choosePinBtn = await V3.PINPrep.choosePIN()
-    await choosePinBtn.waitForDisplayed({ timeout: Timeouts.screenTransition })
-    await choosePinBtn.waitForEnabled({ timeout: Timeouts.screenTransition })
+    await choosePinBtn.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+    await choosePinBtn.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await choosePinBtn.click()
   })
 
@@ -205,7 +205,7 @@ describe('V3 Add Card', () => {
 
     if (driver.isAndroid) {
       const choosePinInput = await V3.PINInput.choosePIN()
-      await choosePinInput.waitForDisplayed({ timeout: Timeouts.screenTransition })
+      await choosePinInput.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
       await choosePinInput.click()
       await choosePinInput.setValue(pin)
 
@@ -220,55 +220,55 @@ describe('V3 Add Card', () => {
       await saveBtn.click()
     } else {
       const choosePinField = await V3.PINInput.choosePIN()
-      await choosePinField.waitForDisplayed({ timeout: Timeouts.screenTransition })
-      await choosePinField.waitForEnabled({ timeout: Timeouts.screenTransition })
+      await choosePinField.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+      await choosePinField.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
       await choosePinField.click()
       for (const char of pin) {
         await choosePinField.addValue(char)
       }
 
       const confirmPinField = await V3.PINInput.confirmPIN()
-      await confirmPinField.waitForEnabled({ timeout: Timeouts.screenTransition })
+      await confirmPinField.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
       await confirmPinField.click()
       for (const char of pin) {
         await confirmPinField.addValue(char)
       }
 
       const checkbox = await V3.PINInput.understandCheckbox()
-      await checkbox.waitForDisplayed({ timeout: Timeouts.screenTransition })
-      await checkbox.waitForEnabled({ timeout: Timeouts.screenTransition })
+      await checkbox.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+      await checkbox.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
       await checkbox.click()
 
       const saveBtn = await V3.PINInput.saveAndContinue()
-      await saveBtn.waitForEnabled({ timeout: Timeouts.screenTransition })
+      await saveBtn.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
       await saveBtn.click()
     }
   })
 
   it('should tap Step 2', async () => {
     const step2 = await V3.SetupSteps.step2()
-    await step2.waitForEnabled({ timeout: Timeouts.screenTransition })
+    await step2.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await step2.click()
   })
 
   it('should select the combined card type', async () => {
     const combined = await V3.CardTypeSelection.combinedCard()
-    await combined.waitForDisplayed({ timeout: Timeouts.screenTransition })
-    await combined.waitForEnabled({ timeout: Timeouts.screenTransition })
+    await combined.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+    await combined.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await combined.click()
   })
 
   it('should choose Enter Manually', async () => {
     const enterManually = await V3.AddCardInstructions.enterManually()
-    await enterManually.waitForDisplayed({ timeout: Timeouts.screenTransition })
-    await enterManually.waitForEnabled({ timeout: Timeouts.screenTransition })
+    await enterManually.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+    await enterManually.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await enterManually.click()
   })
 
   it('should enter the card serial number', async () => {
     const serialInput = await V3.ManualEntry.serialInput()
-    await serialInput.waitForDisplayed({ timeout: Timeouts.screenTransition })
-    await serialInput.waitForEnabled({ timeout: Timeouts.screenTransition })
+    await serialInput.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+    await serialInput.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await serialInput.click()
     await serialInput.setValue(testUser.cardSerial)
 
@@ -284,8 +284,8 @@ describe('V3 Add Card', () => {
     if (driver.isAndroid) {
       // Android: tap the date field to open the spinner date picker dialog
       const dateField = await V3.Birthdate.birthdateInput()
-      await dateField.waitForDisplayed({ timeout: Timeouts.screenTransition })
-      await dateField.waitForEnabled({ timeout: Timeouts.screenTransition })
+      await dateField.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+      await dateField.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
       await dateField.click()
 
       // Wait for the date picker dialog's NumberPickers to appear
@@ -314,7 +314,7 @@ describe('V3 Add Card', () => {
       await validateBtn.click()
     } else {
       const monthWheel = await V3.Birthdate.monthWheel()
-      await monthWheel.waitForDisplayed({ timeout: Timeouts.screenTransition })
+      await monthWheel.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
       await monthWheel.addValue(dob.monthFull)
 
       const dateWheel = await V3.Birthdate.dateWheel()
@@ -332,20 +332,20 @@ describe('V3 Add Card', () => {
 
   it('should tap step 5', async () => {
     const step5 = await V3.SetupSteps.step5()
-    await step5.waitForDisplayed({ timeout: Timeouts.screenTransition })
-    await step5.waitForEnabled({ timeout: Timeouts.screenTransition })
+    await step5.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+    await step5.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await step5.click()
   })
 
   it('should select in-person verification', async () => {
     if (driver.isAndroid) {
       const inPersonOption = await $('android=new UiSelector().textContains("In Person")')
-      await inPersonOption.waitForDisplayed({ timeout: Timeouts.screenTransition })
+      await inPersonOption.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
       await inPersonOption.click()
     } else {
       const verifyInPerson = await V3.VerifyOptions.verifyInPerson()
-      await verifyInPerson.waitForDisplayed({ timeout: Timeouts.screenTransition })
-      await verifyInPerson.waitForEnabled({ timeout: Timeouts.screenTransition })
+      await verifyInPerson.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+      await verifyInPerson.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
       await verifyInPerson.click()
     }
   })
@@ -355,11 +355,11 @@ describe('V3 Add Card', () => {
 
     if (driver.isAndroid) {
       const codeEl = await V3.VerifyInPerson.confirmationCode()
-      await codeEl.waitForDisplayed({ timeout: Timeouts.screenTransition })
+      await codeEl.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
       confirmationCode = await codeEl.getText()
     } else {
       const codeEl = await $('-ios predicate string:label MATCHES "^[A-Z0-9]{4}-[A-Z0-9]{4}$"')
-      await codeEl.waitForDisplayed({ timeout: Timeouts.screenTransition })
+      await codeEl.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
       confirmationCode = await codeEl.getText()
     }
 
@@ -369,17 +369,17 @@ describe('V3 Add Card', () => {
 
   it('should tap complete button once the verification is approved and tap Ok on the "You\'re all set" screen', async () => {
     const completeBtn = await V3.VerifyInPerson.complete()
-    await completeBtn.waitForDisplayed({ timeout: Timeouts.screenTransition })
-    await completeBtn.waitForEnabled({ timeout: Timeouts.screenTransition })
+    await completeBtn.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+    await completeBtn.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await completeBtn.click()
 
     const okBtn = await V3.AllSet.ok()
-    await okBtn.waitForDisplayed({ timeout: Timeouts.screenTransition })
-    await okBtn.waitForEnabled({ timeout: Timeouts.screenTransition })
+    await okBtn.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+    await okBtn.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await okBtn.click()
 
     const homeBtn = await V3.Home.whereToUse()
-    await homeBtn.waitForDisplayed({ timeout: Timeouts.screenTransition })
+    await homeBtn.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     await annotate('Migration: V3 onboarding + verification complete')
   })
 })

--- a/e2e/test/bcsc/migration/v4-unlock.spec.ts
+++ b/e2e/test/bcsc/migration/v4-unlock.spec.ts
@@ -38,7 +38,7 @@ describe('V4 Unlock After Migration', () => {
   })
 
   it('should land on the Home screen', async () => {
-    await Home.waitFor('SettingsMenuButton', Timeouts.screenTransition)
+    await Home.waitFor('SettingsMenuButton', Timeouts.SCREEN_TRANSITION)
     await TabBar.waitFor('Home')
     await annotate('Migration: SUCCESS — v4 unlocked with v3 PIN')
     console.log('[migration] v4 app unlocked successfully with v3 PIN')

--- a/e2e/test/bcsc/onboarding/components/app-launch.spec.ts
+++ b/e2e/test/bcsc/onboarding/components/app-launch.spec.ts
@@ -8,6 +8,6 @@ const AccountSetup = new BaseScreen(BCSC_TestIDs.AccountSetup)
 describe('App Launch', () => {
   it('should display the Account Setup screen', async () => {
     await acceptSystemAlert()
-    await AccountSetup.waitFor('AddAccount', Timeouts.appLaunch)
+    await AccountSetup.waitFor('AddAccount', Timeouts.APP_LAUNCH)
   })
 })

--- a/e2e/test/bcsc/onboarding/onboarding-interaction-sweep.spec.ts
+++ b/e2e/test/bcsc/onboarding/onboarding-interaction-sweep.spec.ts
@@ -1,10 +1,14 @@
 /**
  * Onboarding Interaction Sweep: runs the full onboarding flow and exercises
- * every secondary interaction the happy-path suite skips — account-transfer
- * detour, setup-type radio options, carousel back + external "Where to use"
- * link, privacy-policy learn-more detour, analytics decline, notifications
- * help detour + permission denial, secure-app learn-more detour, and
- * create-PIN visibility toggles. Ends at SetupSteps (verify phase ready).
+ * every secondary interaction the happy-path suite skips — setup-type radio
+ * options, carousel back + external "Where to use" link, privacy-policy
+ * learn-more detour + BC login service link handoff, analytics learn-more
+ * detour + decline, notifications help detour + open-settings handoff,
+ * secure-app learn-more detour, and create-PIN visibility toggles. Ends at
+ * SetupSteps (verify phase ready).
+ *
+ * The account-transfer detour and the notifications deny-permission path
+ * live in `transferee-flow.spec.ts`.
  *
  * Imported by `full-regression/interaction-sweep.spec.ts`.
  */

--- a/e2e/test/bcsc/onboarding/onboarding-interaction-sweep.spec.ts
+++ b/e2e/test/bcsc/onboarding/onboarding-interaction-sweep.spec.ts
@@ -31,7 +31,7 @@ const SetupSteps = new BaseScreen(BCSC_TestIDs.SetupSteps)
 
 describe('Add Account', () => {
   it('should tap Add Account', async () => {
-    await AccountSetup.waitFor('AddAccount', Timeouts.appLaunch)
+    await AccountSetup.waitFor('AddAccount', Timeouts.APP_LAUNCH)
     await AccountSetup.tap('AddAccount')
   })
 })
@@ -166,6 +166,6 @@ describe('PIN Authentication with Visibility Toggles', () => {
   })
 
   it('should land on Setup Steps after PIN creation', async () => {
-    await SetupSteps.waitFor('Step1', Timeouts.appLaunch)
+    await SetupSteps.waitFor('Step1', Timeouts.APP_LAUNCH)
   })
 })

--- a/e2e/test/bcsc/onboarding/onboarding-interaction-sweep.spec.ts
+++ b/e2e/test/bcsc/onboarding/onboarding-interaction-sweep.spec.ts
@@ -9,12 +9,9 @@
  * Imported by `full-regression/interaction-sweep.spec.ts`.
  */
 import { TEST_PIN, Timeouts } from '../../../src/constants.js'
-import { acceptSystemAlert, dismissSystemAlert } from '../../../src/helpers/alerts.js'
 import { getCurrentAppId } from '../../../src/helpers/deep-link.js'
 import { BaseScreen } from '../../../src/screens/BaseScreen.js'
 import { BCSC_TestIDs } from '../../../src/testIDs.js'
-
-const BROWSER_HANDOFF_PAUSE_MS = 2000
 
 const AccountSetup = new BaseScreen(BCSC_TestIDs.AccountSetup)
 const SetupTypes = new BaseScreen(BCSC_TestIDs.SetupTypes)
@@ -30,7 +27,6 @@ const SetupSteps = new BaseScreen(BCSC_TestIDs.SetupSteps)
 
 describe('Add Account', () => {
   it('should tap Add Account', async () => {
-    await acceptSystemAlert()
     await AccountSetup.waitFor('AddAccount', Timeouts.appLaunch)
     await AccountSetup.tap('AddAccount')
   })
@@ -56,7 +52,7 @@ describe('Intro Carousel Interactions', () => {
     await IntroCarousel.waitFor('CarouselNext')
     const appId = await getCurrentAppId()
     await IntroCarousel.tap('WhereToUseButton')
-    await driver.pause(BROWSER_HANDOFF_PAUSE_MS)
+    await driver.pause(Timeouts.BROWSER_HANDOFF_PAUSE_MS)
     await driver.activateApp(appId)
     await IntroCarousel.waitFor('CarouselNext')
   })
@@ -72,10 +68,18 @@ describe('Intro Carousel Interactions', () => {
 })
 
 describe('Privacy Policy Page', () => {
+  it('should open the BC login service in the browser then return and carry onwards', async () => {
+    await PrivacyPolicy.waitFor('Link')
+    const appId = await getCurrentAppId()
+    await PrivacyPolicy.tap('Link')
+    await driver.pause(Timeouts.BROWSER_HANDOFF_PAUSE_MS)
+    await driver.activateApp(appId)
+  })
+
   it('should open learn more web view then return and carry onwards', async () => {
     await PrivacyPolicy.waitFor('LearnMore')
     await PrivacyPolicy.tap('LearnMore')
-    await driver.pause(BROWSER_HANDOFF_PAUSE_MS)
+    await driver.pause(Timeouts.BROWSER_HANDOFF_PAUSE_MS)
     await WebView.waitFor('Back')
     await WebView.tap('Back')
     await PrivacyPolicy.waitFor('Continue')
@@ -84,6 +88,14 @@ describe('Privacy Policy Page', () => {
 })
 
 describe('Opt-In Analytics Decline', () => {
+  it('should open learn more web view then return and carry onwards', async () => {
+    await OptInAnalytics.waitFor('LearnMore')
+    await OptInAnalytics.tap('LearnMore')
+    await driver.pause(Timeouts.BROWSER_HANDOFF_PAUSE_MS)
+    await WebView.waitFor('Back')
+    await WebView.tap('Back')
+  })
+
   it('should decline analytics opt-in', async () => {
     await OptInAnalytics.waitFor('Decline')
     await OptInAnalytics.tap('Decline')
@@ -101,21 +113,20 @@ describe('Notifications Interactions', () => {
   it('should tap Help and return from the WebView', async () => {
     await Notifications.waitFor('Help')
     await Notifications.tap('Help')
-    await driver.pause(BROWSER_HANDOFF_PAUSE_MS)
+    await driver.pause(Timeouts.BROWSER_HANDOFF_PAUSE_MS)
     await WebView.waitFor('Back')
     await WebView.tap('Back')
   })
 
-  it('should click Continue then deny native permissions', async () => {
-    await Notifications.waitFor('Continue')
-    await Notifications.tap('Continue')
-    await dismissSystemAlert()
+  it('should open the settings and navigate back', async () => {
+    await Notifications.waitFor('OpenSettings')
+    const appId = await getCurrentAppId()
+    await Notifications.tap('OpenSettings')
+    await driver.pause(Timeouts.BROWSER_HANDOFF_PAUSE_MS)
+    await driver.activateApp(appId)
   })
 
-  it('should navigate back to the previous screen then continue without notifications', async () => {
-    await SecureApp.waitFor('Back')
-    await SecureApp.tap('Back')
-
+  it('should continue without notifications', async () => {
     await Notifications.waitFor('ContinueWithoutNotifications')
     await Notifications.tap('ContinueWithoutNotifications')
   })
@@ -125,17 +136,18 @@ describe('Secure App Learn More Detour', () => {
   it('should tap Learn More and return from the WebView', async () => {
     await SecureApp.waitFor('LearnMore')
     await SecureApp.tap('LearnMore')
+    await driver.pause(Timeouts.BROWSER_HANDOFF_PAUSE_MS)
     await WebView.waitFor('Back')
     await WebView.tap('Back')
   })
-})
 
-describe('PIN Authentication with Visibility Toggles', () => {
   it('should select PIN auth on the Secure App screen', async () => {
     await SecureApp.waitFor('PinAuth')
     await SecureApp.tap('PinAuth')
   })
+})
 
+describe('PIN Authentication with Visibility Toggles', () => {
   it('should toggle PIN visibility on both inputs and create a PIN', async () => {
     await CreatePIN.waitFor('PINInput1')
     // Toggle each input on then off so both masked and visible states render.

--- a/e2e/test/bcsc/onboarding/transferee-flow.spec.ts
+++ b/e2e/test/bcsc/onboarding/transferee-flow.spec.ts
@@ -75,5 +75,6 @@ describe('Transfer Account Detour', () => {
     await Settings.tap('RemoveAccount')
 
     await tapResetAppConfirm()
+    await AccountSetup.waitFor('TransferAccount')
   })
 })

--- a/e2e/test/bcsc/onboarding/transferee-flow.spec.ts
+++ b/e2e/test/bcsc/onboarding/transferee-flow.spec.ts
@@ -1,5 +1,5 @@
 import { TEST_PIN } from '../../../src/constants.js'
-import { acceptSystemAlert, tapResetAppConfirm } from '../../../src/helpers/alerts.js'
+import { acceptSystemAlert, dismissSystemAlert, tapResetAppConfirm } from '../../../src/helpers/alerts.js'
 import { BaseScreen } from '../../../src/screens/BaseScreen.js'
 import { BCSC_TestIDs } from '../../../src/testIDs.js'
 
@@ -29,9 +29,11 @@ describe('Transfer Account Detour', () => {
     await TermsOfUse.waitFor('AcceptAndContinue')
     await TermsOfUse.tapWhenEnabled('AcceptAndContinue')
 
+    // Dismissing notifications permission to exercise that codepath
     await Notifications.waitFor('Continue')
     await Notifications.tap('Continue')
-    await acceptSystemAlert()
+    await dismissSystemAlert()
+
     await SecureApp.waitFor('PinAuth')
     await SecureApp.tap('PinAuth')
     await CreatePIN.waitFor('PINInput1')

--- a/e2e/test/bcsc/onboarding/transferee-flow.spec.ts
+++ b/e2e/test/bcsc/onboarding/transferee-flow.spec.ts
@@ -1,4 +1,4 @@
-import { TEST_PIN } from '../../../src/constants.js'
+import { TEST_PIN, Timeouts } from '../../../src/constants.js'
 import { acceptSystemAlert, dismissSystemAlert, tapResetAppConfirm } from '../../../src/helpers/alerts.js'
 import { BaseScreen } from '../../../src/screens/BaseScreen.js'
 import { BCSC_TestIDs } from '../../../src/testIDs.js'
@@ -18,8 +18,12 @@ const CreatePIN = new BaseScreen(BCSC_TestIDs.CreatePIN)
 const SetupSteps = new BaseScreen(BCSC_TestIDs.SetupSteps)
 
 describe('Transfer Account Detour', () => {
-  it('should detour through Transfer Account all the way to Setup Steps', async () => {
+  it('should tap Transfer Account', async () => {
+    await AccountSetup.waitFor('TransferAccount', Timeouts.APP_LAUNCH)
     await AccountSetup.tap('TransferAccount')
+  })
+
+  it('should detour through Transfer Account all the way to Setup Steps', async () => {
     await TransferInformation.waitFor('TransferAccountButton')
     await TransferInformation.tap('TransferAccountButton')
     await PrivacyPolicy.waitFor('Continue')

--- a/e2e/test/bcsc/verify/card-scan.spec.ts
+++ b/e2e/test/bcsc/verify/card-scan.spec.ts
@@ -45,7 +45,7 @@ describe(`BCSC ${getVerifyContext().cardTypeLabel} Card Scan`, () => {
   // fall back to manual CSN entry so the rest of the flow can still be verified.
   // TODO: replace with a scan hotwire once that ticket lands.
   it('should wait for the barcode scan to complete or fall back to manual entry', async function () {
-    await ScanSerial.waitFor('EnterManually', Timeouts.screenTransition)
+    await ScanSerial.waitFor('EnterManually', Timeouts.SCREEN_TRANSITION)
 
     const maxAttempts = 3
     let scanSucceeded = false


### PR DESCRIPTION
# Summary of Changes

Adds e2e coverage for the transfer account flows (ticket #3g) and broadens the onboarding interaction sweep.

**Transfer account e2e**

- New `main/transferer-flow.spec.ts`: Account → QR Information (Learn More detour) → QR Display → Get New QR Code → back out to Home. Requires verified state; not yet wired into a full-regression composer (stub import left commented in
  `interaction-sweep.spec.ts` pending a verified-state harness).
- `onboarding/transferee-flow.spec.ts`: now dismisses the notifications permission instead of accepting (exercises the deny codepath) and asserts return to `AccountSetup` after the final reset.
- Wired `transferee-flow.spec.ts` into `full-regression/interaction-sweep.spec.ts`.  


**Onboarding interaction sweep additions**

- Privacy Policy: browser handoff via the "Link" button.
- Opt-In Analytics: Learn More detour (requires new `LearnMore` testID on `OnboardingOptInAnalyticsContent`).
- Notifications: replaced the deny-permission path with an Open Settings → app handoff path (the deny path now lives in the transferee flow).
- Moved SecureApp `PinAuth` tap into the SecureApp describe block for locality.  


**Test IDs**

- `OptInAnalytics.LearnMore`, `TransferAccountQRInformation.Back`, `TransferAccountQRDisplay.Back`.

**Constants**

- `Timeouts` converted from `as const` object to `enum`; added `BROWSER_HANDOFF_PAUSE_MS` (replacing the inline constant in the onboarding sweep). Naming-convention cleanup lives on a follow-up branch.  


## Test plan

- [ ] `--suite full-regression` on iOS: transferee-flow runs as part of interaction-sweep and reaches the QR scanner
- [ ] Same on Android
- [ ] `transferer-flow.spec.ts` run manually from a verified Home state on both platforms
- [ ] `yarn test` — OptInAnalytics test + snapshot updates green
