### PR TITLE
fix: interval cleanup on transfer account

### DIFF
--- a/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.test.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.test.tsx
@@ -161,6 +161,106 @@ describe('TransferQRDisplayScreen', () => {
       })
     })
 
+    it('stops polling for attestation status after a successful attestation', async () => {
+      jest.mocked(getAccount).mockResolvedValue(mockAccount)
+      // First call resolves true (success); any subsequent call would resolve false.
+      mockCheckAttestationStatus.mockResolvedValueOnce(true).mockResolvedValue(false)
+
+      render(
+        <BasicAppContext>
+          <TransferQRDisplayScreen />
+        </BasicAppContext>
+      )
+
+      await waitFor(() => {
+        expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.TransferAccountSuccess)
+      })
+
+      const callsAfterSuccess = mockCheckAttestationStatus.mock.calls.length
+
+      // Advance well past several attestation poll intervals (3s each)
+      await act(async () => {
+        jest.advanceTimersByTime(30000)
+      })
+
+      // No additional polls should have fired
+      expect(mockCheckAttestationStatus).toHaveBeenCalledTimes(callsAfterSuccess)
+    })
+
+    it('stops refreshing the QR code after a successful attestation', async () => {
+      jest.mocked(getAccount).mockResolvedValue(mockAccount)
+      mockCheckAttestationStatus.mockResolvedValueOnce(true).mockResolvedValue(false)
+
+      render(
+        <BasicAppContext>
+          <TransferQRDisplayScreen />
+        </BasicAppContext>
+      )
+
+      await waitFor(() => {
+        expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.TransferAccountSuccess)
+      })
+
+      const tokenCallsAfterSuccess = (createDeviceSignedJWT as jest.Mock).mock.calls.length
+
+      // Advance past several QR refresh intervals (50s each)
+      await act(async () => {
+        jest.advanceTimersByTime(150000)
+      })
+
+      // No additional QR refreshes should have fired
+      expect(createDeviceSignedJWT).toHaveBeenCalledTimes(tokenCallsAfterSuccess)
+    })
+
+    it('only navigates once even if multiple polls resolve as successful', async () => {
+      jest.mocked(getAccount).mockResolvedValue(mockAccount)
+      // Every call returns success — without a completion latch the screen would
+      // re-navigate on every resolved poll, snapping the user back from later screens.
+      mockCheckAttestationStatus.mockResolvedValue(true)
+
+      render(
+        <BasicAppContext>
+          <TransferQRDisplayScreen />
+        </BasicAppContext>
+      )
+
+      await waitFor(() => {
+        expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.TransferAccountSuccess)
+      })
+
+      await act(async () => {
+        jest.advanceTimersByTime(30000)
+      })
+
+      expect(mockNavigation.navigate).toHaveBeenCalledTimes(1)
+    })
+
+    it('clears polling intervals on unmount', async () => {
+      jest.mocked(getAccount).mockResolvedValue(mockAccount)
+
+      const { unmount } = render(
+        <BasicAppContext>
+          <TransferQRDisplayScreen />
+        </BasicAppContext>
+      )
+
+      await waitFor(() => {
+        expect(mockCheckAttestationStatus).toHaveBeenCalled()
+      })
+
+      const pollsBeforeUnmount = mockCheckAttestationStatus.mock.calls.length
+      const tokensBeforeUnmount = (createDeviceSignedJWT as jest.Mock).mock.calls.length
+
+      unmount()
+
+      await act(async () => {
+        jest.advanceTimersByTime(150000)
+      })
+
+      expect(mockCheckAttestationStatus).toHaveBeenCalledTimes(pollsBeforeUnmount)
+      expect(createDeviceSignedJWT).toHaveBeenCalledTimes(tokensBeforeUnmount)
+    })
+
     it('falls back to the locally generated jti when jwtDecode returns no jti', async () => {
       jest.mocked(getAccount).mockResolvedValueOnce(mockAccount)
       ;(jwtDecode as jest.Mock).mockReturnValue({}) // no jti in decoded token

--- a/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
@@ -35,10 +35,23 @@ const TransferQRDisplayScreen: React.FC = () => {
   const [store] = useStore<BCState>()
   const { t } = useTranslation()
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
+  const attestationIntervalRef = useRef<NodeJS.Timeout | null>(null)
+  const completedRef = useRef(false)
   const [isLoading, setIsLoading] = useState(true)
   const navigation = useNavigation<StackNavigationProp<BCSCMainStackParams>>()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const { accountNotFoundAlert } = useAlerts(navigation)
+
+  const stopAllPolling = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+    if (attestationIntervalRef.current) {
+      clearInterval(attestationIntervalRef.current)
+      attestationIntervalRef.current = null
+    }
+  }, [])
 
   const styles = StyleSheet.create({
     qrCodeContainer: {
@@ -84,33 +97,47 @@ const TransferQRDisplayScreen: React.FC = () => {
 
   const checkAttestation = useCallback(
     async (id: string) => {
+      if (completedRef.current) {
+        return
+      }
       try {
         const response = await deviceAttestation.checkAttestationStatus(id)
-        if (response) {
+        // Guard against late responses arriving after we've already navigated. Without this,
+        // the still-mounted screen would re-navigate to TransferAccountSuccess every time a
+        // poll resolved, snapping the user back whenever they tried to leave that screen.
+        if (response && !completedRef.current) {
+          completedRef.current = true
+          stopAllPolling()
           navigation.navigate(BCSCScreens.TransferAccountSuccess)
         }
       } catch (error) {
         // Do nothing, a fail state from this endpoint just means the attestation hasn't been consumed yet
       }
     },
-    [deviceAttestation, navigation]
+    [deviceAttestation, navigation, stopAllPolling]
   )
   const startInterval = useCallback(() => {
     if (intervalRef.current) {
       clearInterval(intervalRef.current)
     }
     intervalRef.current = setInterval(() => {
+      if (completedRef.current) {
+        return
+      }
       createToken()
     }, qrCodeRefreshInterval)
   }, [createToken])
 
   const refreshToken = useCallback(async () => {
+    if (completedRef.current) {
+      return
+    }
     if (intervalRef.current) {
       clearInterval(intervalRef.current)
     }
 
     const success = await createToken()
-    if (success) {
+    if (success && !completedRef.current) {
       startInterval()
     }
   }, [createToken, startInterval])
@@ -118,14 +145,12 @@ const TransferQRDisplayScreen: React.FC = () => {
   useEffect(() => {
     refreshToken()
     return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current)
-      }
+      stopAllPolling()
     }
-  }, [refreshToken, startInterval])
+  }, [refreshToken, stopAllPolling])
 
   useEffect(() => {
-    if (!qrValue) {
+    if (!qrValue || completedRef.current) {
       return
     }
     // Snapshot the JTI at the time this effect runs. Reading jtiRef.current live inside the
@@ -133,10 +158,18 @@ const TransferQRDisplayScreen: React.FC = () => {
     // switches all in-flight polls to the new JTI, abandoning the consumed one before the 200 is seen.
     const jtiSnapshot = jtiRef.current
     checkAttestation(jtiSnapshot)
-    const interval = setInterval(() => {
+    if (attestationIntervalRef.current) {
+      clearInterval(attestationIntervalRef.current)
+    }
+    attestationIntervalRef.current = setInterval(() => {
       checkAttestation(jtiSnapshot)
     }, attestationPollInterval)
-    return () => clearInterval(interval)
+    return () => {
+      if (attestationIntervalRef.current) {
+        clearInterval(attestationIntervalRef.current)
+        attestationIntervalRef.current = null
+      }
+    }
   }, [checkAttestation, qrValue])
 
   if (isLoading) {


### PR DESCRIPTION
# Summary of Changes

Intervals in the transfer account feature weren't being cleaned up properly, resulting in repeated navigation back to the same screen

# Testing Instructions

Transfer some accounts and try to slowly go through the remove account process on the transferrer

# Acceptance Criteria

No unwanted navigation

# Screenshots, videos, or gifs

N/A

# Related Issues

#3796 