### PR TITLE
fix: properly config webrtc / pexip to avoid prompt

### DIFF
--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.test.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.test.ts
@@ -203,13 +203,13 @@ describe('createPeerConnection', () => {
     jest.clearAllMocks()
   })
 
-  it('should set iceTransportPolicy to relay on iOS', async () => {
+  it("should set iceTransportPolicy to 'nohost' on iOS", async () => {
     Platform.OS = 'ios'
 
     await createPeerConnection(mockLocalStream, baseTokenResult, mockLogger)
 
     const config = (RTCPeerConnection as jest.Mock).mock.calls[0][0]
-    expect(config.iceTransportPolicy).toBe('relay')
+    expect(config.iceTransportPolicy).toBe('nohost')
   })
 
   it('should not set iceTransportPolicy on Android', async () => {

--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.test.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.test.ts
@@ -1,6 +1,20 @@
 import { BifoldLogger } from '@bifold/core'
 import type { Result as PexipTokenResult } from '@pexip/infinity-api/dist/token/types'
-import { buildIceServers } from './connect'
+import { Platform } from 'react-native'
+import { RTCPeerConnection } from 'react-native-webrtc'
+import { buildIceServers, createPeerConnection } from './connect'
+
+jest.mock('react-native', () => ({
+  Platform: {
+    OS: 'ios',
+  },
+}))
+
+jest.mock('react-native-webrtc', () => ({
+  RTCPeerConnection: jest.fn(function (config) {
+    this.config = config
+  }),
+}))
 
 const mockLogger: BifoldLogger = {
   info: jest.fn(),
@@ -177,5 +191,49 @@ describe('buildIceServers', () => {
     )
 
     expect(mockLogger.info).toHaveBeenCalledWith('ICE servers configured:', { count: 2 })
+  })
+})
+
+describe('createPeerConnection', () => {
+  const mockLocalStream = {
+    getTracks: jest.fn(() => []),
+  } as any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should set iceTransportPolicy to relay on iOS', async () => {
+    Platform.OS = 'ios'
+
+    await createPeerConnection(mockLocalStream, baseTokenResult, mockLogger)
+
+    const config = (RTCPeerConnection as jest.Mock).mock.calls[0][0]
+    expect(config.iceTransportPolicy).toBe('relay')
+  })
+
+  it('should not set iceTransportPolicy on Android', async () => {
+    Platform.OS = 'android'
+
+    await createPeerConnection(mockLocalStream, baseTokenResult, mockLogger)
+
+    const config = (RTCPeerConnection as jest.Mock).mock.calls[0][0]
+    expect(config.iceTransportPolicy).toBeUndefined()
+  })
+
+  it('should include iceServers in configuration on all platforms', async () => {
+    Platform.OS = 'android'
+
+    await createPeerConnection(
+      mockLocalStream,
+      {
+        ...baseTokenResult,
+        stun: [{ url: 'stun:example.com:3478' }],
+      },
+      mockLogger
+    )
+
+    const config = (RTCPeerConnection as jest.Mock).mock.calls[0][0]
+    expect(config.iceServers).toEqual([{ url: 'stun:example.com:3478' }])
   })
 })

--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
@@ -10,6 +10,7 @@ import {
   withToken,
 } from '@pexip/infinity-api'
 import type { Result as PexipTokenResult, Stun, Turn } from '@pexip/infinity-api/dist/token/types'
+import { Platform } from 'react-native'
 import EventSource from 'react-native-sse'
 import { mediaDevices, MediaStream, RTCIceCandidate, RTCPeerConnection } from 'react-native-webrtc'
 import { RTCOfferOptions } from 'react-native-webrtc/lib/typescript/RTCUtil'
@@ -349,10 +350,24 @@ export const buildIceServers = (tokenResult: PexipTokenResult, logger: BifoldLog
   return iceServers
 }
 
-const createPeerConnection = async (localStream: MediaStream, tokenResult: PexipTokenResult, logger: BifoldLogger) => {
-  const peerConstraints = {
+export const createPeerConnection = async (
+  localStream: MediaStream,
+  tokenResult: PexipTokenResult,
+  logger: BifoldLogger
+) => {
+  interface RTCConfiguration {
+    iceServers: IceServer[]
+    iceTransportPolicy?: 'all' | 'relay'
+  }
+
+  const peerConstraints: RTCConfiguration = {
     iceServers: buildIceServers(tokenResult, logger),
-    iceTransportPolicy: 'relay' as const, // Only use TURN relay servers, prevents iOS local network prompt
+  }
+
+  // On iOS, restrict ICE transport to relay-only to prevent the Local Network permission prompt.
+  // The relay policy works with both STUN and TURN servers, including the Google STUN fallback.
+  if (Platform.OS === 'ios') {
+    peerConstraints.iceTransportPolicy = 'relay'
   }
 
   const peerConnection = new RTCPeerConnection(peerConstraints)

--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
@@ -352,6 +352,7 @@ export const buildIceServers = (tokenResult: PexipTokenResult, logger: BifoldLog
 const createPeerConnection = async (localStream: MediaStream, tokenResult: PexipTokenResult, logger: BifoldLogger) => {
   const peerConstraints = {
     iceServers: buildIceServers(tokenResult, logger),
+    iceTransportPolicy: 'relay' as const, // Only use TURN relay servers, prevents iOS local network prompt
   }
 
   const peerConnection = new RTCPeerConnection(peerConstraints)

--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
@@ -355,19 +355,19 @@ export const createPeerConnection = async (
   tokenResult: PexipTokenResult,
   logger: BifoldLogger
 ) => {
-  interface RTCConfiguration {
-    iceServers: IceServer[]
-    iceTransportPolicy?: 'all' | 'relay'
+  const iceServers = buildIceServers(tokenResult, logger)
+  const peerConstraints: { iceServers: IceServer[]; iceTransportPolicy?: 'all' | 'relay' } = {
+    iceServers,
   }
 
-  const peerConstraints: RTCConfiguration = {
-    iceServers: buildIceServers(tokenResult, logger),
-  }
-
-  // On iOS, restrict ICE transport to relay-only to prevent the Local Network permission prompt.
-  // The relay policy works with both STUN and TURN servers, including the Google STUN fallback.
+  // On iOS, skip gathering host candidates to prevent the Local Network permission prompt.
+  // 'nohost' is supported by the native libwebrtc layer in react-native-webrtc (verified in
+  // RCTConvert+WebRTC.m and WebRTCModule.java) but is not exposed in the public TS types.
+  // STUN reflexive (srflx) and TURN relay candidates are still gathered, so connectivity
+  // works with STUN-only fallbacks too.
   if (Platform.OS === 'ios') {
-    peerConstraints.iceTransportPolicy = 'relay'
+    // @ts-expect-error 'nohost' is accepted by the native layer but missing from the public types.
+    peerConstraints.iceTransportPolicy = 'nohost'
   }
 
   const peerConnection = new RTCPeerConnection(peerConstraints)


### PR DESCRIPTION
# Summary of Changes

This one-line fix prevents the prompt seen in the related issue from appearing

# Testing Instructions

Do a live call on iOS, Android

# Acceptance Criteria

Don't see any prompt

# Screenshots, videos, or gifs

N/A

# Related Issues

#3849 