### PR TITLE
feat: new services tab and animated tab bar

### DIFF
--- a/app/src/bcsc-theme/components/FloatingHelpMenuHeaderButton.tsx
+++ b/app/src/bcsc-theme/components/FloatingHelpMenuHeaderButton.tsx
@@ -23,7 +23,7 @@ const FloatingHelpMenuButton = (props: FloatingHelpMenuButtonProps) => {
     <>
       <IconButton
         buttonLocation={ButtonLocation.Right}
-        icon={'help-circle'}
+        icon={'help-circle-outline'}
         accessibilityLabel={t('BCSC.HelpMenu.AccessibilityLabel')}
         testID={testIdWithKey('HelpMenu')}
         onPress={() => setOpen(true)}

--- a/app/src/bcsc-theme/components/FloatingHelpMenuHeaderButton.tsx
+++ b/app/src/bcsc-theme/components/FloatingHelpMenuHeaderButton.tsx
@@ -48,26 +48,29 @@ export const createMainFloatingMenuButton = () => {
     return (
       <FloatingHelpMenuButton ref={floatingHelpMenuRef}>
         <ListButton
-          text={t('BCSC.HelpMenu.LearnMore')}
           onPress={() => {
             // TODO (V4.1.x): Implement Learn More page and link here
             floatingHelpMenuRef.current?.close()
           }}
-        />
+        >
+          {t('BCSC.HelpMenu.LearnMore')}
+        </ListButton>
         <ListButton
-          text={t('BCSC.HelpMenu.GiveFeedback')}
           onPress={() => {
             // TODO (V4.1.x): Implement Give Feedback page and link here
             floatingHelpMenuRef.current?.close()
           }}
-        />
+        >
+          {t('BCSC.HelpMenu.GiveFeedback')}
+        </ListButton>
         <ListButton
-          text={t('BCSC.HelpMenu.ReportProblem')}
           onPress={() => {
             // TODO (V4.1.x): Implement Report a Problem page and link here
             floatingHelpMenuRef.current?.close()
           }}
-        />
+        >
+          {t('BCSC.HelpMenu.ReportProblem')}
+        </ListButton>
       </FloatingHelpMenuButton>
     )
   }

--- a/app/src/bcsc-theme/components/HeaderWithBanner.tsx
+++ b/app/src/bcsc-theme/components/HeaderWithBanner.tsx
@@ -1,5 +1,7 @@
 import { SHADOW_CASTER_HEIGHT, SHADOW_COLOR, SHADOW_OFFSET_DOWN, SHADOW_OPACITY, SHADOW_RADIUS } from '@/constants'
 import { useTheme } from '@bifold/core'
+import { BottomTabHeaderProps } from '@react-navigation/bottom-tabs'
+import { Header as ElementsHeader, getHeaderTitle } from '@react-navigation/elements'
 import { Header, StackHeaderProps } from '@react-navigation/stack'
 import React from 'react'
 import { View } from 'react-native'
@@ -71,5 +73,37 @@ export const createHeaderWithoutBanner = (props: StackHeaderProps) => (
     <Header {...props} />
   </View>
 )
+
+export const createTabHeaderWithoutBanner = ({ route, options, layout }: BottomTabHeaderProps) => (
+  <TabHeaderWithoutBanner route={route} options={options} layout={layout} />
+)
+
+const TabHeaderWithoutBanner = ({
+  route,
+  options,
+  layout,
+}: Pick<BottomTabHeaderProps, 'route' | 'options' | 'layout'>) => {
+  const { ColorPalette } = useTheme()
+  return (
+    <View>
+      <ElementsHeader {...options} layout={layout} title={getHeaderTitle(options, route.name)} />
+      <DropShadow
+        style={{
+          shadowColor: SHADOW_COLOR,
+          shadowOffset: SHADOW_OFFSET_DOWN,
+          shadowOpacity: SHADOW_OPACITY,
+          shadowRadius: SHADOW_RADIUS,
+        }}
+      >
+        <View
+          style={{
+            height: SHADOW_CASTER_HEIGHT,
+            backgroundColor: ColorPalette.brand.primaryBackground,
+          }}
+        />
+      </DropShadow>
+    </View>
+  )
+}
 
 export default HeaderWithBanner

--- a/app/src/bcsc-theme/components/ListButton.tsx
+++ b/app/src/bcsc-theme/components/ListButton.tsx
@@ -5,20 +5,31 @@ import React, { Children, ReactElement } from 'react'
 import { StyleSheet, View } from 'react-native'
 
 interface ListButtonGroupProps {
+  // Optional gap between buttons in the group. Defaults to theme Spacing.xs / 2
+  gap?: number
   // Accepts either a single ListButton or an array of ListButtons as children
   children: ReactElement<ListButtonProps> | ReactElement<ListButtonProps>[]
 }
 
 export interface ListButtonProps {
-  text: string
   onPress: () => void
-  endAdornment?: React.ReactNode // Optional end adornment (e.g., an icon, text, etc.)
+  /**
+   * The content of the button. Can be any React node (text, views, components, etc.).
+   * Plain string children are wrapped in a `ThemedText` for convenience.
+   */
+  children: React.ReactNode
+  /**
+   * Optional accessibility label. If not provided and `children` is a string,
+   * the string is used to derive the accessibility label.
+   */
+  accessibilityLabel?: string
   position?: 'first' | 'middle' | 'last' | 'only' // Position in the list to determine border radius
 }
 
 /**
- * A ListButton component that renders a button with text and an optional end adornment.
- * It also accepts isFirst and isLast props to determine the border radius of the button.
+ * A ListButton component that renders a pressable list row containing arbitrary content.
+ * Accepts any React node as children (text, views, components, etc.) and a `position`
+ * prop to determine the border radius of the button when used in a group.
  *
  * @example:
  * ╭──────────────╮
@@ -46,7 +57,7 @@ export const ListButton = (props: ListButtonProps) => {
       padding: Spacing.md,
       backgroundColor: ColorPalette.brand.tertiaryBackground,
     },
-    textContainer: {
+    contentContainer: {
       flexDirection: 'row',
       alignItems: 'center',
       gap: Spacing.sm,
@@ -74,17 +85,20 @@ export const ListButton = (props: ListButtonProps) => {
     }
   }
 
+  const isStringChild = typeof props.children === 'string'
+  const resolvedA11yLabel =
+    props.accessibilityLabel ?? (isStringChild ? a11yLabel(props.children as string) : undefined)
+
   return (
     <PressableOpacity
       accessible={true}
       style={[styles.container, getBorderRadiusStyle()]}
       onPress={props.onPress}
       accessibilityRole="button"
-      accessibilityLabel={a11yLabel(props.text)}
+      accessibilityLabel={resolvedA11yLabel}
     >
-      <View style={styles.textContainer}>
-        <ThemedText style={styles.text}>{props.text}</ThemedText>
-        {props.endAdornment}
+      <View style={styles.contentContainer}>
+        {isStringChild ? <ThemedText style={styles.text}>{props.children}</ThemedText> : props.children}
       </View>
     </PressableOpacity>
   )
@@ -104,7 +118,7 @@ export const ListButtonGroup = (props: ListButtonGroupProps) => {
   const styles = StyleSheet.create({
     container: {
       flexDirection: 'column',
-      gap: Spacing.xs / 2,
+      gap: props.gap ?? Spacing.xs / 2,
     },
   })
 

--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
@@ -1,4 +1,5 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
+import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import { useQuickLoginURL } from '@/bcsc-theme/hooks/useQuickLoginUrl'
 import { BCSCMainStackParams, BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
 import { HelpCentreUrl, hitSlop, REPORT_SUSPICIOUS_URL } from '@/constants'
@@ -9,6 +10,7 @@ import {
   Button,
   ButtonType,
   Link,
+  ScreenWrapper,
   testIdWithKey,
   ThemedText,
   TOKENS,
@@ -20,8 +22,7 @@ import { StackScreenProps } from '@react-navigation/stack'
 import { a11yLabel } from '@utils/accessibility'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ActivityIndicator, Alert, Linking, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { ActivityIndicator, Alert, Linking, StyleSheet, TouchableOpacity, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import { usePairingService } from '../pairing'
 import { LocalState, useServiceLoginState } from './hooks/useServiceLoginState'
@@ -58,9 +59,11 @@ const RenderState = {
 } as const
 
 const ServiceLoginLoadingView = () => (
-  <SafeAreaView edges={['bottom']} style={{ flex: 1, justifyContent: 'center' }}>
-    <ActivityIndicator size="large" />
-  </SafeAreaView>
+  <ScreenWrapper scrollable={false}>
+    <View style={{ flex: 1, justifyContent: 'center' }}>
+      <ActivityIndicator size="large" />
+    </View>
+  </ScreenWrapper>
 )
 
 type DevicePreferenceURLViewProps = {
@@ -129,49 +132,54 @@ const ServiceLoginUnavailableView = ({
   logger,
   Spacing,
 }: ServiceLoginUnavailableViewProps) => (
-  <SafeAreaView edges={['bottom']} style={{ flex: 1 }}>
-    <ScrollView contentContainerStyle={styles.screenContainer}>
-      <View style={styles.contentContainer}>
-        <ThemedText variant={'headingThree'}>{state.serviceTitle}</ThemedText>
-        <ThemedText style={styles.descriptionText}>{t('BCSC.Services.NoLoginInstructions')}</ThemedText>
-        <ThemedText style={styles.descriptionText}>{t('BCSC.Services.NoLoginProof')}</ThemedText>
+  <ScreenWrapper
+    padded={false}
+    scrollViewContainerStyle={{
+      flexGrow: 1,
+      padding: Spacing.lg,
+      gap: Spacing.md,
+    }}
+  >
+    <ThemedText variant={'headingThree'} style={{ color: ColorPalette.brand.primary }}>
+      {state.serviceTitle}
+    </ThemedText>
+    <ThemedText style={styles.descriptionText}>{t('BCSC.Services.NoLoginInstructions')}</ThemedText>
+    <ThemedText style={styles.descriptionText}>{t('BCSC.Services.NoLoginProof')}</ThemedText>
 
-        <TouchableOpacity
-          testID={testIdWithKey('GoToServiceClient')}
-          accessibilityLabel={a11yLabel(t('BCSC.Services.GotoService', { service: state.serviceTitle }))}
-          accessibilityRole="link"
-          accessibilityHint={t('Global.A11y.OpensInBrowser')}
-          hitSlop={hitSlop}
-          onPress={async () => {
-            if (!state.serviceClientUri) {
-              logger.error('ServiceLoginScreen: No service client URI available for navigation')
-              return
-            }
+    <TouchableOpacity
+      testID={testIdWithKey('GoToServiceClient')}
+      accessibilityLabel={a11yLabel(t('BCSC.Services.GotoService', { service: state.serviceTitle }))}
+      accessibilityRole="link"
+      accessibilityHint={t('Global.A11y.OpensInBrowser')}
+      hitSlop={hitSlop}
+      onPress={async () => {
+        if (!state.serviceClientUri) {
+          logger.error('ServiceLoginScreen: No service client URI available for navigation')
+          return
+        }
 
-            try {
-              await Linking.openURL(state.serviceClientUri)
-            } catch (error) {
-              logger.error('ServiceLoginScreen: Failed to open service client URL', error as Error)
-              Alert.alert(t('BCSC.Services.OpenUrlErrorTitle'), t('BCSC.Services.OpenUrlErrorMessage'))
-            }
-          }}
-        >
-          <View style={[styles.infoContainer, styles.privacyNoticeContainer]}>
-            <ThemedText style={styles.infoHeader} ellipsizeMode="tail">
-              {t('BCSC.Services.GotoService', { service: state.serviceTitle })}
-            </ThemedText>
-            <Icon name="open-in-new" size={30} color={ColorPalette.brand.primary} />
-          </View>
-        </TouchableOpacity>
-        <DevicePreferenceURLView
-          serviceClientUri={state.serviceClientUri}
-          ColorPalette={ColorPalette}
-          t={t}
-          Spacing={Spacing}
-        />
+        try {
+          await Linking.openURL(state.serviceClientUri)
+        } catch (error) {
+          logger.error('ServiceLoginScreen: Failed to open service client URL', error as Error)
+          Alert.alert(t('BCSC.Services.OpenUrlErrorTitle'), t('BCSC.Services.OpenUrlErrorMessage'))
+        }
+      }}
+    >
+      <View style={[styles.infoContainer, styles.privacyNoticeContainer]}>
+        <ThemedText style={styles.infoHeader} ellipsizeMode="tail">
+          {t('BCSC.Services.GotoService', { service: state.serviceTitle })}
+        </ThemedText>
+        <Icon name="open-in-new" size={30} color={ColorPalette.brand.primary} />
       </View>
-    </ScrollView>
-  </SafeAreaView>
+    </TouchableOpacity>
+    <DevicePreferenceURLView
+      serviceClientUri={state.serviceClientUri}
+      ColorPalette={ColorPalette}
+      t={t}
+      Spacing={Spacing}
+    />
+  </ScreenWrapper>
 )
 
 const ServiceLoginDefaultView = ({
@@ -187,89 +195,95 @@ const ServiceLoginDefaultView = ({
   onOpenInfoShared,
   onOpenPrivacyPolicy,
 }: ServiceLoginDefaultViewProps) => {
+  const controls = (
+    <ControlContainer>
+      <Button
+        title="Continue"
+        accessibilityLabel={a11yLabel('Continue')}
+        testID={testIdWithKey('ServiceLoginContinue')}
+        buttonType={ButtonType.Primary}
+        disabled={isContinueDisabled}
+        onPress={() => {
+          setIsContinueDisabled(true)
+          onContinue()
+        }}
+      />
+      <Button
+        title="Cancel"
+        accessibilityLabel={a11yLabel('Cancel')}
+        testID={testIdWithKey('ServiceLoginCancel')}
+        buttonType={ButtonType.Secondary}
+        onPress={onCancel}
+      />
+    </ControlContainer>
+  )
+
   return (
-    <SafeAreaView edges={['bottom']} style={{ flex: 1 }}>
-      <ScrollView contentContainerStyle={styles.screenContainer}>
-        <View style={styles.contentContainer}>
-          <ThemedText variant={'headingThree'} style={{ fontWeight: 'normal' }}>
-            {`${t('BCSC.Services.WantToLogin')}\n`}
-            <ThemedText variant={'headingThree'}>{state.serviceTitle}?</ThemedText>
-          </ThemedText>
+    <ScreenWrapper
+      padded={false}
+      controls={controls}
+      controlsContainerStyle={{ padding: 0 }}
+      scrollViewContainerStyle={{
+        flexGrow: 1,
+        padding: Spacing.lg,
+        gap: Spacing.md,
+      }}
+    >
+      <ThemedText variant={'headingThree'} style={{ fontWeight: 'normal' }}>
+        {`${t('BCSC.Services.WantToLogin')}\n`}
+        <ThemedText variant={'headingThree'}>{state.serviceTitle}?</ThemedText>
+      </ThemedText>
 
-          <ThemedText style={styles.descriptionText}>{t('BCSC.Services.RequestedInformation')}</ThemedText>
+      <ThemedText style={styles.descriptionText}>{t('BCSC.Services.RequestedInformation')}</ThemedText>
 
-          <View style={styles.cardsContainer}>
-            <View style={styles.infoContainer}>
-              <View
-                style={{
-                  flexDirection: 'row',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  marginBottom: Spacing.sm,
-                }}
-              >
-                <ThemedText style={styles.infoHeader}>
-                  {t('BCSC.Services.FromAccountPrefix')}
-                  <ThemedText variant={'bold'} style={{ color: ColorPalette.brand.primary }}>
-                    {' '}
-                    {t('BCSC.Services.FromAccount')}
-                  </ThemedText>
-                </ThemedText>
-                <TouchableOpacity
-                  testID={testIdWithKey('HelpButton')}
-                  accessibilityLabel={a11yLabel(t('BCSC.Screens.HelpCentre'))}
-                  accessibilityRole="button"
-                  hitSlop={hitSlop}
-                  onPress={onOpenInfoShared}
-                >
-                  <Icon name="help-outline" size={24} color={ColorPalette.brand.primary} />
-                </TouchableOpacity>
-              </View>
-              <ThemedText>{state.claimsDescription}</ThemedText>
+      <View style={styles.cardsContainer}>
+        <View style={styles.infoContainer}>
+          <View
+            style={{
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: Spacing.sm,
+            }}
+          >
+            <ThemedText style={styles.infoHeader}>
+              {t('BCSC.Services.FromAccountPrefix')}
+              <ThemedText variant={'bold'} style={{ color: ColorPalette.brand.primary }}>
+                {' '}
+                {t('BCSC.Services.FromAccount')}
+              </ThemedText>
+            </ThemedText>
+            <TouchableOpacity
+              testID={testIdWithKey('HelpButton')}
+              accessibilityLabel={a11yLabel(t('BCSC.Screens.HelpCentre'))}
+              accessibilityRole="button"
+              hitSlop={hitSlop}
+              onPress={onOpenInfoShared}
+            >
+              <Icon name="help-outline" size={24} color={ColorPalette.brand.primary} />
+            </TouchableOpacity>
+          </View>
+          <ThemedText>{state.claimsDescription}</ThemedText>
+        </View>
+
+        {state.privacyPolicyUri ? (
+          <TouchableOpacity
+            testID={testIdWithKey('ReadPrivacyPolicy')}
+            accessibilityLabel={a11yLabel(t('BCSC.Services.PrivacyNotice'))}
+            accessibilityRole="link"
+            accessibilityHint={t('Global.A11y.OpensInBrowser')}
+            hitSlop={hitSlop}
+            onPress={onOpenPrivacyPolicy}
+          >
+            <View style={[styles.infoContainer, styles.privacyNoticeContainer]}>
+              <ThemedText style={styles.infoHeader}>{t('BCSC.Services.PrivacyNotice')}</ThemedText>
+              <Icon name="open-in-new" size={30} color={ColorPalette.brand.primary} />
             </View>
-
-            {state.privacyPolicyUri ? (
-              <TouchableOpacity
-                testID={testIdWithKey('ReadPrivacyPolicy')}
-                accessibilityLabel={a11yLabel(t('BCSC.Services.PrivacyNotice'))}
-                accessibilityRole="link"
-                accessibilityHint={t('Global.A11y.OpensInBrowser')}
-                hitSlop={hitSlop}
-                onPress={onOpenPrivacyPolicy}
-              >
-                <View style={[styles.infoContainer, styles.privacyNoticeContainer]}>
-                  <ThemedText style={styles.infoHeader}>{t('BCSC.Services.PrivacyNotice')}</ThemedText>
-                  <Icon name="open-in-new" size={30} color={ColorPalette.brand.primary} />
-                </View>
-              </TouchableOpacity>
-            ) : null}
-          </View>
-        </View>
-        <View style={styles.buttonsContainer}>
-          <View style={styles.continueButtonContainer}>
-            <Button
-              title="Continue"
-              accessibilityLabel={a11yLabel('Continue')}
-              testID={testIdWithKey('ServiceLoginContinue')}
-              buttonType={ButtonType.Primary}
-              disabled={isContinueDisabled}
-              onPress={() => {
-                setIsContinueDisabled(true)
-                onContinue()
-              }}
-            />
-          </View>
-          <Button
-            title="Cancel"
-            accessibilityLabel={a11yLabel('Cancel')}
-            testID={testIdWithKey('ServiceLoginCancel')}
-            buttonType={ButtonType.Secondary}
-            onPress={onCancel}
-          />
-        </View>
-        <ReportSuspiciousLink t={t} Spacing={Spacing} testID={testIdWithKey('ReportSuspiciousLink')} />
-      </ScrollView>
-    </SafeAreaView>
+          </TouchableOpacity>
+        ) : null}
+      </View>
+      <ReportSuspiciousLink t={t} Spacing={Spacing} testID={testIdWithKey('ReportSuspiciousLink')} />
+    </ScreenWrapper>
   )
 }
 
@@ -302,26 +316,11 @@ export const ServiceLoginScreen: React.FC<ServiceLoginScreenProps> = ({
   const [isContinueDisabled, setIsContinueDisabled] = useState(false)
 
   const styles = StyleSheet.create({
-    screenContainer: {
-      flexGrow: 1,
-      padding: Spacing.md,
-      justifyContent: 'space-between',
-    },
     cardsContainer: {
       gap: Spacing.md,
     },
     descriptionText: {
       lineHeight: 30,
-    },
-    continueButtonContainer: {
-      marginBottom: 10,
-    },
-    contentContainer: {
-      flex: 1,
-      gap: Spacing.md,
-    },
-    buttonsContainer: {
-      marginTop: Spacing.lg,
     },
     infoContainer: {
       display: 'flex',

--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
@@ -199,8 +199,8 @@ const ServiceLoginDefaultView = ({
   const controls = (
     <ControlContainer>
       <Button
-        title="Continue"
-        accessibilityLabel={a11yLabel('Continue')}
+        title={t('Global.Continue')}
+        accessibilityLabel={a11yLabel(t('Global.Continue'))}
         testID={testIdWithKey('ServiceLoginContinue')}
         buttonType={ButtonType.Primary}
         disabled={isContinueDisabled}
@@ -210,8 +210,8 @@ const ServiceLoginDefaultView = ({
         }}
       />
       <Button
-        title="Cancel"
-        accessibilityLabel={a11yLabel('Cancel')}
+        title={t('Global.Cancel')}
+        accessibilityLabel={a11yLabel(t('Global.Cancel'))}
         testID={testIdWithKey('ServiceLoginCancel')}
         buttonType={ButtonType.Secondary}
         onPress={onCancel}

--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
@@ -50,6 +50,7 @@ type ServiceLoginUnavailableViewProps = {
   Spacing: ReturnType<typeof useTheme>['Spacing']
   t: (key: string, options?: Record<string, unknown>) => string
   logger: any
+  onCancel: () => void
 }
 
 const RenderState = {
@@ -68,40 +69,34 @@ const ServiceLoginLoadingView = () => (
 
 type DevicePreferenceURLViewProps = {
   serviceClientUri?: string
-  ColorPalette: ReturnType<typeof useTheme>['ColorPalette']
   t: (key: string, options?: Record<string, unknown>) => string
   Spacing: ReturnType<typeof useTheme>['Spacing']
 }
 
 const DevicePreferenceURLView: React.FC<DevicePreferenceURLViewProps> = ({
   serviceClientUri,
-  ColorPalette,
   t,
-  Spacing,
-}: DevicePreferenceURLViewProps) =>
-  serviceClientUri ? (
+}: DevicePreferenceURLViewProps) => {
+  const { Spacing, TextTheme } = useTheme()
+
+  return serviceClientUri ? (
     <View style={{ marginTop: Spacing.lg }}>
-      <View
-        style={{
-          borderBottomWidth: 1,
-          borderBottomColor: ColorPalette.grayscale.lightGrey,
-          marginBottom: Spacing.lg,
-        }}
-      />
-      <ThemedText variant={'bold'} style={{ textAlign: 'center' }}>
+      <ThemedText variant={'bold'} style={{ color: TextTheme.headingFour.color }}>
         {t('BCSC.Services.PreferOtherDevice')}
       </ThemedText>
-      <ThemedText style={{ textAlign: 'center' }}>{t('BCSC.Services.Goto')}</ThemedText>
-      <ThemedText selectable={true} style={{ textAlign: 'center' }}>
-        <Link
-          style={{ textAlign: 'center' }}
-          linkText={serviceClientUri}
-          testID={testIdWithKey('ServiceClientLink')}
-          onPress={() => Linking.openURL(serviceClientUri)}
-        />
-      </ThemedText>
+      <View style={{ flexDirection: 'row', gap: Spacing.xs }}>
+        <ThemedText>{t('BCSC.Services.Goto')}</ThemedText>
+        <ThemedText selectable={true}>
+          <Link
+            linkText={serviceClientUri}
+            testID={testIdWithKey('ServiceClientLink')}
+            onPress={() => Linking.openURL(serviceClientUri)}
+          />
+        </ThemedText>
+      </View>
     </View>
   ) : null
+}
 
 type ReportSuspiciousLinkProps = {
   t: (key: string, options?: Record<string, unknown>) => string
@@ -114,7 +109,7 @@ const ReportSuspiciousLink: React.FC<ReportSuspiciousLinkProps> = ({
   testID,
   Spacing,
 }: ReportSuspiciousLinkProps) => (
-  <ThemedText variant={'bold'} style={{ textAlign: 'center', marginTop: Spacing.lg }}>
+  <ThemedText variant={'bold'} style={{ marginTop: Spacing.sm }}>
     {t('BCSC.Services.ReportSuspiciousPrefix')}{' '}
     <Link
       linkText={t('BCSC.Services.ReportSuspicious')}
@@ -131,56 +126,62 @@ const ServiceLoginUnavailableView = ({
   t,
   logger,
   Spacing,
-}: ServiceLoginUnavailableViewProps) => (
-  <ScreenWrapper
-    padded={false}
-    scrollViewContainerStyle={{
-      flexGrow: 1,
-      padding: Spacing.lg,
-      gap: Spacing.md,
-    }}
-  >
-    <ThemedText variant={'headingThree'} style={{ color: ColorPalette.brand.primary }}>
-      {state.serviceTitle}
-    </ThemedText>
-    <ThemedText style={styles.descriptionText}>{t('BCSC.Services.NoLoginInstructions')}</ThemedText>
-    <ThemedText style={styles.descriptionText}>{t('BCSC.Services.NoLoginProof')}</ThemedText>
+  onCancel,
+}: ServiceLoginUnavailableViewProps) => {
+  const controls = (
+    <ControlContainer>
+      <Button
+        title={t('BCSC.Services.GotoService', { service: state.serviceTitle })}
+        accessibilityLabel={a11yLabel(t('BCSC.Services.GotoService', { service: state.serviceTitle }))}
+        accessibilityHint={t('Global.A11y.OpensInBrowser')}
+        testID={testIdWithKey('GoToServiceClient')}
+        buttonType={ButtonType.Primary}
+        onPress={async () => {
+          if (!state.serviceClientUri) {
+            logger.error('ServiceLoginScreen: No service client URI available for navigation')
+            return
+          }
 
-    <TouchableOpacity
-      testID={testIdWithKey('GoToServiceClient')}
-      accessibilityLabel={a11yLabel(t('BCSC.Services.GotoService', { service: state.serviceTitle }))}
-      accessibilityRole="link"
-      accessibilityHint={t('Global.A11y.OpensInBrowser')}
-      hitSlop={hitSlop}
-      onPress={async () => {
-        if (!state.serviceClientUri) {
-          logger.error('ServiceLoginScreen: No service client URI available for navigation')
-          return
-        }
+          try {
+            await Linking.openURL(state.serviceClientUri)
+          } catch (error) {
+            logger.error('ServiceLoginScreen: Failed to open service client URL', error as Error)
+            Alert.alert(t('BCSC.Services.OpenUrlErrorTitle'), t('BCSC.Services.OpenUrlErrorMessage'))
+          }
+        }}
+      >
+        <Icon name="open-in-new" size={20} color={ColorPalette.brand.buttonText} />
+      </Button>
+      <Button
+        buttonType={ButtonType.Secondary}
+        title={t('Global.Cancel')}
+        testID={testIdWithKey('Cancel')}
+        accessibilityLabel={t('Global.Cancel')}
+        onPress={onCancel}
+      />
+    </ControlContainer>
+  )
 
-        try {
-          await Linking.openURL(state.serviceClientUri)
-        } catch (error) {
-          logger.error('ServiceLoginScreen: Failed to open service client URL', error as Error)
-          Alert.alert(t('BCSC.Services.OpenUrlErrorTitle'), t('BCSC.Services.OpenUrlErrorMessage'))
-        }
+  return (
+    <ScreenWrapper
+      padded={false}
+      controls={controls}
+      scrollViewContainerStyle={{
+        flexGrow: 1,
+        padding: Spacing.lg,
+        gap: Spacing.md,
       }}
     >
-      <View style={[styles.infoContainer, styles.privacyNoticeContainer]}>
-        <ThemedText style={styles.infoHeader} ellipsizeMode="tail">
-          {t('BCSC.Services.GotoService', { service: state.serviceTitle })}
-        </ThemedText>
-        <Icon name="open-in-new" size={30} color={ColorPalette.brand.primary} />
-      </View>
-    </TouchableOpacity>
-    <DevicePreferenceURLView
-      serviceClientUri={state.serviceClientUri}
-      ColorPalette={ColorPalette}
-      t={t}
-      Spacing={Spacing}
-    />
-  </ScreenWrapper>
-)
+      <ThemedText variant={'headingThree'} style={{ color: ColorPalette.brand.primary }}>
+        {state.serviceTitle}
+      </ThemedText>
+      <ThemedText style={styles.descriptionText}>{t('BCSC.Services.NoLoginInstructions')}</ThemedText>
+      <ThemedText style={styles.descriptionText}>{t('BCSC.Services.NoLoginProof')}</ThemedText>
+
+      <DevicePreferenceURLView serviceClientUri={state.serviceClientUri} t={t} Spacing={Spacing} />
+    </ScreenWrapper>
+  )
+}
 
 const ServiceLoginDefaultView = ({
   state,
@@ -505,6 +506,7 @@ export const ServiceLoginScreen: React.FC<ServiceLoginScreenProps> = ({
           t={t}
           logger={logger}
           Spacing={Spacing}
+          onCancel={onCancel}
         />
       )
     default:

--- a/app/src/bcsc-theme/features/services/Services.tsx
+++ b/app/src/bcsc-theme/features/services/Services.tsx
@@ -1,3 +1,4 @@
+import { ListButtonGroup } from '@/bcsc-theme/components/ListButton'
 import TabScreenWrapper from '@/bcsc-theme/components/TabScreenWrapper'
 import { useBCSCActivity } from '@/bcsc-theme/contexts/BCSCActivityContext'
 import useDataLoader from '@/bcsc-theme/hooks/useDataLoader'
@@ -7,10 +8,10 @@ import { getCardProcessForCardType } from '@/bcsc-theme/utils/card-utils'
 import { useDebounce } from '@/hooks/useDebounce'
 import { BCState, Mode } from '@/store'
 import { testIdWithKey, ThemedText, TOKENS, useServices, useStore, useTheme } from '@bifold/core'
-import { useNavigation } from '@react-navigation/native'
+import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { a11yLabel } from '@utils/accessibility'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, Keyboard, StyleSheet, TextInput, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
@@ -35,6 +36,7 @@ const Services: React.FC = () => {
   const { ColorPalette, Spacing, TextTheme, Inputs } = useTheme()
   const navigation = useNavigation<ServicesNavigationProp>()
   const [search, setSearch] = useState('')
+  const [sortVersion, setSortVersion] = useState(0)
   const debouncedSearch = useDebounce(search, SEARCH_DEBOUNCE_DELAY_MS)
   const searchInputRef = useRef<View>(null)
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
@@ -53,6 +55,33 @@ const Services: React.FC = () => {
 
   const isBCSCMode = store.mode === Mode.BCSC // isDarkMode? or isBCSCMode?
 
+  // Track the latest bookmarks via a ref so toggling a bookmark does not
+  // re-sort the list. Sort order is recomputed only when the underlying
+  // service list changes (initial load or search filter change), or when
+  // the screen regains focus (e.g. user navigates back to the Services tab).
+  const savedServicesRef = useRef(store.bcscSecure.savedServices)
+  useEffect(() => {
+    savedServicesRef.current = store.bcscSecure.savedServices
+  }, [store.bcscSecure.savedServices])
+
+  useFocusEffect(
+    useCallback(() => {
+      setSortVersion((v) => v + 1)
+    }, [])
+  )
+
+  const sortedServiceClients = useMemo(() => {
+    const saved = new Set(savedServicesRef.current)
+    return [...serviceClients].sort((a, b) => {
+      const aBookmarked = saved.has(a.client_ref_id) ? 1 : 0
+      const bBookmarked = saved.has(b.client_ref_id) ? 1 : 0
+      return bBookmarked - aBookmarked
+    })
+    // sortVersion intentionally included so that returning to the screen
+    // (focus) re-promotes any newly bookmarked services to the top.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serviceClients, sortVersion])
+
   useEffect(() => {
     if (store.bcscSecure.verified) {
       loadIdTokenMetadata()
@@ -61,7 +90,7 @@ const Services: React.FC = () => {
 
   const styles = StyleSheet.create({
     searchInputContainer: {
-      paddingHorizontal: Spacing.md,
+      padding: Spacing.lg,
       paddingBottom: Spacing.md,
       backgroundColor: ColorPalette.brand.primaryBackground,
     },
@@ -79,14 +108,11 @@ const Services: React.FC = () => {
       marginLeft: Spacing.sm,
     },
     servicesContainer: {
-      paddingHorizontal: Spacing.md,
+      paddingHorizontal: Spacing.lg,
       gap: 2,
     },
     bottomContainer: {
-      margin: Spacing.md,
-    },
-    desciptionText: {
-      lineHeight: 30,
+      margin: Spacing.lg,
     },
   })
 
@@ -156,26 +182,27 @@ const Services: React.FC = () => {
       ) : (
         <View>
           <View style={styles.servicesContainer}>
-            {serviceClients.map((service) => (
-              <ServiceButton
-                key={service.client_ref_id}
-                title={service.client_name}
-                description={service.client_description}
-                onPress={() => {
-                  navigation.navigate(BCSCScreens.ServiceLogin, {
-                    serviceClientId: service.client_ref_id,
-                  })
-                }}
-              />
-            ))}
+            <ListButtonGroup gap={Spacing.sm}>
+              {sortedServiceClients.map((service) => (
+                <ServiceButton
+                  key={service.client_ref_id}
+                  clientRefId={service.client_ref_id}
+                  title={service.client_name}
+                  description={service.client_description}
+                  onPress={() => {
+                    navigation.navigate(BCSCScreens.ServiceLogin, {
+                      serviceClientId: service.client_ref_id,
+                    })
+                  }}
+                />
+              ))}
+            </ListButtonGroup>
           </View>
 
           <View style={styles.bottomContainer}>
             <ThemedText variant={'bold'}>{t('BCSC.Services.NotListed')}</ThemedText>
-            <ThemedText style={styles.desciptionText}>{t('BCSC.Services.NotListedDescription')}</ThemedText>
-            <ThemedText style={[styles.desciptionText, { marginTop: Spacing.xl }]}>
-              {t('BCSC.Services.NotListedDescriptionContact')}
-            </ThemedText>
+            <ThemedText>{t('BCSC.Services.NotListedDescription')}</ThemedText>
+            <ThemedText style={{ marginTop: Spacing.xl }}>{t('BCSC.Services.NotListedDescriptionContact')}</ThemedText>
           </View>
         </View>
       )}

--- a/app/src/bcsc-theme/features/services/Services.tsx
+++ b/app/src/bcsc-theme/features/services/Services.tsx
@@ -32,7 +32,7 @@ const Services: React.FC = () => {
   const token = useTokenService()
   const { t } = useTranslation()
   const [store] = useStore<BCState>()
-  const { ColorPalette, Spacing, TextTheme } = useTheme()
+  const { ColorPalette, Spacing, TextTheme, Inputs } = useTheme()
   const navigation = useNavigation<ServicesNavigationProp>()
   const [search, setSearch] = useState('')
   const debouncedSearch = useDebounce(search, SEARCH_DEBOUNCE_DELAY_MS)
@@ -60,24 +60,17 @@ const Services: React.FC = () => {
   }, [loadIdTokenMetadata, store.bcscSecure.verified])
 
   const styles = StyleSheet.create({
-    headerText: {
-      paddingHorizontal: Spacing.md,
-      paddingVertical: Spacing.lg,
-    },
     searchInputContainer: {
       paddingHorizontal: Spacing.md,
       paddingBottom: Spacing.md,
       backgroundColor: ColorPalette.brand.primaryBackground,
     },
     searchInput: {
+      ...Inputs.textInput,
+      color: undefined,
+      fontSize: undefined,
       flexDirection: 'row',
       alignItems: 'center',
-      backgroundColor: ColorPalette.brand.secondaryBackground,
-      borderRadius: 8,
-      height: Spacing.xl * 2,
-      paddingHorizontal: Spacing.md,
-      borderWidth: 1,
-      borderColor: isBCSCMode ? '#1E5189' : '#D8D8D8',
     },
     searchText: {
       flex: 1,
@@ -98,15 +91,10 @@ const Services: React.FC = () => {
   })
 
   return (
-    <TabScreenWrapper scrollViewProps={{ stickyHeaderIndices: [1], keyboardShouldPersistTaps: 'handled' }}>
-      {/* Dismiss keyboard when tapping outside of TextInput */}
-      <ThemedText variant={'headingTwo'} style={styles.headerText}>
-        {t('BCSC.Services.CatalogueTitle')}
-      </ThemedText>
-
+    <TabScreenWrapper scrollViewProps={{ stickyHeaderIndices: [0], keyboardShouldPersistTaps: 'handled' }}>
       <View style={styles.searchInputContainer}>
         <View ref={searchInputRef} style={styles.searchInput}>
-          <Icon name="search" size={24} color={ColorPalette.brand.tertiary} />
+          <Icon name="search" size={24} color={TextTheme.headingFour.color} />
           <TextInput
             placeholder={t('BCSC.Services.CatalogueSearch')}
             placeholderTextColor={ColorPalette.brand.tertiary}
@@ -166,7 +154,7 @@ const Services: React.FC = () => {
           testID={testIdWithKey('ServicesLoading')}
         />
       ) : (
-        <>
+        <View>
           <View style={styles.servicesContainer}>
             {serviceClients.map((service) => (
               <ServiceButton
@@ -189,7 +177,7 @@ const Services: React.FC = () => {
               {t('BCSC.Services.NotListedDescriptionContact')}
             </ThemedText>
           </View>
-        </>
+        </View>
       )}
     </TabScreenWrapper>
   )

--- a/app/src/bcsc-theme/features/services/__snapshots__/ServiceLoginScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/services/__snapshots__/ServiceLoginScreen.test.tsx.snap
@@ -5,20 +5,32 @@ exports[`ServiceLogin renders correctly 1`] = `
   edges={
     {
       "bottom": "additive",
-      "left": "off",
-      "right": "off",
+      "left": "additive",
+      "right": "additive",
       "top": "off",
     }
   }
   style={
-    {
-      "flex": 1,
-      "justifyContent": "center",
-    }
+    [
+      {
+        "backgroundColor": "#F2F2F2",
+        "flex": 1,
+      },
+      undefined,
+    ]
   }
 >
-  <ActivityIndicator
-    size="large"
-  />
+  <View
+    style={
+      {
+        "flex": 1,
+        "justifyContent": "center",
+      }
+    }
+  >
+    <ActivityIndicator
+      size="large"
+    />
+  </View>
 </RNCSafeAreaView>
 `;

--- a/app/src/bcsc-theme/features/services/__snapshots__/Services.test.tsx.snap
+++ b/app/src/bcsc-theme/features/services/__snapshots__/Services.test.tsx.snap
@@ -26,36 +26,17 @@ exports[`Services renders loading indicator when services are loading 1`] = `
     keyboardShouldPersistTaps="handled"
     stickyHeaderIndices={
       [
-        1,
+        0,
       ]
     }
   >
     <View>
-      <Text
-        maxFontSizeMultiplier={2}
-        style={
-          [
-            {
-              "color": "#313132",
-              "fontFamily": "BCSans-Regular",
-              "fontSize": 32,
-              "fontWeight": "bold",
-            },
-            {
-              "paddingHorizontal": 16,
-              "paddingVertical": 24,
-            },
-          ]
-        }
-      >
-        BCSC.Services.CatalogueTitle
-      </Text>
       <View
         style={
           {
             "backgroundColor": "#F2F2F2",
+            "padding": 24,
             "paddingBottom": 16,
-            "paddingHorizontal": 16,
           }
         }
       >
@@ -63,13 +44,15 @@ exports[`Services renders loading indicator when services are loading 1`] = `
           style={
             {
               "alignItems": "center",
-              "backgroundColor": "#FFFFFF",
-              "borderColor": "#D8D8D8",
-              "borderRadius": 8,
+              "backgroundColor": "#D3D3D3",
+              "borderColor": "#D3D3D3",
+              "borderRadius": 4,
               "borderWidth": 1,
+              "color": undefined,
               "flexDirection": "row",
-              "height": 64,
-              "paddingHorizontal": 16,
+              "fontFamily": "BCSans-Regular",
+              "fontSize": undefined,
+              "padding": 10,
             }
           }
         >
@@ -79,7 +62,7 @@ exports[`Services renders loading indicator when services are loading 1`] = `
             style={
               [
                 {
-                  "color": "#606060",
+                  "color": "#313132",
                   "fontSize": 24,
                 },
                 undefined,
@@ -157,36 +140,17 @@ exports[`Services renders service list when loading is complete 1`] = `
     keyboardShouldPersistTaps="handled"
     stickyHeaderIndices={
       [
-        1,
+        0,
       ]
     }
   >
     <View>
-      <Text
-        maxFontSizeMultiplier={2}
-        style={
-          [
-            {
-              "color": "#313132",
-              "fontFamily": "BCSans-Regular",
-              "fontSize": 32,
-              "fontWeight": "bold",
-            },
-            {
-              "paddingHorizontal": 16,
-              "paddingVertical": 24,
-            },
-          ]
-        }
-      >
-        BCSC.Services.CatalogueTitle
-      </Text>
       <View
         style={
           {
             "backgroundColor": "#F2F2F2",
+            "padding": 24,
             "paddingBottom": 16,
-            "paddingHorizontal": 16,
           }
         }
       >
@@ -194,13 +158,15 @@ exports[`Services renders service list when loading is complete 1`] = `
           style={
             {
               "alignItems": "center",
-              "backgroundColor": "#FFFFFF",
-              "borderColor": "#D8D8D8",
-              "borderRadius": 8,
+              "backgroundColor": "#D3D3D3",
+              "borderColor": "#D3D3D3",
+              "borderRadius": 4,
               "borderWidth": 1,
+              "color": undefined,
               "flexDirection": "row",
-              "height": 64,
-              "paddingHorizontal": 16,
+              "fontFamily": "BCSans-Regular",
+              "fontSize": undefined,
+              "padding": 10,
             }
           }
         >
@@ -210,7 +176,7 @@ exports[`Services renders service list when loading is complete 1`] = `
             style={
               [
                 {
-                  "color": "#606060",
+                  "color": "#313132",
                   "fontSize": 24,
                 },
                 undefined,
@@ -246,52 +212,207 @@ exports[`Services renders service list when loading is complete 1`] = `
           />
         </View>
       </View>
-      <View
-        style={
-          {
-            "gap": 2,
-            "paddingHorizontal": 16,
-          }
-        }
-      >
+      <View>
         <View
-          accessibilityLabel="Test Service"
-          accessibilityRole="button"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             {
-              "backgroundColor": "#FFFFFF",
-              "opacity": 1,
-              "padding": 16,
+              "gap": 2,
+              "paddingHorizontal": 24,
             }
           }
-          testID="com.ariesbifold:id/ServiceButton-TestService"
+        >
+          <View
+            style={
+              {
+                "flexDirection": "column",
+                "gap": 8,
+              }
+            }
+          >
+            <View
+              accessibilityLabel="Test Service"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                [
+                  {
+                    "backgroundColor": "#003366",
+                    "padding": 16,
+                  },
+                  {
+                    "borderRadius": 8,
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "gap": 8,
+                  }
+                }
+              >
+                <View
+                  style={
+                    {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "gap": 8,
+                        "justifyContent": "space-between",
+                      }
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={2}
+                      style={
+                        [
+                          {
+                            "color": "#313132",
+                            "fontFamily": "BCSans-Regular",
+                            "fontSize": 18,
+                            "fontWeight": "bold",
+                          },
+                          {
+                            "color": "#003366",
+                            "flex": 1,
+                          },
+                        ]
+                      }
+                      testID="com.ariesbifold:id/ServiceButton-TestService"
+                    >
+                      Test Service
+                    </Text>
+                    <View
+                      accessibilityLabel="Toggle bookmark for Test Service"
+                      accessibilityRole="button"
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      hitSlop={
+                        {
+                          "bottom": 44,
+                          "left": 44,
+                          "right": 44,
+                          "top": 44,
+                        }
+                      }
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                      testID="com.ariesbifold:id/ServiceButton-Bookmark-TestService"
+                    >
+                      <Text
+                        allowFontScaling={false}
+                        selectable={false}
+                        style={
+                          [
+                            {
+                              "color": "#003366",
+                              "fontSize": 24,
+                            },
+                            undefined,
+                            {
+                              "fontFamily": "Material Design Icons",
+                              "fontStyle": "normal",
+                              "fontWeight": "normal",
+                            },
+                            {},
+                          ]
+                        }
+                      >
+                        󰃃
+                      </Text>
+                    </View>
+                  </View>
+                  <Text
+                    maxFontSizeMultiplier={2}
+                    style={
+                      [
+                        {
+                          "color": "#313132",
+                          "fontFamily": "BCSans-Regular",
+                          "fontSize": 14,
+                          "fontWeight": "normal",
+                        },
+                        {
+                          "marginTop": 8,
+                        },
+                      ]
+                    }
+                  >
+                    A test service
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            {
+              "margin": 24,
+            }
+          }
         >
           <Text
             maxFontSizeMultiplier={2}
@@ -300,17 +421,30 @@ exports[`Services renders service list when loading is complete 1`] = `
                 {
                   "color": "#313132",
                   "fontFamily": "BCSans-Regular",
-                  "fontSize": 21,
+                  "fontSize": 18,
                   "fontWeight": "bold",
                 },
-                {
-                  "color": "#003366",
-                  "marginBottom": 8,
-                },
+                undefined,
               ]
             }
           >
-            Test Service
+            BCSC.Services.NotListed
+          </Text>
+          <Text
+            maxFontSizeMultiplier={2}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                },
+                undefined,
+              ]
+            }
+          >
+            BCSC.Services.NotListedDescription
           </Text>
           <Text
             maxFontSizeMultiplier={2}
@@ -323,79 +457,14 @@ exports[`Services renders service list when loading is complete 1`] = `
                   "fontWeight": "normal",
                 },
                 {
-                  "color": "#606060",
+                  "marginTop": 32,
                 },
               ]
             }
           >
-            A test service
+            BCSC.Services.NotListedDescriptionContact
           </Text>
         </View>
-      </View>
-      <View
-        style={
-          {
-            "margin": 16,
-          }
-        }
-      >
-        <Text
-          maxFontSizeMultiplier={2}
-          style={
-            [
-              {
-                "color": "#313132",
-                "fontFamily": "BCSans-Regular",
-                "fontSize": 18,
-                "fontWeight": "bold",
-              },
-              undefined,
-            ]
-          }
-        >
-          BCSC.Services.NotListed
-        </Text>
-        <Text
-          maxFontSizeMultiplier={2}
-          style={
-            [
-              {
-                "color": "#313132",
-                "fontFamily": "BCSans-Regular",
-                "fontSize": 18,
-                "fontWeight": "normal",
-              },
-              {
-                "lineHeight": 30,
-              },
-            ]
-          }
-        >
-          BCSC.Services.NotListedDescription
-        </Text>
-        <Text
-          maxFontSizeMultiplier={2}
-          style={
-            [
-              {
-                "color": "#313132",
-                "fontFamily": "BCSans-Regular",
-                "fontSize": 18,
-                "fontWeight": "normal",
-              },
-              [
-                {
-                  "lineHeight": 30,
-                },
-                {
-                  "marginTop": 32,
-                },
-              ],
-            ]
-          }
-        >
-          BCSC.Services.NotListedDescriptionContact
-        </Text>
       </View>
     </View>
   </RCTScrollView>

--- a/app/src/bcsc-theme/features/services/components/ServiceButton.tsx
+++ b/app/src/bcsc-theme/features/services/components/ServiceButton.tsx
@@ -1,43 +1,85 @@
-import { testIdWithKey, ThemedText, useTheme } from '@bifold/core'
-import React from 'react'
-import { StyleSheet, TouchableOpacity } from 'react-native'
-
+import { ListButton, ListButtonProps } from '@/bcsc-theme/components/ListButton'
+import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
+import { hitSlop } from '@/constants'
+import { BCState } from '@/store'
+import { testIdWithKey, ThemedText, useStore, useTheme } from '@bifold/core'
 import { a11yLabel } from '@utils/accessibility'
+import React from 'react'
+import { Pressable, StyleSheet, View } from 'react-native'
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
 interface ServiceButtonProps {
+  clientRefId: string
   title: string
   description?: string
   onPress: () => void
   testID?: string
+  /** Injected by ListButtonGroup to control border radius */
+  position?: ListButtonProps['position']
 }
 
-const ServiceButton: React.FC<ServiceButtonProps> = ({ title, description, onPress, testID }) => {
+const ServiceButton: React.FC<ServiceButtonProps> = ({
+  clientRefId,
+  title,
+  description,
+  onPress,
+  testID,
+  position,
+}) => {
   const { ColorPalette, Spacing } = useTheme()
+  const [store] = useStore<BCState>()
+  const { updateSavedService } = useSecureActions()
+
+  const isBookmarked = store.bcscSecure.savedServices.includes(clientRefId)
 
   const styles = StyleSheet.create({
-    container: {
-      padding: Spacing.md,
-      backgroundColor: ColorPalette.brand.secondaryBackground,
+    contentContainer: {
+      flex: 1,
+    },
+    topRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: Spacing.sm,
     },
     title: {
-      marginBottom: Spacing.sm,
+      flex: 1,
       color: ColorPalette.brand.primary,
     },
   })
 
+  const handleToggleBookmark = () => {
+    updateSavedService(clientRefId, !isBookmarked, { clientName: title })
+  }
+
   return (
-    <TouchableOpacity
-      onPress={onPress}
-      style={styles.container}
-      accessibilityLabel={a11yLabel(title)}
-      accessibilityRole="button"
-      testID={testID ?? testIdWithKey(`ServiceButton-${title.replaceAll(/\s+/g, '')}`)}
-    >
-      <ThemedText variant={'headingFour'} style={styles.title}>
-        {title}
-      </ThemedText>
-      {description ? <ThemedText style={{ color: ColorPalette.brand.tertiary }}>{description}</ThemedText> : null}
-    </TouchableOpacity>
+    <ListButton onPress={onPress} position={position} accessibilityLabel={a11yLabel(title)}>
+      <View style={styles.contentContainer}>
+        <View style={styles.topRow}>
+          <ThemedText
+            variant={'bold'}
+            style={styles.title}
+            testID={testID ?? testIdWithKey(`ServiceButton-${title.replaceAll(/\s+/g, '')}`)}
+          >
+            {title}
+          </ThemedText>
+          <Pressable
+            onPress={handleToggleBookmark}
+            hitSlop={hitSlop}
+            accessibilityRole={'button'}
+            accessibilityLabel={a11yLabel(`Toggle bookmark for ${title}`)}
+            testID={testIdWithKey(`ServiceButton-Bookmark-${title.replaceAll(/\s+/g, '')}`)}
+          >
+            <Icon name={isBookmarked ? 'bookmark' : 'bookmark-outline'} size={24} color={ColorPalette.brand.primary} />
+          </Pressable>
+        </View>
+        {description ? (
+          <ThemedText variant={'caption'} style={{ marginTop: Spacing.sm }}>
+            {description}
+          </ThemedText>
+        ) : null}
+      </View>
+    </ListButton>
   )
 }
 

--- a/app/src/bcsc-theme/features/settings/SettingsContent.tsx
+++ b/app/src/bcsc-theme/features/settings/SettingsContent.tsx
@@ -15,8 +15,16 @@ import { ErrorRegistry } from '@/errors/errorRegistry'
 import { AppEventCode } from '@/events/appEventCode'
 import { BCDispatchAction, BCState } from '@/store'
 import { Analytics } from '@/utils/analytics/analytics-singleton'
-import TabScreenWrapper from '@bcsc-theme/components/TabScreenWrapper'
-import { testIdWithKey, ThemedText, TOKENS, useDeveloperMode, useServices, useStore, useTheme } from '@bifold/core'
+import {
+  ScreenWrapper,
+  testIdWithKey,
+  ThemedText,
+  TOKENS,
+  useDeveloperMode,
+  useServices,
+  useStore,
+  useTheme,
+} from '@bifold/core'
 import { useFocusEffect } from '@react-navigation/native'
 import React, { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -185,8 +193,7 @@ export const SettingsContent: React.FC<SettingsContentProps> = ({
 
   const styles = StyleSheet.create({
     container: {
-      flex: 1,
-      padding: Spacing.md,
+      padding: Spacing.lg,
     },
     sectionHeader: {
       paddingVertical: Spacing.md,
@@ -317,86 +324,80 @@ export const SettingsContent: React.FC<SettingsContentProps> = ({
   const isAuthenticated = store.authentication.didAuthenticate
 
   return (
-    <TabScreenWrapper edges={['bottom', 'left', 'right']}>
-      <View style={styles.container}>
-        {isAuthenticated ? (
-          <AuthenticatedSection
-            styles={styles}
-            accountSecurityMethod={accountSecurityMethod}
-            onAppSecurity={onAppSecurity}
-            onChangePIN={onChangePIN}
-            onEditNickname={onEditNickname}
-            onAutoLock={onAutoLock}
-            onForgetAllPairings={onForgetAllPairings}
-            onPressOptInAnalytics={onPressOptInAnalytics}
-            onPressRemoveAccount={onPressRemoveAccount}
-            onLogout={logout}
-            setTheme={setTheme}
-            themeName={themeName}
+    <ScreenWrapper padded={false} scrollViewContainerStyle={styles.container}>
+      {isAuthenticated ? (
+        <AuthenticatedSection
+          styles={styles}
+          accountSecurityMethod={accountSecurityMethod}
+          onAppSecurity={onAppSecurity}
+          onChangePIN={onChangePIN}
+          onEditNickname={onEditNickname}
+          onAutoLock={onAutoLock}
+          onForgetAllPairings={onForgetAllPairings}
+          onPressOptInAnalytics={onPressOptInAnalytics}
+          onPressRemoveAccount={onPressRemoveAccount}
+          onLogout={logout}
+          setTheme={setTheme}
+          themeName={themeName}
+        />
+      ) : null}
+
+      <ThemedText variant={'bold'} style={styles.sectionHeader}>
+        {t('BCSC.Settings.HeaderB')}
+      </ThemedText>
+      <View style={styles.sectionContainer}>
+        <SettingsActionCard title={t('BCSC.Settings.Help')} onPress={onHelp} testID={testIdWithKey('Help')} />
+        <SettingsActionCard title={t('BCSC.Settings.Privacy')} onPress={onPrivacy} testID={testIdWithKey('Privacy')} />
+        <SettingsActionCard
+          title={t('BCSC.Settings.ContactUs')}
+          onPress={onContactUs}
+          testID={testIdWithKey('ContactUs')}
+        />
+        <SettingsActionCard
+          title={t('BCSC.Settings.Feedback')}
+          onPress={onPressFeedback}
+          testID={testIdWithKey('Feedback')}
+          accessibilityHint={t('Global.A11y.OpensInBrowser')}
+        />
+        <SettingsActionCard
+          title={t('BCSC.Settings.Accessibility')}
+          onPress={onPressAccessibility}
+          testID={testIdWithKey('Accessibility')}
+          accessibilityHint={t('Global.A11y.OpensInBrowser')}
+        />
+        <SettingsActionCard
+          title={t('BCSC.Settings.TermsOfUse')}
+          onPress={onPressTermsOfUse}
+          testID={testIdWithKey('TermsOfUse')}
+          accessibilityHint={t('Global.A11y.OpensInBrowser')}
+        />
+        <SettingsActionCard
+          title={t('BCSC.Settings.Analytics')}
+          onPress={onPressAnalytics}
+          testID={testIdWithKey('Analytics')}
+          accessibilityHint={t('Global.A11y.OpensInBrowser')}
+        />
+        {store.preferences.developerModeEnabled ? (
+          <SettingsActionCard
+            title={t('Developer.DeveloperMode')}
+            onPress={onPressDeveloperMode}
+            testID={testIdWithKey('DeveloperMode')}
           />
         ) : null}
-
-        <ThemedText variant={'bold'} style={styles.sectionHeader}>
-          {t('BCSC.Settings.HeaderB')}
-        </ThemedText>
-        <View style={styles.sectionContainer}>
-          <SettingsActionCard title={t('BCSC.Settings.Help')} onPress={onHelp} testID={testIdWithKey('Help')} />
-          <SettingsActionCard
-            title={t('BCSC.Settings.Privacy')}
-            onPress={onPrivacy}
-            testID={testIdWithKey('Privacy')}
-          />
-          <SettingsActionCard
-            title={t('BCSC.Settings.ContactUs')}
-            onPress={onContactUs}
-            testID={testIdWithKey('ContactUs')}
-          />
-          <SettingsActionCard
-            title={t('BCSC.Settings.Feedback')}
-            onPress={onPressFeedback}
-            testID={testIdWithKey('Feedback')}
-            accessibilityHint={t('Global.A11y.OpensInBrowser')}
-          />
-          <SettingsActionCard
-            title={t('BCSC.Settings.Accessibility')}
-            onPress={onPressAccessibility}
-            testID={testIdWithKey('Accessibility')}
-            accessibilityHint={t('Global.A11y.OpensInBrowser')}
-          />
-          <SettingsActionCard
-            title={t('BCSC.Settings.TermsOfUse')}
-            onPress={onPressTermsOfUse}
-            testID={testIdWithKey('TermsOfUse')}
-            accessibilityHint={t('Global.A11y.OpensInBrowser')}
-          />
-          <SettingsActionCard
-            title={t('BCSC.Settings.Analytics')}
-            onPress={onPressAnalytics}
-            testID={testIdWithKey('Analytics')}
-            accessibilityHint={t('Global.A11y.OpensInBrowser')}
-          />
-          {store.preferences.developerModeEnabled ? (
-            <SettingsActionCard
-              title={t('Developer.DeveloperMode')}
-              onPress={onPressDeveloperMode}
-              testID={testIdWithKey('DeveloperMode')}
-            />
-          ) : null}
-        </View>
-
-        <View style={styles.versionContainer}>
-          <TouchableWithoutFeedback
-            onPress={incrementDeveloperMenuCounter}
-            disabled={store.preferences.developerModeEnabled}
-            accessible={false}
-          >
-            <View style={{ alignItems: 'center' }}>
-              <ThemedText variant="labelSubtitle">{t('BCSC.Title')}</ThemedText>
-              <ThemedText variant="labelSubtitle">{`Version ${getVersion()} (${getBuildNumber()})`}</ThemedText>
-            </View>
-          </TouchableWithoutFeedback>
-        </View>
       </View>
-    </TabScreenWrapper>
+
+      <View style={styles.versionContainer}>
+        <TouchableWithoutFeedback
+          onPress={incrementDeveloperMenuCounter}
+          disabled={store.preferences.developerModeEnabled}
+          accessible={false}
+        >
+          <View style={{ alignItems: 'center' }}>
+            <ThemedText variant="labelSubtitle">{t('BCSC.Title')}</ThemedText>
+            <ThemedText variant="labelSubtitle">{`Version ${getVersion()} (${getBuildNumber()})`}</ThemedText>
+          </View>
+        </TouchableWithoutFeedback>
+      </View>
+    </ScreenWrapper>
   )
 }

--- a/app/src/bcsc-theme/features/settings/__snapshots__/AuthSettingsScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/settings/__snapshots__/AuthSettingsScreen.test.tsx.snap
@@ -22,566 +22,169 @@ exports[`AuthSettings renders correctly 1`] = `
         }
       }
       style={
-        {
-          "backgroundColor": "#F2F2F2",
-          "flex": 1,
-        }
+        [
+          {
+            "backgroundColor": "#F2F2F2",
+            "flex": 1,
+          },
+          undefined,
+        ]
       }
     >
       <RCTScrollView
         contentContainerStyle={
-          {
-            "flexGrow": 1,
-          }
+          [
+            false,
+            {
+              "padding": 24,
+            },
+          ]
         }
+        showsVerticalScrollIndicator={false}
       >
         <View>
+          <Text
+            maxFontSizeMultiplier={2}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                },
+                {
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            BCSC.Settings.HeaderB
+          </Text>
           <View
             style={
               {
-                "flex": 1,
-                "padding": 16,
+                "borderRadius": 8,
+                "gap": 2,
+                "overflow": "hidden",
               }
             }
           >
-            <Text
-              maxFontSizeMultiplier={2}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontFamily": "BCSans-Regular",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                  {
-                    "paddingVertical": 16,
-                  },
-                ]
-              }
-            >
-              BCSC.Settings.HeaderB
-            </Text>
             <View
+              accessibilityLabel="BCSC.Settings.Help"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
                 {
-                  "borderRadius": 8,
-                  "gap": 2,
-                  "overflow": "hidden",
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
                 }
               }
+              testID="com.ariesbifold:id/Help"
             >
               <View
-                accessibilityLabel="BCSC.Settings.Help"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
                   }
                 }
-                testID="com.ariesbifold:id/Help"
               >
-                <View
+                <Text
+                  maxFontSizeMultiplier={2}
                   style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      undefined,
+                    ]
                   }
                 >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.Help
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityLabel="BCSC.Settings.Privacy"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/Privacy"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.Privacy
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityLabel="BCSC.Settings.ContactUs"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/ContactUs"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.ContactUs
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.Feedback"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/Feedback"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.Feedback
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.Accessibility"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/Accessibility"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.Accessibility
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.TermsOfUse"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/TermsOfUse"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.TermsOfUse
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.Analytics"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/Analytics"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.Analytics
-                  </Text>
-                </View>
+                  BCSC.Settings.Help
+                </Text>
               </View>
             </View>
             <View
-              style={
+              accessibilityLabel="BCSC.Settings.Privacy"
+              accessibilityRole="button"
+              accessibilityState={
                 {
-                  "gap": 4,
-                  "paddingTop": 16,
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
                 }
               }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/Privacy"
             >
               <View
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessible={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   {
-                    "alignItems": "center",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
                   }
                 }
               >
@@ -592,15 +195,67 @@ exports[`AuthSettings renders correctly 1`] = `
                       {
                         "color": "#313132",
                         "fontFamily": "BCSans-Regular",
-                        "fontSize": 14,
+                        "fontSize": 18,
                         "fontWeight": "normal",
                       },
                       undefined,
                     ]
                   }
                 >
-                  BCSC.Title
+                  BCSC.Settings.Privacy
                 </Text>
+              </View>
+            </View>
+            <View
+              accessibilityLabel="BCSC.Settings.ContactUs"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/ContactUs"
+            >
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
+                  }
+                }
+              >
                 <Text
                   maxFontSizeMultiplier={2}
                   style={
@@ -608,16 +263,359 @@ exports[`AuthSettings renders correctly 1`] = `
                       {
                         "color": "#313132",
                         "fontFamily": "BCSans-Regular",
-                        "fontSize": 14,
+                        "fontSize": 18,
                         "fontWeight": "normal",
                       },
                       undefined,
                     ]
                   }
                 >
-                  Version 4.0.0 (142)
+                  BCSC.Settings.ContactUs
                 </Text>
               </View>
+            </View>
+            <View
+              accessibilityHint="Global.A11y.OpensInBrowser"
+              accessibilityLabel="BCSC.Settings.Feedback"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/Feedback"
+            >
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={2}
+                  style={
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  BCSC.Settings.Feedback
+                </Text>
+              </View>
+            </View>
+            <View
+              accessibilityHint="Global.A11y.OpensInBrowser"
+              accessibilityLabel="BCSC.Settings.Accessibility"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/Accessibility"
+            >
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={2}
+                  style={
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  BCSC.Settings.Accessibility
+                </Text>
+              </View>
+            </View>
+            <View
+              accessibilityHint="Global.A11y.OpensInBrowser"
+              accessibilityLabel="BCSC.Settings.TermsOfUse"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/TermsOfUse"
+            >
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={2}
+                  style={
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  BCSC.Settings.TermsOfUse
+                </Text>
+              </View>
+            </View>
+            <View
+              accessibilityHint="Global.A11y.OpensInBrowser"
+              accessibilityLabel="BCSC.Settings.Analytics"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/Analytics"
+            >
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={2}
+                  style={
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  BCSC.Settings.Analytics
+                </Text>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              {
+                "gap": 4,
+                "paddingTop": 16,
+              }
+            }
+          >
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessible={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "alignItems": "center",
+                }
+              }
+            >
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "normal",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                BCSC.Title
+              </Text>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "normal",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                Version 4.0.0 (142)
+              </Text>
             </View>
           </View>
         </View>

--- a/app/src/bcsc-theme/features/settings/__snapshots__/MainSettingsScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/settings/__snapshots__/MainSettingsScreen.test.tsx.snap
@@ -22,566 +22,169 @@ exports[`MainSettings renders correctly 1`] = `
         }
       }
       style={
-        {
-          "backgroundColor": "#F2F2F2",
-          "flex": 1,
-        }
+        [
+          {
+            "backgroundColor": "#F2F2F2",
+            "flex": 1,
+          },
+          undefined,
+        ]
       }
     >
       <RCTScrollView
         contentContainerStyle={
-          {
-            "flexGrow": 1,
-          }
+          [
+            false,
+            {
+              "padding": 24,
+            },
+          ]
         }
+        showsVerticalScrollIndicator={false}
       >
         <View>
+          <Text
+            maxFontSizeMultiplier={2}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                },
+                {
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            BCSC.Settings.HeaderB
+          </Text>
           <View
             style={
               {
-                "flex": 1,
-                "padding": 16,
+                "borderRadius": 8,
+                "gap": 2,
+                "overflow": "hidden",
               }
             }
           >
-            <Text
-              maxFontSizeMultiplier={2}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontFamily": "BCSans-Regular",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                  {
-                    "paddingVertical": 16,
-                  },
-                ]
-              }
-            >
-              BCSC.Settings.HeaderB
-            </Text>
             <View
+              accessibilityLabel="BCSC.Settings.Help"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
                 {
-                  "borderRadius": 8,
-                  "gap": 2,
-                  "overflow": "hidden",
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
                 }
               }
+              testID="com.ariesbifold:id/Help"
             >
               <View
-                accessibilityLabel="BCSC.Settings.Help"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
                   }
                 }
-                testID="com.ariesbifold:id/Help"
               >
-                <View
+                <Text
+                  maxFontSizeMultiplier={2}
                   style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      undefined,
+                    ]
                   }
                 >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.Help
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityLabel="BCSC.Settings.Privacy"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/Privacy"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.Privacy
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityLabel="BCSC.Settings.ContactUs"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/ContactUs"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.ContactUs
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.Feedback"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/Feedback"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.Feedback
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.Accessibility"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/Accessibility"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.Accessibility
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.TermsOfUse"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/TermsOfUse"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.TermsOfUse
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.Analytics"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/Analytics"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.Analytics
-                  </Text>
-                </View>
+                  BCSC.Settings.Help
+                </Text>
               </View>
             </View>
             <View
-              style={
+              accessibilityLabel="BCSC.Settings.Privacy"
+              accessibilityRole="button"
+              accessibilityState={
                 {
-                  "gap": 4,
-                  "paddingTop": 16,
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
                 }
               }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/Privacy"
             >
               <View
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessible={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   {
-                    "alignItems": "center",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
                   }
                 }
               >
@@ -592,15 +195,67 @@ exports[`MainSettings renders correctly 1`] = `
                       {
                         "color": "#313132",
                         "fontFamily": "BCSans-Regular",
-                        "fontSize": 14,
+                        "fontSize": 18,
                         "fontWeight": "normal",
                       },
                       undefined,
                     ]
                   }
                 >
-                  BCSC.Title
+                  BCSC.Settings.Privacy
                 </Text>
+              </View>
+            </View>
+            <View
+              accessibilityLabel="BCSC.Settings.ContactUs"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/ContactUs"
+            >
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
+                  }
+                }
+              >
                 <Text
                   maxFontSizeMultiplier={2}
                   style={
@@ -608,16 +263,359 @@ exports[`MainSettings renders correctly 1`] = `
                       {
                         "color": "#313132",
                         "fontFamily": "BCSans-Regular",
-                        "fontSize": 14,
+                        "fontSize": 18,
                         "fontWeight": "normal",
                       },
                       undefined,
                     ]
                   }
                 >
-                  Version 4.0.0 (142)
+                  BCSC.Settings.ContactUs
                 </Text>
               </View>
+            </View>
+            <View
+              accessibilityHint="Global.A11y.OpensInBrowser"
+              accessibilityLabel="BCSC.Settings.Feedback"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/Feedback"
+            >
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={2}
+                  style={
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  BCSC.Settings.Feedback
+                </Text>
+              </View>
+            </View>
+            <View
+              accessibilityHint="Global.A11y.OpensInBrowser"
+              accessibilityLabel="BCSC.Settings.Accessibility"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/Accessibility"
+            >
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={2}
+                  style={
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  BCSC.Settings.Accessibility
+                </Text>
+              </View>
+            </View>
+            <View
+              accessibilityHint="Global.A11y.OpensInBrowser"
+              accessibilityLabel="BCSC.Settings.TermsOfUse"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/TermsOfUse"
+            >
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={2}
+                  style={
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  BCSC.Settings.TermsOfUse
+                </Text>
+              </View>
+            </View>
+            <View
+              accessibilityHint="Global.A11y.OpensInBrowser"
+              accessibilityLabel="BCSC.Settings.Analytics"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/Analytics"
+            >
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={2}
+                  style={
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  BCSC.Settings.Analytics
+                </Text>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              {
+                "gap": 4,
+                "paddingTop": 16,
+              }
+            }
+          >
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessible={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "alignItems": "center",
+                }
+              }
+            >
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "normal",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                BCSC.Title
+              </Text>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "normal",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                Version 4.0.0 (142)
+              </Text>
             </View>
           </View>
         </View>

--- a/app/src/bcsc-theme/features/settings/__snapshots__/VerifySettingsScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/settings/__snapshots__/VerifySettingsScreen.test.tsx.snap
@@ -22,566 +22,169 @@ exports[`VerifySettings renders correctly 1`] = `
         }
       }
       style={
-        {
-          "backgroundColor": "#F2F2F2",
-          "flex": 1,
-        }
+        [
+          {
+            "backgroundColor": "#F2F2F2",
+            "flex": 1,
+          },
+          undefined,
+        ]
       }
     >
       <RCTScrollView
         contentContainerStyle={
-          {
-            "flexGrow": 1,
-          }
+          [
+            false,
+            {
+              "padding": 24,
+            },
+          ]
         }
+        showsVerticalScrollIndicator={false}
       >
         <View>
+          <Text
+            maxFontSizeMultiplier={2}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                },
+                {
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            BCSC.Settings.HeaderB
+          </Text>
           <View
             style={
               {
-                "flex": 1,
-                "padding": 16,
+                "borderRadius": 8,
+                "gap": 2,
+                "overflow": "hidden",
               }
             }
           >
-            <Text
-              maxFontSizeMultiplier={2}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontFamily": "BCSans-Regular",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                  {
-                    "paddingVertical": 16,
-                  },
-                ]
-              }
-            >
-              BCSC.Settings.HeaderB
-            </Text>
             <View
+              accessibilityLabel="BCSC.Settings.Help"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
                 {
-                  "borderRadius": 8,
-                  "gap": 2,
-                  "overflow": "hidden",
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
                 }
               }
+              testID="com.ariesbifold:id/Help"
             >
               <View
-                accessibilityLabel="BCSC.Settings.Help"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
                   }
                 }
-                testID="com.ariesbifold:id/Help"
               >
-                <View
+                <Text
+                  maxFontSizeMultiplier={2}
                   style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      undefined,
+                    ]
                   }
                 >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.Help
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityLabel="BCSC.Settings.Privacy"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/Privacy"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.Privacy
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityLabel="BCSC.Settings.ContactUs"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/ContactUs"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.ContactUs
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.Feedback"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/Feedback"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.Feedback
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.Accessibility"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/Accessibility"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.Accessibility
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.TermsOfUse"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/TermsOfUse"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.TermsOfUse
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.Analytics"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "backgroundColor": "#FFFFFF",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "padding": 16,
-                  }
-                }
-                testID="com.ariesbifold:id/Analytics"
-              >
-                <View
-                  style={
-                    {
-                      "display": "flex",
-                      "flexDirection": "row",
-                      "gap": 8,
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    BCSC.Settings.Analytics
-                  </Text>
-                </View>
+                  BCSC.Settings.Help
+                </Text>
               </View>
             </View>
             <View
-              style={
+              accessibilityLabel="BCSC.Settings.Privacy"
+              accessibilityRole="button"
+              accessibilityState={
                 {
-                  "gap": 4,
-                  "paddingTop": 16,
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
                 }
               }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/Privacy"
             >
               <View
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessible={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   {
-                    "alignItems": "center",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
                   }
                 }
               >
@@ -592,15 +195,67 @@ exports[`VerifySettings renders correctly 1`] = `
                       {
                         "color": "#313132",
                         "fontFamily": "BCSans-Regular",
-                        "fontSize": 14,
+                        "fontSize": 18,
                         "fontWeight": "normal",
                       },
                       undefined,
                     ]
                   }
                 >
-                  BCSC.Title
+                  BCSC.Settings.Privacy
                 </Text>
+              </View>
+            </View>
+            <View
+              accessibilityLabel="BCSC.Settings.ContactUs"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/ContactUs"
+            >
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
+                  }
+                }
+              >
                 <Text
                   maxFontSizeMultiplier={2}
                   style={
@@ -608,16 +263,359 @@ exports[`VerifySettings renders correctly 1`] = `
                       {
                         "color": "#313132",
                         "fontFamily": "BCSans-Regular",
-                        "fontSize": 14,
+                        "fontSize": 18,
                         "fontWeight": "normal",
                       },
                       undefined,
                     ]
                   }
                 >
-                  Version 4.0.0 (142)
+                  BCSC.Settings.ContactUs
                 </Text>
               </View>
+            </View>
+            <View
+              accessibilityHint="Global.A11y.OpensInBrowser"
+              accessibilityLabel="BCSC.Settings.Feedback"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/Feedback"
+            >
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={2}
+                  style={
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  BCSC.Settings.Feedback
+                </Text>
+              </View>
+            </View>
+            <View
+              accessibilityHint="Global.A11y.OpensInBrowser"
+              accessibilityLabel="BCSC.Settings.Accessibility"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/Accessibility"
+            >
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={2}
+                  style={
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  BCSC.Settings.Accessibility
+                </Text>
+              </View>
+            </View>
+            <View
+              accessibilityHint="Global.A11y.OpensInBrowser"
+              accessibilityLabel="BCSC.Settings.TermsOfUse"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/TermsOfUse"
+            >
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={2}
+                  style={
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  BCSC.Settings.TermsOfUse
+                </Text>
+              </View>
+            </View>
+            <View
+              accessibilityHint="Global.A11y.OpensInBrowser"
+              accessibilityLabel="BCSC.Settings.Analytics"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/Analytics"
+            >
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": 8,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={2}
+                  style={
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  BCSC.Settings.Analytics
+                </Text>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              {
+                "gap": 4,
+                "paddingTop": 16,
+              }
+            }
+          >
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessible={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "alignItems": "center",
+                }
+              }
+            >
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "normal",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                BCSC.Title
+              </Text>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "normal",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                Version 4.0.0 (142)
+              </Text>
             </View>
           </View>
         </View>

--- a/app/src/bcsc-theme/navigators/TabStack.tsx
+++ b/app/src/bcsc-theme/navigators/TabStack.tsx
@@ -2,6 +2,7 @@ import { useCustomNotifications } from '@/hooks/useCustomNotifications'
 import { CredentialStack, testIdWithKey, useTheme } from '@bifold/core'
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, useWindowDimensions, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
@@ -59,6 +60,7 @@ const BCSCTabStack: React.FC = () => {
   const Tab = createBottomTabNavigator<BCSCTabStackParams>()
   const { TabTheme, ColorPalette } = useTheme()
   const { customNotifications } = useCustomNotifications()
+  const { t } = useTranslation()
 
   // FIXME (V4.1.x): Add custom notifications and credential notifications together to calculate badge count.
   // Need to wait until useNotifications doesn't throw an error when un-wrapped by the providers.
@@ -112,6 +114,7 @@ const BCSCTabStack: React.FC = () => {
             tabBarAccessibilityLabel: 'Services',
             tabBarTestID: testIdWithKey('Services'),
             headerLeft: createMainSettingsHeaderButton(),
+            title: t('BCSC.Services.CatalogueTitle'),
           }}
         />
         <Tab.Screen

--- a/app/src/bcsc-theme/navigators/TabStack.tsx
+++ b/app/src/bcsc-theme/navigators/TabStack.tsx
@@ -1,12 +1,13 @@
 import { useCustomNotifications } from '@/hooks/useCustomNotifications'
 import { CredentialStack, testIdWithKey, useTheme } from '@bifold/core'
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
-import React from 'react'
+import { BottomTabBar, BottomTabBarProps, createBottomTabNavigator } from '@react-navigation/bottom-tabs'
+import React, { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text, useWindowDimensions, View } from 'react-native'
+import { Animated, StyleSheet, Text, useWindowDimensions, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 import { createMainFloatingMenuButton } from '../components/FloatingHelpMenuHeaderButton'
+import { createTabHeaderWithoutBanner } from '../components/HeaderWithBanner'
 import { createMainSettingsHeaderButton } from '../components/SettingsHeaderButton'
 import { AgentReadyGate } from '../features/agent'
 import Home from '../features/home/Home'
@@ -56,6 +57,47 @@ const createTabBarIcon = (label: string, iconName: string) => {
   return TabBarIconComponent
 }
 
+const ACTIVE_INDICATOR_COLOR = '#FCBA19'
+const ACTIVE_INDICATOR_HEIGHT = 4
+const ACTIVE_INDICATOR_DURATION_MS = 100
+
+const AnimatedTabBar: React.FC<BottomTabBarProps> = (props) => {
+  const { state } = props
+  const tabCount = state.routes.length
+  const { width: windowWidth } = useWindowDimensions()
+  const tabWidth = windowWidth / tabCount
+  const indicatorWidth = tabWidth * 0.8
+  const indicatorOffset = (tabWidth - indicatorWidth) / 2
+  const translateX = useRef(new Animated.Value(state.index * tabWidth + indicatorOffset)).current
+
+  useEffect(() => {
+    Animated.timing(translateX, {
+      toValue: state.index * tabWidth + indicatorOffset,
+      duration: ACTIVE_INDICATOR_DURATION_MS,
+      useNativeDriver: true,
+    }).start()
+  }, [state.index, tabWidth, indicatorOffset, translateX])
+
+  return (
+    <View>
+      <Animated.View
+        pointerEvents="none"
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: indicatorWidth,
+          height: ACTIVE_INDICATOR_HEIGHT,
+          backgroundColor: ACTIVE_INDICATOR_COLOR,
+          transform: [{ translateX }],
+          zIndex: 1,
+        }}
+      />
+      <BottomTabBar {...props} />
+    </View>
+  )
+}
+
 const BCSCTabStack: React.FC = () => {
   const Tab = createBottomTabNavigator<BCSCTabStackParams>()
   const { TabTheme, ColorPalette } = useTheme()
@@ -78,6 +120,7 @@ const BCSCTabStack: React.FC = () => {
     <>
       <Tab.Navigator
         initialRouteName={BCSCScreens.Home}
+        tabBar={(props) => <AnimatedTabBar {...props} />}
         screenOptions={{
           unmountOnBlur: false,
           lazy: true,
@@ -88,6 +131,7 @@ const BCSCTabStack: React.FC = () => {
           tabBarActiveTintColor: TabTheme.tabBarActiveTintColor,
           tabBarInactiveTintColor: TabTheme.tabBarInactiveTintColor,
           title: '',
+          header: createTabHeaderWithoutBanner,
           headerRight: createMainFloatingMenuButton(),
         }}
       >
@@ -114,7 +158,7 @@ const BCSCTabStack: React.FC = () => {
             tabBarAccessibilityLabel: 'Services',
             tabBarTestID: testIdWithKey('Services'),
             headerLeft: createMainSettingsHeaderButton(),
-            title: t('BCSC.Services.CatalogueTitle'),
+            title: t('BCSC.Services.Title'),
           }}
         />
         <Tab.Screen

--- a/app/src/bcsc-theme/navigators/TabStack.tsx
+++ b/app/src/bcsc-theme/navigators/TabStack.tsx
@@ -57,11 +57,11 @@ const createTabBarIcon = (label: string, iconName: string) => {
   return TabBarIconComponent
 }
 
-const ACTIVE_INDICATOR_COLOR = '#FCBA19'
-const ACTIVE_INDICATOR_HEIGHT = 4
+const ACTIVE_INDICATOR_HEIGHT = 3
 const ACTIVE_INDICATOR_DURATION_MS = 100
 
 const AnimatedTabBar: React.FC<BottomTabBarProps> = (props) => {
+  const { ColorPalette } = useTheme()
   const { state } = props
   const tabCount = state.routes.length
   const { width: windowWidth } = useWindowDimensions()
@@ -88,7 +88,7 @@ const AnimatedTabBar: React.FC<BottomTabBarProps> = (props) => {
           left: 0,
           width: indicatorWidth,
           height: ACTIVE_INDICATOR_HEIGHT,
-          backgroundColor: ACTIVE_INDICATOR_COLOR,
+          backgroundColor: ColorPalette.brand.highlight,
           transform: [{ translateX }],
           zIndex: 1,
         }}

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -348,7 +348,7 @@ const translation = {
       "OpenUrlErrorMessage": "Could not open the service URL. Please try again later.",
       "NoLoginInstructions": "You will need to go to their website first if you want to log in to it. You can't log in to services directly from this app.",
       "NoLoginProof": "You will use this app to prove who you are when you log in.",
-      "Goto": "On that device, go to:",
+      "Goto": "Go to:",
       "GotoService": "Go to {{- service}}",
       "GotoUrl": "Go to: {{- url}}",
       "NotListed": "Services not listed?",

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -334,7 +334,7 @@ const translation = {
       },
     },
     "Services": {
-      "CatalogueTitle": "Services",
+      "Title": "Services",
       "CatalogueSearch": "Search services",
       "WantToLogin": "Do you want to log in to",
       "RequestedInformation": "They will receive the following information:",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -348,7 +348,7 @@ const translation = {
       "OpenUrlErrorMessage": "Could not open the service URL. Please try again later. (FR)",
       "NoLoginInstructions": "You will need to go to their website first if you want to log in to it. You can't log in to services directly from this app. (FR)",
       "NoLoginProof": "You will use this app to prove who you are when you log in. (FR)",
-      "Goto": "On that device, go to: (FR)",
+      "Goto": "Go to: (FR)",
       "GotoService": "Go to {{- service}} (FR)",
       "GotoUrl": "Go to: {{- url}} (FR)",
       "NotListed": "Services not listed? (FR)",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -334,7 +334,7 @@ const translation = {
       },
     },
     "Services": {
-      "CatalogueTitle": "Services (FR)",
+      "Title": "Services (FR)",
       "CatalogueSearch": "Search services (FR)",
       "WantToLogin": "Do you want to log in to (FR)",
       "RequestedInformation": "They will receive the following information: (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -348,7 +348,7 @@ const translation = {
       "OpenUrlErrorMessage": "Could not open the service URL. Please try again later. (PT-BR)",
       "NoLoginInstructions": "You will need to go to their website first if you want to log in to it. You can't log in to services directly from this app. (PT-BR)",
       "NoLoginProof": "You will use this app to prove who you are when you log in. (PT-BR)",
-      "Goto": "On that device, go to: (PT-BR)",
+      "Goto": "Go to: (PT-BR)",
       "GotoService": "Go to {{- service}} (PT-BR)",
       "GotoUrl": "Go to: {{- url}} (PT-BR)",
       "NotListed": "Services not listed? (PT-BR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -334,7 +334,7 @@ const translation = {
       },
     },
     "Services": {
-      "CatalogueTitle": "Services (PT-BR)",
+      "Title": "Services (PT-BR)",
       "CatalogueSearch": "Search services (PT-BR)",
       "WantToLogin": "Do you want to log in to (PT-BR)",
       "RequestedInformation": "They will receive the following information: (PT-BR)",


### PR DESCRIPTION
# Summary of Changes

Screenshot attached explains best. A small amount of more work is still required for the ServiceLoginScreen but I will tackle that in a follow-up PR, mostly just additions to the bifold button api

# Testing Instructions

Be verified, play with the services tab, bookmark some stuff

# Acceptance Criteria

Services tab looks like wireframes and users can bookmark from the tab itself

# Screenshots, videos, or gifs

<img width="284" height="614" alt="services" src="https://github.com/user-attachments/assets/406f87e1-dca2-48ca-a3f1-56b40b13d4a6" />

# Related Issues

#3768 