### PR TITLE
feat(scan): complete proof-request follow-through

### DIFF
--- a/.yarn/patches/@credo-ts-anoncreds-npm-0.6.3-95e0920301.patch
+++ b/.yarn/patches/@credo-ts-anoncreds-npm-0.6.3-95e0920301.patch
@@ -1,0 +1,13 @@
+diff --git a/build/utils/proofRequest.mjs b/build/utils/proofRequest.mjs
+index cae32453f4ab3afea960b996f748e30f705ce5a9..88fc7e5f06e03412ae9d062f185f4ec0ee8add4a 100644
+--- a/build/utils/proofRequest.mjs
++++ b/build/utils/proofRequest.mjs
+@@ -2,7 +2,7 @@ import { isUnqualifiedCredentialDefinitionId, isUnqualifiedIndyDid, isUnqualifie
+ 
+ //#region src/utils/proofRequest.ts
+ function proofRequestUsesUnqualifiedIdentifiers(proofRequest) {
+-	return [...Object.values(proofRequest.requested_attributes), ...Object.values(proofRequest.requested_predicates)].some((attribute) => attribute.restrictions?.some((restriction) => restriction.cred_def_id && isUnqualifiedCredentialDefinitionId(restriction.cred_def_id) || restriction.schema_id && isUnqualifiedSchemaId(restriction.schema_id) || restriction.issuer_did && isUnqualifiedIndyDid(restriction.issuer_did) || restriction.issuer_id && isUnqualifiedIndyDid(restriction.issuer_id) || restriction.schema_issuer_did && isUnqualifiedIndyDid(restriction.schema_issuer_did) || restriction.schema_issuer_id && isUnqualifiedIndyDid(restriction.schema_issuer_id) || restriction.rev_reg_id && isUnqualifiedRevocationRegistryId(restriction.rev_reg_id)));
++	return [...Object.values(proofRequest.requested_attributes), ...Object.values(proofRequest.requested_predicates)].some((attribute) => attribute.restrictions?.some((restriction) => (!restriction.cred_def_id && !restriction.schema_id && !restriction.issuer_did && !restriction.issuer_id && !restriction.schema_issuer_did && !restriction.schema_issuer_id && !restriction.rev_reg_id) || restriction.cred_def_id && isUnqualifiedCredentialDefinitionId(restriction.cred_def_id) || restriction.schema_id && isUnqualifiedSchemaId(restriction.schema_id) || restriction.issuer_did && isUnqualifiedIndyDid(restriction.issuer_did) || restriction.issuer_id && isUnqualifiedIndyDid(restriction.issuer_id) || restriction.schema_issuer_did && isUnqualifiedIndyDid(restriction.schema_issuer_did) || restriction.schema_issuer_id && isUnqualifiedIndyDid(restriction.schema_issuer_id) || restriction.rev_reg_id && isUnqualifiedRevocationRegistryId(restriction.rev_reg_id)));
+ }
+ 
+ //#endregion

--- a/app/src/bcsc-theme/features/qr-core/BifoldNavigationAdapter.test.ts
+++ b/app/src/bcsc-theme/features/qr-core/BifoldNavigationAdapter.test.ts
@@ -143,4 +143,54 @@ describe('BifoldNavigationAdapter', () => {
     adapted.dispatch(action)
     expect(nav.dispatch).toHaveBeenCalledWith(action)
   })
+
+  // The following cases mirror the exact navigate payloads Bifold's
+  // `ProofRequest` and `ProofRequestAccept` emit on exit, so a future Bifold
+  // bump or adapter refactor that breaks the proof flow surfaces here.
+
+  it('proof-request decline routes to BCSC Home (ProofRequest.handleDeclineTouched)', () => {
+    // ProofRequest.js: navigation.getParent()?.navigate('Tab Home Stack', { screen: 'Home' })
+    const { nav, parent } = mkNav()
+    const adapted = createBifoldNavigationAdapter(nav as any, { t })
+    adapted.getParent()?.navigate('Tab Home Stack' as never, { screen: 'Home' } as never)
+    expect(parent.dispatch).toHaveBeenCalledWith(
+      CommonActions.reset({
+        index: 0,
+        routes: [{ name: BCSCStacks.Tab, state: { routes: [{ name: BCSCScreens.Home }] } }],
+      })
+    )
+  })
+
+  it('proof-request share-success Back-to-Home routes to BCSC Home (ProofRequestAccept.onBackToHomeTouched)', () => {
+    // ProofRequestAccept reads navigation via useNavigation(); in production the
+    // NavigationContext.Provider in ConnectionLoadingScreen makes that the
+    // adapter. The emitted payload is identical to the decline case.
+    const { nav, parent } = mkNav()
+    const adapted = createBifoldNavigationAdapter(nav as any, { t })
+    adapted.getParent()?.navigate('Tab Home Stack' as never, { screen: 'Home' } as never)
+    expect(parent.dispatch).toHaveBeenCalledWith(
+      CommonActions.reset({
+        index: 0,
+        routes: [{ name: BCSCStacks.Tab, state: { routes: [{ name: BCSCScreens.Home }] } }],
+      })
+    )
+  })
+
+  it('proof-request alt-credential picker is deferred — toasts feature-unavailable', () => {
+    // ProofRequest.js: navigation.getParent()?.navigate('Proof Requests Stack', { screen: 'Choose a credential', ... })
+    // Deferred to v4.2 — tracked in issue #3877. Current behaviour is a soft no-op with toast.
+    const { nav } = mkNav()
+    const adapted = createBifoldNavigationAdapter(nav as any, { t })
+    adapted.getParent()?.navigate('Proof Requests Stack' as never, { screen: 'Choose a credential' } as never)
+    expect(Toast.show).toHaveBeenCalledWith({ type: 'info', text1: 'BCSC.Scan.FeatureUnavailable' })
+  })
+
+  it('proof-request View-JSON debug surface toasts feature-unavailable (Bifold ContactStack/JSONDetails)', () => {
+    // ProofRequest.js: navigation.navigate('Contacts Stack', { screen: 'JSON Details', ... })
+    const { nav } = mkNav()
+    const adapted = createBifoldNavigationAdapter(nav as any, { t })
+    adapted.navigate('Contacts Stack' as never, { screen: 'JSON Details' } as never)
+    expect(Toast.show).toHaveBeenCalledWith({ type: 'info', text1: 'BCSC.Scan.FeatureUnavailable' })
+    expect(nav.navigate).not.toHaveBeenCalled()
+  })
 })

--- a/app/src/bcsc-theme/features/qr-core/BifoldNavigationAdapter.test.ts
+++ b/app/src/bcsc-theme/features/qr-core/BifoldNavigationAdapter.test.ts
@@ -148,23 +148,15 @@ describe('BifoldNavigationAdapter', () => {
   // `ProofRequest` and `ProofRequestAccept` emit on exit, so a future Bifold
   // bump or adapter refactor that breaks the proof flow surfaces here.
 
-  it('proof-request decline routes to BCSC Home (ProofRequest.handleDeclineTouched)', () => {
-    // ProofRequest.js: navigation.getParent()?.navigate('Tab Home Stack', { screen: 'Home' })
-    const { nav, parent } = mkNav()
-    const adapted = createBifoldNavigationAdapter(nav as any, { t })
-    adapted.getParent()?.navigate('Tab Home Stack' as never, { screen: 'Home' } as never)
-    expect(parent.dispatch).toHaveBeenCalledWith(
-      CommonActions.reset({
-        index: 0,
-        routes: [{ name: BCSCStacks.Tab, state: { routes: [{ name: BCSCScreens.Home }] } }],
-      })
-    )
-  })
-
-  it('proof-request share-success Back-to-Home routes to BCSC Home (ProofRequestAccept.onBackToHomeTouched)', () => {
-    // ProofRequestAccept reads navigation via useNavigation(); in production the
-    // NavigationContext.Provider in ConnectionLoadingScreen makes that the
-    // adapter. The emitted payload is identical to the decline case.
+  // Both Bifold call sites emit an identical getParent()?.navigate('Tab Home Stack', { screen: 'Home' })
+  // today, but pinning each site by name keeps the contract grep-able if Bifold ever diverges them
+  // (e.g. ProofRequestAccept switching to popToTop, or decline routing via dispatch(reset)).
+  // ProofRequestAccept reads navigation via useNavigation() — NavigationContext.Provider in
+  // ConnectionLoadingScreen is what makes that resolve to the adapter at runtime.
+  it.each([
+    ['ProofRequest.handleDeclineTouched (decline)'],
+    ['ProofRequestAccept.onBackToHomeTouched (share success)'],
+  ])('proof-request %s routes to BCSC Home', () => {
     const { nav, parent } = mkNav()
     const adapted = createBifoldNavigationAdapter(nav as any, { t })
     adapted.getParent()?.navigate('Tab Home Stack' as never, { screen: 'Home' } as never)

--- a/app/src/bcsc-theme/features/qr-core/BifoldNavigationAdapter.ts
+++ b/app/src/bcsc-theme/features/qr-core/BifoldNavigationAdapter.ts
@@ -13,6 +13,16 @@ import type { TFunction } from 'i18next'
  * else passes through untouched, including getParent (which returns its own
  * adapter so chained calls continue to be translated) and dispatch (which we
  * also intercept to catch reset actions that target Bifold's nav graph).
+ *
+ * Proof-request exit paths (Bifold's `ProofRequest` rendered inline by
+ * `Connection.tsx`) all funnel through these same intercepts: decline,
+ * cancel-done, the `Declined`/`Abandoned` state effect, and the share-success
+ * "Back to Home" button inside `ProofRequestAccept` all call
+ * `navigation.getParent()?.navigate('Tab Home Stack', { screen: 'Home' })`,
+ * which the navigate intercept resets onto `BCSCStacks.Tab` / `Home`.
+ * `ProofRequestAccept` reads `navigation` via `useNavigation()` rather than a
+ * prop, so the `NavigationContext.Provider` wrapping in `ConnectionLoadingScreen`
+ * (not just the prop-level adapter) is what makes its calls reach this code.
  */
 
 // Bifold route names that don't exist in BCSC's nav graph.

--- a/app/src/bcsc-theme/features/qr-core/ConnectionLoadingScreen.test.tsx
+++ b/app/src/bcsc-theme/features/qr-core/ConnectionLoadingScreen.test.tsx
@@ -1,4 +1,6 @@
+import { BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
 import { Connection } from '@bifold/core'
+import { CommonActions } from '@react-navigation/native'
 import { render } from '@testing-library/react-native'
 import React from 'react'
 
@@ -46,5 +48,24 @@ describe('ConnectionLoadingScreen', () => {
     props.navigation.navigate('Tab Home Stack')
     expect(navigation.navigate).not.toHaveBeenCalled()
     expect(navigation.dispatch).toHaveBeenCalled()
+  })
+
+  it('exit calls from inside Bifold (proof-request share / decline) reset to BCSC Home', () => {
+    // Bifold's ProofRequest + ProofRequestAccept exit paths call
+    //   navigation.getParent()?.navigate('Tab Home Stack', { screen: 'Home' })
+    // In production, NavigationContext.Provider makes useNavigation() inside
+    // ProofRequestAccept return this same adapter. Drive that call through the
+    // adapter prop the mocked Connection received and assert the underlying nav
+    // sees the BCSC reset — proving the share/decline contract end-to-end.
+    const { navigation, route } = mkProps()
+    render(<ConnectionLoadingScreen navigation={navigation} route={route} />)
+    const props = ConnectionMock.mock.calls.at(-1)![0] as any
+    props.navigation.getParent()?.navigate('Tab Home Stack', { screen: 'Home' })
+    expect(navigation.dispatch).toHaveBeenCalledWith(
+      CommonActions.reset({
+        index: 0,
+        routes: [{ name: BCSCStacks.Tab, state: { routes: [{ name: BCSCScreens.Home }] } }],
+      })
+    )
   })
 })

--- a/package.json
+++ b/package.json
@@ -69,7 +69,9 @@
     "@animo-id/pex@npm:4.1.1-alpha.0": "patch:@animo-id/pex@npm%3A4.1.1-alpha.0#~/.yarn/patches/@animo-id-pex-npm-4.1.1-alpha.0-f29edfffa2.patch",
     "@sphereon/pex@npm:5.0.0-unstable.24": "patch:@sphereon/pex@npm%3A5.0.0-unstable.24#~/.yarn/patches/@sphereon-pex-npm-5.0.0-unstable.24-921df3a8ac.patch",
     "react-native-fs@npm:~2.20.0": "patch:react-native-fs@npm%3A2.20.0#~/.yarn/patches/react-native-fs-npm-2.20.0-a38fe24051.patch",
-    "handlebars": "4.7.9"
+    "handlebars": "4.7.9",
+    "@credo-ts/anoncreds@npm:0.6.3": "patch:@credo-ts/anoncreds@npm%3A0.6.3#~/.yarn/patches/@credo-ts-anoncreds-npm-0.6.3-95e0920301.patch",
+    "@credo-ts/anoncreds@npm:^0.6.1": "patch:@credo-ts/anoncreds@npm%3A0.6.3#~/.yarn/patches/@credo-ts-anoncreds-npm-0.6.3-95e0920301.patch"
   },
   "dependencies": {
     "react-native-bcsc-core": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,7 +2132,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@credo-ts/anoncreds@npm:0.6.3, @credo-ts/anoncreds@npm:^0.6.1":
+"@credo-ts/anoncreds@npm:0.6.3":
   version: 0.6.3
   resolution: "@credo-ts/anoncreds@npm:0.6.3"
   dependencies:
@@ -2146,6 +2146,23 @@ __metadata:
   peerDependencies:
     "@hyperledger/anoncreds-shared": ^0.3.4
   checksum: 10c0/a9897f2a8bc71e6d36b6527d985f12d6fbee5a0e33de9a96323b13c7b9821e2b8d418ee04ec03a84b7d7a3ed171f9c58cb9441481b040f5e6a567d07a4da32e5
+  languageName: node
+  linkType: hard
+
+"@credo-ts/anoncreds@patch:@credo-ts/anoncreds@npm%3A0.6.3#~/.yarn/patches/@credo-ts-anoncreds-npm-0.6.3-95e0920301.patch":
+  version: 0.6.3
+  resolution: "@credo-ts/anoncreds@patch:@credo-ts/anoncreds@npm%3A0.6.3#~/.yarn/patches/@credo-ts-anoncreds-npm-0.6.3-95e0920301.patch::version=0.6.3&hash=c2cfa2"
+  dependencies:
+    "@astronautlabs/jsonpath": "npm:^1.1.2"
+    "@credo-ts/core": "npm:0.6.3"
+    "@credo-ts/didcomm": "npm:0.6.3"
+    "@sphereon/pex-models": "npm:^2.3.2"
+    class-transformer: "npm:0.5.1"
+    class-validator: "npm:^0.14.3"
+    reflect-metadata: "npm:0.2.2"
+  peerDependencies:
+    "@hyperledger/anoncreds-shared": ^0.3.4
+  checksum: 10c0/4540928f9207767715a5c94e8a4736068a8397326120e162e6357ab4ff512088f7384d9f47fe2276fc2900c7993a31d82ed503098c5eb7343f7503c87732491d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Follow-up to #3846 (Bifold Connection adoption). The adapter intercepts already cover Bifold's `ProofRequest` exit paths — decline, cancel, share-success Back-to-Home, and the state-driven `Declined`/`Abandoned` effect all funnel through `Tab Home Stack` and reset onto BCSC Home. So no new wrapper code; mostly verification + tests + a stale-patch fix surfaced during manual E2E.


https://github.com/user-attachments/assets/337aa67b-2161-4de4-8c4d-a5ca68011e48

 Closes #3840

## What's in here

- **Patch reinstatement** (`fix(deps)`): the `@credo-ts/anoncreds` unqualified-identifier patch was registered against 0.5.19 in `.yarn/patches/`, but the installed version is 0.6.3, so the patch didn't apply. Credo 0.6.3 is byte-identical to unpatched 0.5.19 here — fix was never absorbed upstream. Without the patch, proof responses to Showcase silently failed because `proofRequestUsesUnqualifiedIdentifiers` returned `false` for restrictions with no qualified-id fields, and the AnonCreds holder used qualified-id tags that the wallet's `did:sov` credentials don't match. Re-generated patch against 0.6.3.
- **Adapter tests** (`test(scan)`): four named cases mirroring exact Bifold `ProofRequest` / `ProofRequestAccept` payloads (decline, share-success, alt-cred picker, View-JSON), plus one `ConnectionLoadingScreen` smoke that drives a `getParent().navigate('Tab Home Stack', { screen: 'Home' })` through the wrapped adapter prop. Future Bifold bumps that break the contract surface here.
- **Adapter docstring**: extended to document the proof-request coverage and why `NavigationContext.Provider` matters for `useNavigation()`-based callers like `ProofRequestAccept`.

## Test plan

- [x] `yarn test` — 1952 passing (+5 new)
- [x] `yarn typecheck` + `yarn lint:ts` clean
- [x] Manual: scan Showcase proof → review → share → Showcase registers the response, BCSC lands on Home
- [ ] Manual: same flow with Decline → BCSC lands on Home
- [ ] Smoke: credential-offer Done button still resets to Wallet

## Follow-ups

- #3877 — alt-credential picker (`Stacks.ProofRequestsStack` / `ProofChangeCredential`), currently toasted as unavailable; deferred to v4.2
- The other stale `@credo-ts/*@0.5.19` patches (core / indy-vdr / openid4vc) are separate triage — not implicated by this symptom, left for a follow-up sweep
- Upstream the anoncreds fix to Credo 0.6.x so the patch becomes dead weight on the next bump