### PR TITLE
fix: missing non-bcsc text on send video screen

### DIFF
--- a/app/src/bcsc-theme/features/verify/send-video/InformationRequiredScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/InformationRequiredScreen.test.tsx
@@ -2,6 +2,7 @@ import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
 import { render } from '@testing-library/react-native'
 import React from 'react'
+import { BCSCCardProcess } from 'react-native-bcsc-core'
 import { BCSCLoadingProvider } from '../../../contexts/BCSCLoadingContext'
 import InformationRequiredScreen from './InformationRequiredScreen'
 
@@ -28,5 +29,29 @@ describe('InformationRequired', () => {
     )
 
     expect(tree).toMatchSnapshot()
+  })
+
+  it('renders NonBCSCMessage when cardProcess is NonBCSC', () => {
+    const { queryByText } = render(
+      <BasicAppContext initialStateOverride={{ bcscSecure: { cardProcess: BCSCCardProcess.NonBCSC } as any }}>
+        <BCSCLoadingProvider>
+          <InformationRequiredScreen navigation={mockNavigation as never} />
+        </BCSCLoadingProvider>
+      </BasicAppContext>
+    )
+
+    expect(queryByText('BCSC.SendVideo.InformationRequired.NonBCSCMessage')).toBeTruthy()
+  })
+
+  it('does not render NonBCSCMessage when cardProcess is not NonBCSC', () => {
+    const { queryByText } = render(
+      <BasicAppContext initialStateOverride={{ bcscSecure: { cardProcess: BCSCCardProcess.BCSCPhoto } as any }}>
+        <BCSCLoadingProvider>
+          <InformationRequiredScreen navigation={mockNavigation as never} />
+        </BCSCLoadingProvider>
+      </BasicAppContext>
+    )
+
+    expect(queryByText('BCSC.SendVideo.InformationRequired.NonBCSCMessage')).toBeNull()
   })
 })

--- a/app/src/bcsc-theme/features/verify/send-video/InformationRequiredScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/InformationRequiredScreen.tsx
@@ -1,9 +1,10 @@
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { BCState } from '@/store'
-import { Button, ButtonType, ScreenWrapper, useStore, useTheme } from '@bifold/core'
+import { Button, ButtonType, ScreenWrapper, ThemedText, useStore, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet } from 'react-native'
+import { BCSCCardProcess } from 'react-native-bcsc-core'
 import TakeMediaButton from './components/TakeMediaButton'
 import useEvidenceUploadModel from './useEvidenceUploadModel'
 
@@ -60,6 +61,11 @@ const InformationRequiredScreen = ({ navigation }: InformationRequiredScreenProp
           store.bcsc.videoPath && store.bcsc.videoThumbnailPath && `file://${store.bcsc.videoThumbnailPath}`
         }
       />
+      {store.bcscSecure.cardProcess === BCSCCardProcess.NonBCSC ? (
+        <ThemedText style={{ padding: Spacing.md }}>
+          {t('BCSC.SendVideo.InformationRequired.NonBCSCMessage')}
+        </ThemedText>
+      ) : null}
     </ScreenWrapper>
   )
 }

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -776,6 +776,7 @@ const translation = {
         "ActionLabel": "Take Photo",
         "ActionLabel2": "Record Video",
         "ButtonText": "Send to Service BC Now",
+        "NonBCSCMessage": "Please note: Service BC will check if you have a BC Services Card. If you have one, then your account will be updated to link to it.",
       },
       "PendingReview": {
         "Heading": "Request pending review",


### PR DESCRIPTION
# Summary of Changes

Missing text content

# Testing Instructions


# Acceptance Criteria


# Screenshots, videos, or gifs

<img width="250" height="550" alt="IMG_0463" src="https://github.com/user-attachments/assets/9993b8be-493f-4109-9fc0-69f70d345920" />

# Related Issues

#3860 