### PR TITLE
fix: birthdate off-by-one in non-BCSC verification request

### DIFF
--- a/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.tsx
@@ -1,5 +1,6 @@
 import DateInput from '@/bcsc-theme/components/DateInput'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
+import { parseBirthdateToLocalDate } from '@/bcsc-theme/utils/birthdate'
 import { isHandledAppError } from '@/errors/appError'
 import {
   Button,
@@ -59,8 +60,7 @@ const EnterBirthdateScreen: React.FC<EnterBirthdateScreenProps> = ({ navigation 
         navigation.goBack()
         return null
       }
-      // Converting date format from YYYY/MM/DD to YYYY-MM-DD for api
-      await vm.authorizeDevice(vm.serial, moment(birthDate, 'YYYY-MM-DD').toDate())
+      await vm.authorizeDevice(vm.serial, parseBirthdateToLocalDate(birthDate))
     } catch (error) {
       if (isHandledAppError(error)) {
         return

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
@@ -2,6 +2,7 @@ import DateInput from '@/bcsc-theme/components/DateInput'
 import { InputWithValidation } from '@/bcsc-theme/components/InputWithValidation'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
+import { parseBirthdateToLocalDate } from '@/bcsc-theme/utils/birthdate'
 import { MINIMUM_VERIFICATION_AGE } from '@/constants'
 import { BCState, NonBCSCUserMetadata } from '@/store'
 import {
@@ -144,7 +145,7 @@ const EvidenceIDCollectionScreen = ({ navigation, route }: EvidenceIDCollectionS
         const canonicalBirthDate = toCanonicalBirthDate(formState.birthDate)
 
         await updateUserInfo({
-          birthdate: new Date(canonicalBirthDate),
+          birthdate: parseBirthdateToLocalDate(canonicalBirthDate),
         })
 
         const newUserMetadata: NonBCSCUserMetadata = {

--- a/app/src/bcsc-theme/utils/birthdate.test.ts
+++ b/app/src/bcsc-theme/utils/birthdate.test.ts
@@ -1,0 +1,34 @@
+import { parseBirthdateToLocalDate } from './birthdate'
+
+describe('parseBirthdateToLocalDate', () => {
+  // Asserting local Date components keeps these assertions TZ-invariant —
+  // they hold whether Jest runs under TZ=GMT (CI default) or a real local TZ.
+  // The bug being guarded against (issue #3798) is `new Date('YYYY-MM-DD')`
+  // parsing as UTC midnight, which would yield getDate()/getHours() differing
+  // from the entered values when the host is west of UTC.
+  const assertLocalMidnight = (d: Date, year: number, monthIndex: number, day: number) => {
+    expect(d.getFullYear()).toBe(year)
+    expect(d.getMonth()).toBe(monthIndex)
+    expect(d.getDate()).toBe(day)
+    expect(d.getHours()).toBe(0)
+    expect(d.getMinutes()).toBe(0)
+    expect(d.getSeconds()).toBe(0)
+  }
+
+  it('parses YYYY-MM-DD as local midnight', () => {
+    assertLocalMidnight(parseBirthdateToLocalDate('2000-01-01'), 2000, 0, 1)
+  })
+
+  it('parses YYYY/MM/DD as local midnight', () => {
+    assertLocalMidnight(parseBirthdateToLocalDate('2000/01/01'), 2000, 0, 1)
+  })
+
+  it('handles leap-day input', () => {
+    assertLocalMidnight(parseBirthdateToLocalDate('2000-02-29'), 2000, 1, 29)
+  })
+
+  it('returns Invalid Date for unparseable input (strict mode)', () => {
+    expect(Number.isNaN(parseBirthdateToLocalDate('not-a-date').getTime())).toBe(true)
+    expect(Number.isNaN(parseBirthdateToLocalDate('2000-13-01').getTime())).toBe(true)
+  })
+})

--- a/app/src/bcsc-theme/utils/birthdate.ts
+++ b/app/src/bcsc-theme/utils/birthdate.ts
@@ -5,6 +5,9 @@ import moment from 'moment'
  * Date pinned to LOCAL midnight on that calendar day. Avoids the JS gotcha where
  * `new Date('YYYY-MM-DD')` parses as UTC midnight and shifts to the previous day
  * when later formatted in any local TZ west of UTC.
+ *
+ * Callers must validate format before calling — returns Invalid Date for
+ * unparseable input.
  */
 export const parseBirthdateToLocalDate = (value: string): Date =>
   moment(value, ['YYYY-MM-DD', 'YYYY/MM/DD'], true).toDate()

--- a/app/src/bcsc-theme/utils/birthdate.ts
+++ b/app/src/bcsc-theme/utils/birthdate.ts
@@ -1,0 +1,10 @@
+import moment from 'moment'
+
+/**
+ * Parse a user-entered birthdate string ('YYYY-MM-DD' or 'YYYY/MM/DD') into a
+ * Date pinned to LOCAL midnight on that calendar day. Avoids the JS gotcha where
+ * `new Date('YYYY-MM-DD')` parses as UTC midnight and shifts to the previous day
+ * when later formatted in any local TZ west of UTC.
+ */
+export const parseBirthdateToLocalDate = (value: string): Date =>
+  moment(value, ['YYYY-MM-DD', 'YYYY/MM/DD'], true).toDate()


### PR DESCRIPTION
Non-BCSC users entering DOB `2000-01-01` had `1999-12-31` sent to IAS. Cause: `new Date('YYYY-MM-DD')` parses as UTC midnight per ECMAScript, so in any TZ west of UTC the stored Date represented the prior calendar day, and the residential-address submission then formatted it back in local time.

The BCSC card flow already dodged this via `moment(value, format).toDate()`; the non-photo path slipped in with a plain `new Date(...)`.

Pulled the parsing into a shared `parseBirthdateToLocalDate` helper so both DOB-entry paths build local-midnight Dates from the same code, plus a TZ-invariant regression test (asserts local Date components instead of relying on `TZ=GMT` masking the bug).

# Manual Testin

1. Do a BCSC activation, should accept DoB as expected.

2. Do a Non-BCSC activation, the DoB you enter for ID 1 should be shown in the `idcheck` process. I did send video.

