### PR TITLE
fix: added ref to ignore invalid qr code popup after navigation

### DIFF
--- a/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.test.ts
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.test.ts
@@ -234,6 +234,50 @@ describe('useTransferQRScannerViewModel', () => {
       expect(result.current.scanError?.message).toBe('BCSC.Scan.InvalidQrCode')
     })
 
+    it('should not set scanError if navigation.navigate throws after isNavigating is set', async () => {
+      mockAuthorizeDevice.mockResolvedValue(mockDeviceAuth)
+      mockNavigation.navigate.mockImplementation(() => {
+        throw new Error('navigation error')
+      })
+
+      const { result } = renderHook(() => useTransferQRScannerViewModel(mockNavigation))
+
+      await waitFor(() => {
+        expect(mockAuthorizeDevice).toHaveBeenCalled()
+      })
+
+      await act(async () => {
+        await result.current.handleScan(validQrValue)
+      })
+
+      expect(result.current.scanError).toBeNull()
+    })
+
+    it('should not show scan error when camera re-fires after navigation is triggered', async () => {
+      mockAuthorizeDevice.mockResolvedValue(mockDeviceAuth)
+
+      const { result } = renderHook(() => useTransferQRScannerViewModel(mockNavigation))
+
+      await waitFor(() => {
+        expect(mockAuthorizeDevice).toHaveBeenCalled()
+      })
+
+      // First scan succeeds and triggers navigation
+      await act(async () => {
+        await result.current.handleScan(validQrValue)
+      })
+
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.VerificationSuccess)
+
+      // Camera still active during nav transition — fires again with an invalid QR
+      await act(async () => {
+        await result.current.handleScan('https://example.com')
+      })
+
+      // Should be suppressed — no error shown on the VerificationSuccess screen
+      expect(result.current.scanError).toBeNull()
+    })
+
     it('should handle non-Error throws with String fallback', async () => {
       mockAuthorizeDevice.mockResolvedValue(mockDeviceAuth)
       mockVerifyAttestation.mockRejectedValue('raw string error')

--- a/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.ts
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.ts
@@ -27,6 +27,7 @@ const useTransferQRScannerViewModel = (navigation: StackNavigationProp<BCSCVerif
   const deviceCodeRef = useRef<string | undefined>(store.bcscSecure.deviceCode)
   const registrationPromiseRef = useRef<Promise<void>>(Promise.resolve())
   const isProcessingRef = useRef(false)
+  const isNavigatingRef = useRef(false)
 
   const registerDevice = useCallback(async () => {
     // we already have a device code, no need to authorize again
@@ -69,8 +70,8 @@ const useTransferQRScannerViewModel = (navigation: StackNavigationProp<BCSCVerif
 
   const handleScan = useCallback(
     async (value: string) => {
-      // exit early if processing a scan already or if there's an error showing
-      if (isProcessingRef.current || scanError != null) {
+      // exit early if scanning already, navigating away or if an error is showing
+      if (isProcessingRef.current || isNavigatingRef.current || scanError != null) {
         return
       }
 
@@ -131,8 +132,12 @@ const useTransferQRScannerViewModel = (navigation: StackNavigationProp<BCSCVerif
         apiClient.tokens = deviceToken
         await updateTokens({ refreshToken: deviceToken.refresh_token, accessToken: deviceToken.access_token })
 
+        isNavigatingRef.current = true
         navigation.navigate(BCSCScreens.VerificationSuccess)
       } catch (error) {
+        if (isNavigatingRef.current) {
+          return
+        }
         if (error instanceof QrCodeScanError) {
           setScanError(error)
         } else {


### PR DESCRIPTION
# Summary of Changes

- added ref to ignore potential extra scans if the screen navigates successfully 

# Testing Instructions

- transfer a verified account from android -> iOS
- no error popup on a successful transfer

# Acceptance Criteria

n/a

# Screenshots, videos, or gifs

n/a

# Related Issues

[BC-Wallet: 3813](https://github.com/bcgov/bc-wallet-mobile/issues/3813)
