### PR TITLE
fix: timezone and initial zoom

### DIFF
--- a/app/src/bcsc-theme/components/CodeScanningCamera.tsx
+++ b/app/src/bcsc-theme/components/CodeScanningCamera.tsx
@@ -128,7 +128,7 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
   showBarcodeHighlight = false,
   enableScanZones = false,
   scanZones,
-  initialZoom = 2,
+  initialZoom = 1,
 }) => {
   // Derive scanner code types from the declared scan zones (deduped)
   const codeTypes = [...new Set(scanZones.flatMap((z) => z.types))] as CodeType[]
@@ -146,9 +146,9 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
   const focusScale = useRef(new Animated.Value(1)).current
 
   // Zoom management – uses Reanimated shared value for smooth pinch-to-zoom
-  const zoom = useSharedValue(1)
+  const zoom = useSharedValue(initialZoom)
   const zoomOffset = useSharedValue(0)
-  const [zoomDisplay, setZoomDisplay] = useState(1)
+  const [zoomDisplay, setZoomDisplay] = useState(initialZoom)
 
   // Barcode highlight state
   const [detectedCodes, setDetectedCodes] = useState<EnhancedCode[]>([])

--- a/app/src/bcsc-theme/components/__snapshots__/CodeScanningCamera.test.tsx.snap
+++ b/app/src/bcsc-theme/components/__snapshots__/CodeScanningCamera.test.tsx.snap
@@ -1921,7 +1921,7 @@ exports[`CodeScanningCamera renders with custom initial zoom 1`] = `
     <View
       animatedProps={
         {
-          "zoom": 1,
+          "zoom": 3,
         }
       }
       codeScanner={
@@ -2051,7 +2051,7 @@ exports[`CodeScanningCamera renders with custom initial zoom 1`] = `
       }
     >
       Zoom: 
-      1.00
+      3.00
       x
     </Text>
     <Text
@@ -2192,7 +2192,7 @@ exports[`CodeScanningCamera renders with initial zoom set 1`] = `
     <View
       animatedProps={
         {
-          "zoom": 1,
+          "zoom": 2,
         }
       }
       codeScanner={
@@ -2322,7 +2322,7 @@ exports[`CodeScanningCamera renders with initial zoom set 1`] = `
       }
     >
       Zoom: 
-      1.00
+      2.00
       x
     </Text>
     <Text

--- a/app/src/bcsc-theme/features/verify/ScanSerialScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/ScanSerialScreen.tsx
@@ -87,7 +87,7 @@ const ScanSerialScreen: React.FC<ScanSerialScreenProps> = ({ navigation }: ScanS
       <CodeScanningCamera
         onCodeScanned={onCodeScanned}
         cameraType={'back'}
-        initialZoom={2}
+        initialZoom={1}
         scanZones={BCSC_SN_SCAN_ZONES}
         style={StyleSheet.absoluteFillObject}
       />

--- a/app/src/bcsc-theme/utils/service-hours-formatter.ts
+++ b/app/src/bcsc-theme/utils/service-hours-formatter.ts
@@ -199,7 +199,7 @@ const getCurrentTimeInTimezone = (timezone: string): Date => {
   const now = new Date()
   if (timezone === PACIFIC_TIMEZONE) {
     const utcTime = now.getTime() + now.getTimezoneOffset() * 60000
-    const pacificOffset = -8 * 60 * 60000
+    const pacificOffset = -7 * 60 * 60000
     return new Date(utcTime + pacificOffset)
   }
   return now


### PR DESCRIPTION
# Summary of Changes

- Timezone corrected (BC is now permanently +7, no more DST changing)
- Initial zoom always 1x now (there is a bug on Android that is fixed in v5 of react native vision camera that will enable us to use other initial zooms without issue)

# Testing Instructions

Card serial scanning. Timezone is hard to verify except at 5pm - 6pm or 7:30am-830am

# Acceptance Criteria

Works

# Screenshots, videos, or gifs

N/A

# Related Issues

#3834 
#3835 