### PR TITLE
fix: use displayName as fallback for missing nickname from earlier v3

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useInitializeAccountStatus.test.tsx
+++ b/app/src/bcsc-theme/api/hooks/useInitializeAccountStatus.test.tsx
@@ -167,9 +167,9 @@ describe('useInitializeAccountStatus', () => {
     expect(mockDispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: BCDispatchAction.ADD_NICKNAME }))
   })
 
-  it('does not dispatch ADD_NICKNAME when account has no nickname', async () => {
+  it('does not dispatch ADD_NICKNAME when account has no nickname or displayName', async () => {
     const mockDispatch = jest.fn()
-    const mockAccount = { nickname: undefined }
+    const mockAccount = { nickname: undefined, displayName: undefined }
     jest
       .mocked(Bifold.useStore)
       .mockReturnValue([{ stateLoaded: true, bcsc: { hasAccount: false, nicknames: [] } } as any, mockDispatch])
@@ -181,6 +181,48 @@ describe('useInitializeAccountStatus', () => {
     await act(async () => {})
 
     expect(mockDispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: BCDispatchAction.ADD_NICKNAME }))
+  })
+
+  it('falls back to displayName when nickname is missing (e.g. v3 ias-ios migrated users)', async () => {
+    const mockDispatch = jest.fn()
+    const mockAccount = { nickname: undefined, displayName: 'Jane' }
+    jest
+      .mocked(Bifold.useStore)
+      .mockReturnValue([{ stateLoaded: true, bcsc: { hasAccount: false, nicknames: [] } } as any, mockDispatch])
+    jest.mocked(Bifold.useServices).mockReturnValue([{ info: jest.fn(), error: jest.fn() }] as any)
+    jest.mocked(retryModule.retryAsync).mockResolvedValue(mockAccount)
+
+    renderHook(() => useInitializeAccountStatus())
+
+    await act(async () => {})
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: BCDispatchAction.ADD_NICKNAME,
+      payload: ['Jane'],
+    })
+  })
+
+  it('prefers nickname over displayName when both are present', async () => {
+    const mockDispatch = jest.fn()
+    const mockAccount = { nickname: 'My Wallet', displayName: 'Jane' }
+    jest
+      .mocked(Bifold.useStore)
+      .mockReturnValue([{ stateLoaded: true, bcsc: { hasAccount: false, nicknames: [] } } as any, mockDispatch])
+    jest.mocked(Bifold.useServices).mockReturnValue([{ info: jest.fn(), error: jest.fn() }] as any)
+    jest.mocked(retryModule.retryAsync).mockResolvedValue(mockAccount)
+
+    renderHook(() => useInitializeAccountStatus())
+
+    await act(async () => {})
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: BCDispatchAction.ADD_NICKNAME,
+      payload: ['My Wallet'],
+    })
+    expect(mockDispatch).not.toHaveBeenCalledWith({
+      type: BCDispatchAction.ADD_NICKNAME,
+      payload: ['Jane'],
+    })
   })
 
   it('logs error when getAccount throws', async () => {

--- a/app/src/bcsc-theme/api/hooks/useInitializeAccountStatus.test.tsx
+++ b/app/src/bcsc-theme/api/hooks/useInitializeAccountStatus.test.tsx
@@ -225,6 +225,30 @@ describe('useInitializeAccountStatus', () => {
     })
   })
 
+  it('falls back to displayName when nickname is an empty string', async () => {
+    // Uses `||` (not `??`) so empty-string nicknames fall through to displayName.
+    const mockDispatch = jest.fn()
+    const mockAccount = { nickname: '', displayName: 'Jane' }
+    jest
+      .mocked(Bifold.useStore)
+      .mockReturnValue([{ stateLoaded: true, bcsc: { hasAccount: false, nicknames: [] } } as any, mockDispatch])
+    jest.mocked(Bifold.useServices).mockReturnValue([{ info: jest.fn(), error: jest.fn() }] as any)
+    jest.mocked(retryModule.retryAsync).mockResolvedValue(mockAccount)
+
+    renderHook(() => useInitializeAccountStatus())
+
+    await act(async () => {})
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: BCDispatchAction.ADD_NICKNAME,
+      payload: ['Jane'],
+    })
+    expect(mockDispatch).not.toHaveBeenCalledWith({
+      type: BCDispatchAction.ADD_NICKNAME,
+      payload: [''],
+    })
+  })
+
   it('logs error when getAccount throws', async () => {
     const mockDispatch = jest.fn()
     const mockLogger = { info: jest.fn(), error: jest.fn() }

--- a/app/src/bcsc-theme/api/hooks/useInitializeAccountStatus.tsx
+++ b/app/src/bcsc-theme/api/hooks/useInitializeAccountStatus.tsx
@@ -32,7 +32,7 @@ export const useInitializeAccountStatus = () => {
 
       dispatch({ type: BCDispatchAction.SET_HAS_ACCOUNT, payload: [Boolean(account)] })
 
-      const nickname = account?.nickname ?? account?.displayName
+      const nickname = account?.nickname || account?.displayName
 
       if (nickname && !store.bcsc.nicknames.includes(nickname)) {
         dispatch({ type: BCDispatchAction.ADD_NICKNAME, payload: [nickname] })

--- a/app/src/bcsc-theme/api/hooks/useInitializeAccountStatus.tsx
+++ b/app/src/bcsc-theme/api/hooks/useInitializeAccountStatus.tsx
@@ -32,8 +32,10 @@ export const useInitializeAccountStatus = () => {
 
       dispatch({ type: BCDispatchAction.SET_HAS_ACCOUNT, payload: [Boolean(account)] })
 
-      if (account?.nickname && !store.bcsc.nicknames.includes(account.nickname)) {
-        dispatch({ type: BCDispatchAction.ADD_NICKNAME, payload: [account.nickname] })
+      const nickname = account?.nickname ?? account?.displayName
+
+      if (nickname && !store.bcsc.nicknames.includes(nickname)) {
+        dispatch({ type: BCDispatchAction.ADD_NICKNAME, payload: [nickname] })
       }
     } catch (error) {
       logger.error('[useInitializeAccountStatus] Error checking for existing account:', error as Error)

--- a/app/src/bcsc-theme/features/auth/AccountSelectorScreen.test.tsx
+++ b/app/src/bcsc-theme/features/auth/AccountSelectorScreen.test.tsx
@@ -62,7 +62,7 @@ describe('AccountSetup', () => {
         </BasicAppContext>
       )
 
-      expect(tree.getByText('Global.ContinueSetup')).toBeTruthy()
+      expect(tree.getByText('Global.Continue')).toBeTruthy()
       expect(tree.queryByText('BCSC.AccountSetup.ContinueAs')).toBeNull()
       expect(tree).toMatchSnapshot()
     })
@@ -74,7 +74,7 @@ describe('AccountSetup', () => {
         </BasicAppContext>
       )
 
-      const continueButton = tree.getByTestId('com.ariesbifold:id/ContinueSetup')
+      const continueButton = tree.getByTestId('com.ariesbifold:id/Continue')
       fireEvent.press(continueButton)
 
       expect(mockUnlockApp).toHaveBeenCalled()

--- a/app/src/bcsc-theme/features/auth/AccountSelectorScreen.tsx
+++ b/app/src/bcsc-theme/features/auth/AccountSelectorScreen.tsx
@@ -51,9 +51,9 @@ const AccountSelectorScreen = ({ navigation }: AccountSelectorScreenProps) => {
   ) : (
     <Button
       buttonType={ButtonType.Primary}
-      testID={testIdWithKey('ContinueSetup')}
-      title={t('Global.ContinueSetup')}
-      accessibilityLabel={a11yLabel(t('Global.ContinueSetup'))}
+      testID={testIdWithKey('Continue')}
+      title={t('Global.Continue')}
+      accessibilityLabel={a11yLabel(t('Global.Continue'))}
       onPress={authentication.unlockApp}
     />
   )

--- a/app/src/bcsc-theme/features/auth/__snapshots__/AccountSelectorScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/auth/__snapshots__/AccountSelectorScreen.test.tsx.snap
@@ -376,7 +376,7 @@ exports[`AccountSetup when no nicknames exist renders Continue setting up accoun
       }
     >
       <View
-        accessibilityLabel="Global.ContinueSetup"
+        accessibilityLabel="Global.Continue"
         accessibilityRole="button"
         accessibilityState={
           {
@@ -413,7 +413,7 @@ exports[`AccountSetup when no nicknames exist renders Continue setting up accoun
             "padding": 16,
           }
         }
-        testID="com.ariesbifold:id/ContinueSetup"
+        testID="com.ariesbifold:id/Continue"
       >
         <View
           style={
@@ -448,7 +448,7 @@ exports[`AccountSetup when no nicknames exist renders Continue setting up accoun
               ]
             }
           >
-            Global.ContinueSetup
+            Global.Continue
           </Text>
         </View>
       </View>

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -13,7 +13,6 @@ const translation = {
     "HideDetails": "Hide Details",
     "Dismiss": "Dismiss",
     "GetHelp": "Get help",
-    "ContinueSetup": "Continue setup",
     "A11y": {
       "OpensInBrowser": "This opens in browser",
     }

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -13,7 +13,6 @@ const translation = {
     "HideDetails": "Masquer les détails",
     "Dismiss": "Fermer",
     "GetHelp": "Get help (FR)",
-    "ContinueSetup": "Continue setup (FR)",
     "A11y": {
       "OpensInBrowser": "This opens in browser (FR)",
     }

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -13,7 +13,6 @@ const translation = {
     "HideDetails": "Ocultar detalhes",
     "Dismiss": "Dispensar",
     "GetHelp": "Get help (PT-BR)",
-    "ContinueSetup": "Continue setup (PT-BR)",
     "A11y": {
       "OpensInBrowser": "This opens in browser (PT-BR)",
     }

--- a/e2e/src/testIDs.ts
+++ b/e2e/src/testIDs.ts
@@ -276,7 +276,7 @@ export const BCSC_TestIDs = {
   },
   AccountSelector: {
     SettingsMenuButton: 'com.ariesbifold:id/SettingsMenuButton',
-    ContinueSetup: 'com.ariesbifold:id/ContinueSetup',
+    ContinueSetup: 'com.ariesbifold:id/Continue',
   },
   EnterPIN: {
     PINInput: 'com.ariesbifold:id/PINInput',


### PR DESCRIPTION
# Summary of Changes

Two changes:
- use displayName as fallback nickname in initial account check
- change button to "Continue" rather than "Continue setup" so if someone verified manages to migrate without a displayName or nickname, they don't mistakenly think they need to re-verify

# Testing Instructions
In ias-ios:
```zsh
git checkout 3.5.1_489
# install, get verified
git checkout 3.12.0_618
# install, unlock app
# then build this branch overtop, confirm nickname gets set to displayName (will be given name or family name)
```

Then, do a fresh install of this branch and create an account but don't yet create a nickname. Cycle the app and check that the button shown says "Continue" not "Continue setup"

# Acceptance Criteria

Fallback works, button label changes

# Screenshots, videos, or gifs

N/A

# Related Issues

#3794 