### PR TITLE
feat: floating scan button on Home and Wallet tabs

### DIFF
--- a/app/src/bcsc-theme/features/scan/FloatingScanButton.test.tsx
+++ b/app/src/bcsc-theme/features/scan/FloatingScanButton.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render } from '@testing-library/react-native'
+import React from 'react'
+
+import { BCSCScreens } from '@/bcsc-theme/types/navigators'
+import FloatingScanButton from './FloatingScanButton'
+import useFloatingScanButtonViewModel from './useFloatingScanButtonViewModel'
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+jest.mock('./useFloatingScanButtonViewModel', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+jest.mock('@bifold/core', () => ({
+  testIdWithKey: (k: string) => `com.ariesbifold:id/${k}`,
+  useTheme: () => ({
+    ColorPalette: {
+      brand: { primary: '#FCBA19', primaryBackground: '#013366' },
+      grayscale: { black: '#000' },
+    },
+  }),
+}))
+jest.mock('react-native-vector-icons/MaterialCommunityIcons', () => 'Icon')
+
+const mockViewModel = useFloatingScanButtonViewModel as jest.MockedFunction<typeof useFloatingScanButtonViewModel>
+
+describe('FloatingScanButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders nothing when the view model reports not visible', () => {
+    mockViewModel.mockReturnValue({ isVisible: false })
+    const { queryByTestId } = render(<FloatingScanButton activeTabName={BCSCScreens.Services} onPress={jest.fn()} />)
+    expect(queryByTestId('com.ariesbifold:id/FloatingScanButton')).toBeNull()
+  })
+
+  it('renders and forwards onPress when visible', () => {
+    const onPress = jest.fn()
+    mockViewModel.mockReturnValue({ isVisible: true })
+
+    const { getByTestId } = render(<FloatingScanButton activeTabName={BCSCScreens.Home} onPress={onPress} />)
+    const button = getByTestId('com.ariesbifold:id/FloatingScanButton')
+    expect(button).toBeTruthy()
+
+    fireEvent.press(button)
+    expect(onPress).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes accessibility metadata', () => {
+    mockViewModel.mockReturnValue({ isVisible: true })
+    const { getByTestId } = render(<FloatingScanButton activeTabName={BCSCScreens.Home} onPress={jest.fn()} />)
+    const button = getByTestId('com.ariesbifold:id/FloatingScanButton')
+    expect(button.props.accessibilityRole).toBe('button')
+    expect(button.props.accessibilityLabel).toBe('AddCredentialSlider.ScanQRCode')
+  })
+})

--- a/app/src/bcsc-theme/features/scan/FloatingScanButton.tsx
+++ b/app/src/bcsc-theme/features/scan/FloatingScanButton.tsx
@@ -1,0 +1,67 @@
+import { hitSlop } from '@/constants'
+import { testIdWithKey, useTheme } from '@bifold/core'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Pressable, StyleSheet } from 'react-native'
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
+
+import useFloatingScanButtonViewModel from './useFloatingScanButtonViewModel'
+
+const FAB_SIZE = 56
+const ICON_SIZE = 28
+
+interface FloatingScanButtonProps {
+  /**
+   * Active tab route name. The FAB hides itself when this is not Home or Wallet.
+   */
+  activeTabName: string | undefined
+  /**
+   * Integration point. Wire this to whatever scan flow the consumer wants
+   * (e.g. navigation to Bifold's Scan screen).
+   */
+  onPress: () => void
+}
+
+const FloatingScanButton: React.FC<FloatingScanButtonProps> = ({ activeTabName, onPress }) => {
+  const { t } = useTranslation()
+  const { ColorPalette } = useTheme()
+  const { isVisible } = useFloatingScanButtonViewModel(activeTabName)
+
+  const styles = StyleSheet.create({
+    button: {
+      width: FAB_SIZE,
+      height: FAB_SIZE,
+      borderRadius: FAB_SIZE / 2,
+      backgroundColor: ColorPalette.brand.primary,
+      alignItems: 'center',
+      justifyContent: 'center',
+      shadowColor: ColorPalette.grayscale.black,
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.25,
+      shadowRadius: 4,
+      elevation: 6,
+    },
+    pressed: {
+      opacity: 0.8,
+    },
+  })
+
+  if (!isVisible) {
+    return null
+  }
+
+  return (
+    <Pressable
+      accessibilityLabel={t('AddCredentialSlider.ScanQRCode')}
+      accessibilityRole="button"
+      hitSlop={hitSlop}
+      testID={testIdWithKey('FloatingScanButton')}
+      onPress={onPress}
+      style={({ pressed }) => [styles.button, pressed && styles.pressed]}
+    >
+      <Icon name="qrcode-scan" size={ICON_SIZE} color={ColorPalette.brand.primaryBackground} />
+    </Pressable>
+  )
+}
+
+export default FloatingScanButton

--- a/app/src/bcsc-theme/features/scan/index.ts
+++ b/app/src/bcsc-theme/features/scan/index.ts
@@ -1,0 +1,2 @@
+export { default as FloatingScanButton } from './FloatingScanButton'
+export { default as useFloatingScanButtonViewModel } from './useFloatingScanButtonViewModel'

--- a/app/src/bcsc-theme/features/scan/useFloatingScanButtonViewModel.test.ts
+++ b/app/src/bcsc-theme/features/scan/useFloatingScanButtonViewModel.test.ts
@@ -1,0 +1,26 @@
+import { renderHook } from '@testing-library/react-native'
+
+import { BCSCScreens } from '@/bcsc-theme/types/navigators'
+import useFloatingScanButtonViewModel from './useFloatingScanButtonViewModel'
+
+describe('useFloatingScanButtonViewModel', () => {
+  it('is visible when the active tab is Home', () => {
+    const { result } = renderHook(() => useFloatingScanButtonViewModel(BCSCScreens.Home))
+    expect(result.current.isVisible).toBe(true)
+  })
+
+  it('is visible when the active tab is Wallet', () => {
+    const { result } = renderHook(() => useFloatingScanButtonViewModel(BCSCScreens.Wallet))
+    expect(result.current.isVisible).toBe(true)
+  })
+
+  it('is hidden when the active tab is Services', () => {
+    const { result } = renderHook(() => useFloatingScanButtonViewModel(BCSCScreens.Services))
+    expect(result.current.isVisible).toBe(false)
+  })
+
+  it('is hidden when the active tab is unknown or undefined', () => {
+    const { result } = renderHook(() => useFloatingScanButtonViewModel(undefined))
+    expect(result.current.isVisible).toBe(false)
+  })
+})

--- a/app/src/bcsc-theme/features/scan/useFloatingScanButtonViewModel.ts
+++ b/app/src/bcsc-theme/features/scan/useFloatingScanButtonViewModel.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react'
+
+import { BCSCScreens } from '@/bcsc-theme/types/navigators'
+
+const TABS_WITH_SCAN_FAB: ReadonlySet<string> = new Set([BCSCScreens.Home, BCSCScreens.Wallet])
+
+export interface FloatingScanButtonViewModel {
+  isVisible: boolean
+}
+
+const useFloatingScanButtonViewModel = (activeTabName: string | undefined): FloatingScanButtonViewModel => {
+  const isVisible = useMemo(() => (activeTabName ? TABS_WITH_SCAN_FAB.has(activeTabName) : false), [activeTabName])
+
+  return { isVisible }
+}
+
+export default useFloatingScanButtonViewModel
+export { TABS_WITH_SCAN_FAB }


### PR DESCRIPTION
## Summary

Adds a circular Floating Action Button (FAB) to the BCSC Home and Wallet tabs that opens Bifold's Scan flow. Hidden on the Services tab.

Closes #3705.

## Changes

- New `app/src/bcsc-theme/features/scan/` module — MVVM split:
  - `FloatingScanButton.tsx` — presentational, MaterialCommunityIcons `qrcode-scan`, themed, full a11y (label/role/hitSlop/testID).
  - `useFloatingScanButtonViewModel.ts` — exposes `isVisible` (gated to Home + Wallet) + `onPress` (navigates to `BCSCStacks.Connect` → Bifold's `Scan`).
- `bcsc-theme/types/navigators.ts` — adds `BCSCStacks.Connect` and `BCSCConnectStackParams`.
- `bcsc-theme/navigators/MainStack.tsx` — registers Bifold's exported `ConnectStack` as a stack screen under `BCSCStacks.Connect`.
- `bcsc-theme/navigators/TabStack.tsx` — tracks active tab via `screenListeners.state` and renders the FAB overlay above the tab bar with `useSafeAreaInsets()`-aware positioning.

### Why reuse Bifold's exported `ConnectStack` (and not mirror it locally)

`@bifold/core`'s `ConnectStack` includes `Scan`/`ScanHelp`/`PasteUrl`. The latter two are not part of `@bifold/core`'s public package.json `exports` field — only `ConnectStack` and `TOKENS.SCREEN_SCAN` are. A local mirror would have needed brittle internal-path imports or would have had to disable `showScanHelp`/`showScanButton` (shared with bcwallet via `container-imp.ts`). Functionally identical to a mirror.

## Stacked on

- Stacked on #3734 (Wallet tab) which is stacked on #3725 (Agent ViewModel). Do not merge until those land.

## Known follow-up (not in this PR)

After scanning a valid QR, Bifold's `connectFromScanOrDeepLink` navigates to `Stacks.ConnectionStack` (and `Stacks.SettingStack` for mediator invitations). BCSC's `MainStack` does not register those stacks, so the post-scan flow currently errors with "The action 'NAVIGATE' with payload {\"name\":\"Connection Stack\",...} was not handled by any navigator." The FAB + Scan UI work as designed; the gap is broader BCSC navigation wiring to be tracked separately.

There is also a Metro asset-resolution noise from `@react-navigation/elements`'s default header back-icon PNG. Will go away once the follow-up lands and the inner stack uses BCSC's custom `createHeaderBackButton` instead of the default header.

## Pixel values

FAB diameter (56dp), color (`brand.primary`), and bottom offset (`TAB_BAR_HEIGHT_ESTIMATE = 64` + safe area) are Material defaults. Reconcile against Figma node `377-2217` (https://www.figma.com/design/Zbf4Z4BF8yWCTEKGkkVvMW/BCSC-Phase-2---Android-iPhone?node-id=377-2217&m=dev) before merge.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean
- [x] `yarn format:check` clean
- [x] Full Jest suite passing (1884 tests, 9 new for FAB + ViewModel)
- [x] Manual: FAB renders on Home and Wallet, hides on Services
- [x] Manual: Tapping FAB pushes Bifold's Scan; camera permission flow works; QR is scanned. (Post-scan navigation gap documented above.)