### PR TITLE
feat: wire and style My QR Code screen on Scan stack (#3836)

### DIFF
--- a/app/src/bcsc-theme/features/qr-core/QRDisplay.test.tsx
+++ b/app/src/bcsc-theme/features/qr-core/QRDisplay.test.tsx
@@ -1,14 +1,22 @@
+import { useBCSCAgent } from '@/bcsc-theme/features/agent'
 import * as Bifold from '@bifold/core'
+import { testIdWithKey } from '@bifold/core'
 import { useNavigation } from '@mocks/@react-navigation/native'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { act, render, waitFor } from '@testing-library/react-native'
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import { Share } from 'react-native'
+
 import QRDisplay from './QRDisplay'
+
+jest.mock('@/bcsc-theme/features/agent', () => ({
+  useBCSCAgent: jest.fn(),
+}))
 
 jest.mock('@bifold/core', () => ({
   ...jest.requireActual('@bifold/core'),
   QRRenderer: jest.fn().mockReturnValue(null),
+  createConnectionInvitation: jest.fn(),
 }))
 
 jest.mock('./WalletNameDisplay', () => ({
@@ -16,12 +24,30 @@ jest.mock('./WalletNameDisplay', () => ({
   default: () => null,
 }))
 
+const mockUseBCSCAgent = jest.mocked(useBCSCAgent)
+const mockCreateInvitation = jest.mocked(Bifold.createConnectionInvitation)
+
+const realInvitationUrl = 'https://realhost.example/invitation?oob=abc123'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const fakeAgent = {} as any
+
+const readyAgentReturn = { agent: fakeAgent, loading: false, error: null, retry: jest.fn() }
+const noAgentReturn = { agent: null, loading: true, error: null, retry: jest.fn() }
+
 describe('QRDisplay', () => {
   let mockNavigation: ReturnType<typeof useNavigation>
 
   beforeEach(() => {
     jest.clearAllMocks()
     mockNavigation = useNavigation()
+    mockCreateInvitation.mockResolvedValue({
+      invitationUrl: realInvitationUrl,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      record: {} as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      invitation: {} as any,
+    })
   })
 
   const renderComponent = () =>
@@ -31,43 +57,77 @@ describe('QRDisplay', () => {
       </BasicAppContext>
     )
 
-  it('renders without crashing', async () => {
-    const { toJSON } = renderComponent()
+  it('shows the loading state and does not call createConnectionInvitation when the agent is not ready', async () => {
+    mockUseBCSCAgent.mockReturnValue(noAgentReturn)
+
+    const { getByTestId } = renderComponent()
     await act(async () => {})
-    expect(toJSON()).toBeTruthy()
+
+    expect(getByTestId(testIdWithKey('QRDisplay.Loading'))).toBeTruthy()
+    expect(mockCreateInvitation).not.toHaveBeenCalled()
   })
 
-  it('passes the placeholder invitation URL to QRRenderer', async () => {
+  it('passes the real invitation URL to QRRenderer once the agent is ready', async () => {
+    mockUseBCSCAgent.mockReturnValue(readyAgentReturn)
+
     renderComponent()
+
     await waitFor(() => {
+      expect(mockCreateInvitation).toHaveBeenCalledWith(fakeAgent)
       const calls = jest.mocked(Bifold.QRRenderer).mock.calls
-      expect(calls.at(-1)![0]).toMatchObject({ value: 'https://example.com/invitation' })
+      expect(calls.at(-1)![0]).toMatchObject({ value: realInvitationUrl })
     })
   })
 
-  it('configures the navigation header with a share button', async () => {
-    renderComponent()
-    await act(async () => {})
-    expect(mockNavigation.setOptions).toHaveBeenCalledWith(
-      expect.objectContaining({ headerRight: expect.any(Function) })
-    )
+  it('renders the error state and recovers via retry', async () => {
+    mockUseBCSCAgent.mockReturnValue(readyAgentReturn)
+    mockCreateInvitation.mockRejectedValueOnce(new Error('agent boom'))
+
+    const { findByTestId, getByText } = renderComponent()
+
+    const errorBox = await findByTestId(testIdWithKey('QRDisplay.Error'))
+    expect(errorBox).toBeTruthy()
+
+    fireEvent.press(getByText('BCSC.QRDisplay.RetryCta'))
+
+    await waitFor(() => {
+      expect(mockCreateInvitation).toHaveBeenCalledTimes(2)
+      const calls = jest.mocked(Bifold.QRRenderer).mock.calls
+      expect(calls.at(-1)![0]).toMatchObject({ value: realInvitationUrl })
+    })
   })
 
-  it('calls Share.share with the invitation when share is triggered', async () => {
+  it('renders a header share button only when ready and shares the real invitation', async () => {
+    mockUseBCSCAgent.mockReturnValue(readyAgentReturn)
     const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: Share.sharedAction })
 
     renderComponent()
-    await act(async () => {})
 
-    // The last setOptions call has the invitation in scope (after state update)
-    const lastCall = jest.mocked(mockNavigation.setOptions).mock.calls.at(-1)!
-    const shareButtonElement = lastCall[0].headerRight()
-
-    await act(async () => {
-      await shareButtonElement.props.onPress()
+    await waitFor(() => {
+      const setOptionsCalls = jest.mocked(mockNavigation.setOptions).mock.calls
+      const latest = setOptionsCalls.at(-1)?.[0]?.headerRight
+      expect(latest?.()).not.toBeNull()
     })
 
-    expect(shareSpy).toHaveBeenCalledWith({ message: 'https://example.com/invitation' })
+    const setOptionsCalls = jest.mocked(mockNavigation.setOptions).mock.calls
+    const shareElement = setOptionsCalls.at(-1)![0].headerRight()
+
+    await act(async () => {
+      await shareElement.props.onPress()
+    })
+
+    expect(shareSpy).toHaveBeenCalledWith({ message: realInvitationUrl })
     shareSpy.mockRestore()
+  })
+
+  it('omits the share button while the QR is not ready', async () => {
+    mockUseBCSCAgent.mockReturnValue(noAgentReturn)
+
+    renderComponent()
+    await act(async () => {})
+
+    const setOptionsCalls = jest.mocked(mockNavigation.setOptions).mock.calls
+    const latestHeaderRight = setOptionsCalls.at(-1)![0].headerRight
+    expect(latestHeaderRight()).toBeNull()
   })
 })

--- a/app/src/bcsc-theme/features/qr-core/QRDisplay.tsx
+++ b/app/src/bcsc-theme/features/qr-core/QRDisplay.tsx
@@ -17,7 +17,7 @@ import { ActivityIndicator, ScrollView, StyleSheet, useWindowDimensions, View } 
 
 import { useBCSCAgent } from '../agent'
 
-import useQRDisplayViewModel from './useQRDisplayViewModel'
+import useQRDisplayViewModel, { QRDisplayStatus } from './useQRDisplayViewModel'
 import WalletNameDisplay from './WalletNameDisplay'
 
 const QRDisplay: React.FC = () => {
@@ -32,7 +32,7 @@ const QRDisplay: React.FC = () => {
   const qrSize = width - Spacing.lg * 2
 
   const headerRight = useCallback(() => {
-    if (vm.status !== 'ready') {
+    if (vm.status !== QRDisplayStatus.READY) {
       return null
     }
     return (
@@ -73,7 +73,7 @@ const QRDisplay: React.FC = () => {
     },
   })
 
-  if (vm.status === 'loading') {
+  if (vm.status === QRDisplayStatus.LOADING) {
     return (
       <View style={styles.stateContainer} testID={testIdWithKey('QRDisplay.Loading')}>
         <ActivityIndicator size="large" color={ColorPalette.brand.primary} />
@@ -81,7 +81,7 @@ const QRDisplay: React.FC = () => {
     )
   }
 
-  if (vm.status === 'error') {
+  if (vm.status === QRDisplayStatus.ERROR) {
     return (
       <View style={styles.stateContainer} testID={testIdWithKey('QRDisplay.Error')}>
         <InfoBox

--- a/app/src/bcsc-theme/features/qr-core/QRDisplay.tsx
+++ b/app/src/bcsc-theme/features/qr-core/QRDisplay.tsx
@@ -1,65 +1,108 @@
-import { ButtonLocation, IconButton, QRRenderer, TOKENS, ThemedText, testIdWithKey, useServices } from '@bifold/core'
+import {
+  ButtonLocation,
+  IconButton,
+  InfoBox,
+  InfoBoxType,
+  QRRenderer,
+  testIdWithKey,
+  ThemedText,
+  TOKENS,
+  useServices,
+  useTheme,
+} from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ScrollView, Share, StyleSheet, View, useWindowDimensions } from 'react-native'
-// import { useBCSCAgent } from '../agent'
+import { ActivityIndicator, ScrollView, StyleSheet, useWindowDimensions, View } from 'react-native'
+
+import { useBCSCAgent } from '../agent'
+
+import useQRDisplayViewModel from './useQRDisplayViewModel'
 import WalletNameDisplay from './WalletNameDisplay'
 
 const QRDisplay: React.FC = () => {
-  // const { agent } = useBCSCAgent()
+  const { agent } = useBCSCAgent()
   const { t } = useTranslation()
   const navigation = useNavigation()
   const { width } = useWindowDimensions()
-  const qrSize = width - 80
-  const [invitation, setInvitation] = useState<string | undefined>(undefined)
+  const { ColorPalette, Spacing } = useTheme()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const vm = useQRDisplayViewModel({ agent, logger })
 
-  const headerRight = useCallback(
-    () => (
+  const qrSize = width - Spacing.lg * 2
+
+  const headerRight = useCallback(() => {
+    if (vm.status !== 'ready') {
+      return null
+    }
+    return (
       <IconButton
         buttonLocation={ButtonLocation.Right}
         icon="share-variant"
-        accessibilityLabel="Share"
+        accessibilityLabel={t('Global.Share')}
         testID={testIdWithKey('Share')}
-        onPress={() => {
-          if (!invitation) {
-            return
-          }
-          logger.info('Sharing QR invitation')
-          Share.share({ message: invitation }).catch((error) => logger.error('Error sharing QR invitation', error))
-        }}
+        onPress={vm.share}
       />
-    ),
-    [invitation, logger]
-  )
+    )
+  }, [t, vm.share, vm.status])
 
   useEffect(() => {
     navigation.setOptions({ headerRight })
   }, [navigation, headerRight])
 
-  useEffect(() => {
-    const fetchInvitation = async () => {
-      // const newInvitation = await createConnectionInvitation(agent as Agent)
-      // setInvitation(newInvitation.invitationUrl)
-      setInvitation('https://example.com/invitation') // Placeholder for testing
-    }
-    fetchInvitation()
-  }, [])
-
   const styles = StyleSheet.create({
-    content: {
+    container: {
+      flexGrow: 1,
+    },
+    qrFrame: {
+      padding: Spacing.lg,
       alignItems: 'center',
-      paddingTop: 20,
+    },
+    descriptionBlock: {
+      padding: Spacing.lg,
+      gap: Spacing.sm,
+    },
+    description: {
+      textAlign: 'left',
+    },
+    stateContainer: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: Spacing.lg,
     },
   })
 
+  if (vm.status === 'loading') {
+    return (
+      <View style={styles.stateContainer} testID={testIdWithKey('QRDisplay.Loading')}>
+        <ActivityIndicator size="large" color={ColorPalette.brand.primary} />
+      </View>
+    )
+  }
+
+  if (vm.status === 'error') {
+    return (
+      <View style={styles.stateContainer} testID={testIdWithKey('QRDisplay.Error')}>
+        <InfoBox
+          notificationType={InfoBoxType.Error}
+          title={t('BCSC.QRDisplay.ErrorTitle')}
+          description={t('BCSC.QRDisplay.ErrorBody')}
+          onCallToActionPressed={vm.retry}
+          onCallToActionLabel={t('BCSC.QRDisplay.RetryCta')}
+        />
+      </View>
+    )
+  }
+
   return (
-    <ScrollView contentContainerStyle={styles.content}>
-      <QRRenderer value={invitation || ''} size={qrSize} />
-      <WalletNameDisplay />
-      <View>
-        <ThemedText style={{ marginTop: 20 }}>{t('BCSC.QRDisplay.SharingDescription')}</ThemedText>
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.qrFrame}>
+        <QRRenderer value={vm.invitation ?? ''} size={qrSize} />
+      </View>
+      <View style={styles.descriptionBlock}>
+        <WalletNameDisplay />
+        <ThemedText style={styles.description}>{t('BCSC.QRDisplay.SharingDescription')}</ThemedText>
       </View>
     </ScrollView>
   )

--- a/app/src/bcsc-theme/features/qr-core/useQRDisplayViewModel.test.ts
+++ b/app/src/bcsc-theme/features/qr-core/useQRDisplayViewModel.test.ts
@@ -1,0 +1,157 @@
+import * as Bifold from '@bifold/core'
+import { act, renderHook, waitFor } from '@testing-library/react-native'
+import { Share } from 'react-native'
+
+import useQRDisplayViewModel from './useQRDisplayViewModel'
+
+jest.mock('@bifold/core', () => ({
+  ...jest.requireActual('@bifold/core'),
+  createConnectionInvitation: jest.fn(),
+}))
+
+const mockCreateInvitation = jest.mocked(Bifold.createConnectionInvitation)
+
+const makeLogger = () =>
+  ({
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    trace: jest.fn(),
+    fatal: jest.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const fakeAgent = {} as any
+
+const url = 'https://realhost.example/invitation?oob=abc'
+
+describe('useQRDisplayViewModel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('stays loading and does not call createConnectionInvitation when agent is null', async () => {
+    const logger = makeLogger()
+    const { result } = renderHook(() => useQRDisplayViewModel({ agent: null, logger }))
+
+    expect(result.current.status).toBe('loading')
+    expect(mockCreateInvitation).not.toHaveBeenCalled()
+  })
+
+  it('transitions loading -> ready when invitation resolves', async () => {
+    const logger = makeLogger()
+    mockCreateInvitation.mockResolvedValueOnce({
+      invitationUrl: url,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      record: {} as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      invitation: {} as any,
+    })
+
+    const { result } = renderHook(() => useQRDisplayViewModel({ agent: fakeAgent, logger }))
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('ready')
+    })
+
+    expect(result.current.invitation).toBe(url)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('transitions loading -> error when invitation rejects and recovers via retry', async () => {
+    const logger = makeLogger()
+    mockCreateInvitation.mockRejectedValueOnce(new Error('agent boom'))
+
+    const { result } = renderHook(() => useQRDisplayViewModel({ agent: fakeAgent, logger }))
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error')
+    })
+    expect(result.current.error?.message).toBe('agent boom')
+    expect(logger.error).toHaveBeenCalled()
+
+    mockCreateInvitation.mockResolvedValueOnce({
+      invitationUrl: url,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      record: {} as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      invitation: {} as any,
+    })
+
+    act(() => {
+      result.current.retry()
+    })
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('ready')
+    })
+    expect(result.current.invitation).toBe(url)
+  })
+
+  it('share is a no-op when invitation is undefined', async () => {
+    const logger = makeLogger()
+    const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: Share.sharedAction })
+
+    const { result } = renderHook(() => useQRDisplayViewModel({ agent: null, logger }))
+
+    await act(async () => {
+      await result.current.share()
+    })
+
+    expect(shareSpy).not.toHaveBeenCalled()
+    shareSpy.mockRestore()
+  })
+
+  it('share invokes Share.share with the resolved invitation URL', async () => {
+    const logger = makeLogger()
+    mockCreateInvitation.mockResolvedValueOnce({
+      invitationUrl: url,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      record: {} as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      invitation: {} as any,
+    })
+    const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: Share.sharedAction })
+
+    const { result } = renderHook(() => useQRDisplayViewModel({ agent: fakeAgent, logger }))
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('ready')
+    })
+
+    await act(async () => {
+      await result.current.share()
+    })
+
+    expect(shareSpy).toHaveBeenCalledWith({ message: url })
+    expect(logger.info).toHaveBeenCalled()
+    shareSpy.mockRestore()
+  })
+
+  it('logs but does not throw when Share.share rejects', async () => {
+    const logger = makeLogger()
+    mockCreateInvitation.mockResolvedValueOnce({
+      invitationUrl: url,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      record: {} as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      invitation: {} as any,
+    })
+    const shareSpy = jest.spyOn(Share, 'share').mockRejectedValue(new Error('user cancelled'))
+
+    const { result } = renderHook(() => useQRDisplayViewModel({ agent: fakeAgent, logger }))
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('ready')
+    })
+
+    await act(async () => {
+      await result.current.share()
+    })
+
+    expect(logger.error).toHaveBeenCalled()
+    shareSpy.mockRestore()
+  })
+})

--- a/app/src/bcsc-theme/features/qr-core/useQRDisplayViewModel.test.ts
+++ b/app/src/bcsc-theme/features/qr-core/useQRDisplayViewModel.test.ts
@@ -2,7 +2,7 @@ import * as Bifold from '@bifold/core'
 import { act, renderHook, waitFor } from '@testing-library/react-native'
 import { Share } from 'react-native'
 
-import useQRDisplayViewModel from './useQRDisplayViewModel'
+import useQRDisplayViewModel, { QRDisplayStatus } from './useQRDisplayViewModel'
 
 jest.mock('@bifold/core', () => ({
   ...jest.requireActual('@bifold/core'),
@@ -36,7 +36,7 @@ describe('useQRDisplayViewModel', () => {
     const logger = makeLogger()
     const { result } = renderHook(() => useQRDisplayViewModel({ agent: null, logger }))
 
-    expect(result.current.status).toBe('loading')
+    expect(result.current.status).toBe(QRDisplayStatus.LOADING)
     expect(mockCreateInvitation).not.toHaveBeenCalled()
   })
 
@@ -53,7 +53,7 @@ describe('useQRDisplayViewModel', () => {
     const { result } = renderHook(() => useQRDisplayViewModel({ agent: fakeAgent, logger }))
 
     await waitFor(() => {
-      expect(result.current.status).toBe('ready')
+      expect(result.current.status).toBe(QRDisplayStatus.READY)
     })
 
     expect(result.current.invitation).toBe(url)
@@ -67,7 +67,7 @@ describe('useQRDisplayViewModel', () => {
     const { result } = renderHook(() => useQRDisplayViewModel({ agent: fakeAgent, logger }))
 
     await waitFor(() => {
-      expect(result.current.status).toBe('error')
+      expect(result.current.status).toBe(QRDisplayStatus.ERROR)
     })
     expect(result.current.error?.message).toBe('agent boom')
     expect(logger.error).toHaveBeenCalled()
@@ -85,7 +85,7 @@ describe('useQRDisplayViewModel', () => {
     })
 
     await waitFor(() => {
-      expect(result.current.status).toBe('ready')
+      expect(result.current.status).toBe(QRDisplayStatus.READY)
     })
     expect(result.current.invitation).toBe(url)
   })
@@ -118,7 +118,7 @@ describe('useQRDisplayViewModel', () => {
     const { result } = renderHook(() => useQRDisplayViewModel({ agent: fakeAgent, logger }))
 
     await waitFor(() => {
-      expect(result.current.status).toBe('ready')
+      expect(result.current.status).toBe(QRDisplayStatus.READY)
     })
 
     await act(async () => {
@@ -144,7 +144,7 @@ describe('useQRDisplayViewModel', () => {
     const { result } = renderHook(() => useQRDisplayViewModel({ agent: fakeAgent, logger }))
 
     await waitFor(() => {
-      expect(result.current.status).toBe('ready')
+      expect(result.current.status).toBe(QRDisplayStatus.READY)
     })
 
     await act(async () => {

--- a/app/src/bcsc-theme/features/qr-core/useQRDisplayViewModel.test.ts
+++ b/app/src/bcsc-theme/features/qr-core/useQRDisplayViewModel.test.ts
@@ -130,6 +130,35 @@ describe('useQRDisplayViewModel', () => {
     shareSpy.mockRestore()
   })
 
+  it('resets to loading and clears invitation when agent flips from ready back to null', async () => {
+    const logger = makeLogger()
+    mockCreateInvitation.mockResolvedValueOnce({
+      invitationUrl: url,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      record: {} as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      invitation: {} as any,
+    })
+
+    const { result, rerender } = renderHook(
+      ({ agent }: { agent: typeof fakeAgent | null }) => useQRDisplayViewModel({ agent, logger }),
+      { initialProps: { agent: fakeAgent } }
+    )
+
+    await waitFor(() => {
+      expect(result.current.status).toBe(QRDisplayStatus.READY)
+    })
+    expect(result.current.invitation).toBe(url)
+
+    rerender({ agent: null })
+
+    await waitFor(() => {
+      expect(result.current.status).toBe(QRDisplayStatus.LOADING)
+    })
+    expect(result.current.invitation).toBeUndefined()
+    expect(result.current.error).toBeNull()
+  })
+
   it('logs but does not throw when Share.share rejects', async () => {
     const logger = makeLogger()
     mockCreateInvitation.mockResolvedValueOnce({

--- a/app/src/bcsc-theme/features/qr-core/useQRDisplayViewModel.ts
+++ b/app/src/bcsc-theme/features/qr-core/useQRDisplayViewModel.ts
@@ -44,6 +44,15 @@ const useQRDisplayViewModel = ({ agent, logger }: QRDisplayViewModelInputs): QRD
         if (cancelled) {
           return
         }
+        // SEAM (issue #3777): the OOB record id from `result.record.id` is the
+        // handle for watching connection acceptance. To match BC Wallet's
+        // behaviour (auto-navigate to chat when the remote scans + accepts),
+        // surface the id from this VM and add an effect using Bifold's
+        // `useConnectionByOutOfBandId(oobRecordId)` to observe the connection
+        // record. When `record.state === DidCommDidExchangeState.Completed`,
+        // fire an `onConnectionAccepted(oobRecordId)` callback that the screen
+        // wraps into `navigation.navigate(...)` for the chat / connection
+        // landing destination.
         setInvitation(result.invitationUrl)
         setStatus(QRDisplayStatus.READY)
       })

--- a/app/src/bcsc-theme/features/qr-core/useQRDisplayViewModel.ts
+++ b/app/src/bcsc-theme/features/qr-core/useQRDisplayViewModel.ts
@@ -2,7 +2,11 @@ import { BifoldAgent, BifoldLogger, createConnectionInvitation } from '@bifold/c
 import { useCallback, useEffect, useState } from 'react'
 import { Share } from 'react-native'
 
-export type QRDisplayStatus = 'loading' | 'ready' | 'error'
+export enum QRDisplayStatus {
+  LOADING = 'loading',
+  READY = 'ready',
+  ERROR = 'error',
+}
 
 export interface QRDisplayViewModelInputs {
   agent: BifoldAgent | null
@@ -19,7 +23,7 @@ export interface QRDisplayViewModel {
 
 const useQRDisplayViewModel = ({ agent, logger }: QRDisplayViewModelInputs): QRDisplayViewModel => {
   const [invitation, setInvitation] = useState<string | undefined>(undefined)
-  const [status, setStatus] = useState<QRDisplayStatus>('loading')
+  const [status, setStatus] = useState<QRDisplayStatus>(QRDisplayStatus.LOADING)
   const [error, setError] = useState<Error | null>(null)
   const [retryToken, setRetryToken] = useState(0)
 
@@ -29,7 +33,7 @@ const useQRDisplayViewModel = ({ agent, logger }: QRDisplayViewModelInputs): QRD
     }
 
     let cancelled = false
-    setStatus('loading')
+    setStatus(QRDisplayStatus.LOADING)
     setError(null)
 
     createConnectionInvitation(agent)
@@ -38,7 +42,7 @@ const useQRDisplayViewModel = ({ agent, logger }: QRDisplayViewModelInputs): QRD
           return
         }
         setInvitation(result.invitationUrl)
-        setStatus('ready')
+        setStatus(QRDisplayStatus.READY)
       })
       .catch((err) => {
         if (cancelled) {
@@ -47,7 +51,7 @@ const useQRDisplayViewModel = ({ agent, logger }: QRDisplayViewModelInputs): QRD
         const wrapped = err instanceof Error ? err : new Error(String(err))
         logger.error('[QRDisplay] createConnectionInvitation failed', wrapped)
         setError(wrapped)
-        setStatus('error')
+        setStatus(QRDisplayStatus.ERROR)
       })
 
     return () => {

--- a/app/src/bcsc-theme/features/qr-core/useQRDisplayViewModel.ts
+++ b/app/src/bcsc-theme/features/qr-core/useQRDisplayViewModel.ts
@@ -29,6 +29,9 @@ const useQRDisplayViewModel = ({ agent, logger }: QRDisplayViewModelInputs): QRD
 
   useEffect(() => {
     if (!agent) {
+      setInvitation(undefined)
+      setError(null)
+      setStatus(QRDisplayStatus.LOADING)
       return
     }
 

--- a/app/src/bcsc-theme/features/qr-core/useQRDisplayViewModel.ts
+++ b/app/src/bcsc-theme/features/qr-core/useQRDisplayViewModel.ts
@@ -1,0 +1,77 @@
+import { BifoldAgent, BifoldLogger, createConnectionInvitation } from '@bifold/core'
+import { useCallback, useEffect, useState } from 'react'
+import { Share } from 'react-native'
+
+export type QRDisplayStatus = 'loading' | 'ready' | 'error'
+
+export interface QRDisplayViewModelInputs {
+  agent: BifoldAgent | null
+  logger: BifoldLogger
+}
+
+export interface QRDisplayViewModel {
+  invitation: string | undefined
+  status: QRDisplayStatus
+  error: Error | null
+  retry: () => void
+  share: () => Promise<void>
+}
+
+const useQRDisplayViewModel = ({ agent, logger }: QRDisplayViewModelInputs): QRDisplayViewModel => {
+  const [invitation, setInvitation] = useState<string | undefined>(undefined)
+  const [status, setStatus] = useState<QRDisplayStatus>('loading')
+  const [error, setError] = useState<Error | null>(null)
+  const [retryToken, setRetryToken] = useState(0)
+
+  useEffect(() => {
+    if (!agent) {
+      return
+    }
+
+    let cancelled = false
+    setStatus('loading')
+    setError(null)
+
+    createConnectionInvitation(agent)
+      .then((result) => {
+        if (cancelled) {
+          return
+        }
+        setInvitation(result.invitationUrl)
+        setStatus('ready')
+      })
+      .catch((err) => {
+        if (cancelled) {
+          return
+        }
+        const wrapped = err instanceof Error ? err : new Error(String(err))
+        logger.error('[QRDisplay] createConnectionInvitation failed', wrapped)
+        setError(wrapped)
+        setStatus('error')
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [agent, retryToken, logger])
+
+  const retry = useCallback(() => {
+    setRetryToken((n) => n + 1)
+  }, [])
+
+  const share = useCallback(async () => {
+    if (!invitation) {
+      return
+    }
+    logger.info('[QRDisplay] Sharing invitation')
+    try {
+      await Share.share({ message: invitation })
+    } catch (err) {
+      logger.error('[QRDisplay] Share failed', err instanceof Error ? err : new Error(String(err)))
+    }
+  }, [invitation, logger])
+
+  return { invitation, status, error, retry, share }
+}
+
+export default useQRDisplayViewModel

--- a/app/src/bcsc-theme/features/qr-core/useQRDisplayViewModel.ts
+++ b/app/src/bcsc-theme/features/qr-core/useQRDisplayViewModel.ts
@@ -21,6 +21,8 @@ export interface QRDisplayViewModel {
   share: () => Promise<void>
 }
 
+const toError = (err: unknown): Error => (err instanceof Error ? err : new Error(String(err)))
+
 const useQRDisplayViewModel = ({ agent, logger }: QRDisplayViewModelInputs): QRDisplayViewModel => {
   const [invitation, setInvitation] = useState<string | undefined>(undefined)
   const [status, setStatus] = useState<QRDisplayStatus>(QRDisplayStatus.LOADING)
@@ -44,15 +46,9 @@ const useQRDisplayViewModel = ({ agent, logger }: QRDisplayViewModelInputs): QRD
         if (cancelled) {
           return
         }
-        // SEAM (issue #3777): the OOB record id from `result.record.id` is the
-        // handle for watching connection acceptance. To match BC Wallet's
-        // behaviour (auto-navigate to chat when the remote scans + accepts),
-        // surface the id from this VM and add an effect using Bifold's
-        // `useConnectionByOutOfBandId(oobRecordId)` to observe the connection
-        // record. When `record.state === DidCommDidExchangeState.Completed`,
-        // fire an `onConnectionAccepted(oobRecordId)` callback that the screen
-        // wraps into `navigation.navigate(...)` for the chat / connection
-        // landing destination.
+        // SEAM (#3777): result.record.id is the OOB handle for auto-navigate-to-chat
+        // on acceptance. Hook useConnectionByOutOfBandId + an onConnectionAccepted
+        // callback here when chat lands.
         setInvitation(result.invitationUrl)
         setStatus(QRDisplayStatus.READY)
       })
@@ -60,7 +56,7 @@ const useQRDisplayViewModel = ({ agent, logger }: QRDisplayViewModelInputs): QRD
         if (cancelled) {
           return
         }
-        const wrapped = err instanceof Error ? err : new Error(String(err))
+        const wrapped = toError(err)
         logger.error('[QRDisplay] createConnectionInvitation failed', wrapped)
         setError(wrapped)
         setStatus(QRDisplayStatus.ERROR)
@@ -83,7 +79,7 @@ const useQRDisplayViewModel = ({ agent, logger }: QRDisplayViewModelInputs): QRD
     try {
       await Share.share({ message: invitation })
     } catch (err) {
-      logger.error('[QRDisplay] Share failed', err instanceof Error ? err : new Error(String(err)))
+      logger.error('[QRDisplay] Share failed', toError(err))
     }
   }, [invitation, logger])
 

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -14,6 +14,7 @@ const translation = {
     "Dismiss": "Dismiss",
     "GetHelp": "Get help",
     "ContinueSetup": "Continue setup",
+    "Share": "Share",
     "Skip": "Skip",
     "A11y": {
       "OpensInBrowser": "This opens in browser",

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -952,6 +952,9 @@ const translation = {
     },
     "QRDisplay": {
       "SharingDescription": "Sharing this QR code with someone will add them as a Contact.",
+      "ErrorTitle": "Unable to generate QR code",
+      "ErrorBody": "Something went wrong while creating your QR code. Please try again.",
+      "RetryCta": "Try again",
     },
     "TransferQRDisplay": {
       "Instructions": "Scan this QR code in the BC Services Card app on your other mobile device",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -14,6 +14,7 @@ const translation = {
     "Dismiss": "Fermer",
     "GetHelp": "Get help (FR)",
     "ContinueSetup": "Continue setup (FR)",
+    "Share": "Share (FR)",
     "Skip": "Skip (FR)",
     "A11y": {
       "OpensInBrowser": "This opens in browser (FR)",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -943,6 +943,9 @@ const translation = {
     },
     "QRDisplay": {
       "SharingDescription": "Sharing this QR code with someone will add them as a Contact. (FR)",
+      "ErrorTitle": "Unable to generate QR code (FR)",
+      "ErrorBody": "Something went wrong while creating your QR code. Please try again. (FR)",
+      "RetryCta": "Try again (FR)",
     },
     "TransferQRDisplay": {
       "Instructions": "Scan this QR code in the BC Services Card app on your other mobile device (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -943,6 +943,9 @@ const translation = {
     },
     "QRDisplay": {
       "SharingDescription": "Sharing this QR code with someone will add them as a Contact. (PT-BR)",
+      "ErrorTitle": "Unable to generate QR code (PT-BR)",
+      "ErrorBody": "Something went wrong while creating your QR code. Please try again. (PT-BR)",
+      "RetryCta": "Try again (PT-BR)",
     },
     "TransferQRDisplay": {
       "Instructions": "Scan this QR code in the BC Services Card app on your other mobile device (PT-BR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -14,6 +14,7 @@ const translation = {
     "Dismiss": "Dispensar",
     "GetHelp": "Get help (PT-BR)",
     "ContinueSetup": "Continue setup (PT-BR)",
+    "Share": "Share (PT-BR)",
     "Skip": "Skip (PT-BR)",
     "A11y": {
       "OpensInBrowser": "This opens in browser (PT-BR)",


### PR DESCRIPTION
Finishes the `Display` (My QR) tab on `QRCoreStack` scaffolded by #3809: replaces the placeholder URL with a real DIDComm OOB invitation generated from the live BCSC agent.

## Summary

- **Real invitation wiring.** `useQRDisplayViewModel` calls `createConnectionInvitation(agent)` from the live BCSC agent (via `useBCSCAgent()`) and feeds the resulting URL into `QRRenderer` + the header share button.
- **MVVM split.** Business logic moved into `useQRDisplayViewModel`; `QRDisplay.tsx` is now a thin view that pulls inputs and renders one of three branches (`loading` / `error` / `ready`). Matches the established BCSC pattern.
- **Loading + error states.** Loading: centered `ActivityIndicator`. Error: Bifold `InfoBox` (`Error` type) with a retry CTA that re-runs the invitation flow. The header share button is hidden while not ready.
- **Figma node `1240:4800` styling.** Outer padding `Spacing.lg` (24) around the QR frame and around the description block, `Spacing.sm` (8) gap inside the description block. `qrSize = width - Spacing.lg * 2`.
- **i18n.** New keys `BCSC.QRDisplay.{ErrorTitle, ErrorBody, RetryCta}` and defensive `Global.Share` added to `en`, `fr`, `pt-br`.
- **Seam for #3777.** Comment in the ViewModel points at where `useConnectionByOutOfBandId` + an `onConnectionAccepted` callback will hook in for auto-navigate-to-chat behaviour once BCSC chat screens land.


https://github.com/user-attachments/assets/834ab502-6450-49c0-b228-85ffb88d7de9


Closes #3836. 

## Tab visibility

Display tab stays **unconditional** (no Developer-Mode gate), matching `Scanner` and `PairingCode`.

## Bifold export note

`createConnectionInvitation` was originally identified as a candidate for a yarn-patch + upstream PR (per the ticket). It's already exported from `@bifold/core@3.0.6` — no patch needed.

## Tests

- `QRDisplay.test.tsx` extended to 5 cases: agent-not-ready loading, real-invitation-passes-to-QRRenderer, error+retry recovery, share-with-real-URL, share-button-hidden-while-not-ready.
- New `useQRDisplayViewModel.test.ts` — 7 unit cases on the hook in isolation via `renderHook` (loading→ready, loading→error→retry→ready, share no-op when not ready, share success, share rejection handled, agent-null does not call invitation, ready→null reset).

## Test plan

- [x] `yarn check` passes (typecheck + lint + format + tests). 59/59 qr-core tests green locally.
- [x] `cd app && yarn ios` with `BUILD_TARGET=bcsc` → Scan tab → Display tab.
  - [x] Loading spinner shown briefly.
  - [x] QR renders; scan with another DIDComm-capable wallet, contact appears. _(Pending agent-init env fix — required `adb shell pm clear` / iOS reinstall to clear stale wallet on dev devices.)_
  - [x] Header share icon opens iOS share sheet with the same DIDComm URL.
- [x] Visual diff against Figma

## Manual Testing

1. Open the app, Press Scan button
2. Select the My QR code tab
3. Your QR should correctly be displayed, this can be scanned by BC Wallet 1.0.27.
