### PR TITLE
feat: added email veriy help button

### DIFF
--- a/app/src/bcsc-theme/navigators/VerifyStack.tsx
+++ b/app/src/bcsc-theme/navigators/VerifyStack.tsx
@@ -142,7 +142,13 @@ const VerifyStack = () => {
       <Stack.Screen name={BCSCScreens.VerificationCardError} component={VerificationCardErrorScreen} />
       <Stack.Screen name={BCSCScreens.BirthdateLockout} component={BirthdateLockoutScreen} />
       <Stack.Screen name={BCSCScreens.EnterEmail} component={EnterEmailScreen} />
-      <Stack.Screen name={BCSCScreens.EmailConfirmation} component={EmailConfirmationScreen} />
+      <Stack.Screen
+        name={BCSCScreens.EmailConfirmation}
+        component={EmailConfirmationScreen}
+        options={{
+          headerRight: createVerifyHelpHeaderButton({ helpCentreUrl: HelpCentreUrl.VERIFY_EMAIL }),
+        }}
+      />
       <Stack.Screen
         name={BCSCScreens.VerificationMethodSelection}
         component={VerificationMethodSelectionScreen}

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -75,6 +75,7 @@ export enum HelpCentreUrl {
   FORGOT_PIN = 'https://id.gov.bc.ca/static/help/secure_app.html?fromapp=1#section-forgotpin',
   INFO_SHARED = 'https://id.gov.bc.ca/static/help/info_shared.html?fromapp=1',
   COMPUTER_LOGIN = 'https://id.gov.bc.ca/static/help/login_fromcomputer.html?fromapp=1',
+  VERIFY_EMAIL = 'https://id.gov.bc.ca/static/help/email.html?fromapp=1',
 }
 
 export const formStringLengths = {


### PR DESCRIPTION
# Summary of Changes

- added help button to verify your email screen

# Testing Instructions

- select non BC card flow
- go through verification process
- press help button at verify your email step


# Acceptance Criteria

- help center page opens 

# Screenshots, videos, or gifs
<img width="400" height="876" alt="verify-email-help" src="https://github.com/user-attachments/assets/82c3956f-5cb3-4047-a37f-97da2b9d0543" />

# Related Issues

[BC-Wallet: 3857](https://github.com/bcgov/bc-wallet-mobile/issues/3857)
