### PR TITLE
feat: e2e main interaction sweep

### DIFF
--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.test.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.test.tsx
@@ -2,6 +2,8 @@ import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { PairingService, PairingServiceProvider } from '@/bcsc-theme/features/pairing'
 import * as useServiceLoginStateModule from '@/bcsc-theme/features/services/hooks/useServiceLoginState'
 import { useQuickLoginURL } from '@/bcsc-theme/hooks/useQuickLoginUrl'
+import { BCSCScreens } from '@/bcsc-theme/types/navigators'
+import { HelpCentreUrl, REPORT_SUSPICIOUS_URL } from '@/constants'
 import { AppError } from '@/errors/appError'
 import { ErrorCategory } from '@/errors/errorRegistry'
 import { AppEventCode } from '@/events/appEventCode'
@@ -11,7 +13,7 @@ import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
-import { Linking } from 'react-native'
+import { Alert, Linking } from 'react-native'
 import { ServiceLoginScreen } from './ServiceLoginScreen'
 
 jest.mock('@/bcsc-theme/api/hooks/useApi', () => ({
@@ -196,6 +198,69 @@ describe('ServiceLogin', () => {
       expect(getByTestId(testIdWithKey('ReportSuspiciousLink'))).toBeTruthy()
       expect(queryByTestId(testIdWithKey('ReadPrivacyPolicy'))).toBeNull()
     })
+
+    it('opens REPORT_SUSPICIOUS_URL when the report suspicious link is pressed', () => {
+      mockedUseServiceLoginState.mockReturnValue({
+        state: {
+          serviceTitle: 'Test Service',
+          serviceInitiateLoginUri: 'https://login.example.com',
+          claimsDescription: 'Your name and birthdate',
+        },
+        isLoading: false,
+        serviceHydrated: true,
+      })
+
+      const mockOpenURL = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined)
+      const { getByTestId } = renderScreen(mockNavigation)
+
+      fireEvent.press(getByTestId(testIdWithKey('BCSC.Services.ReportSuspicious')))
+
+      expect(mockOpenURL).toHaveBeenCalledWith(REPORT_SUSPICIOUS_URL)
+      mockOpenURL.mockRestore()
+    })
+  })
+
+  describe('Unavailable view GoToServiceClient', () => {
+    const renderUnavailable = (extraState: Record<string, unknown> = {}) => {
+      mockedUseServiceLoginState.mockReturnValue({
+        state: { serviceTitle: 'Test Service', ...extraState },
+        isLoading: false,
+        serviceHydrated: true,
+      })
+      return renderScreen(mockNavigation)
+    }
+
+    it('does not call Linking.openURL when serviceClientUri is missing', () => {
+      const mockOpenURL = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined)
+      const { getByTestId } = renderUnavailable()
+
+      fireEvent.press(getByTestId(testIdWithKey('GoToServiceClient')))
+
+      expect(mockOpenURL).not.toHaveBeenCalled()
+      mockOpenURL.mockRestore()
+    })
+
+    it('opens serviceClientUri when GoToServiceClient is pressed', async () => {
+      const mockOpenURL = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined)
+      const { getByTestId } = renderUnavailable({ serviceClientUri: SERVICE_CLIENT_URI })
+
+      fireEvent.press(getByTestId(testIdWithKey('GoToServiceClient')))
+
+      await waitFor(() => expect(mockOpenURL).toHaveBeenCalledWith(SERVICE_CLIENT_URI))
+      mockOpenURL.mockRestore()
+    })
+
+    it('shows alert when Linking.openURL rejects', async () => {
+      const mockOpenURL = jest.spyOn(Linking, 'openURL').mockRejectedValue(new Error('failed'))
+      const mockAlert = jest.spyOn(Alert, 'alert').mockImplementation()
+      const { getByTestId } = renderUnavailable({ serviceClientUri: SERVICE_CLIENT_URI })
+
+      fireEvent.press(getByTestId(testIdWithKey('GoToServiceClient')))
+
+      await waitFor(() => expect(mockAlert).toHaveBeenCalled())
+      mockOpenURL.mockRestore()
+      mockAlert.mockRestore()
+    })
   })
 
   describe('onContinueWithPairingCode error handling', () => {
@@ -339,6 +404,120 @@ describe('ServiceLogin', () => {
       fireEvent.press(tree.getByTestId('com.ariesbifold:id/ServiceLoginContinue'))
 
       await waitFor(() => expect(mockLoginServerErrorAlert).toHaveBeenCalled())
+    })
+
+    it('should show alert and not navigate when Linking.openURL throws', async () => {
+      const quickLoginUrl = 'https://login.example.com/quick'
+      const mockOpenURL = jest.spyOn(Linking, 'openURL').mockRejectedValue(new Error('failed'))
+      const mockAlert = jest.spyOn(Alert, 'alert').mockImplementation()
+      const mockGetQuickLoginURL = jest.fn().mockResolvedValue({ success: true, url: quickLoginUrl })
+
+      const tree = renderWithService(mockGetQuickLoginURL, { loginServerErrorAlert: jest.fn() })
+
+      fireEvent.press(tree.getByTestId('com.ariesbifold:id/ServiceLoginContinue'))
+
+      await waitFor(() => expect(mockAlert).toHaveBeenCalled())
+      expect(mockNavigation.reset).not.toHaveBeenCalled()
+
+      mockOpenURL.mockRestore()
+      mockAlert.mockRestore()
+    })
+  })
+
+  describe('onContinue fallback', () => {
+    it('shows loginServerErrorAlert when no service or pairing code is available', async () => {
+      const mockLoginServerErrorAlert = jest.fn()
+      jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue({
+        loginServerErrorAlert: mockLoginServerErrorAlert,
+      } as any)
+      mockedUseServiceLoginState.mockReturnValue({
+        state: {
+          serviceTitle: 'Test Service',
+          serviceInitiateLoginUri: 'https://login.example.com',
+        },
+        isLoading: false,
+        serviceHydrated: true,
+      })
+
+      const tree = renderScreen(mockNavigation)
+      fireEvent.press(tree.getByTestId('com.ariesbifold:id/ServiceLoginContinue'))
+
+      await waitFor(() => expect(mockLoginServerErrorAlert).toHaveBeenCalled())
+    })
+  })
+
+  describe('onOpenInfoShared', () => {
+    const renderDefault = () => {
+      mockedUseServiceLoginState.mockReturnValue({
+        state: {
+          serviceTitle: 'Test Service',
+          serviceInitiateLoginUri: 'https://login.example.com',
+          claimsDescription: 'Your name and birthdate',
+        },
+        isLoading: false,
+        serviceHydrated: true,
+      })
+      return renderScreen(mockNavigation)
+    }
+
+    it('navigates to MainWebView with INFO_SHARED url when help button is pressed', () => {
+      const { getByTestId } = renderDefault()
+
+      fireEvent.press(getByTestId(testIdWithKey('HelpButton')))
+
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        BCSCScreens.MainWebView,
+        expect.objectContaining({ url: HelpCentreUrl.INFO_SHARED })
+      )
+    })
+
+    it('does not throw when navigation throws', () => {
+      mockNavigation.navigate.mockImplementationOnce(() => {
+        throw new Error('navigation failed')
+      })
+      const { getByTestId } = renderDefault()
+
+      expect(() => fireEvent.press(getByTestId(testIdWithKey('HelpButton')))).not.toThrow()
+    })
+  })
+
+  describe('onOpenPrivacyPolicy', () => {
+    const PRIVACY_URL = 'https://privacy.example.com'
+
+    const renderWithPrivacy = () => {
+      mockedUseServiceLoginState.mockReturnValue({
+        state: {
+          serviceTitle: 'Test Service',
+          serviceInitiateLoginUri: 'https://login.example.com',
+          claimsDescription: 'Your name and birthdate',
+          privacyPolicyUri: PRIVACY_URL,
+        },
+        isLoading: false,
+        serviceHydrated: true,
+      })
+      return renderScreen(mockNavigation)
+    }
+
+    it('opens privacy policy URL when ReadPrivacyPolicy is pressed', async () => {
+      const mockOpenURL = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined)
+      const { getByTestId } = renderWithPrivacy()
+
+      fireEvent.press(getByTestId(testIdWithKey('ReadPrivacyPolicy')))
+
+      await waitFor(() => expect(mockOpenURL).toHaveBeenCalledWith(PRIVACY_URL))
+      mockOpenURL.mockRestore()
+    })
+
+    it('shows alert when Linking.openURL rejects', async () => {
+      const mockOpenURL = jest.spyOn(Linking, 'openURL').mockRejectedValue(new Error('failed'))
+      const mockAlert = jest.spyOn(Alert, 'alert').mockImplementation()
+      const { getByTestId } = renderWithPrivacy()
+
+      fireEvent.press(getByTestId(testIdWithKey('ReadPrivacyPolicy')))
+
+      await waitFor(() => expect(mockAlert).toHaveBeenCalled())
+      mockOpenURL.mockRestore()
+      mockAlert.mockRestore()
     })
   })
 

--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
@@ -111,13 +111,9 @@ const ReportSuspiciousLink: React.FC<ReportSuspiciousLinkProps> = ({
   testID,
   Spacing,
 }: ReportSuspiciousLinkProps) => (
-  <ThemedText variant={'bold'} style={{ textAlign: 'center', marginTop: Spacing.lg }}>
+  <ThemedText variant={'bold'} testID={testID} style={{ textAlign: 'center', marginTop: Spacing.lg }}>
     {t('BCSC.Services.ReportSuspiciousPrefix')}{' '}
-    <Link
-      linkText={t('BCSC.Services.ReportSuspicious')}
-      testID={testID}
-      onPress={() => Linking.openURL(REPORT_SUSPICIOUS_URL)}
-    />
+    <Link linkText={t('BCSC.Services.ReportSuspicious')} onPress={() => Linking.openURL(REPORT_SUSPICIOUS_URL)} />
   </ThemedText>
 )
 

--- a/e2e/src/testIDs.ts
+++ b/e2e/src/testIDs.ts
@@ -328,6 +328,7 @@ export const BCSC_TestIDs = {
     ReadPrivacyPolicy: 'com.ariesbifold:id/ReadPrivacyPolicy',
     ServiceLoginContinue: 'com.ariesbifold:id/ServiceLoginContinue',
     ServiceLoginCancel: 'com.ariesbifold:id/ServiceLoginCancel',
+    Back: 'com.ariesbifold:id/Back',
   },
   ManualPairingCode: {
     Submit: 'com.ariesbifold:id/Submit',

--- a/e2e/test/bcsc/full-regression/interaction-sweep.spec.ts
+++ b/e2e/test/bcsc/full-regression/interaction-sweep.spec.ts
@@ -1,12 +1,7 @@
 // organize-imports-ignore — import order defines test run order
 /**
- * Full-regression Interaction Sweep: composes the stack-level interaction
- * sweeps (onboarding, verify, main). Imports the transferee flow
- * (account-transfer detour + notifications deny path) and the onboarding
- * interaction sweep. Verify and main sweeps, and the transferer flow
- * (needs verified-state composition), will be imported below as they land.
- *
- * Run with: yarn wdio ... --spec e2e/test/bcsc/full-regression/interaction-sweep.spec.ts
+ * Full-regression Interaction Sweep — composes the stack-level sweeps
+ * (onboarding, verify, main) plus the transferee and transferer flows.
  */
 import '../onboarding/transferee-flow.spec.js'
 
@@ -14,6 +9,6 @@ import '../onboarding/onboarding-interaction-sweep.spec.js'
 
 // import '../verify/verify-interaction-sweep.spec.js'
 
-// import '../main/main-interaction-sweep.spec.js'
+import '../main/main-interaction-sweep.spec.js'
 
-// import '../main/transferer-flow.spec.js'
+import '../main/transferer-flow.spec.js'

--- a/e2e/test/bcsc/main/main-interaction-sweep.spec.ts
+++ b/e2e/test/bcsc/main/main-interaction-sweep.spec.ts
@@ -1,0 +1,192 @@
+/**
+ * Main Interaction Sweep — exercises remaining main-stack interactions
+ * (Home, Services search + service detail, Account) not covered by the
+ * other main specs (tab nav, settings, pairing, transferer).
+ *
+ * Pre: verified, resting on Home. Post: back on Home.
+ */
+import { Timeouts } from '../../../src/constants.js'
+import { getCurrentAppId } from '../../../src/helpers/deep-link.js'
+import { BaseScreen } from '../../../src/screens/BaseScreen.js'
+import { BCSC_TestIDs } from '../../../src/testIDs.js'
+
+const Account = new BaseScreen(BCSC_TestIDs.Account)
+const TabBar = new BaseScreen(BCSC_TestIDs.TabBar)
+const Home = new BaseScreen(BCSC_TestIDs.Home)
+const Services = new BaseScreen(BCSC_TestIDs.Services)
+const ServiceLogin = new BaseScreen(BCSC_TestIDs.ServiceLogin)
+const WebView = new BaseScreen(BCSC_TestIDs.WebView)
+
+const SEARCH_QUERY = 'first'
+
+const SERVICES_TO_EXERCISE = 5
+
+function serviceButtonSelector(): string {
+  return driver.isIOS
+    ? '-ios predicate string:name BEGINSWITH "com.ariesbifold:id/ServiceButton-"'
+    : 'android=new UiSelector().resourceIdMatches(".*ServiceButton-.*")'
+}
+
+describe('Home → secondary interactions', () => {
+  before(async () => {
+    await Home.waitFor('SettingsMenuButton', Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('opens the Home Help WebView and returns Home', async () => {
+    await Home.waitFor('Help')
+    await Home.tap('Help')
+    await WebView.waitFor('Back', Timeouts.SCREEN_TRANSITION)
+    await WebView.tap('Back')
+    await Home.waitFor('SettingsMenuButton')
+  })
+
+  it('routes Where To Use to the Services tab and returns Home', async () => {
+    await Home.waitFor('WhereToUse')
+    await Home.tap('WhereToUse')
+    await Services.waitFor('Search', Timeouts.SCREEN_TRANSITION)
+  })
+})
+
+describe('Services → search and clear', () => {
+  it('types a query and verifies the clear button appears', async () => {
+    await Services.type('Search', SEARCH_QUERY, { tapFirst: true })
+    await Services.dismissKeyboard()
+    await Services.waitFor('ClearSearch', Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('clears the query and verifies the clear button disappears', async () => {
+    await Services.tap('ClearSearch')
+    await driver.waitUntil(async () => !(await Services.isDisplayed('ClearSearch')), {
+      timeout: Timeouts.SCREEN_TRANSITION,
+      timeoutMsg: 'Expected ClearSearch button to disappear after clearing search',
+    })
+  })
+})
+
+describe('Services → service detail interactions', () => {
+  it('opens the first service and exercises every safe ServiceLoginScreen button', async () => {
+    const services = await $$(serviceButtonSelector()).getElements()
+
+    if (!services.length) {
+      throw new Error('No ServiceButtons rendered in the Services catalogue')
+    }
+
+    await services[2].waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+    await services[2].click()
+
+    await ServiceLogin.waitFor('ServiceLoginCancel', Timeouts.SCREEN_TRANSITION)
+    const continueButton = await ServiceLogin.findByTestId(ServiceLogin.ids.ServiceLoginContinue)
+    await continueButton.waitForDisplayed({ timeout: Timeouts.ELEMENT_VISIBLE })
+
+    if (await continueButton.isEnabled()) {
+      const appIdForPrivacy = await getCurrentAppId()
+      await ServiceLogin.tap('ServiceLoginContinue')
+      await driver.pause(Timeouts.BROWSER_HANDOFF_PAUSE_MS)
+      await driver.activateApp(appIdForPrivacy)
+    }
+  })
+
+  it('opens the service Help WebView and returns to the service detail', async () => {
+    await Home.waitFor('SettingsMenuButton', Timeouts.SCREEN_TRANSITION)
+    await TabBar.waitFor('Services')
+    await TabBar.tap('Services')
+    await driver.pause(Timeouts.BROWSER_HANDOFF_PAUSE_MS)
+
+    const services = await $$(serviceButtonSelector()).getElements()
+
+    if (!services.length) {
+      throw new Error('No ServiceButtons rendered in the Services catalogue')
+    }
+
+    await services[2].waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+    await services[2].click()
+
+    await ServiceLogin.tap('HelpButton')
+
+    await WebView.waitFor('Back', Timeouts.SCREEN_TRANSITION)
+    await WebView.tap('Back')
+
+    await ServiceLogin.waitFor('ServiceLoginCancel')
+
+    if (await ServiceLogin.isDisplayed('ReadPrivacyPolicy')) {
+      const appIdForPrivacy = await getCurrentAppId()
+      await ServiceLogin.tap('ReadPrivacyPolicy')
+      await driver.pause(Timeouts.BROWSER_HANDOFF_PAUSE_MS)
+      await driver.activateApp(appIdForPrivacy)
+      await ServiceLogin.waitFor('ServiceLoginCancel', Timeouts.SCREEN_TRANSITION)
+    }
+  })
+
+  it('opens Report Suspicious Link in the system browser and returns to the service detail', async () => {
+    await driver.pause(Timeouts.BROWSER_HANDOFF_PAUSE_MS)
+
+    const appIdForReport = await getCurrentAppId()
+
+    await ServiceLogin.waitFor('ReportSuspiciousLink', Timeouts.ELEMENT_VISIBLE)
+    await ServiceLogin.tap('ReportSuspiciousLink')
+
+    await driver.pause(Timeouts.BROWSER_HANDOFF_PAUSE_MS)
+    await driver.activateApp(appIdForReport)
+
+    await ServiceLogin.waitFor('ServiceLoginCancel', Timeouts.SCREEN_TRANSITION)
+
+    await ServiceLogin.tap('ServiceLoginCancel')
+    await Services.waitFor('Search', Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('opens additional services and cancels back, just to confirm navigation works for any catalogue entry', async () => {
+    const services = await $$(serviceButtonSelector()).getElements()
+
+    if (!services.length) {
+      throw new Error('No ServiceButtons rendered in the Services catalogue')
+    }
+
+    for (let i = 0; i < SERVICES_TO_EXERCISE; i++) {
+      await services[i].waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+      await services[i].click()
+      await ServiceLogin.waitFor('Back', Timeouts.SCREEN_TRANSITION)
+      await ServiceLogin.tap('Back')
+      await Services.waitFor('Search', Timeouts.SCREEN_TRANSITION)
+    }
+  })
+
+  it('returns to the Home tab', async () => {
+    await TabBar.tap('Home')
+    await Home.waitFor('SettingsMenuButton')
+  })
+})
+
+describe('Account → All Account Details', () => {
+  it('navigates to the Account tab', async () => {
+    await Home.waitFor('SettingsMenuButton', Timeouts.SCREEN_TRANSITION)
+    await TabBar.tap('Account')
+    await Account.waitFor('AccountScreen')
+    await Account.waitFor('AllAccountDetails')
+  })
+
+  it('opens All Account Details in the system browser and returns to the Account tab', async () => {
+    const appId = await getCurrentAppId()
+    await Account.tap('AllAccountDetails')
+    // `handleAllAccountDetailsPress` resolves a quick-login URL then calls
+    // `Linking.openURL`, which hands off to Safari (iOS) / Chrome (Android).
+    // Pause to let the OS swap apps before pulling BCSC back to the front.
+    await driver.pause(Timeouts.BROWSER_HANDOFF_PAUSE_MS)
+    await driver.activateApp(appId)
+    await Account.waitFor('AccountScreen', Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('opens My Devices in the system browser and returns to the Account tab', async () => {
+    await Account.waitFor('MyDevices')
+    await Account.tap('MyDevices')
+
+    await driver.pause(Timeouts.BROWSER_HANDOFF_PAUSE_MS)
+    WebView.waitFor('Back', Timeouts.SCREEN_TRANSITION)
+    await WebView.tap('Back')
+    await Account.waitFor('AccountScreen', Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('returns to the Home tab', async () => {
+    await TabBar.tap('Home')
+    await Home.waitFor('SettingsMenuButton')
+  })
+})

--- a/e2e/test/bcsc/main/settings/settings.spec.ts
+++ b/e2e/test/bcsc/main/settings/settings.spec.ts
@@ -191,7 +191,7 @@ describe('Settings', () => {
     await Home.waitFor('SettingsMenuButton')
   })
 
-  it('opens App Security, verifies PIN is the current method, and returns to Settings', async () => {
+  it('opens App Security, verifies PIN is the current method, opens Learn More, and returns to Settings', async () => {
     // Previous test (Sign Out) ended on Home as its documented exception,
     // so re-open Settings before walking into the App Security row.
     await TabBar.tap('SettingsMenuButton')
@@ -224,6 +224,14 @@ describe('Settings', () => {
       const deviceAuthEnabled = await deviceAuthButton.isEnabled()
       if (!deviceAuthEnabled) throw new Error('Expected device auth button to be enabled')
     }
+
+    // Tap Learn More — `MainChangeSecurityScreen.handleLearnMorePress`
+    // navigates to MainWebView with SECURE_APP_LEARN_MORE_URL. Back returns
+    // to MainAppSecurity (LearnMoreButton renders again).
+    await MainAppSecurity.tap('LearnMoreButton')
+    await WebView.waitFor('Back', Timeouts.SCREEN_TRANSITION)
+    await WebView.tap('Back')
+    await MainAppSecurity.waitFor('LearnMoreButton')
 
     await MainAppSecurity.tap('BackButton')
     await Settings.waitFor('EditNickname')

--- a/e2e/test/bcsc/onboarding/onboarding-interaction-sweep.spec.ts
+++ b/e2e/test/bcsc/onboarding/onboarding-interaction-sweep.spec.ts
@@ -1,16 +1,8 @@
 /**
- * Onboarding Interaction Sweep: runs the full onboarding flow and exercises
- * every secondary interaction the happy-path suite skips — setup-type radio
- * options, carousel back + external "Where to use" link, privacy-policy
- * learn-more detour + BC login service link handoff, analytics learn-more
- * detour + decline, notifications help detour + open-settings handoff,
- * secure-app learn-more detour, and create-PIN visibility toggles. Ends at
- * SetupSteps (verify phase ready).
- *
- * The account-transfer detour and the notifications deny-permission path
- * live in `transferee-flow.spec.ts`.
- *
- * Imported by `full-regression/interaction-sweep.spec.ts`.
+ * Onboarding Interaction Sweep — exercises every reachable onboarding
+ * interaction in a single flow, including WebView detours. Excludes
+ * account type selection (onboarding-basic.spec.ts) and the transferee
+ * flow (transferee-flow.spec.ts).
  */
 import { TEST_PIN, Timeouts } from '../../../src/constants.js'
 import { getCurrentAppId } from '../../../src/helpers/deep-link.js'


### PR DESCRIPTION
# Summary of Changes

Adds `e2e/test/bcsc/main/main-interaction-sweep.spec.ts`, exercising main-stack interactions not already covered by `main/main.spec.ts`, `main/account.spec.ts`, or `settings/settings.spec.ts`:

- **Home** — `Help` (WebView) and `WhereToUse` (routes to Services tab)
- **Services** — `Search` + `ClearSearch`, opening service detail, `HelpButton` (WebView), `ReadPrivacyPolicy` and `ReportSuspiciousLink` (system browser handoff), `Back`/`Cancel` navigation across multiple catalogue entries
- **Account** — `AllAccountDetails` (system browser handoff) and `MyDevices` (WebView)

Also:

- Extends the existing Settings sweep to tap `MainAppSecurity.LearnMoreButton` and back-navigate from the WebView (the only Settings gap from the ticket).
- Wires `main-interaction-sweep.spec.ts` and `transferer-flow.spec.ts` into `full-regression/interaction-sweep.spec.ts`.
- Adds `ServiceLogin.Back` testID and moves the `ReportSuspiciousLink` testID onto the wrapping text so it can be located reliably on both platforms.

# Testing Instructions

From `e2e/`:

```sh
yarn test:android:local --spec test/bcsc/full-regression/interaction-sweep.spec.ts
yarn test:ios:local     --spec test/bcsc/full-regression/interaction-sweep.spec.ts
```

# Acceptance Criteria

- [x] `main-interaction-sweep.spec.ts` runs from verified home state and ends back on Home
- [x] `AppSecurity.LearnMoreButton` opens the WebView and back-navigates to Settings
- [x] `AllAccountDetails` and `MyDevices` are exercised and return to the Account tab
- [x] `Home.WhereToUse`, `Home.Help`, and service-detail `HelpButton` each return to the originating screen
- [x] `Services.Search` accepts input and `Services.ClearSearch` resets results
- [x] No duplication of flows already covered by `settings/settings.spec.ts`
- [x] Passes on iOS and Android

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A
