### PR TITLE
fix: card not found error

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useAuthorizationApi.test.tsx
+++ b/app/src/bcsc-theme/api/hooks/useAuthorizationApi.test.tsx
@@ -1,0 +1,221 @@
+import useAuthorizationApi from '@/bcsc-theme/api/hooks/useAuthorizationApi'
+import { act, renderHook } from '@testing-library/react-native'
+import moment from 'moment'
+import * as BcscCore from 'react-native-bcsc-core'
+
+const IAS_SCOPE = 'openid profile email address offline_access'
+const DEVICE_AUTH_ENDPOINT = '/device/devicecode'
+const FAKE_CLIENT_ID = 'client-uuid-1234'
+
+const buildMockApiClient = () => ({
+  post: jest.fn().mockResolvedValue({ data: {} }),
+  endpoints: { deviceAuthorization: DEVICE_AUTH_ENDPOINT },
+})
+
+const renderAuthApi = (apiClient: ReturnType<typeof buildMockApiClient>) =>
+  renderHook(() => useAuthorizationApi(apiClient as any)).result.current
+
+describe('useAuthorizationApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.mocked(BcscCore.getAccount).mockResolvedValue({ clientID: FAKE_CLIENT_ID } as any)
+  })
+
+  describe('authorizeDevice', () => {
+    it('posts the form-encoded body to the deviceAuthorization endpoint with skipBearerAuth', async () => {
+      const apiClient = buildMockApiClient()
+      const api = renderAuthApi(apiClient)
+
+      await act(async () => {
+        await api.authorizeDevice('C82643367', new Date(1995, 11, 17))
+      })
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        DEVICE_AUTH_ENDPOINT,
+        expect.objectContaining({
+          response_type: 'device_code',
+          client_id: FAKE_CLIENT_ID,
+          card_serial_number: 'C82643367',
+          birth_date: '1995-12-17',
+          scope: IAS_SCOPE,
+        }),
+        {
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          skipBearerAuth: true,
+        }
+      )
+    })
+
+    it('formats birth_date from local-time components, not UTC (regression: TZ-shift card_not_found)', async () => {
+      // Production constructs birthdate via moment(...).toDate() — local-midnight on whatever
+      // device runs the app. The OLD impl used .toISOString().split('T')[0] which converts to
+      // UTC and shifts the date back a day for any TZ east of UTC (Sauce Labs cloud devices,
+      // travelers outside BC). IAS then can't find the card and returns card_not_found.
+      const apiClient = buildMockApiClient()
+      const api = renderAuthApi(apiClient)
+      const userEnteredDate = moment('1995-12-17', 'YYYY-MM-DD').toDate()
+
+      await act(async () => {
+        await api.authorizeDevice('C82643367', userEnteredDate)
+      })
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        DEVICE_AUTH_ENDPOINT,
+        expect.objectContaining({ birth_date: '1995-12-17' }),
+        expect.anything()
+      )
+    })
+
+    it('omits card_serial_number and birth_date when neither is provided (transfer flow)', async () => {
+      const apiClient = buildMockApiClient()
+      const api = renderAuthApi(apiClient)
+
+      await act(async () => {
+        await api.authorizeDevice()
+      })
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        DEVICE_AUTH_ENDPOINT,
+        expect.objectContaining({
+          response_type: 'device_code',
+          client_id: FAKE_CLIENT_ID,
+          card_serial_number: undefined,
+          birth_date: undefined,
+          scope: IAS_SCOPE,
+        }),
+        expect.anything()
+      )
+    })
+
+    it('throws when a serial is provided without a birthdate', async () => {
+      const apiClient = buildMockApiClient()
+      const api = renderAuthApi(apiClient)
+
+      await act(async () => {
+        await expect(api.authorizeDevice('C82643367')).rejects.toThrow(
+          'Birthdate is required when providing a serial number'
+        )
+      })
+      expect(apiClient.post).not.toHaveBeenCalled()
+    })
+
+    it('returns the response data from IAS', async () => {
+      const apiClient = buildMockApiClient()
+      const mockResponse = {
+        device_code: 'dev-abc',
+        user_code: 'USER1234',
+        verified_email: 'a****1@gmail.com',
+        attestation_uri: 'https://example/attest',
+        verification_options: 'video_call back_check',
+        process: 'photo',
+        expires_in: 600,
+      }
+      apiClient.post.mockResolvedValueOnce({ data: mockResponse })
+
+      const api = renderAuthApi(apiClient)
+      let result: any
+      await act(async () => {
+        result = await api.authorizeDevice('C82643367', new Date(1995, 11, 17))
+      })
+
+      expect(result).toEqual(mockResponse)
+    })
+  })
+
+  describe('authorizeDeviceWithUnknownBCSC', () => {
+    const baseConfig = {
+      firstName: 'Velma',
+      lastName: 'Dinkley',
+      birthdate: '1995-12-17',
+      address: {
+        streetAddress: '123 Main St',
+        postalCode: 'V6B 1A1',
+        city: 'Vancouver',
+        province: 'BC' as const,
+      },
+    }
+
+    beforeEach(() => {
+      jest.mocked(BcscCore.createDeviceSignedJWT).mockResolvedValue('signed-jwt-token')
+    })
+
+    it('posts with an id_token_hint JWT and the standard form-encoded headers', async () => {
+      const apiClient = buildMockApiClient()
+      const api = renderAuthApi(apiClient)
+
+      await act(async () => {
+        await api.authorizeDeviceWithUnknownBCSC(baseConfig)
+      })
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        DEVICE_AUTH_ENDPOINT,
+        expect.objectContaining({
+          client_id: FAKE_CLIENT_ID,
+          response_type: 'device_code',
+          scope: IAS_SCOPE,
+          id_token_hint: 'signed-jwt-token',
+        }),
+        {
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          skipBearerAuth: true,
+        }
+      )
+    })
+
+    it('passes user/address claims through to createDeviceSignedJWT', async () => {
+      const apiClient = buildMockApiClient()
+      const api = renderAuthApi(apiClient)
+
+      await act(async () => {
+        await api.authorizeDeviceWithUnknownBCSC({ ...baseConfig, gender: 'female', middleNames: 'May' })
+      })
+
+      expect(BcscCore.createDeviceSignedJWT).toHaveBeenCalledWith(
+        expect.objectContaining({
+          family_name: 'Dinkley',
+          given_name: 'Velma',
+          birthdate: '1995-12-17',
+          address: {
+            street_address: '123 Main St',
+            postal_code: 'V6B 1A1',
+            locality: 'Vancouver',
+            region: 'BC',
+            country: 'CA',
+          },
+          gender: 'female',
+          middle_name: 'May',
+        })
+      )
+    })
+
+    it("defaults gender to 'unknown' when not provided", async () => {
+      const apiClient = buildMockApiClient()
+      const api = renderAuthApi(apiClient)
+
+      await act(async () => {
+        await api.authorizeDeviceWithUnknownBCSC(baseConfig)
+      })
+
+      expect(BcscCore.createDeviceSignedJWT).toHaveBeenCalledWith(expect.objectContaining({ gender: 'unknown' }))
+    })
+
+    it('omits middle_name when not provided or empty', async () => {
+      const apiClient = buildMockApiClient()
+      const api = renderAuthApi(apiClient)
+
+      await act(async () => {
+        await api.authorizeDeviceWithUnknownBCSC(baseConfig)
+      })
+      expect(BcscCore.createDeviceSignedJWT).toHaveBeenLastCalledWith(
+        expect.objectContaining({ middle_name: undefined })
+      )
+
+      await act(async () => {
+        await api.authorizeDeviceWithUnknownBCSC({ ...baseConfig, middleNames: '' })
+      })
+      expect(BcscCore.createDeviceSignedJWT).toHaveBeenLastCalledWith(
+        expect.objectContaining({ middle_name: undefined })
+      )
+    })
+  })
+})

--- a/app/src/bcsc-theme/api/hooks/useAuthorizationApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useAuthorizationApi.tsx
@@ -1,4 +1,5 @@
 import { ProvinceCode } from '@/bcsc-theme/utils/address-utils'
+import moment from 'moment'
 import { useCallback, useMemo } from 'react'
 import { BCSCCardProcess, createDeviceSignedJWT } from 'react-native-bcsc-core'
 import BCSCApiClient from '../client'
@@ -62,7 +63,9 @@ const useAuthorizationApi = (apiClient: BCSCApiClient) => {
           response_type: 'device_code',
           client_id: account.clientID,
           card_serial_number: serial ?? undefined,
-          birth_date: birthdate?.toISOString().split('T')[0] ?? undefined,
+          // Format in local time. toISOString() shifts to UTC, which moves the date back a day
+          // for any TZ east of UTC (e.g. Sauce Labs cloud devices) and breaks IAS card lookup.
+          birth_date: birthdate ? moment(birthdate).format('YYYY-MM-DD') : undefined,
           scope: IAS_SCOPE,
         }
 

--- a/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.tsx
@@ -16,7 +16,7 @@ import { StackNavigationProp } from '@react-navigation/stack'
 import moment from 'moment'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Alert, StyleSheet, View } from 'react-native'
+import { StyleSheet, View } from 'react-native'
 import { VerificationCardError } from '../verificationCardError'
 import { useEnterBirthdateViewModel } from './useEnterBirthdateViewModel'
 
@@ -66,37 +66,10 @@ const EnterBirthdateScreen: React.FC<EnterBirthdateScreenProps> = ({ navigation 
         return
       }
 
-      // TEMP DEBUG (S25 / Android 16 "Card not found"): surface the IAS 4xx body + request data
-      // on-device so we can see exactly what was sent. Remove once root cause is fixed.
-      const cause = (error as any)?.cause
-      const requestData = cause?.config?.data
-      const debug = {
-        appEvent: (error as any)?.appEvent,
-        technicalMessage: (error as any)?.technicalMessage,
-        status: cause?.response?.status,
-        iasError: cause?.response?.data?.error,
-        iasErrorDescription: cause?.response?.data?.error_description,
-        url: cause?.config?.url,
-        userAgent: cause?.config?.headers?.['User-Agent'] ?? cause?.config?.headers?.['user-agent'],
-        contentType: cause?.config?.headers?.['Content-Type'] ?? cause?.config?.headers?.['content-type'],
-        requestBody: typeof requestData === 'string' ? requestData : JSON.stringify(requestData),
-      }
-      logger.error('CSN and birthdate mismatch, card not found', { error, debug })
-      Alert.alert(
-        '[DEBUG] Card not found',
-        Object.entries(debug)
-          .map(([k, v]) => `${k}: ${v ?? '—'}`)
-          .join('\n'),
-        [
-          {
-            text: 'OK',
-            onPress: () =>
-              navigation.navigate(BCSCScreens.VerificationCardError, {
-                errorType: VerificationCardError.MismatchedSerial,
-              }),
-          },
-        ]
-      )
+      logger.error('CSN and birthdate mismatch, card not found', { error })
+      navigation.navigate(BCSCScreens.VerificationCardError, {
+        errorType: VerificationCardError.MismatchedSerial,
+      })
     } finally {
       setLoading(false)
     }

--- a/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.tsx
@@ -66,9 +66,10 @@ const EnterBirthdateScreen: React.FC<EnterBirthdateScreenProps> = ({ navigation 
         return
       }
 
-      // TEMP DEBUG (S25 / Android 16 "Card not found"): surface the IAS 4xx body on-device so a
-      // tester without access to remote logs can capture it. Remove once root cause is fixed.
+      // TEMP DEBUG (S25 / Android 16 "Card not found"): surface the IAS 4xx body + request data
+      // on-device so we can see exactly what was sent. Remove once root cause is fixed.
       const cause = (error as any)?.cause
+      const requestData = cause?.config?.data
       const debug = {
         appEvent: (error as any)?.appEvent,
         technicalMessage: (error as any)?.technicalMessage,
@@ -77,6 +78,8 @@ const EnterBirthdateScreen: React.FC<EnterBirthdateScreenProps> = ({ navigation 
         iasErrorDescription: cause?.response?.data?.error_description,
         url: cause?.config?.url,
         userAgent: cause?.config?.headers?.['User-Agent'] ?? cause?.config?.headers?.['user-agent'],
+        contentType: cause?.config?.headers?.['Content-Type'] ?? cause?.config?.headers?.['content-type'],
+        requestBody: typeof requestData === 'string' ? requestData : JSON.stringify(requestData),
       }
       logger.error('CSN and birthdate mismatch, card not found', { error, debug })
       Alert.alert(

--- a/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.tsx
@@ -16,7 +16,7 @@ import { StackNavigationProp } from '@react-navigation/stack'
 import moment from 'moment'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, View } from 'react-native'
+import { Alert, StyleSheet, View } from 'react-native'
 import { VerificationCardError } from '../verificationCardError'
 import { useEnterBirthdateViewModel } from './useEnterBirthdateViewModel'
 
@@ -66,10 +66,34 @@ const EnterBirthdateScreen: React.FC<EnterBirthdateScreenProps> = ({ navigation 
         return
       }
 
-      logger.error('CSN and birthdate mismatch, card not found', { error })
-      navigation.navigate(BCSCScreens.VerificationCardError, {
-        errorType: VerificationCardError.MismatchedSerial,
-      })
+      // TEMP DEBUG (S25 / Android 16 "Card not found"): surface the IAS 4xx body on-device so a
+      // tester without access to remote logs can capture it. Remove once root cause is fixed.
+      const cause = (error as any)?.cause
+      const debug = {
+        appEvent: (error as any)?.appEvent,
+        technicalMessage: (error as any)?.technicalMessage,
+        status: cause?.response?.status,
+        iasError: cause?.response?.data?.error,
+        iasErrorDescription: cause?.response?.data?.error_description,
+        url: cause?.config?.url,
+        userAgent: cause?.config?.headers?.['User-Agent'] ?? cause?.config?.headers?.['user-agent'],
+      }
+      logger.error('CSN and birthdate mismatch, card not found', { error, debug })
+      Alert.alert(
+        '[DEBUG] Card not found',
+        Object.entries(debug)
+          .map(([k, v]) => `${k}: ${v ?? '—'}`)
+          .join('\n'),
+        [
+          {
+            text: 'OK',
+            onPress: () =>
+              navigation.navigate(BCSCScreens.VerificationCardError, {
+                errorType: VerificationCardError.MismatchedSerial,
+              }),
+          },
+        ]
+      )
     } finally {
       setLoading(false)
     }

--- a/app/src/bcsc-theme/features/verify/_models/useResidentialAddressModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/_models/useResidentialAddressModel.test.ts
@@ -51,7 +51,7 @@ describe('useResidentialAddressModel', () => {
 
   const mockStore: any = {
     bcscSecure: {
-      birthdate: new Date('1990-01-15'),
+      birthdate: new Date(1990, 0, 15),
       deviceCode: null,
       deviceCodeExpiresAt: null,
       userMetadata: {
@@ -174,7 +174,7 @@ describe('useResidentialAddressModel', () => {
 
       const storeWithEmptyAddress = {
         bcscSecure: {
-          birthdate: new Date('1990-01-15'),
+          birthdate: new Date(1990, 0, 15),
           userMetadata: {
             name: { first: 'John', last: 'Doe' },
             address: null,
@@ -209,7 +209,7 @@ describe('useResidentialAddressModel', () => {
 
       const storeWithEmptyAddress = {
         bcscSecure: {
-          birthdate: new Date('1990-01-15'),
+          birthdate: new Date(1990, 0, 15),
           userMetadata: {
             name: { first: 'John', last: 'Doe' },
             address: null,
@@ -502,7 +502,7 @@ describe('useResidentialAddressModel', () => {
     it('should throw error when user name is missing', async () => {
       const storeWithoutName = {
         bcscSecure: {
-          birthdate: new Date('1990-01-15'),
+          birthdate: new Date(1990, 0, 15),
           deviceCode: null,
           deviceCodeExpiresAt: null,
           userMetadata: {

--- a/app/src/bcsc-theme/features/verify/_models/useResidentialAddressModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useResidentialAddressModel.tsx
@@ -7,6 +7,7 @@ import { BCState, NonBCSCUserMetadata } from '@/store'
 import { ToastType, TOKENS, useServices, useStore, useTheme } from '@bifold/core'
 import { CommonActions } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
+import moment from 'moment'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Toast from 'react-native-toast-message'
@@ -157,7 +158,7 @@ const useResidentialAddressModel = ({ navigation }: useResidentialAddressModelPr
       const deviceAuth = await authorization.authorizeDeviceWithUnknownBCSC({
         firstName: store.bcscSecure.userMetadata.name.first,
         lastName: store.bcscSecure.userMetadata.name.last,
-        birthdate: store.bcscSecure.birthdate.toISOString().split('T')[0],
+        birthdate: moment(store.bcscSecure.birthdate).format('YYYY-MM-DD'),
         middleNames: store.bcscSecure.userMetadata.name.middle,
         address: {
           streetAddress: mergedStreetAddress,

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
@@ -19,6 +19,7 @@ import {
 import { CommonActions, RouteProp } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { a11yLabel } from '@utils/accessibility'
+import moment from 'moment'
 import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, View } from 'react-native'
@@ -93,7 +94,7 @@ const EvidenceIDCollectionScreen = ({ navigation, route }: EvidenceIDCollectionS
     firstName: store.bcscSecure.userMetadata?.name?.first ?? '',
     middleNames: store.bcscSecure.userMetadata?.name?.middle ?? '',
     lastName: store.bcscSecure.userMetadata?.name?.last ?? '',
-    birthDate: store.bcscSecure.birthdate?.toISOString().split('T')[0] ?? '',
+    birthDate: store.bcscSecure.birthdate ? moment(store.bcscSecure.birthdate).format('YYYY-MM-DD') : '',
   })
   const [formErrors, setFormErrors] = useState<EvidenceCollectionFormErrors>({})
 


### PR DESCRIPTION
# Summary of Changes

Fix off-by-one-day error in the birthdate sent to IAS `deviceAuthorization`.

`birthdate.toISOString().split('T')[0]` converts a local-midnight `Date` to UTC, shifting the date back a day on any device east of UTC (Sauce Labs cloud devices, users outside BC, devices set to UTC). IAS then can't find the card and returns `{error: invalid_request, error_description: card_not_found}`, which the app displays as "Card not found".

Replaced with `moment(date).format('YYYY-MM-DD')` (formats in local time) at three call sites:
- `app/src/bcsc-theme/api/hooks/useAuthorizationApi.tsx` — manual entry + camera scan
- `app/src/bcsc-theme/features/verify/_models/useResidentialAddressModel.tsx` — non-BCSC JWT claim
- `app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx` — form prefill

Test updated to use local-midnight `new Date(1990, 0, 15)` instead of UTC-midnight `new Date('1990-01-15')`, so it mirrors real-world `Date` construction.

# Testing Instructions

1. Run e2e flow on a Sauce Labs Android device with the `e2e_velma` combined card (DOB `1995-12-17`).
2. Manual entry path: enter `1995/12/17` on the birthdate screen and submit.
3. Camera scan path: scan the combo barcode.
4. Both paths should authorize the device successfully and proceed to setup steps (no "Card not found" screen).

# Acceptance Criteria

- `e2e_velma` combined card succeeds on Sauce Labs cloud devices (previously failing).
- All passing tests still pass: `useResidentialAddressModel.test.ts`, `EnterBirthdateScreen.test.tsx`, `EvidenceIDCollectionScreen.test.tsx`.
- No regression on Pixel/local PST devices.

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A
