### PR TITLE
feat: wire BCSC agent init via ViewModel and provider

### DIFF
--- a/app/src/bcsc-theme/features/agent/BCSCAgentProvider.test.tsx
+++ b/app/src/bcsc-theme/features/agent/BCSCAgentProvider.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react-native'
 import React from 'react'
 import { Text } from 'react-native'
 
-import BCSCAgentProvider from './BCSCAgentProvider'
+import BCSCAgentProvider, { useBCSCAgent } from './BCSCAgentProvider'
 import useAgentSetupViewModel from './useAgentSetupViewModel'
 
 jest.mock('react-i18next', () => ({
@@ -20,11 +20,25 @@ jest.mock('../../contexts/BCSCLoadingContext', () => {
     LoadingScreen: ({ message }: { message: string }) => <Text>{message}</Text>,
   }
 })
-jest.mock('@bifold/core', () => ({
-  AgentProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}))
+jest.mock('@bifold/core', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+  const { Text } = require('react-native')
+  return {
+    AgentProvider: ({ children }: { children: React.ReactNode }) => (
+      <>
+        <Text>bifold-agent-provider</Text>
+        {children}
+      </>
+    ),
+  }
+})
 
 const mockViewModel = useAgentSetupViewModel as jest.MockedFunction<typeof useAgentSetupViewModel>
+
+const StatusProbe: React.FC = () => {
+  const { status, agent, error } = useBCSCAgent()
+  return <Text>{`status=${status} hasAgent=${agent !== null} hasError=${error !== null}`}</Text>
+}
 
 describe('BCSCAgentProvider', () => {
   beforeEach(() => {
@@ -34,41 +48,49 @@ describe('BCSCAgentProvider', () => {
   it('renders LoadingScreen while initializing', () => {
     mockViewModel.mockReturnValue({ agent: null, status: 'initializing', error: null, retry: jest.fn() })
 
-    const { getByText } = render(
+    const { getByText, queryByText } = render(
       <BCSCAgentProvider>
         <Text>hidden</Text>
       </BCSCAgentProvider>
     )
 
     expect(getByText('Init.InitializingAgent')).toBeTruthy()
+    expect(queryByText('bifold-agent-provider')).toBeNull()
   })
 
-  it('renders children wrapped in AgentProvider when ready', () => {
+  it('wraps children in Bifold AgentProvider and exposes agent via BCSC context when ready', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const agent = {} as any
     mockViewModel.mockReturnValue({ agent, status: 'ready', error: null, retry: jest.fn() })
 
-    const { getByText, queryByText } = render(
+    const { getByText } = render(
       <BCSCAgentProvider>
-        <Text>home-screen</Text>
+        <StatusProbe />
       </BCSCAgentProvider>
     )
 
-    expect(getByText('home-screen')).toBeTruthy()
-    expect(queryByText('Init.InitializingAgent')).toBeNull()
+    expect(getByText('bifold-agent-provider')).toBeTruthy()
+    expect(getByText('status=ready hasAgent=true hasError=false')).toBeTruthy()
   })
 
-  it('renders children without AgentProvider when init fails (non-blocking)', () => {
+  it('renders children inside BCSC context but skips Bifold AgentProvider when init fails', () => {
     const error = AppError.fromErrorDefinition(ErrorRegistry.AGENT_INITIALIZATION_ERROR)
     mockViewModel.mockReturnValue({ agent: null, status: 'error', error, retry: jest.fn() })
 
     const { getByText, queryByText } = render(
       <BCSCAgentProvider>
-        <Text>home-screen</Text>
+        <StatusProbe />
       </BCSCAgentProvider>
     )
 
-    expect(getByText('home-screen')).toBeTruthy()
-    expect(queryByText('Init.InitializingAgent')).toBeNull()
+    expect(getByText('status=error hasAgent=false hasError=true')).toBeTruthy()
+    expect(queryByText('bifold-agent-provider')).toBeNull()
+  })
+
+  it('useBCSCAgent throws when called outside the provider', () => {
+    // suppress expected console.error from React rendering the throw
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => render(<StatusProbe />)).toThrow('useBCSCAgent must be used within a BCSCAgentProvider')
+    consoleSpy.mockRestore()
   })
 })

--- a/app/src/bcsc-theme/features/agent/BCSCAgentProvider.test.tsx
+++ b/app/src/bcsc-theme/features/agent/BCSCAgentProvider.test.tsx
@@ -1,0 +1,111 @@
+import * as ErrorAlertContext from '@/contexts/ErrorAlertContext'
+import { AppError, ErrorRegistry } from '@/errors'
+import { render, waitFor } from '@testing-library/react-native'
+import React from 'react'
+import { Text } from 'react-native'
+
+import BCSCAgentProvider from './BCSCAgentProvider'
+import useAgentSetupViewModel from './useAgentSetupViewModel'
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+jest.mock('./useAgentSetupViewModel', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+jest.mock('../../contexts/BCSCLoadingContext', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+  const { Text } = require('react-native')
+  return {
+    LoadingScreen: ({ message }: { message: string }) => <Text>{message}</Text>,
+  }
+})
+jest.mock('@bifold/core', () => ({
+  AgentProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+jest.mock('@/contexts/ErrorAlertContext', () => ({
+  useErrorAlert: jest.fn(),
+}))
+
+const mockViewModel = useAgentSetupViewModel as jest.MockedFunction<typeof useAgentSetupViewModel>
+
+describe('BCSCAgentProvider', () => {
+  const emitErrorModal = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(ErrorAlertContext, 'useErrorAlert').mockReturnValue({ emitErrorModal, emitAlert: jest.fn() })
+  })
+
+  it('renders LoadingScreen while initializing', () => {
+    mockViewModel.mockReturnValue({ agent: null, status: 'initializing', error: null, retry: jest.fn() })
+
+    const { getByText } = render(
+      <BCSCAgentProvider>
+        <Text>hidden</Text>
+      </BCSCAgentProvider>
+    )
+
+    expect(getByText('Init.InitializingAgent')).toBeTruthy()
+  })
+
+  it('renders children wrapped in AgentProvider when ready', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const agent = {} as any
+    mockViewModel.mockReturnValue({ agent, status: 'ready', error: null, retry: jest.fn() })
+
+    const { getByText, queryByText } = render(
+      <BCSCAgentProvider>
+        <Text>home-screen</Text>
+      </BCSCAgentProvider>
+    )
+
+    expect(getByText('home-screen')).toBeTruthy()
+    expect(queryByText('Init.InitializingAgent')).toBeNull()
+  })
+
+  it('calls emitErrorModal once per error transition with retry action', async () => {
+    const retry = jest.fn()
+    const error = AppError.fromErrorDefinition(ErrorRegistry.AGENT_INITIALIZATION_ERROR)
+    mockViewModel.mockReturnValue({ agent: null, status: 'error', error, retry })
+
+    const { rerender } = render(
+      <BCSCAgentProvider>
+        <Text>hidden</Text>
+      </BCSCAgentProvider>
+    )
+
+    await waitFor(() => expect(emitErrorModal).toHaveBeenCalledTimes(1))
+    expect(emitErrorModal).toHaveBeenCalledWith(
+      'Error.Title2901',
+      'Error.Message2901',
+      error,
+      expect.objectContaining({
+        action: expect.objectContaining({ text: 'Init.Retry', onPress: retry }),
+      })
+    )
+
+    // Re-render with same error — should not emit again
+    rerender(
+      <BCSCAgentProvider>
+        <Text>hidden</Text>
+      </BCSCAgentProvider>
+    )
+    expect(emitErrorModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits modal with 2902 strings when walletKey is missing', async () => {
+    const error = AppError.fromErrorDefinition(ErrorRegistry.WALLET_SECRET_NOT_FOUND)
+    mockViewModel.mockReturnValue({ agent: null, status: 'error', error, retry: jest.fn() })
+
+    render(
+      <BCSCAgentProvider>
+        <Text>hidden</Text>
+      </BCSCAgentProvider>
+    )
+
+    await waitFor(() => expect(emitErrorModal).toHaveBeenCalledTimes(1))
+    expect(emitErrorModal).toHaveBeenCalledWith('Error.Title2902', 'Error.Message2902', error, expect.anything())
+  })
+})

--- a/app/src/bcsc-theme/features/agent/BCSCAgentProvider.test.tsx
+++ b/app/src/bcsc-theme/features/agent/BCSCAgentProvider.test.tsx
@@ -6,38 +6,16 @@ import { Text } from 'react-native'
 import BCSCAgentProvider, { useBCSCAgent } from './BCSCAgentProvider'
 import useAgentSetupViewModel from './useAgentSetupViewModel'
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
-}))
 jest.mock('./useAgentSetupViewModel', () => ({
   __esModule: true,
   default: jest.fn(),
 }))
-jest.mock('../../contexts/BCSCLoadingContext', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-  const { Text } = require('react-native')
-  return {
-    LoadingScreen: ({ message }: { message: string }) => <Text>{message}</Text>,
-  }
-})
-jest.mock('@bifold/core', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-  const { Text } = require('react-native')
-  return {
-    AgentProvider: ({ children }: { children: React.ReactNode }) => (
-      <>
-        <Text>bifold-agent-provider</Text>
-        {children}
-      </>
-    ),
-  }
-})
 
 const mockViewModel = useAgentSetupViewModel as jest.MockedFunction<typeof useAgentSetupViewModel>
 
-const StatusProbe: React.FC = () => {
-  const { status, agent, error } = useBCSCAgent()
-  return <Text>{`status=${status} hasAgent=${agent !== null} hasError=${error !== null}`}</Text>
+const Probe: React.FC = () => {
+  const { agent, loading, error } = useBCSCAgent()
+  return <Text>{`loading=${loading} hasAgent=${agent !== null} hasError=${error !== null}`}</Text>
 }
 
 describe('BCSCAgentProvider', () => {
@@ -45,52 +23,60 @@ describe('BCSCAgentProvider', () => {
     jest.clearAllMocks()
   })
 
-  it('renders LoadingScreen while initializing', () => {
-    mockViewModel.mockReturnValue({ agent: null, status: 'initializing', error: null, retry: jest.fn() })
+  it('exposes loading=true while idle', () => {
+    mockViewModel.mockReturnValue({ agent: null, status: 'idle', error: null, retry: jest.fn() })
 
-    const { getByText, queryByText } = render(
+    const { getByText } = render(
       <BCSCAgentProvider>
-        <Text>hidden</Text>
+        <Probe />
       </BCSCAgentProvider>
     )
 
-    expect(getByText('Init.InitializingAgent')).toBeTruthy()
-    expect(queryByText('bifold-agent-provider')).toBeNull()
+    expect(getByText('loading=true hasAgent=false hasError=false')).toBeTruthy()
   })
 
-  it('wraps children in Bifold AgentProvider and exposes agent via BCSC context when ready', () => {
+  it('exposes loading=true while initializing', () => {
+    mockViewModel.mockReturnValue({ agent: null, status: 'initializing', error: null, retry: jest.fn() })
+
+    const { getByText } = render(
+      <BCSCAgentProvider>
+        <Probe />
+      </BCSCAgentProvider>
+    )
+
+    expect(getByText('loading=true hasAgent=false hasError=false')).toBeTruthy()
+  })
+
+  it('exposes the agent and loading=false when ready', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const agent = {} as any
     mockViewModel.mockReturnValue({ agent, status: 'ready', error: null, retry: jest.fn() })
 
     const { getByText } = render(
       <BCSCAgentProvider>
-        <StatusProbe />
+        <Probe />
       </BCSCAgentProvider>
     )
 
-    expect(getByText('bifold-agent-provider')).toBeTruthy()
-    expect(getByText('status=ready hasAgent=true hasError=false')).toBeTruthy()
+    expect(getByText('loading=false hasAgent=true hasError=false')).toBeTruthy()
   })
 
-  it('renders children inside BCSC context but skips Bifold AgentProvider when init fails', () => {
+  it('exposes the error and loading=false when init fails', () => {
     const error = AppError.fromErrorDefinition(ErrorRegistry.AGENT_INITIALIZATION_ERROR)
     mockViewModel.mockReturnValue({ agent: null, status: 'error', error, retry: jest.fn() })
 
-    const { getByText, queryByText } = render(
+    const { getByText } = render(
       <BCSCAgentProvider>
-        <StatusProbe />
+        <Probe />
       </BCSCAgentProvider>
     )
 
-    expect(getByText('status=error hasAgent=false hasError=true')).toBeTruthy()
-    expect(queryByText('bifold-agent-provider')).toBeNull()
+    expect(getByText('loading=false hasAgent=false hasError=true')).toBeTruthy()
   })
 
   it('useBCSCAgent throws when called outside the provider', () => {
-    // suppress expected console.error from React rendering the throw
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
-    expect(() => render(<StatusProbe />)).toThrow('useBCSCAgent must be used within a BCSCAgentProvider')
+    expect(() => render(<Probe />)).toThrow('useBCSCAgent must be used within a BCSCAgentProvider')
     consoleSpy.mockRestore()
   })
 })

--- a/app/src/bcsc-theme/features/agent/BCSCAgentProvider.test.tsx
+++ b/app/src/bcsc-theme/features/agent/BCSCAgentProvider.test.tsx
@@ -1,6 +1,5 @@
-import * as ErrorAlertContext from '@/contexts/ErrorAlertContext'
 import { AppError, ErrorRegistry } from '@/errors'
-import { render, waitFor } from '@testing-library/react-native'
+import { render } from '@testing-library/react-native'
 import React from 'react'
 import { Text } from 'react-native'
 
@@ -24,18 +23,12 @@ jest.mock('../../contexts/BCSCLoadingContext', () => {
 jest.mock('@bifold/core', () => ({
   AgentProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
-jest.mock('@/contexts/ErrorAlertContext', () => ({
-  useErrorAlert: jest.fn(),
-}))
 
 const mockViewModel = useAgentSetupViewModel as jest.MockedFunction<typeof useAgentSetupViewModel>
 
 describe('BCSCAgentProvider', () => {
-  const emitErrorModal = jest.fn()
-
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.spyOn(ErrorAlertContext, 'useErrorAlert').mockReturnValue({ emitErrorModal, emitAlert: jest.fn() })
   })
 
   it('renders LoadingScreen while initializing', () => {
@@ -65,47 +58,17 @@ describe('BCSCAgentProvider', () => {
     expect(queryByText('Init.InitializingAgent')).toBeNull()
   })
 
-  it('calls emitErrorModal once per error transition with retry action', async () => {
-    const retry = jest.fn()
+  it('renders children without AgentProvider when init fails (non-blocking)', () => {
     const error = AppError.fromErrorDefinition(ErrorRegistry.AGENT_INITIALIZATION_ERROR)
-    mockViewModel.mockReturnValue({ agent: null, status: 'error', error, retry })
-
-    const { rerender } = render(
-      <BCSCAgentProvider>
-        <Text>hidden</Text>
-      </BCSCAgentProvider>
-    )
-
-    await waitFor(() => expect(emitErrorModal).toHaveBeenCalledTimes(1))
-    expect(emitErrorModal).toHaveBeenCalledWith(
-      'Error.Title2901',
-      'Error.Message2901',
-      error,
-      expect.objectContaining({
-        action: expect.objectContaining({ text: 'Init.Retry', onPress: retry }),
-      })
-    )
-
-    // Re-render with same error — should not emit again
-    rerender(
-      <BCSCAgentProvider>
-        <Text>hidden</Text>
-      </BCSCAgentProvider>
-    )
-    expect(emitErrorModal).toHaveBeenCalledTimes(1)
-  })
-
-  it('emits modal with 2902 strings when walletKey is missing', async () => {
-    const error = AppError.fromErrorDefinition(ErrorRegistry.WALLET_SECRET_NOT_FOUND)
     mockViewModel.mockReturnValue({ agent: null, status: 'error', error, retry: jest.fn() })
 
-    render(
+    const { getByText, queryByText } = render(
       <BCSCAgentProvider>
-        <Text>hidden</Text>
+        <Text>home-screen</Text>
       </BCSCAgentProvider>
     )
 
-    await waitFor(() => expect(emitErrorModal).toHaveBeenCalledTimes(1))
-    expect(emitErrorModal).toHaveBeenCalledWith('Error.Title2902', 'Error.Message2902', error, expect.anything())
+    expect(getByText('home-screen')).toBeTruthy()
+    expect(queryByText('Init.InitializingAgent')).toBeNull()
   })
 })

--- a/app/src/bcsc-theme/features/agent/BCSCAgentProvider.tsx
+++ b/app/src/bcsc-theme/features/agent/BCSCAgentProvider.tsx
@@ -1,41 +1,24 @@
-import { useErrorAlert } from '@/contexts/ErrorAlertContext'
 import { AgentProvider } from '@bifold/core'
-import React, { PropsWithChildren, useEffect, useRef } from 'react'
+import React, { PropsWithChildren } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { LoadingScreen } from '../../contexts/BCSCLoadingContext'
 
 import useAgentSetupViewModel from './useAgentSetupViewModel'
 
+// Non-blocking on error: init failures are logged by the ViewModel but we do
+// not surface a modal — children render without an active agent context, and
+// downstream credential features will surface their own errors when invoked.
 const BCSCAgentProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const { t } = useTranslation()
-  const { emitErrorModal } = useErrorAlert()
-  const { agent, status, error, retry } = useAgentSetupViewModel()
-  const lastErrorCodeRef = useRef<number | null>(null)
-
-  useEffect(() => {
-    if (status !== 'error' || !error) {
-      lastErrorCodeRef.current = null
-      return
-    }
-
-    if (lastErrorCodeRef.current === error.statusCode) {
-      return
-    }
-    lastErrorCodeRef.current = error.statusCode
-
-    const title = t(`Error.Title${error.statusCode}`)
-    const description = t(`Error.Message${error.statusCode}`)
-    emitErrorModal(title, description, error, {
-      action: {
-        text: t('Init.Retry'),
-        onPress: retry,
-      },
-    })
-  }, [status, error, emitErrorModal, retry, t])
+  const { agent, status } = useAgentSetupViewModel()
 
   if (status === 'ready' && agent) {
     return <AgentProvider agent={agent}>{children}</AgentProvider>
+  }
+
+  if (status === 'error') {
+    return <>{children}</>
   }
 
   return <LoadingScreen message={t('Init.InitializingAgent')} />

--- a/app/src/bcsc-theme/features/agent/BCSCAgentProvider.tsx
+++ b/app/src/bcsc-theme/features/agent/BCSCAgentProvider.tsx
@@ -1,24 +1,55 @@
 import { AgentProvider } from '@bifold/core'
-import React, { PropsWithChildren } from 'react'
+import { Agent } from '@credo-ts/core'
+import React, { createContext, PropsWithChildren, useContext, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+
+import { AppError } from '@/errors'
 
 import { LoadingScreen } from '../../contexts/BCSCLoadingContext'
 
-import useAgentSetupViewModel from './useAgentSetupViewModel'
+import useAgentSetupViewModel, { AgentSetupStatus } from './useAgentSetupViewModel'
+
+export interface BCSCAgentContextValue {
+  agent: Agent | null
+  status: AgentSetupStatus
+  error: AppError | null
+  retry: () => void
+}
+
+const BCSCAgentContext = createContext<BCSCAgentContextValue | null>(null)
+
+export const useBCSCAgent = (): BCSCAgentContextValue => {
+  const ctx = useContext(BCSCAgentContext)
+  if (!ctx) {
+    throw new Error('useBCSCAgent must be used within a BCSCAgentProvider')
+  }
+  return ctx
+}
 
 // Non-blocking on error: init failures are logged by the ViewModel but we do
-// not surface a modal — children render without an active agent context, and
-// downstream credential features will surface their own errors when invoked.
+// not surface a modal — children render inside the BCSC context (so they can
+// inspect status/error and react), but Bifold's AgentProvider is skipped on
+// error since it requires a live agent. Downstream credential features will
+// surface their own errors when invoked.
 const BCSCAgentProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const { t } = useTranslation()
-  const { agent, status } = useAgentSetupViewModel()
+  const { agent, status, error, retry } = useAgentSetupViewModel()
+
+  const value = useMemo<BCSCAgentContextValue>(
+    () => ({ agent, status, error, retry }),
+    [agent, status, error, retry]
+  )
 
   if (status === 'ready' && agent) {
-    return <AgentProvider agent={agent}>{children}</AgentProvider>
+    return (
+      <BCSCAgentContext.Provider value={value}>
+        <AgentProvider agent={agent}>{children}</AgentProvider>
+      </BCSCAgentContext.Provider>
+    )
   }
 
   if (status === 'error') {
-    return <>{children}</>
+    return <BCSCAgentContext.Provider value={value}>{children}</BCSCAgentContext.Provider>
   }
 
   return <LoadingScreen message={t('Init.InitializingAgent')} />

--- a/app/src/bcsc-theme/features/agent/BCSCAgentProvider.tsx
+++ b/app/src/bcsc-theme/features/agent/BCSCAgentProvider.tsx
@@ -1,17 +1,13 @@
-import { AgentProvider } from '@bifold/core'
 import { Agent } from '@credo-ts/core'
 import React, { createContext, PropsWithChildren, useContext, useMemo } from 'react'
-import { useTranslation } from 'react-i18next'
 
 import { AppError } from '@/errors'
 
-import { LoadingScreen } from '../../contexts/BCSCLoadingContext'
-
-import useAgentSetupViewModel, { AgentSetupStatus } from './useAgentSetupViewModel'
+import useAgentSetupViewModel from './useAgentSetupViewModel'
 
 export interface BCSCAgentContextValue {
   agent: Agent | null
-  status: AgentSetupStatus
+  loading: boolean
   error: AppError | null
   retry: () => void
 }
@@ -26,33 +22,25 @@ export const useBCSCAgent = (): BCSCAgentContextValue => {
   return ctx
 }
 
-// Non-blocking on error: init failures are logged by the ViewModel but we do
-// not surface a modal — children render inside the BCSC context (so they can
-// inspect status/error and react), but Bifold's AgentProvider is skipped on
-// error since it requires a live agent. Downstream credential features will
-// surface their own errors when invoked.
+// Non-blocking and decoupled from Bifold's AgentProvider. Children always
+// render; consumers inspect { agent, loading, error } via useBCSCAgent and
+// decide what to show. Init failures are logged by the ViewModel — no modal,
+// no fall-through to Bifold hooks. Screens that need the live agent reach
+// for it through useBCSCAgent().agent rather than Bifold's useAgent().
 const BCSCAgentProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  const { t } = useTranslation()
   const { agent, status, error, retry } = useAgentSetupViewModel()
 
   const value = useMemo<BCSCAgentContextValue>(
-    () => ({ agent, status, error, retry }),
+    () => ({
+      agent,
+      loading: status === 'idle' || status === 'initializing',
+      error,
+      retry,
+    }),
     [agent, status, error, retry]
   )
 
-  if (status === 'ready' && agent) {
-    return (
-      <BCSCAgentContext.Provider value={value}>
-        <AgentProvider agent={agent}>{children}</AgentProvider>
-      </BCSCAgentContext.Provider>
-    )
-  }
-
-  if (status === 'error') {
-    return <BCSCAgentContext.Provider value={value}>{children}</BCSCAgentContext.Provider>
-  }
-
-  return <LoadingScreen message={t('Init.InitializingAgent')} />
+  return <BCSCAgentContext.Provider value={value}>{children}</BCSCAgentContext.Provider>
 }
 
 export default BCSCAgentProvider

--- a/app/src/bcsc-theme/features/agent/BCSCAgentProvider.tsx
+++ b/app/src/bcsc-theme/features/agent/BCSCAgentProvider.tsx
@@ -1,0 +1,44 @@
+import { useErrorAlert } from '@/contexts/ErrorAlertContext'
+import { AgentProvider } from '@bifold/core'
+import React, { PropsWithChildren, useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { LoadingScreen } from '../../contexts/BCSCLoadingContext'
+
+import useAgentSetupViewModel from './useAgentSetupViewModel'
+
+const BCSCAgentProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const { t } = useTranslation()
+  const { emitErrorModal } = useErrorAlert()
+  const { agent, status, error, retry } = useAgentSetupViewModel()
+  const lastErrorCodeRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (status !== 'error' || !error) {
+      lastErrorCodeRef.current = null
+      return
+    }
+
+    if (lastErrorCodeRef.current === error.statusCode) {
+      return
+    }
+    lastErrorCodeRef.current = error.statusCode
+
+    const title = t(`Error.Title${error.statusCode}`)
+    const description = t(`Error.Message${error.statusCode}`)
+    emitErrorModal(title, description, error, {
+      action: {
+        text: t('Init.Retry'),
+        onPress: retry,
+      },
+    })
+  }, [status, error, emitErrorModal, retry, t])
+
+  if (status === 'ready' && agent) {
+    return <AgentProvider agent={agent}>{children}</AgentProvider>
+  }
+
+  return <LoadingScreen message={t('Init.InitializingAgent')} />
+}
+
+export default BCSCAgentProvider

--- a/app/src/bcsc-theme/features/agent/index.ts
+++ b/app/src/bcsc-theme/features/agent/index.ts
@@ -1,1 +1,3 @@
+export { default as BCSCAgentProvider, useBCSCAgent } from './BCSCAgentProvider'
+export type { BCSCAgentContextValue } from './BCSCAgentProvider'
 export * from './services/agent-service'

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
@@ -153,6 +153,46 @@ describe('useAgentSetupViewModel', () => {
     expect(result.current.agent).toBeNull()
   })
 
+  it('shuts down partially-built agent when init step throws', async () => {
+    const newAgent = mockAgent()
+    newAgent.initialize = jest.fn().mockRejectedValue(new Error('initialize failed'))
+    jest.mocked(agentService.buildAgent).mockReturnValue(newAgent)
+
+    const { result } = renderHook(() => useAgentSetupViewModel())
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    expect(agentService.shutdownAgent).toHaveBeenCalledWith(newAgent, logger)
+  })
+
+  it('shuts down agent built mid-init when didAuthenticate flips false', async () => {
+    let resolveInit: () => void = () => undefined
+    const initPromise = new Promise<void>((resolve) => {
+      resolveInit = resolve
+    })
+    const newAgent = mockAgent()
+    newAgent.initialize = jest.fn().mockReturnValue(initPromise)
+    jest.mocked(agentService.buildAgent).mockReturnValue(newAgent)
+
+    const store: Record<string, unknown> = {
+      authentication: { didAuthenticate: true },
+      bcscSecure: { walletKey: 'wallet-key-hash' },
+      preferences: { selectedMediator: 'https://m', walletName: 'BC Wallet', usePushNotifications: false },
+      developer: { enableProxy: false },
+      migration: { didMigrateToAskar: true },
+    }
+    jest.mocked(Bifold.useStore).mockImplementation(() => [store as never, jest.fn()])
+
+    const { result, rerender } = renderHook(() => useAgentSetupViewModel())
+
+    await waitFor(() => expect(result.current.status).toBe('initializing'))
+
+    ;(store.authentication as Record<string, unknown>).didAuthenticate = false
+    rerender({})
+
+    resolveInit()
+    await waitFor(() => expect(agentService.shutdownAgent).toHaveBeenCalledWith(newAgent, logger))
+  })
+
   it('shuts down agent when didAuthenticate flips to false', async () => {
     const store: Record<string, unknown> = {
       authentication: { didAuthenticate: true },

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
@@ -47,7 +47,6 @@ describe('useAgentSetupViewModel', () => {
     jest.mocked(Bifold.useServices).mockReturnValue([logger, [], attestationMonitor, [], []] as never)
     jest.mocked(Bifold.useStore).mockReturnValue(mockedStore() as never)
     jest.mocked(Bifold.createLinkSecretIfRequired).mockResolvedValue(undefined as never)
-    jest.mocked(Bifold.migrateToAskar).mockResolvedValue(undefined as never)
     jest.mocked(agentService.loadCachedLedgers).mockResolvedValue(undefined)
     jest.mocked(agentService.buildAgent).mockReturnValue(mockAgent())
     jest.mocked(agentService.restartAgent).mockResolvedValue(undefined)

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
@@ -181,9 +181,7 @@ describe('useAgentSetupViewModel', () => {
 
     // Force pickup to fail on the next iteration so we land in catch with
     // agentRef.current still pointing at agent1.
-    agent1.mediationRecipient.initiateMessagePickup = jest
-      .fn()
-      .mockRejectedValueOnce(new Error('pickup failed'))
+    agent1.mediationRecipient.initiateMessagePickup = jest.fn().mockRejectedValueOnce(new Error('pickup failed'))
 
     act(() => {
       result.current.retry()
@@ -225,7 +223,6 @@ describe('useAgentSetupViewModel', () => {
     const { result, rerender } = renderHook(() => useAgentSetupViewModel())
 
     await waitFor(() => expect(result.current.status).toBe('initializing'))
-
     ;(store.authentication as Record<string, unknown>).didAuthenticate = false
     rerender({})
 

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
@@ -1,0 +1,144 @@
+import { AppError, ErrorRegistry } from '@/errors'
+import { AppEventCode } from '@/events/appEventCode'
+import * as Bifold from '@bifold/core'
+import { act, renderHook, waitFor } from '@testing-library/react-native'
+
+import * as agentService from './services/agent-service'
+import useAgentSetupViewModel from './useAgentSetupViewModel'
+
+jest.mock('@bifold/core')
+jest.mock('@/utils/PushNotificationsHelper', () => ({ activate: jest.fn().mockResolvedValue(undefined) }))
+jest.mock('react-native-config', () => ({ Config: { INDY_VDR_PROXY_URL: '' } }))
+jest.mock('@credo-ts/core', () => {
+  const actual = jest.requireActual('@credo-ts/core')
+  return {
+    ...actual,
+    MediatorPickupStrategy: { PickUpV2LiveMode: 'PickUpV2LiveMode' },
+  }
+})
+jest.mock('./services/agent-service')
+
+const mockedStore = (overrides: Record<string, unknown> = {}) => {
+  const base = {
+    authentication: { didAuthenticate: true },
+    bcscSecure: { walletKey: 'wallet-key-hash' },
+    preferences: { selectedMediator: 'https://mediator.example', walletName: 'BC Wallet', usePushNotifications: false },
+    developer: { enableProxy: false },
+    migration: { didMigrateToAskar: true },
+    ...overrides,
+  }
+  return [base, jest.fn()]
+}
+
+const mockAgent = () =>
+  ({
+    mediationRecipient: { initiateMessagePickup: jest.fn().mockResolvedValue(undefined) },
+    initialize: jest.fn().mockResolvedValue(undefined),
+    shutdown: jest.fn().mockResolvedValue(undefined),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any
+
+const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), trace: jest.fn() }
+const attestationMonitor = { start: jest.fn(), stop: jest.fn() }
+
+describe('useAgentSetupViewModel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.mocked(Bifold.useServices).mockReturnValue([logger, [], attestationMonitor, [], []] as never)
+    jest.mocked(Bifold.useStore).mockReturnValue(mockedStore() as never)
+    jest.mocked(Bifold.createLinkSecretIfRequired).mockResolvedValue(undefined as never)
+    jest.mocked(Bifold.migrateToAskar).mockResolvedValue(undefined as never)
+    jest.mocked(agentService.loadCachedLedgers).mockResolvedValue(undefined)
+    jest.mocked(agentService.buildAgent).mockReturnValue(mockAgent())
+    jest.mocked(agentService.restartAgent).mockResolvedValue(undefined)
+    jest.mocked(agentService.warmCache).mockResolvedValue(undefined)
+    jest.mocked(agentService.shutdownAgent).mockResolvedValue(undefined)
+  })
+
+  it('happy path: builds agent and reaches ready status', async () => {
+    const { result } = renderHook(() => useAgentSetupViewModel())
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(result.current.agent).not.toBeNull()
+    expect(result.current.error).toBeNull()
+    expect(agentService.buildAgent).toHaveBeenCalled()
+    expect(agentService.warmCache).toHaveBeenCalled()
+  })
+
+  it('missing walletKey yields 2902 WALLET_SECRET_NOT_FOUND error', async () => {
+    jest.mocked(Bifold.useStore).mockReturnValue(mockedStore({ bcscSecure: { walletKey: undefined } }) as never)
+
+    const { result } = renderHook(() => useAgentSetupViewModel())
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    expect(result.current.error).toBeInstanceOf(AppError)
+    expect(result.current.error?.statusCode).toBe(2902)
+    expect(result.current.error?.appEvent).toBe(AppEventCode.WALLET_SECRET_NOT_FOUND)
+    expect(agentService.buildAgent).not.toHaveBeenCalled()
+  })
+
+  it('wraps non-AppError throws in 2901 AGENT_INITIALIZATION_ERROR', async () => {
+    jest.mocked(agentService.buildAgent).mockImplementationOnce(() => {
+      throw new Error('mediator unreachable')
+    })
+
+    const { result } = renderHook(() => useAgentSetupViewModel())
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    expect(result.current.error?.statusCode).toBe(2901)
+    expect(result.current.error?.appEvent).toBe(AppEventCode.AGENT_INITIALIZATION_ERROR)
+    expect(result.current.error?.cause).toBeInstanceOf(Error)
+  })
+
+  it('preserves AppError thrown by service (does not re-wrap)', async () => {
+    const thrownAppError = AppError.fromErrorDefinition(ErrorRegistry.AGENT_INITIALIZATION_ERROR, {
+      cause: new Error('Mediator URL is required to build agent'),
+    })
+    jest.mocked(agentService.buildAgent).mockImplementationOnce(() => {
+      throw thrownAppError
+    })
+
+    const { result } = renderHook(() => useAgentSetupViewModel())
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    expect(result.current.error).toBe(thrownAppError)
+  })
+
+  it('retry resets status to initializing and re-runs init', async () => {
+    jest.mocked(agentService.buildAgent).mockImplementationOnce(() => {
+      throw new Error('first attempt fails')
+    })
+
+    const { result } = renderHook(() => useAgentSetupViewModel())
+    await waitFor(() => expect(result.current.status).toBe('error'))
+
+    act(() => {
+      result.current.retry()
+    })
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(agentService.buildAgent).toHaveBeenCalledTimes(2)
+  })
+
+  it('shuts down agent when didAuthenticate flips to false', async () => {
+    const store: Record<string, unknown> = {
+      authentication: { didAuthenticate: true },
+      bcscSecure: { walletKey: 'wallet-key-hash' },
+      preferences: { selectedMediator: 'https://m', walletName: 'BC Wallet', usePushNotifications: false },
+      developer: { enableProxy: false },
+      migration: { didMigrateToAskar: true },
+    }
+    jest.mocked(Bifold.useStore).mockImplementation(() => [store as never, jest.fn()])
+
+    const { result, rerender } = renderHook(() => useAgentSetupViewModel())
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+
+    // Flip to unauthenticated
+    ;(store.authentication as Record<string, unknown>).didAuthenticate = false
+    rerender({})
+
+    await waitFor(() => expect(result.current.status).toBe('idle'))
+    expect(agentService.shutdownAgent).toHaveBeenCalled()
+    expect(result.current.agent).toBeNull()
+  })
+})

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
@@ -1,6 +1,7 @@
 import { AppError, ErrorRegistry } from '@/errors'
 import { AppEventCode } from '@/events/appEventCode'
 import * as Bifold from '@bifold/core'
+import { Agent } from '@credo-ts/core'
 import { act, renderHook, waitFor } from '@testing-library/react-native'
 
 import * as agentService from './services/agent-service'

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
@@ -230,6 +230,41 @@ describe('useAgentSetupViewModel', () => {
     await waitFor(() => expect(agentService.shutdownAgent).toHaveBeenCalledWith(newAgent, logger))
   })
 
+  it('does not double-launch init when setStatus(initializing) re-renders mid-flight', async () => {
+    // Regression test: previously `status` was in the effect dep array, so
+    // setStatus('initializing') re-fired the effect and the cleanup reset
+    // initializingRef before the in-flight run had a chance to bail, racing
+    // a second restartAgent call on the same agent instance.
+    const agent1 = mockAgent()
+    jest.mocked(agentService.buildAgent).mockReturnValueOnce(agent1)
+
+    let resolveRestart: (val: Agent | undefined) => void = () => undefined
+    const restartPromise = new Promise<Agent | undefined>((resolve) => {
+      resolveRestart = resolve
+    })
+    jest.mocked(agentService.restartAgent).mockReturnValueOnce(restartPromise)
+
+    const { result } = renderHook(() => useAgentSetupViewModel())
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+
+    act(() => {
+      result.current.retry()
+    })
+
+    await waitFor(() => expect(result.current.status).toBe('initializing'))
+    // Flush microtasks so any spurious re-fire would have launched a second run.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    expect(agentService.restartAgent).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveRestart(agent1)
+    })
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+  })
+
   it('shuts down agent when didAuthenticate flips to false', async () => {
     const store: Record<string, unknown> = {
       authentication: { didAuthenticate: true },

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
@@ -153,6 +153,46 @@ describe('useAgentSetupViewModel', () => {
     expect(result.current.agent).toBeNull()
   })
 
+  it('shuts down old agent when restart returns undefined before building fresh', async () => {
+    const agent1 = mockAgent()
+    const agent2 = mockAgent()
+    jest.mocked(agentService.buildAgent).mockReturnValueOnce(agent1).mockReturnValueOnce(agent2)
+    jest.mocked(agentService.restartAgent).mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useAgentSetupViewModel())
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+
+    act(() => {
+      result.current.retry()
+    })
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(agentService.shutdownAgent).toHaveBeenCalledWith(agent1, logger)
+    expect(agentService.buildAgent).toHaveBeenCalledTimes(2)
+  })
+
+  it('shuts down stale agent on init failure so retry rebuilds fresh', async () => {
+    const agent1 = mockAgent()
+    jest.mocked(agentService.buildAgent).mockReturnValue(agent1)
+    jest.mocked(agentService.restartAgent).mockResolvedValueOnce(agent1)
+
+    const { result } = renderHook(() => useAgentSetupViewModel())
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+
+    // Force pickup to fail on the next iteration so we land in catch with
+    // agentRef.current still pointing at agent1.
+    agent1.mediationRecipient.initiateMessagePickup = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('pickup failed'))
+
+    act(() => {
+      result.current.retry()
+    })
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    expect(agentService.shutdownAgent).toHaveBeenCalledWith(agent1, logger)
+  })
+
   it('shuts down partially-built agent when init step throws', async () => {
     const newAgent = mockAgent()
     newAgent.initialize = jest.fn().mockRejectedValue(new Error('initialize failed'))

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
@@ -119,6 +119,40 @@ describe('useAgentSetupViewModel', () => {
     expect(agentService.buildAgent).toHaveBeenCalledTimes(2)
   })
 
+  it('does not transition to ready when didAuthenticate flips false mid-init', async () => {
+    let resolveInit: () => void = () => undefined
+    const initPromise = new Promise<void>((resolve) => {
+      resolveInit = resolve
+    })
+    const newAgent = mockAgent()
+    newAgent.initialize = jest.fn().mockReturnValue(initPromise)
+    jest.mocked(agentService.buildAgent).mockReturnValue(newAgent)
+
+    const store: Record<string, unknown> = {
+      authentication: { didAuthenticate: true },
+      bcscSecure: { walletKey: 'wallet-key-hash' },
+      preferences: { selectedMediator: 'https://m', walletName: 'BC Wallet', usePushNotifications: false },
+      developer: { enableProxy: false },
+      migration: { didMigrateToAskar: true },
+    }
+    jest.mocked(Bifold.useStore).mockImplementation(() => [store as never, jest.fn()])
+
+    const { result, rerender } = renderHook(() => useAgentSetupViewModel())
+
+    await waitFor(() => expect(result.current.status).toBe('initializing'))
+
+    // Flip to unauthenticated while initialize() is still pending
+    ;(store.authentication as Record<string, unknown>).didAuthenticate = false
+    rerender({})
+
+    // Now allow the in-flight initialize to resolve
+    resolveInit()
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(result.current.status).toBe('idle')
+    expect(result.current.agent).toBeNull()
+  })
+
   it('shuts down agent when didAuthenticate flips to false', async () => {
     const store: Record<string, unknown> = {
       authentication: { didAuthenticate: true },

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
@@ -2,7 +2,7 @@ import { WALLET_ID } from '@/constants'
 import { AppError, ErrorRegistry } from '@/errors'
 import { BCState } from '@/store'
 import { activate } from '@/utils/PushNotificationsHelper'
-import { createLinkSecretIfRequired, DispatchAction, migrateToAskar, TOKENS, useServices, useStore } from '@bifold/core'
+import { createLinkSecretIfRequired, DispatchAction, TOKENS, useServices, useStore } from '@bifold/core'
 import { Agent, MediatorPickupStrategy } from '@credo-ts/core'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Config } from 'react-native-config'
@@ -111,8 +111,9 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
           logger,
         })
 
+        // BCSC v4.1 starts fresh on Askar — no legacy Indy wallet to migrate.
+        // Mark the flag so any downstream code that still checks it stays consistent.
         if (!didMigrateToAskar) {
-          await migrateToAskar(walletSecret.id, walletSecret.key, newAgent)
           dispatch({ type: DispatchAction.DID_MIGRATE_TO_ASKAR })
         }
 

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
@@ -34,6 +34,8 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
   const [retryCount, setRetryCount] = useState(0)
   const agentRef = useRef<Agent | null>(null)
   const initializingRef = useRef(false)
+  const statusRef = useRef<AgentSetupStatus>('idle')
+  statusRef.current = status
 
   const didAuthenticate = store.authentication.didAuthenticate
   const walletKey = store.bcscSecure.walletKey
@@ -69,7 +71,7 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
       return
     }
 
-    if (initializingRef.current || status === 'ready' || status === 'error') {
+    if (initializingRef.current || statusRef.current === 'ready' || statusRef.current === 'error') {
       return
     }
 
@@ -195,7 +197,6 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
     enableProxy,
     usePushNotifications,
     retryCount,
-    status,
     logger,
     indyLedgers,
     credDefs,

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
@@ -90,10 +90,14 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
 
         if (agentRef.current) {
           const restarted = await restartAgent(agentRef.current, walletSecret, logger)
-          if (cancelled) return
+          if (cancelled) {
+            return
+          }
           if (restarted) {
             await restarted.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
-            if (cancelled) return
+            if (cancelled) {
+              return
+            }
             refreshAttestationMonitor(restarted)
             agentRef.current = restarted
             setAgent(restarted)
@@ -107,7 +111,9 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
         }
 
         const cachedLedgers = await loadCachedLedgers()
-        if (cancelled) return
+        if (cancelled) {
+          return
+        }
         const ledgers = cachedLedgers ?? indyLedgers
 
         inFlightAgent = buildAgent({
@@ -121,13 +127,21 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
         })
 
         await inFlightAgent.initialize()
-        if (cancelled) return
+        if (cancelled) {
+          return
+        }
         await inFlightAgent.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
-        if (cancelled) return
+        if (cancelled) {
+          return
+        }
         await warmCache(inFlightAgent, credDefs, schemas, cachedLedgers, logger)
-        if (cancelled) return
+        if (cancelled) {
+          return
+        }
         await createLinkSecretIfRequired(inFlightAgent)
-        if (cancelled) return
+        if (cancelled) {
+          return
+        }
 
         if (usePushNotifications) {
           activate(inFlightAgent).catch((err) => logger.warn(`Push notification activation failed: ${err}`))
@@ -140,7 +154,9 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
         setStatus('ready')
         inFlightAgent = undefined
       } catch (err) {
-        if (cancelled) return
+        if (cancelled) {
+          return
+        }
         const appError =
           err instanceof AppError
             ? err

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
@@ -2,7 +2,7 @@ import { WALLET_ID } from '@/constants'
 import { AppError, ErrorRegistry } from '@/errors'
 import { BCState } from '@/store'
 import { activate } from '@/utils/PushNotificationsHelper'
-import { createLinkSecretIfRequired, DispatchAction, TOKENS, useServices, useStore } from '@bifold/core'
+import { createLinkSecretIfRequired, TOKENS, useServices, useStore } from '@bifold/core'
 import { Agent, MediatorPickupStrategy } from '@credo-ts/core'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Config } from 'react-native-config'
@@ -19,7 +19,7 @@ export interface AgentSetupResult {
 }
 
 const useAgentSetupViewModel = (): AgentSetupResult => {
-  const [store, dispatch] = useStore<BCState>()
+  const [store] = useStore<BCState>()
   const [logger, indyLedgers, attestationMonitor, credDefs, schemas] = useServices([
     TOKENS.UTIL_LOGGER,
     TOKENS.UTIL_LEDGERS,
@@ -41,7 +41,6 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
   const walletLabel = store.preferences.walletName || 'BC Wallet'
   const enableProxy = store.developer.enableProxy
   const usePushNotifications = store.preferences.usePushNotifications
-  const didMigrateToAskar = store.migration.didMigrateToAskar
 
   const refreshAttestationMonitor = useCallback(
     (liveAgent: Agent) => {
@@ -111,12 +110,6 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
           logger,
         })
 
-        // BCSC v4.1 starts fresh on Askar — no legacy Indy wallet to migrate.
-        // Mark the flag so any downstream code that still checks it stays consistent.
-        if (!didMigrateToAskar) {
-          dispatch({ type: DispatchAction.DID_MIGRATE_TO_ASKAR })
-        }
-
         await newAgent.initialize()
         await newAgent.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
         await warmCache(newAgent, credDefs, schemas, cachedLedgers, logger)
@@ -152,14 +145,12 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
     walletLabel,
     enableProxy,
     usePushNotifications,
-    didMigrateToAskar,
     retryCount,
     status,
     logger,
     indyLedgers,
     credDefs,
     schemas,
-    dispatch,
     refreshAttestationMonitor,
   ])
 

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
@@ -77,6 +77,8 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
     setStatus('initializing')
     setError(null)
 
+    let cancelled = false
+
     const run = async (): Promise<void> => {
       try {
         if (!walletKey) {
@@ -87,8 +89,10 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
 
         if (agentRef.current) {
           const restarted = await restartAgent(agentRef.current, walletSecret, logger)
+          if (cancelled) return
           if (restarted) {
             await restarted.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
+            if (cancelled) return
             refreshAttestationMonitor(restarted)
             agentRef.current = restarted
             setAgent(restarted)
@@ -98,6 +102,7 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
         }
 
         const cachedLedgers = await loadCachedLedgers()
+        if (cancelled) return
         const ledgers = cachedLedgers ?? indyLedgers
 
         const newAgent = buildAgent({
@@ -111,9 +116,13 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
         })
 
         await newAgent.initialize()
+        if (cancelled) return
         await newAgent.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
+        if (cancelled) return
         await warmCache(newAgent, credDefs, schemas, cachedLedgers, logger)
+        if (cancelled) return
         await createLinkSecretIfRequired(newAgent)
+        if (cancelled) return
 
         if (usePushNotifications) {
           activate(newAgent).catch((err) => logger.warn(`Push notification activation failed: ${err}`))
@@ -125,6 +134,7 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
         setAgent(newAgent)
         setStatus('ready')
       } catch (err) {
+        if (cancelled) return
         const appError =
           err instanceof AppError
             ? err
@@ -133,11 +143,18 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
         setError(appError)
         setStatus('error')
       } finally {
-        initializingRef.current = false
+        if (!cancelled) {
+          initializingRef.current = false
+        }
       }
     }
 
     run()
+
+    return () => {
+      cancelled = true
+      initializingRef.current = false
+    }
   }, [
     didAuthenticate,
     walletKey,

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
@@ -100,6 +100,10 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
             setStatus('ready')
             return
           }
+          // Restart failed — old agent may still hold open transports/listeners.
+          // Best-effort shut it down before falling through to build a fresh one.
+          await shutdownAgent(agentRef.current, logger)
+          agentRef.current = null
         }
 
         const cachedLedgers = await loadCachedLedgers()
@@ -142,6 +146,13 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
             ? err
             : AppError.fromErrorDefinition(ErrorRegistry.AGENT_INITIALIZATION_ERROR, { cause: err })
         logger.error(`[${appError.appEvent}] Agent init failed: ${appError.message}`)
+        // Clear any stale agent so retry takes the fresh build path instead of
+        // re-attempting restart on a broken instance.
+        if (agentRef.current) {
+          await shutdownAgent(agentRef.current, logger)
+          agentRef.current = null
+          setAgent(null)
+        }
         setError(appError)
         setStatus('error')
       } finally {

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
@@ -78,6 +78,7 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
     setError(null)
 
     let cancelled = false
+    let inFlightAgent: Agent | undefined
 
     const run = async (): Promise<void> => {
       try {
@@ -105,7 +106,7 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
         if (cancelled) return
         const ledgers = cachedLedgers ?? indyLedgers
 
-        const newAgent = buildAgent({
+        inFlightAgent = buildAgent({
           ledgers,
           walletSecret,
           mediatorUrl,
@@ -115,24 +116,25 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
           logger,
         })
 
-        await newAgent.initialize()
+        await inFlightAgent.initialize()
         if (cancelled) return
-        await newAgent.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
+        await inFlightAgent.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
         if (cancelled) return
-        await warmCache(newAgent, credDefs, schemas, cachedLedgers, logger)
+        await warmCache(inFlightAgent, credDefs, schemas, cachedLedgers, logger)
         if (cancelled) return
-        await createLinkSecretIfRequired(newAgent)
+        await createLinkSecretIfRequired(inFlightAgent)
         if (cancelled) return
 
         if (usePushNotifications) {
-          activate(newAgent).catch((err) => logger.warn(`Push notification activation failed: ${err}`))
+          activate(inFlightAgent).catch((err) => logger.warn(`Push notification activation failed: ${err}`))
         }
 
-        refreshAttestationMonitor(newAgent)
+        refreshAttestationMonitor(inFlightAgent)
 
-        agentRef.current = newAgent
-        setAgent(newAgent)
+        agentRef.current = inFlightAgent
+        setAgent(inFlightAgent)
         setStatus('ready')
+        inFlightAgent = undefined
       } catch (err) {
         if (cancelled) return
         const appError =
@@ -143,6 +145,9 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
         setError(appError)
         setStatus('error')
       } finally {
+        if (inFlightAgent) {
+          await shutdownAgent(inFlightAgent, logger)
+        }
         if (!cancelled) {
           initializingRef.current = false
         }

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
@@ -1,0 +1,168 @@
+import { WALLET_ID } from '@/constants'
+import { AppError, ErrorRegistry } from '@/errors'
+import { BCState } from '@/store'
+import { activate } from '@/utils/PushNotificationsHelper'
+import { createLinkSecretIfRequired, DispatchAction, migrateToAskar, TOKENS, useServices, useStore } from '@bifold/core'
+import { Agent, MediatorPickupStrategy } from '@credo-ts/core'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Config } from 'react-native-config'
+
+import { buildAgent, loadCachedLedgers, restartAgent, shutdownAgent, warmCache } from './services/agent-service'
+
+export type AgentSetupStatus = 'idle' | 'initializing' | 'ready' | 'error'
+
+export interface AgentSetupResult {
+  agent: Agent | null
+  status: AgentSetupStatus
+  error: AppError | null
+  retry: () => void
+}
+
+const useAgentSetupViewModel = (): AgentSetupResult => {
+  const [store, dispatch] = useStore<BCState>()
+  const [logger, indyLedgers, attestationMonitor, credDefs, schemas] = useServices([
+    TOKENS.UTIL_LOGGER,
+    TOKENS.UTIL_LEDGERS,
+    TOKENS.UTIL_ATTESTATION_MONITOR,
+    TOKENS.CACHE_CRED_DEFS,
+    TOKENS.CACHE_SCHEMAS,
+  ])
+
+  const [status, setStatus] = useState<AgentSetupStatus>('idle')
+  const [agent, setAgent] = useState<Agent | null>(null)
+  const [error, setError] = useState<AppError | null>(null)
+  const [retryCount, setRetryCount] = useState(0)
+  const agentRef = useRef<Agent | null>(null)
+  const initializingRef = useRef(false)
+
+  const didAuthenticate = store.authentication.didAuthenticate
+  const walletKey = store.bcscSecure.walletKey
+  const mediatorUrl = store.preferences.selectedMediator
+  const walletLabel = store.preferences.walletName || 'BC Wallet'
+  const enableProxy = store.developer.enableProxy
+  const usePushNotifications = store.preferences.usePushNotifications
+  const didMigrateToAskar = store.migration.didMigrateToAskar
+
+  const refreshAttestationMonitor = useCallback(
+    (liveAgent: Agent) => {
+      attestationMonitor?.stop()
+      attestationMonitor?.start(liveAgent)
+    },
+    [attestationMonitor]
+  )
+
+  const retry = useCallback(() => {
+    setError(null)
+    setStatus('idle')
+    setRetryCount((c) => c + 1)
+  }, [])
+
+  useEffect(() => {
+    if (!didAuthenticate) {
+      if (agentRef.current) {
+        shutdownAgent(agentRef.current, logger)
+        agentRef.current = null
+        setAgent(null)
+      }
+      setStatus('idle')
+      setError(null)
+      initializingRef.current = false
+      return
+    }
+
+    if (initializingRef.current || status === 'ready' || status === 'error') {
+      return
+    }
+
+    initializingRef.current = true
+    setStatus('initializing')
+    setError(null)
+
+    const run = async (): Promise<void> => {
+      try {
+        if (!walletKey) {
+          throw AppError.fromErrorDefinition(ErrorRegistry.WALLET_SECRET_NOT_FOUND)
+        }
+
+        const walletSecret = { id: WALLET_ID, key: walletKey }
+
+        if (agentRef.current) {
+          const restarted = await restartAgent(agentRef.current, walletSecret, logger)
+          if (restarted) {
+            await restarted.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
+            refreshAttestationMonitor(restarted)
+            agentRef.current = restarted
+            setAgent(restarted)
+            setStatus('ready')
+            return
+          }
+        }
+
+        const cachedLedgers = await loadCachedLedgers()
+        const ledgers = cachedLedgers ?? indyLedgers
+
+        const newAgent = buildAgent({
+          ledgers,
+          walletSecret,
+          mediatorUrl,
+          walletLabel,
+          enableProxy,
+          proxyBaseUrl: Config.INDY_VDR_PROXY_URL,
+          logger,
+        })
+
+        if (!didMigrateToAskar) {
+          await migrateToAskar(walletSecret.id, walletSecret.key, newAgent)
+          dispatch({ type: DispatchAction.DID_MIGRATE_TO_ASKAR })
+        }
+
+        await newAgent.initialize()
+        await newAgent.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
+        await warmCache(newAgent, credDefs, schemas, cachedLedgers, logger)
+        await createLinkSecretIfRequired(newAgent)
+
+        if (usePushNotifications) {
+          activate(newAgent).catch((err) => logger.warn(`Push notification activation failed: ${err}`))
+        }
+
+        refreshAttestationMonitor(newAgent)
+
+        agentRef.current = newAgent
+        setAgent(newAgent)
+        setStatus('ready')
+      } catch (err) {
+        const appError =
+          err instanceof AppError
+            ? err
+            : AppError.fromErrorDefinition(ErrorRegistry.AGENT_INITIALIZATION_ERROR, { cause: err })
+        logger.error(`[${appError.appEvent}] Agent init failed: ${appError.message}`)
+        setError(appError)
+        setStatus('error')
+      } finally {
+        initializingRef.current = false
+      }
+    }
+
+    run()
+  }, [
+    didAuthenticate,
+    walletKey,
+    mediatorUrl,
+    walletLabel,
+    enableProxy,
+    usePushNotifications,
+    didMigrateToAskar,
+    retryCount,
+    status,
+    logger,
+    indyLedgers,
+    credDefs,
+    schemas,
+    dispatch,
+    refreshAttestationMonitor,
+  ])
+
+  return { agent, status, error, retry }
+}
+
+export default useAgentSetupViewModel

--- a/app/src/bcsc-theme/navigators/RootStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.test.tsx
@@ -59,6 +59,10 @@ jest.mock('../contexts/BCSCAccountContext', () => ({
 jest.mock('../contexts/BCSCIdTokenContext', () => ({
   BCSCIdTokenProvider: ({ children }: any) => children,
 }))
+jest.mock('../features/agent/BCSCAgentProvider', () => ({
+  __esModule: true,
+  default: ({ children }: any) => children,
+}))
 
 const mockStore = (overrides: Record<string, any> = {}) => ({
   stateLoaded: true,

--- a/app/src/bcsc-theme/navigators/RootStack.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.tsx
@@ -67,10 +67,7 @@ const BCSCRootStack: React.FC = () => {
 
   return (
     <BCSCAgentProvider>
-      <AuthenticatedStack
-        verified={store.bcscSecure.verified}
-        verifiedStatus={store.bcscSecure.verifiedStatus}
-      />
+      <AuthenticatedStack verified={store.bcscSecure.verified} verifiedStatus={store.bcscSecure.verifiedStatus} />
     </BCSCAgentProvider>
   )
 }

--- a/app/src/bcsc-theme/navigators/RootStack.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.tsx
@@ -67,33 +67,20 @@ const BCSCRootStack: React.FC = () => {
 
   return (
     <BCSCAgentProvider>
-      <AuthenticatedStack verified={store.bcscSecure.verified} verifiedStatus={store.bcscSecure.verifiedStatus} />
+      {store.bcscSecure.verified === false && store.bcscSecure.verifiedStatus === VerificationStatus.IN_PROGRESS ? (
+        <BCSCActivityProvider>
+          <VerifyStack />
+        </BCSCActivityProvider>
+      ) : (
+        <BCSCActivityProvider>
+          <BCSCAccountProvider>
+            {/* <BCSCIdTokenProvider> */}
+            <BCSCMainStack />
+            {/* </BCSCIdTokenProvider> */}
+          </BCSCAccountProvider>
+        </BCSCActivityProvider>
+      )}
     </BCSCAgentProvider>
-  )
-}
-
-interface AuthenticatedStackProps {
-  verified: boolean | undefined
-  verifiedStatus: VerificationStatus
-}
-
-const AuthenticatedStack: React.FC<AuthenticatedStackProps> = ({ verified, verifiedStatus }) => {
-  if (verified === false && verifiedStatus === VerificationStatus.IN_PROGRESS) {
-    return (
-      <BCSCActivityProvider>
-        <VerifyStack />
-      </BCSCActivityProvider>
-    )
-  }
-
-  return (
-    <BCSCActivityProvider>
-      <BCSCAccountProvider>
-        {/* <BCSCIdTokenProvider> */}
-        <BCSCMainStack />
-        {/* </BCSCIdTokenProvider> */}
-      </BCSCAccountProvider>
-    </BCSCActivityProvider>
   )
 }
 

--- a/app/src/bcsc-theme/navigators/RootStack.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.tsx
@@ -10,6 +10,7 @@ import useThirdPartyKeyboardWarning from '../api/hooks/useThirdPartyKeyboardWarn
 import { BCSCAccountProvider } from '../contexts/BCSCAccountContext'
 import { BCSCActivityProvider } from '../contexts/BCSCActivityContext'
 import { LoadingScreen } from '../contexts/BCSCLoadingContext'
+import BCSCAgentProvider from '../features/agent/BCSCAgentProvider'
 import { useFcmService } from '../features/fcm'
 import { useBCSCApiClientState } from '../hooks/useBCSCApiClient'
 import { SystemCheckScope, useSystemChecks } from '../hooks/useSystemChecks'
@@ -64,7 +65,23 @@ const BCSCRootStack: React.FC = () => {
     return <AuthStack />
   }
 
-  if (store.bcscSecure.verified === false && store.bcscSecure.verifiedStatus === VerificationStatus.IN_PROGRESS) {
+  return (
+    <BCSCAgentProvider>
+      <AuthenticatedStack
+        verified={store.bcscSecure.verified}
+        verifiedStatus={store.bcscSecure.verifiedStatus}
+      />
+    </BCSCAgentProvider>
+  )
+}
+
+interface AuthenticatedStackProps {
+  verified: boolean | undefined
+  verifiedStatus: VerificationStatus
+}
+
+const AuthenticatedStack: React.FC<AuthenticatedStackProps> = ({ verified, verifiedStatus }) => {
+  if (verified === false && verifiedStatus === VerificationStatus.IN_PROGRESS) {
     return (
       <BCSCActivityProvider>
         <VerifyStack />


### PR DESCRIPTION
Wires the v4.1 BCSC Credo agent on top of #3724's service scaffold. New `useAgentSetupViewModel` orchestrates init (load ledgers → build → initialize → mediator pickup → warm cache → link secret → push activate). New `BCSCAgentProvider` + `useBCSCAgent` hook exposes `{ agent, loading, error, retry }` to BCSC screens, decoupled from Bifold's `AgentProvider` so the BCSC subtree stays free of Bifold's data-hook stack. Non-blocking on error — failures log via typed `AppError`, children always render, screens decide what to show. Recreated after #3725 was auto-marked merged when #3724's squash deleted the stack base.

Closes #3720.