### PR TITLE
fix: fallback for missing clientId, issuer

### DIFF
--- a/app/src/bcsc-theme/features/verify/send-video/InformationRequiredScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/InformationRequiredScreen.test.tsx
@@ -2,6 +2,7 @@ import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
 import { render } from '@testing-library/react-native'
 import React from 'react'
+import { BCSCCardProcess } from 'react-native-bcsc-core'
 import { BCSCLoadingProvider } from '../../../contexts/BCSCLoadingContext'
 import InformationRequiredScreen from './InformationRequiredScreen'
 
@@ -28,5 +29,29 @@ describe('InformationRequired', () => {
     )
 
     expect(tree).toMatchSnapshot()
+  })
+
+  it('renders NonBCSCMessage when cardProcess is NonBCSC', () => {
+    const { queryByText } = render(
+      <BasicAppContext initialStateOverride={{ bcscSecure: { cardProcess: BCSCCardProcess.NonBCSC } as any }}>
+        <BCSCLoadingProvider>
+          <InformationRequiredScreen navigation={mockNavigation as never} />
+        </BCSCLoadingProvider>
+      </BasicAppContext>
+    )
+
+    expect(queryByText('BCSC.SendVideo.InformationRequired.NonBCSCMessage')).toBeTruthy()
+  })
+
+  it('does not render NonBCSCMessage when cardProcess is not NonBCSC', () => {
+    const { queryByText } = render(
+      <BasicAppContext initialStateOverride={{ bcscSecure: { cardProcess: BCSCCardProcess.BCSCPhoto } as any }}>
+        <BCSCLoadingProvider>
+          <InformationRequiredScreen navigation={mockNavigation as never} />
+        </BCSCLoadingProvider>
+      </BasicAppContext>
+    )
+
+    expect(queryByText('BCSC.SendVideo.InformationRequired.NonBCSCMessage')).toBeNull()
   })
 })

--- a/app/src/bcsc-theme/features/verify/send-video/InformationRequiredScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/InformationRequiredScreen.tsx
@@ -1,9 +1,10 @@
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { BCState } from '@/store'
-import { Button, ButtonType, ScreenWrapper, useStore, useTheme } from '@bifold/core'
+import { Button, ButtonType, ScreenWrapper, ThemedText, useStore, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet } from 'react-native'
+import { BCSCCardProcess } from 'react-native-bcsc-core'
 import TakeMediaButton from './components/TakeMediaButton'
 import useEvidenceUploadModel from './useEvidenceUploadModel'
 
@@ -60,6 +61,11 @@ const InformationRequiredScreen = ({ navigation }: InformationRequiredScreenProp
           store.bcsc.videoPath && store.bcsc.videoThumbnailPath && `file://${store.bcsc.videoThumbnailPath}`
         }
       />
+      {store.bcscSecure.cardProcess === BCSCCardProcess.NonBCSC ? (
+        <ThemedText style={{ padding: Spacing.md }}>
+          {t('BCSC.SendVideo.InformationRequired.NonBCSCMessage')}
+        </ThemedText>
+      ) : null}
     </ScreenWrapper>
   )
 }

--- a/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
@@ -1,13 +1,42 @@
 import { BCDispatchAction } from '@/store'
 import * as Bifold from '@bifold/core'
 import { act, renderHook } from '@testing-library/react-native'
-import { EvidenceMetadata, setEvidence } from 'react-native-bcsc-core'
+import {
+  AccountSecurityMethod,
+  EvidenceMetadata,
+  getAccount,
+  getAccountFlags,
+  getAccountSecurityMethod,
+  getAuthorizationRequest,
+  getCredential,
+  getEvidence,
+  getSavedServices,
+  getToken,
+  setAccount,
+  setEvidence,
+} from 'react-native-bcsc-core'
 import * as useBCSCApiClientModule from './useBCSCApiClient'
 import { useSecureActions } from './useSecureActions'
 
 jest.mock('@bifold/core')
 jest.mock('react-native-bcsc-core', () => ({
+  AccountSecurityMethod: {
+    PinNoDeviceAuth: 'app_pin_no_device_authn',
+    PinWithDeviceAuth: 'app_pin_has_device_authn',
+    DeviceAuth: 'device_authentication',
+  },
+  TokenType: { Refresh: 0, Registration: 2, Access: 1 },
   setEvidence: jest.fn(),
+  setAccount: jest.fn(),
+  setToken: jest.fn(),
+  getAccount: jest.fn(),
+  getAccountFlags: jest.fn(),
+  getAccountSecurityMethod: jest.fn(),
+  getAuthorizationRequest: jest.fn(),
+  getCredential: jest.fn(),
+  getEvidence: jest.fn(),
+  getSavedServices: jest.fn(),
+  getToken: jest.fn(),
 }))
 jest.mock('./useBCSCApiClient')
 
@@ -158,6 +187,122 @@ describe('useSecureActions', () => {
         type: BCDispatchAction.UPDATE_SECURE_EVIDENCE_METADATA,
         payload: [[complete]],
       })
+    })
+  })
+
+  describe('hydrateSecureState account recovery', () => {
+    const baseAccount = {
+      id: 'account-1',
+      issuer: '',
+      clientID: '',
+      displayName: 'Test User',
+    }
+
+    beforeEach(() => {
+      jest.mocked(getToken).mockResolvedValue(null as any)
+      jest.mocked(getAccountFlags).mockResolvedValue({} as any)
+      jest.mocked(getEvidence).mockResolvedValue([] as any)
+      jest.mocked(getCredential).mockResolvedValue(null as any)
+      jest.mocked(getSavedServices).mockResolvedValue([] as any)
+      jest.mocked(getAccountSecurityMethod).mockResolvedValue(AccountSecurityMethod.PinNoDeviceAuth)
+    })
+
+    it('recovers issuer/clientID from authorization request and updates account', async () => {
+      jest.mocked(getAccount).mockResolvedValue(baseAccount as any)
+      jest.mocked(getAuthorizationRequest).mockResolvedValue({
+        issuer: 'https://idsit.gov.bc.ca',
+        clientID: 'recovered-client-id',
+      } as any)
+
+      const { result } = renderHook(() => useSecureActions())
+
+      await act(async () => {
+        await result.current.hydrateSecureState()
+      })
+
+      expect(getAccountSecurityMethod).toHaveBeenCalled()
+      expect(setAccount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'account-1',
+          issuer: 'https://idsit.gov.bc.ca',
+          clientID: 'recovered-client-id',
+          securityMethod: AccountSecurityMethod.PinNoDeviceAuth,
+        })
+      )
+    })
+
+    it('does not call setAccount when account already has issuer and clientID', async () => {
+      jest.mocked(getAccount).mockResolvedValue({
+        ...baseAccount,
+        issuer: 'https://idsit.gov.bc.ca',
+        clientID: 'existing-client-id',
+      } as any)
+      jest.mocked(getAuthorizationRequest).mockResolvedValue({
+        issuer: 'https://other.example.com',
+        clientID: 'other-client-id',
+      } as any)
+
+      const { result } = renderHook(() => useSecureActions())
+
+      await act(async () => {
+        await result.current.hydrateSecureState()
+      })
+
+      expect(setAccount).not.toHaveBeenCalled()
+    })
+
+    it('does not call setAccount when authorization request lacks issuer/clientID', async () => {
+      jest.mocked(getAccount).mockResolvedValue(baseAccount as any)
+      jest.mocked(getAuthorizationRequest).mockResolvedValue({
+        // no issuer or clientID
+        deviceCode: 'abc',
+      } as any)
+
+      const { result } = renderHook(() => useSecureActions())
+
+      await act(async () => {
+        await result.current.hydrateSecureState()
+      })
+
+      expect(setAccount).not.toHaveBeenCalled()
+    })
+
+    it('does not call setAccount when authorization request is null', async () => {
+      jest.mocked(getAccount).mockResolvedValue(baseAccount as any)
+      jest.mocked(getAuthorizationRequest).mockResolvedValue(null)
+
+      const { result } = renderHook(() => useSecureActions())
+
+      await act(async () => {
+        await result.current.hydrateSecureState()
+      })
+
+      expect(setAccount).not.toHaveBeenCalled()
+    })
+
+    it('backfills only the missing field (clientID) from authorization request', async () => {
+      jest.mocked(getAccount).mockResolvedValue({
+        ...baseAccount,
+        issuer: 'https://idsit.gov.bc.ca',
+        clientID: '',
+      } as any)
+      jest.mocked(getAuthorizationRequest).mockResolvedValue({
+        issuer: 'https://ignored-because-account-has-one.example.com',
+        clientID: 'recovered-client-id',
+      } as any)
+
+      const { result } = renderHook(() => useSecureActions())
+
+      await act(async () => {
+        await result.current.hydrateSecureState()
+      })
+
+      expect(setAccount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          issuer: 'https://idsit.gov.bc.ca',
+          clientID: 'recovered-client-id',
+        })
+      )
     })
   })
 })

--- a/app/src/bcsc-theme/hooks/useSecureActions.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.tsx
@@ -19,6 +19,7 @@ import {
   EvidenceType,
   getAccount,
   getAccountFlags,
+  getAccountSecurityMethod,
   getAuthorizationRequest,
   getCredential,
   getEvidence,
@@ -27,6 +28,7 @@ import {
   NativeAuthorizationRequest,
   NativeSavedService,
   PhotoMetadata,
+  setAccount,
   setAccountFlags,
   setAuthorizationRequest,
   setCredential,
@@ -733,6 +735,7 @@ export const useSecureActions = () => {
 
       // Load all data from native storage in parallel
       const [
+        account,
         authRequest,
         refreshTokenObj,
         registrationAccessTokenObj,
@@ -742,6 +745,7 @@ export const useSecureActions = () => {
         credential,
         nativeSavedServices,
       ] = await Promise.all([
+        getAccount(),
         getAuthorizationRequest(),
         getToken(TokenType.Refresh),
         getToken(TokenType.Registration),
@@ -759,6 +763,41 @@ export const useSecureActions = () => {
       if (!credential && refreshToken) {
         // Potential bug detected: Missing credential but refresh token exists? Log a warning for visibility, but treat as not verified to avoid false positives.
         logger.warn('[IsVerified] No credential found but refresh token exists — treating as not verified.')
+      }
+
+      if (account && (!account.issuer || !account.clientID)) {
+        // Account is missing issuer or clientID - this prevents token refresh from working.
+        // Recover from authRequest, which preserves these fields from older v3 storage during migration.
+        logger.warn(
+          `[hydrateSecureState] Account missing required fields: issuer=${!account.issuer ? 'MISSING' : 'OK'}, clientID=${!account.clientID ? 'MISSING' : 'OK'}. Attempting recovery from authorization request.`
+        )
+
+        if (authRequest) {
+          try {
+            const recoveredIssuer = account.issuer || authRequest.issuer
+            const recoveredClientID = account.clientID || authRequest.clientID
+
+            if (recoveredIssuer && recoveredClientID) {
+              const securityMethod = await getAccountSecurityMethod()
+              const updatedAccount = {
+                ...account,
+                issuer: recoveredIssuer,
+                clientID: recoveredClientID,
+                securityMethod,
+              }
+              logger.info('[hydrateSecureState] Recovered issuer/clientID from authorization request; updating account')
+              await setAccount(updatedAccount)
+            } else {
+              logger.warn(
+                `[hydrateSecureState] Could not recover account fields from authorization request: issuer=${recoveredIssuer ? 'OK' : 'MISSING'}, clientID=${recoveredClientID ? 'OK' : 'MISSING'}`
+              )
+            }
+          } catch (error) {
+            logger.warn(
+              `[hydrateSecureState] Failed to update account with recovered values: ${error instanceof Error ? error.message : String(error)}`
+            )
+          }
+        }
       }
 
       let freshTokens: TokenResponse | null = null

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -776,6 +776,7 @@ const translation = {
         "ActionLabel": "Take Photo",
         "ActionLabel2": "Record Video",
         "ButtonText": "Send to Service BC Now",
+        "NonBCSCMessage": "Please note: Service BC will check if you have a BC Services Card. If you have one, then your account will be updated to link to it.",
       },
       "PendingReview": {
         "Heading": "Request pending review",

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -2767,13 +2767,26 @@ class BcscCoreModule(
             val accountId = account.getString("id")
             val issuer = account.getString("issuer")
 
-            if (accountId.isNullOrEmpty() || issuer.isNullOrEmpty()) {
-                Log.d(NAME, "getAuthorizationRequest: No issuer")
+            if (accountId.isNullOrEmpty()) {
+                Log.d(NAME, "getAuthorizationRequest: No account id")
                 promise.resolve(null)
                 return
             }
 
-            val issuerName = nativeStorage.getIssuerNameFromIssuer(issuer)
+            // If the account's issuer is missing (e.g. incomplete v3 migration), fall back
+            // to the default issuer name derived from the issuer file / account directories.
+            // This lets the v3 provider read below recover issuer/clientID for callers.
+            val issuerName =
+                if (issuer.isNullOrEmpty()) {
+                    val fallbackName = nativeStorage.getDefaultIssuerName()
+                    Log.w(
+                        NAME,
+                        "getAuthorizationRequest: account.issuer missing; using default issuer name '$fallbackName' to attempt v3 recovery",
+                    )
+                    fallbackName
+                } else {
+                    nativeStorage.getIssuerNameFromIssuer(issuer)
+                }
 
             // First try to read from our v4 storage location
             var authRequest: NativeAuthorizationRequest? = nativeStorage.readAuthorizationRequest(issuerName, accountId)
@@ -2806,7 +2819,11 @@ class BcscCoreModule(
                     authRequest.firstName?.let { putString("firstName", it) }
                     authRequest.lastName?.let { putString("lastName", it) }
                     authRequest.middleNames?.let { putString("middleNames", it) }
-                    authRequest.issuer?.let { putString("audience", it) }
+                    authRequest.issuer?.let {
+                        putString("issuer", it)
+                        putString("audience", it)
+                    }
+                    authRequest.clientID?.let { putString("clientID", it) }
                     authRequest.verificationOptions?.let { putString("verificationOptions", it) }
                     authRequest.verificationUriVideo?.let { putString("verificationURIVideo", it) }
                     authRequest.backCheckVerificationId?.let { putString("backCheckVerificationId", it) }

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/storage/NativeAuthorizationRequest.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/storage/NativeAuthorizationRequest.kt
@@ -66,6 +66,11 @@ enum class NativeAuthorizationMethod(
  * maintaining the same data structure for migration compatibility.
  */
 data class NativeAuthorizationRequest(
+    // OAuth client context (preserved from v3 storage for migration/recovery).
+    // In v3 Android, these lived on Provider/ClientRegistration; surfaced here so callers
+    // can recover issuer/clientID when the Account record is incomplete after migration.
+    @SerializedName("clientID")
+    val clientID: String? = null,
     // Device/user codes
     @SerializedName("deviceCode")
     val deviceCode: String? = null,

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/storage/NativeCompatibleStorage.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/storage/NativeCompatibleStorage.kt
@@ -596,8 +596,20 @@ class NativeCompatibleStorage(
             val clientReg = jsonObject.optJSONObject("clientRegistration") ?: return null
             val authReqJson = clientReg.optJSONObject("authorizationRequest") ?: return null
 
+            // v3 stored OAuth client context on Provider/ClientRegistration; surface them
+            // on the AuthorizationRequest so callers can recover issuer/clientID when the
+            // Account record is incomplete after migration.
+            val v3Issuer =
+                authReqJson.optString("issuer", null)
+                    ?: jsonObject.optString("issuer", null)
+            val v3ClientID =
+                clientReg.optString("client_id", null)
+                    ?: clientReg.optString("clientID", null)
+                    ?: authReqJson.optString("audience", null)
+
             // Convert to our model
             NativeAuthorizationRequest(
+                clientID = v3ClientID,
                 deviceCode = authReqJson.optString("deviceCode", null),
                 userCode = authReqJson.optString("userCode", null),
                 birthDate = authReqJson.optString("birth_date", null),
@@ -607,7 +619,7 @@ class NativeCompatibleStorage(
                 lastName = authReqJson.optString("lastName", null),
                 middleNames = authReqJson.optString("middleNames", null),
                 residentialAddress = authReqJson.optString("residentialAddress", null),
-                issuer = authReqJson.optString("issuer", null),
+                issuer = v3Issuer,
                 verificationOptions = authReqJson.optString("verification_options", null),
                 verificationUri = authReqJson.optString("verification_uri", null),
                 verificationUriVideo = authReqJson.optString("verification_uri_video", null),

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/storage/NativeCompatibleStorage.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/storage/NativeCompatibleStorage.kt
@@ -593,19 +593,40 @@ class NativeCompatibleStorage(
         return try {
             // Parse the nested structure: Provider -> ClientRegistration -> AuthorizationRequest
             val jsonObject = org.json.JSONObject(jsonContent)
-            val clientReg = jsonObject.optJSONObject("clientRegistration") ?: return null
-            val authReqJson = clientReg.optJSONObject("authorizationRequest") ?: return null
+            val clientReg = jsonObject.optJSONObject("clientRegistration")
+            val authReqJson = clientReg?.optJSONObject("authorizationRequest")
 
             // v3 stored OAuth client context on Provider/ClientRegistration; surface them
             // on the AuthorizationRequest so callers can recover issuer/clientID when the
-            // Account record is incomplete after migration.
+            // Account record is incomplete after migration. Extract these even when the
+            // nested authorizationRequest object is absent so recovery still works.
             val v3Issuer =
-                authReqJson.optString("issuer", null)
+                authReqJson?.optString("issuer", null)
                     ?: jsonObject.optString("issuer", null)
             val v3ClientID =
-                clientReg.optString("client_id", null)
-                    ?: clientReg.optString("clientID", null)
-                    ?: authReqJson.optString("audience", null)
+                clientReg?.optString("client_id", null)
+                    ?: clientReg?.optString("clientID", null)
+                    ?: authReqJson?.optString("audience", null)
+
+            if (authReqJson == null) {
+                // No nested authorization request, but we may still be able to surface
+                // issuer/clientID from the v3 Provider/ClientRegistration for recovery.
+                if (v3Issuer.isNullOrEmpty() && v3ClientID.isNullOrEmpty()) {
+                    Log.d(
+                        TAG,
+                        "readAuthorizationRequestFromV3Provider: v3 provider lacks authorizationRequest and issuer/clientID",
+                    )
+                    return null
+                }
+                Log.d(
+                    TAG,
+                    "readAuthorizationRequestFromV3Provider: v3 provider lacks authorizationRequest; returning minimal record with issuer/clientID for recovery",
+                )
+                return NativeAuthorizationRequest(
+                    clientID = v3ClientID,
+                    issuer = v3Issuer,
+                )
+            }
 
             // Convert to our model
             NativeAuthorizationRequest(

--- a/packages/bcsc-core/android/src/test/java/com/bcsccore/storage/NativeCompatibleStorageV3ProviderTest.kt
+++ b/packages/bcsc-core/android/src/test/java/com/bcsccore/storage/NativeCompatibleStorageV3ProviderTest.kt
@@ -1,0 +1,196 @@
+package com.bcsccore.storage
+
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+/**
+ * Tests for v3 Provider -> AuthorizationRequest recovery.
+ *
+ * The 2502 "Token reference was null at point of use" error surfaces when a
+ * v3-migrated Account record lacks `issuer` / `clientID` (v3 stored these on
+ * Provider/ClientRegistration, not on Account). This test asserts that
+ * `readAuthorizationRequestFromV3Provider` surfaces those fields from the
+ * v3 Provider blob so the JS hydration layer can backfill the Account.
+ */
+@RunWith(RobolectricTestRunner::class)
+class NativeCompatibleStorageV3ProviderTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var context: Context
+    private lateinit var storage: NativeCompatibleStorage
+
+    private val issuerName = "sit"
+    private val accountUuid = "test-account-uuid"
+
+    @Before
+    fun setUp() {
+        context = mockk(relaxed = true)
+        every { context.filesDir } returns tempFolder.root
+        storage = spyk(NativeCompatibleStorage(context), recordPrivateCalls = true)
+    }
+
+    /**
+     * Create the v3 provider file on disk so File.exists() returns true,
+     * and stub readEncryptedFile to return our test JSON without invoking
+     * the Android keystore.
+     */
+    private fun stageProvider(json: String) {
+        val accountDir = File(tempFolder.root, issuerName + File.separator + accountUuid)
+        accountDir.mkdirs()
+        val providerFile = File(accountDir, "providers")
+        providerFile.writeText("encrypted-placeholder")
+
+        every { storage.readEncryptedFile(providerFile) } returns json
+    }
+
+    @Test
+    fun `returns null when provider file does not exist`() {
+        val result = storage.readAuthorizationRequestFromV3Provider(issuerName, accountUuid)
+        assertNull(result)
+    }
+
+    @Test
+    fun `extracts issuer and clientID from v3 Provider when authorizationRequest is present`() {
+        // Representative v3 Provider blob: nested clientRegistration with client_id
+        // and a child authorizationRequest. The issuer can live on either the
+        // Provider root or the authorizationRequest depending on v3 version.
+        val json =
+            """
+            {
+                "issuer": "https://idsit.gov.bc.ca",
+                "clientRegistration": {
+                    "client_id": "test-v3-client-id",
+                    "authorizationRequest": {
+                        "deviceCode": "device-abc",
+                        "userCode": "USER-123"
+                    }
+                }
+            }
+            """.trimIndent()
+        stageProvider(json)
+
+        val result = storage.readAuthorizationRequestFromV3Provider(issuerName, accountUuid)
+
+        assertNotNull(result)
+        assertEquals("test-v3-client-id", result!!.clientID)
+        assertEquals("https://idsit.gov.bc.ca", result.issuer)
+        assertEquals("device-abc", result.deviceCode)
+        assertEquals("USER-123", result.userCode)
+    }
+
+    @Test
+    fun `prefers issuer from authorizationRequest over Provider root`() {
+        val json =
+            """
+            {
+                "issuer": "https://root.example.com",
+                "clientRegistration": {
+                    "client_id": "client-xyz",
+                    "authorizationRequest": {
+                        "issuer": "https://idsit.gov.bc.ca",
+                        "deviceCode": "dc"
+                    }
+                }
+            }
+            """.trimIndent()
+        stageProvider(json)
+
+        val result = storage.readAuthorizationRequestFromV3Provider(issuerName, accountUuid)
+
+        assertNotNull(result)
+        assertEquals("https://idsit.gov.bc.ca", result!!.issuer)
+        assertEquals("client-xyz", result.clientID)
+    }
+
+    /**
+     * The PR feedback case: with the previous early-return code path the function
+     * returned null whenever the nested authorizationRequest was absent, denying
+     * callers the chance to recover issuer / clientID. This test asserts the
+     * fixed behaviour — a minimal record with issuer + clientID is returned.
+     */
+    @Test
+    fun `returns minimal record with issuer and clientID when authorizationRequest is missing`() {
+        val json =
+            """
+            {
+                "issuer": "https://idsit.gov.bc.ca",
+                "clientRegistration": {
+                    "client_id": "recovered-client-id"
+                }
+            }
+            """.trimIndent()
+        stageProvider(json)
+
+        val result = storage.readAuthorizationRequestFromV3Provider(issuerName, accountUuid)
+
+        assertNotNull("Expected minimal record so JS layer can backfill Account", result)
+        assertEquals("recovered-client-id", result!!.clientID)
+        assertEquals("https://idsit.gov.bc.ca", result.issuer)
+        // Other fields should be null since the nested authorizationRequest is absent
+        assertNull(result.deviceCode)
+        assertNull(result.userCode)
+    }
+
+    @Test
+    fun `returns minimal record when clientRegistration is missing but Provider root has issuer`() {
+        val json =
+            """
+            {
+                "issuer": "https://idsit.gov.bc.ca"
+            }
+            """.trimIndent()
+        stageProvider(json)
+
+        val result = storage.readAuthorizationRequestFromV3Provider(issuerName, accountUuid)
+
+        assertNotNull(result)
+        assertEquals("https://idsit.gov.bc.ca", result!!.issuer)
+        assertNull(result.clientID)
+    }
+
+    @Test
+    fun `returns null when no issuer and no clientID can be recovered`() {
+        // No authorizationRequest, no clientRegistration.client_id, no Provider.issuer
+        val json = """{ "unrelated": "value" }""".trimIndent()
+        stageProvider(json)
+
+        val result = storage.readAuthorizationRequestFromV3Provider(issuerName, accountUuid)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `falls back to audience as clientID when client_id is missing`() {
+        val json =
+            """
+            {
+                "clientRegistration": {
+                    "authorizationRequest": {
+                        "audience": "audience-as-client-id",
+                        "issuer": "https://idsit.gov.bc.ca"
+                    }
+                }
+            }
+            """.trimIndent()
+        stageProvider(json)
+
+        val result = storage.readAuthorizationRequestFromV3Provider(issuerName, accountUuid)
+
+        assertNotNull(result)
+        assertEquals("audience-as-client-id", result!!.clientID)
+        assertEquals("https://idsit.gov.bc.ca", result.issuer)
+    }
+}

--- a/packages/bcsc-core/src/NativeBcscCore.ts
+++ b/packages/bcsc-core/src/NativeBcscCore.ts
@@ -145,6 +145,12 @@ export enum BCSCCardProcess {
 }
 
 export type NativeAuthorizationRequest = {
+  // OAuth client context (preserved from v3 storage for migration/recovery)
+  // In v3, these were stored alongside AuthorizationRequest within Provider->ClientRegistration.
+  // Surfaced here as optional fields so callers can recover issuer/clientID if Account is incomplete.
+  issuer?: string;
+  clientID?: string;
+
   // Device/user codes
   deviceCode?: string;
   userCode?: string;


### PR DESCRIPTION
# Summary of Changes

Older versions of v3 migrated through many different versions can have empty clientID / issuer fields on their account object. This fallback catches that scenario, and writes it to their account going forward. This prevents a failing startup where client ID and issuer are required for a token fetch

# Testing Instructions

I have not found a reproducible migration path yet. For now, good enough to test fresh installs and simple migrations from latest v3.

# Acceptance Criteria

Fixes the app startup issue that we thought was related to tokens

# Screenshots, videos, or gifs

N/A

# Related Issues

#3841 