### PR TITLE
feat(scan): route pairing-code QR codes into the PairingCode tab

### DIFF
--- a/app/__mocks__/@react-navigation/native.ts
+++ b/app/__mocks__/@react-navigation/native.ts
@@ -6,6 +6,7 @@ const navigation = {
   navigate,
   replace,
   setOptions: jest.fn(),
+  setParams: jest.fn(),
   getParent: () => {
     return {
       navigate,

--- a/app/src/bcsc-theme/features/pairing/ManualPairing.test.tsx
+++ b/app/src/bcsc-theme/features/pairing/ManualPairing.test.tsx
@@ -1,7 +1,7 @@
 import { BCSCLoadingProvider } from '@/bcsc-theme/contexts/BCSCLoadingContext'
 import { BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { testIdWithKey } from '@bifold/core'
-import { useNavigation } from '@mocks/@react-navigation/native'
+import { useNavigation, useRoute } from '@mocks/@react-navigation/native'
 import { BasicAppContext } from '@mocks/helpers/app'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native'
 import React from 'react'
@@ -24,6 +24,7 @@ describe('ManualPairing', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockNavigation = useNavigation()
+    jest.mocked(useRoute).mockReturnValue({ params: {} } as ReturnType<typeof useRoute>)
     jest.useFakeTimers()
   })
 
@@ -117,6 +118,39 @@ describe('ManualPairing', () => {
           serviceName: 'Test Service',
         })
       })
+    })
+  })
+
+  describe('Pre-populated from route param', () => {
+    test('auto-submits and navigates when route.params.pairingCode is a full-length code', async () => {
+      mockLoginByPairingCode.mockResolvedValue({
+        client_ref_id: 'ref-456',
+        client_name: 'BC Parks Discover Camping',
+      })
+      jest.mocked(useRoute).mockReturnValue({ params: { pairingCode: 'SKGAZZ' } } as ReturnType<typeof useRoute>)
+
+      renderScreen()
+
+      await waitFor(() => {
+        expect(mockLoginByPairingCode).toHaveBeenCalledWith('SKGAZZ')
+      })
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.PairingConfirmation, {
+        serviceId: 'ref-456',
+        serviceName: 'BC Parks Discover Camping',
+      })
+      // Param is cleared after consumption so re-focus doesn't re-submit
+      expect(mockNavigation.setParams).toHaveBeenCalledWith({ pairingCode: undefined })
+    })
+
+    test('does not auto-submit when the param is too short', async () => {
+      jest.mocked(useRoute).mockReturnValue({ params: { pairingCode: 'ABC' } } as ReturnType<typeof useRoute>)
+
+      renderScreen()
+
+      await waitFor(() => {
+        expect(mockLoginByPairingCode).not.toHaveBeenCalled()
+      })
+      expect(mockNavigation.setParams).not.toHaveBeenCalled()
     })
   })
 })

--- a/app/src/bcsc-theme/features/pairing/ManualPairing.tsx
+++ b/app/src/bcsc-theme/features/pairing/ManualPairing.tsx
@@ -49,11 +49,11 @@ const ManualPairing: React.FC = () => {
 
   // QRCoreStack keeps tabs mounted (unmountOnBlur: false), so a pre-populated
   // pairingCode param must be consumed-and-cleared or it would re-fire on every
-  // focus. Tab navigator handles setParams; cast off the type-system mismatch
-  // since useNavigation typing is split between parent stack and sibling tab.
+  // focus. setParams lives on the tab navigator, so we hold a separately-typed
+  // `tabNavigation` handle just for this call.
   useEffect(() => {
     const pre = route.params?.pairingCode
-    if (pre && pre.length === PAIRING_CODE_LENGTH) {
+    if (pre?.length === PAIRING_CODE_LENGTH) {
       setCode(pre)
       onSubmit(pre)
       tabNavigation.setParams({ pairingCode: undefined })

--- a/app/src/bcsc-theme/features/pairing/ManualPairing.tsx
+++ b/app/src/bcsc-theme/features/pairing/ManualPairing.tsx
@@ -1,19 +1,23 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import CodeInput from '@/bcsc-theme/components/CodeInput'
 import { useLoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
+import { QRCoreTabParams } from '@/bcsc-theme/navigators/QRCoreStack'
 import { PAIRING_CODE_LENGTH } from '@/constants'
 import { BCSCMainStackParams, BCSCScreens } from '@bcsc-theme/types/navigators'
 import { ScreenWrapper, testIdWithKey, ThemedText, TOKENS, useServices, useTheme } from '@bifold/core'
-import { useNavigation } from '@react-navigation/native'
+import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs'
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, View } from 'react-native'
 
 const ManualPairing: React.FC = () => {
   const navigation = useNavigation<StackNavigationProp<BCSCMainStackParams>>()
+  const tabNavigation = useNavigation<BottomTabNavigationProp<QRCoreTabParams, 'PairingCode'>>()
+  const route = useRoute<RouteProp<QRCoreTabParams, 'PairingCode'>>()
   const { t } = useTranslation()
-  const [code, setCode] = useState('')
+  const [code, setCode] = useState(route.params?.pairingCode ?? '')
   const [error, setError] = useState<string | null>(null)
   const { Spacing, ColorPalette } = useTheme()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
@@ -42,6 +46,19 @@ const ManualPairing: React.FC = () => {
     },
     [loadingScreen, logger, navigation, pairing, t]
   )
+
+  // QRCoreStack keeps tabs mounted (unmountOnBlur: false), so a pre-populated
+  // pairingCode param must be consumed-and-cleared or it would re-fire on every
+  // focus. Tab navigator handles setParams; cast off the type-system mismatch
+  // since useNavigation typing is split between parent stack and sibling tab.
+  useEffect(() => {
+    const pre = route.params?.pairingCode
+    if (pre && pre.length === PAIRING_CODE_LENGTH) {
+      setCode(pre)
+      onSubmit(pre)
+      tabNavigation.setParams({ pairingCode: undefined })
+    }
+  }, [route.params?.pairingCode, onSubmit, tabNavigation])
 
   const handleChangeCode = useCallback(
     (text: string) => {

--- a/app/src/bcsc-theme/features/qr-core/QRScanner.tsx
+++ b/app/src/bcsc-theme/features/qr-core/QRScanner.tsx
@@ -1,5 +1,6 @@
 import { PermissionDisabled } from '@/bcsc-theme/components/PermissionDisabled'
 import { LoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
+import { QRCoreTabParams } from '@/bcsc-theme/navigators/QRCoreStack'
 import { BCSCMainStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { hitSlop } from '@/constants'
 import {
@@ -11,6 +12,7 @@ import {
   ThemedText,
   useTheme,
 } from '@bifold/core'
+import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs'
 import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { useCallback, useState } from 'react'
@@ -23,7 +25,7 @@ import useScanScreenViewModel from './useScanScreenViewModel'
 const QRScanner: React.FC = () => {
   const { ColorPalette, Spacing } = useTheme()
   const { t } = useTranslation()
-  const navigation = useNavigation<StackNavigationProp<BCSCMainStackParams>>()
+  const navigation = useNavigation<BottomTabNavigationProp<QRCoreTabParams>>()
   const [torchActive, setTorchActive] = useState(false)
 
   const onConnectionFound = useCallback(
@@ -37,8 +39,15 @@ const QRScanner: React.FC = () => {
     [navigation]
   )
 
+  const onPairingCodeFound = useCallback(
+    (pairingCode: string) => {
+      navigation.navigate('PairingCode', { pairingCode })
+    },
+    [navigation]
+  )
+
   const { isPermissionLoading, hasPermission, isProcessing, scanError, handleScan, dismissError, resetNavigationLock } =
-    useScanScreenViewModel({ onConnectionFound })
+    useScanScreenViewModel({ onConnectionFound, onPairingCodeFound })
 
   // QRCoreStack has `unmountOnBlur: false` so the scanner persists across the
   // ConnectionLoading round trip; reset the nav lock on each focus so the

--- a/app/src/bcsc-theme/features/qr-core/uri-strategies/PairingCodeStrategy.test.ts
+++ b/app/src/bcsc-theme/features/qr-core/uri-strategies/PairingCodeStrategy.test.ts
@@ -1,6 +1,6 @@
 import { isDidCommInvitation, type BifoldLogger } from '@bifold/core'
 
-import PairingCodeStrategy, { isPairingCode } from './PairingCodeStrategy'
+import PairingCodeStrategy, { extractPairingCode } from './PairingCodeStrategy'
 import type { ScanContext } from './types'
 
 const makeLogger = (): BifoldLogger =>
@@ -12,43 +12,78 @@ const makeLogger = (): BifoldLogger =>
     trace: jest.fn(),
   }) as unknown as BifoldLogger
 
-describe('isPairingCode', () => {
-  it('matches plain alphanumeric codes within length bounds', () => {
-    expect(isPairingCode('ABC123')).toBe(true)
-    expect(isPairingCode('XYZ12ABCDE')).toBe(true)
+const DEMO_URL = 'https://idsit.gov.bc.ca/static/pairingqrcode.html#SKGAZZ'
+
+describe('extractPairingCode', () => {
+  it('extracts the fragment from the BC Parks demo URL shape', () => {
+    expect(extractPairingCode(DEMO_URL)).toBe('SKGAZZ')
   })
 
-  it('rejects codes outside length bounds', () => {
-    expect(isPairingCode('ABC')).toBe(false)
-    expect(isPairingCode('ABCDEFGHIJKLMN')).toBe(false)
+  it('is host-agnostic (any host with pairingqrcode.html path)', () => {
+    expect(extractPairingCode('https://www.example.com/static/pairingqrcode.html#ABCDEF')).toBe('ABCDEF')
   })
 
-  it('rejects URLs and lower-case strings', () => {
-    expect(isPairingCode('didcomm://oob?abc=1')).toBe(false)
-    expect(isPairingCode('abc123')).toBe(false)
+  it('rejects URLs without a fragment', () => {
+    expect(extractPairingCode('https://idsit.gov.bc.ca/static/pairingqrcode.html')).toBeNull()
   })
 
-  it('trims surrounding whitespace before matching', () => {
-    expect(isPairingCode('  ABC123  ')).toBe(true)
+  it('rejects fragments shorter or longer than PAIRING_CODE_LENGTH', () => {
+    expect(extractPairingCode('https://idsit.gov.bc.ca/static/pairingqrcode.html#ABC')).toBeNull()
+    expect(extractPairingCode('https://idsit.gov.bc.ca/static/pairingqrcode.html#ABCDEFGH')).toBeNull()
+  })
+
+  it('rejects fragments containing non-alphanumeric or lowercase characters', () => {
+    expect(extractPairingCode('https://idsit.gov.bc.ca/static/pairingqrcode.html#abc123')).toBeNull()
+    expect(extractPairingCode('https://idsit.gov.bc.ca/static/pairingqrcode.html#AB-123')).toBeNull()
+  })
+
+  it('rejects URLs without the pairingqrcode.html path', () => {
+    expect(extractPairingCode('https://www.gov.bc.ca/#SKGAZZ')).toBeNull()
+    expect(extractPairingCode('https://idsit.gov.bc.ca/static/other.html#SKGAZZ')).toBeNull()
+  })
+
+  it('rejects unparseable inputs', () => {
+    expect(extractPairingCode('not a url')).toBeNull()
+    expect(extractPairingCode('')).toBeNull()
+    expect(extractPairingCode('SKGAZZ')).toBeNull()
   })
 })
 
-describe('PairingCodeStrategy', () => {
-  it('returns unsupported with PairingCodePending reason today (real handler tracked separately)', async () => {
+describe('PairingCodeStrategy.matches', () => {
+  it('matches the BC Parks demo URL', () => {
+    expect(PairingCodeStrategy.matches(DEMO_URL)).toBe(true)
+  })
+
+  it('does not match DIDComm, OpenID, or random URLs', () => {
+    expect(PairingCodeStrategy.matches('didcomm://oob?abc=1')).toBe(false)
+    expect(PairingCodeStrategy.matches('openid://abc')).toBe(false)
+    expect(PairingCodeStrategy.matches('https://www.gov.bc.ca')).toBe(false)
+  })
+})
+
+describe('PairingCodeStrategy.handle', () => {
+  it('returns pairing-code with the extracted fragment', async () => {
     const ctx: ScanContext = { agent: undefined, logger: makeLogger() }
-    const result = await PairingCodeStrategy.handle('ABC123', ctx)
-    expect(result).toEqual({ kind: 'unsupported', reason: 'PairingCodePending' })
-    expect(ctx.logger.info).toHaveBeenCalled()
+    const result = await PairingCodeStrategy.handle(DEMO_URL, ctx)
+    expect(result).toEqual({ kind: 'pairing-code', pairingCode: 'SKGAZZ' })
+  })
+
+  it('returns unrecognized + logs warn if matches passes but extraction fails', async () => {
+    // Defensive guard — matches() and extractPairingCode() share the same logic,
+    // so this branch is only reachable if the URL parser produces inconsistent results.
+    const ctx: ScanContext = { agent: undefined, logger: makeLogger() }
+    const result = await PairingCodeStrategy.handle('not a url', ctx)
+    expect(result).toEqual({ kind: 'unrecognized' })
+    expect(ctx.logger.warn).toHaveBeenCalled()
   })
 })
 
-// Boundary assumption: DEFAULT_STRATEGIES lists DidCommOob before PairingCode
-// and uses Array.find first-match. PairingCode is the catch-all looser matcher.
-// If Bifold ever loosens `isDidCommInvitation` such that bare alphanumeric
-// strings classify as DIDComm, pairing codes would be silently shadowed.
+// Boundary assumption: DidCommOob runs first in DEFAULT_STRATEGIES.
+// PairingCode now matches a different URL shape (pairingqrcode.html), so the
+// strategies are disjoint, but pin the negative case in case Bifold ever
+// loosens isDidCommInvitation to accept the pairing-QR shape.
 describe('strategy ordering boundary', () => {
-  it('isDidCommInvitation does not match a bare alphanumeric pairing-code shape — keeps PairingCode reachable', () => {
-    expect(isDidCommInvitation('ABC123')).toBe(false)
-    expect(isDidCommInvitation('XYZ12ABCDE')).toBe(false)
+  it('isDidCommInvitation does not match the pairing-QR URL shape', () => {
+    expect(isDidCommInvitation(DEMO_URL)).toBe(false)
   })
 })

--- a/app/src/bcsc-theme/features/qr-core/uri-strategies/PairingCodeStrategy.ts
+++ b/app/src/bcsc-theme/features/qr-core/uri-strategies/PairingCodeStrategy.ts
@@ -1,26 +1,40 @@
+import { PAIRING_CODE_LENGTH } from '@/constants'
+
 import type { ScanContext, ScanResult, UriStrategy } from './types'
 
-// Pairing-code QR codes carry a short alphanumeric code (typically the same
-// shape ManualPairing accepts). The actual handler that surfaces this into
-// the PairingCode tab is tracked in #3838 — this stub just exercises the
-// multi-strategy seam so #3838 only adds a body.
-const PAIRING_CODE_PATTERN = /^[A-Z0-9]{6,12}$/
+// Pairing QRs encode a landing-page URL with the code in the fragment, e.g.
+//   https://idsit.gov.bc.ca/static/pairingqrcode.html#SKGAZZ
+// Host varies across environments, so we anchor on the path + fragment shape.
+const PAIRING_QR_PATH = /pairingqrcode\.html$/i
+const PAIRING_CODE_FRAGMENT = new RegExp(`^[A-Z0-9]{${PAIRING_CODE_LENGTH}}$`)
 
-export const isPairingCode = (value: string): boolean => PAIRING_CODE_PATTERN.test(value.trim())
+export const extractPairingCode = (uri: string): string | null => {
+  try {
+    const url = new URL(uri)
+    if (!PAIRING_QR_PATH.test(url.pathname)) {
+      return null
+    }
+    const fragment = url.hash.startsWith('#') ? url.hash.slice(1) : url.hash
+    return PAIRING_CODE_FRAGMENT.test(fragment) ? fragment : null
+  } catch {
+    return null
+  }
+}
 
 const PairingCodeStrategy: UriStrategy = {
   name: 'pairing-code',
 
   matches(uri) {
-    return isPairingCode(uri)
+    return extractPairingCode(uri) !== null
   },
 
-  async handle(_uri, ctx: ScanContext): Promise<ScanResult> {
-    ctx.logger.info('[PairingCodeStrategy] pairing-code QR detected — handler pending (#3838)')
-    // Surface as `unsupported` so the user sees a "pending" message instead of the
-    // generic "QR code not recognized" surfaced for truly unknown codes. #3838 will
-    // replace this with a real `connection`-style result.
-    return { kind: 'unsupported', reason: 'PairingCodePending' }
+  async handle(uri, ctx: ScanContext): Promise<ScanResult> {
+    const code = extractPairingCode(uri)
+    if (!code) {
+      ctx.logger.warn('[PairingCodeStrategy] matched but failed to extract code')
+      return { kind: 'unrecognized' }
+    }
+    return { kind: 'pairing-code', pairingCode: code }
   },
 }
 

--- a/app/src/bcsc-theme/features/qr-core/uri-strategies/types.ts
+++ b/app/src/bcsc-theme/features/qr-core/uri-strategies/types.ts
@@ -3,7 +3,8 @@ import type { Agent } from '@credo-ts/core'
 
 export type ScanResult =
   | { kind: 'connection'; oobRecordId: string }
-  | { kind: 'unsupported'; reason: 'OpenID' | 'Mediator' | 'AgentNotReady' | 'PairingCodePending' }
+  | { kind: 'pairing-code'; pairingCode: string }
+  | { kind: 'unsupported'; reason: 'OpenID' | 'Mediator' | 'AgentNotReady' }
   | { kind: 'unrecognized' }
 
 export interface ScanContext {

--- a/app/src/bcsc-theme/features/qr-core/useScanScreenViewModel.test.ts
+++ b/app/src/bcsc-theme/features/qr-core/useScanScreenViewModel.test.ts
@@ -49,8 +49,11 @@ describe('useScanScreenViewModel', () => {
 
   it('invokes onConnectionFound with the oobRecordId on connection result', async () => {
     const onConnectionFound = jest.fn()
+    const onPairingCodeFound = jest.fn()
     const strat = mkStrategy(true, { kind: 'connection', oobRecordId: 'rec-1' })
-    const { result } = renderHook(() => useScanScreenViewModel({ onConnectionFound, strategies: [strat] }))
+    const { result } = renderHook(() =>
+      useScanScreenViewModel({ onConnectionFound, onPairingCodeFound, strategies: [strat] })
+    )
     await act(async () => {
       await result.current.handleScan('didcomm://x')
     })
@@ -60,8 +63,11 @@ describe('useScanScreenViewModel', () => {
 
   it('sets scanError with localized key when result is unsupported', async () => {
     const onConnectionFound = jest.fn()
+    const onPairingCodeFound = jest.fn()
     const strat = mkStrategy(true, { kind: 'unsupported', reason: 'OpenID' })
-    const { result } = renderHook(() => useScanScreenViewModel({ onConnectionFound, strategies: [strat] }))
+    const { result } = renderHook(() =>
+      useScanScreenViewModel({ onConnectionFound, onPairingCodeFound, strategies: [strat] })
+    )
     await act(async () => {
       await result.current.handleScan('openid://x')
     })
@@ -71,8 +77,11 @@ describe('useScanScreenViewModel', () => {
 
   it('sets scanError when no strategy matches', async () => {
     const onConnectionFound = jest.fn()
+    const onPairingCodeFound = jest.fn()
     const strat = mkStrategy(false, { kind: 'connection', oobRecordId: 'x' })
-    const { result } = renderHook(() => useScanScreenViewModel({ onConnectionFound, strategies: [strat] }))
+    const { result } = renderHook(() =>
+      useScanScreenViewModel({ onConnectionFound, onPairingCodeFound, strategies: [strat] })
+    )
     await act(async () => {
       await result.current.handleScan('https://random.example.com')
     })
@@ -81,8 +90,11 @@ describe('useScanScreenViewModel', () => {
 
   it('wraps generic strategy errors as InvalidQrCode and stashes the underlying message in details', async () => {
     const onConnectionFound = jest.fn()
+    const onPairingCodeFound = jest.fn()
     const strat = mkStrategy(true, new Error('boom'))
-    const { result } = renderHook(() => useScanScreenViewModel({ onConnectionFound, strategies: [strat] }))
+    const { result } = renderHook(() =>
+      useScanScreenViewModel({ onConnectionFound, onPairingCodeFound, strategies: [strat] })
+    )
     await act(async () => {
       await result.current.handleScan('didcomm://x')
     })
@@ -95,8 +107,11 @@ describe('useScanScreenViewModel', () => {
     const { QrCodeScanError } = jest.requireMock('@bifold/core') as { QrCodeScanError: any }
     const thrown = new QrCodeScanError('Strategy.SpecificTitle', 'didcomm://y', 'strategy-detail')
     const onConnectionFound = jest.fn()
+    const onPairingCodeFound = jest.fn()
     const strat = mkStrategy(true, thrown)
-    const { result } = renderHook(() => useScanScreenViewModel({ onConnectionFound, strategies: [strat] }))
+    const { result } = renderHook(() =>
+      useScanScreenViewModel({ onConnectionFound, onPairingCodeFound, strategies: [strat] })
+    )
     await act(async () => {
       await result.current.handleScan('didcomm://y')
     })
@@ -105,6 +120,7 @@ describe('useScanScreenViewModel', () => {
 
   it('skips repeat scans while one is processing or an error is showing', async () => {
     const onConnectionFound = jest.fn()
+    const onPairingCodeFound = jest.fn()
     let resolveOne: (() => void) | undefined
     const strat: UriStrategy = {
       name: 'slow',
@@ -113,7 +129,9 @@ describe('useScanScreenViewModel', () => {
         async () => new Promise((res) => (resolveOne = () => res({ kind: 'connection', oobRecordId: 'r' })))
       ),
     }
-    const { result } = renderHook(() => useScanScreenViewModel({ onConnectionFound, strategies: [strat] }))
+    const { result } = renderHook(() =>
+      useScanScreenViewModel({ onConnectionFound, onPairingCodeFound, strategies: [strat] })
+    )
     let firstPromise: Promise<void> | undefined
     await act(async () => {
       firstPromise = result.current.handleScan('didcomm://1')
@@ -133,8 +151,11 @@ describe('useScanScreenViewModel', () => {
 
   it('suppresses subsequent scans after a successful navigation handoff (ScanCamera re-fire race)', async () => {
     const onConnectionFound = jest.fn()
+    const onPairingCodeFound = jest.fn()
     const strat = mkStrategy(true, { kind: 'connection', oobRecordId: 'rec-1' })
-    const { result } = renderHook(() => useScanScreenViewModel({ onConnectionFound, strategies: [strat] }))
+    const { result } = renderHook(() =>
+      useScanScreenViewModel({ onConnectionFound, onPairingCodeFound, strategies: [strat] })
+    )
     await act(async () => {
       await result.current.handleScan('didcomm://x')
     })
@@ -150,6 +171,7 @@ describe('useScanScreenViewModel', () => {
 
   it('swallows errors thrown during the post-navigation transition (no modal on top of the success flow)', async () => {
     const onConnectionFound = jest.fn()
+    const onPairingCodeFound = jest.fn()
     // Strategy succeeds on the first call (latching isNavigatingRef) and throws on subsequent calls
     // — mirrors ScanCamera re-firing after the OOB record has already been received upstream.
     let calls = 0
@@ -164,7 +186,9 @@ describe('useScanScreenViewModel', () => {
         throw new Error('post-nav boom')
       }),
     }
-    const { result } = renderHook(() => useScanScreenViewModel({ onConnectionFound, strategies: [strat] }))
+    const { result } = renderHook(() =>
+      useScanScreenViewModel({ onConnectionFound, onPairingCodeFound, strategies: [strat] })
+    )
     await act(async () => {
       await result.current.handleScan('didcomm://x')
     })
@@ -179,8 +203,11 @@ describe('useScanScreenViewModel', () => {
 
   it('resetNavigationLock re-enables scanning after navigation (e.g. user returns to the scanner)', async () => {
     const onConnectionFound = jest.fn()
+    const onPairingCodeFound = jest.fn()
     const strat = mkStrategy(true, { kind: 'connection', oobRecordId: 'rec-1' })
-    const { result } = renderHook(() => useScanScreenViewModel({ onConnectionFound, strategies: [strat] }))
+    const { result } = renderHook(() =>
+      useScanScreenViewModel({ onConnectionFound, onPairingCodeFound, strategies: [strat] })
+    )
     await act(async () => {
       await result.current.handleScan('didcomm://x')
     })
@@ -192,10 +219,34 @@ describe('useScanScreenViewModel', () => {
     expect(onConnectionFound).toHaveBeenCalledTimes(2)
   })
 
+  it('invokes onPairingCodeFound with the code on pairing-code result, latching against re-scans', async () => {
+    const onConnectionFound = jest.fn()
+    const onPairingCodeFound = jest.fn()
+    const strat = mkStrategy(true, { kind: 'pairing-code', pairingCode: 'SKGAZZ' })
+    const { result } = renderHook(() =>
+      useScanScreenViewModel({ onConnectionFound, onPairingCodeFound, strategies: [strat] })
+    )
+    await act(async () => {
+      await result.current.handleScan('https://idsit.gov.bc.ca/static/pairingqrcode.html#SKGAZZ')
+    })
+    expect(onPairingCodeFound).toHaveBeenCalledWith('SKGAZZ')
+    expect(result.current.scanError).toBeNull()
+
+    // Camera frames during the tab-switch transition must be ignored.
+    await act(async () => {
+      await result.current.handleScan('https://idsit.gov.bc.ca/static/pairingqrcode.html#SKGAZZ')
+    })
+    expect(strat.handle).toHaveBeenCalledTimes(1)
+    expect(onPairingCodeFound).toHaveBeenCalledTimes(1)
+  })
+
   it('dismissError clears scanError', async () => {
     const onConnectionFound = jest.fn()
+    const onPairingCodeFound = jest.fn()
     const strat = mkStrategy(false, { kind: 'connection', oobRecordId: 'x' })
-    const { result } = renderHook(() => useScanScreenViewModel({ onConnectionFound, strategies: [strat] }))
+    const { result } = renderHook(() =>
+      useScanScreenViewModel({ onConnectionFound, onPairingCodeFound, strategies: [strat] })
+    )
     await act(async () => {
       await result.current.handleScan('https://x')
     })

--- a/app/src/bcsc-theme/features/qr-core/useScanScreenViewModel.ts
+++ b/app/src/bcsc-theme/features/qr-core/useScanScreenViewModel.ts
@@ -14,18 +14,21 @@ export interface UseScanScreenViewModelOptions {
    * how to navigate (push within its own stack, or escape up to MainStack).
    */
   onConnectionFound: (oobRecordId: string) => void
+  /**
+   * Called when a strategy returns `{ kind: 'pairing-code' }`. The screen
+   * routes the code into the pairing flow (typically the sibling PairingCode tab).
+   */
+  onPairingCodeFound: (pairingCode: string) => void
   strategies?: UriStrategy[]
 }
 
-// Ordering matters: `Array.find` returns the first matching strategy. Keep
-// `DidCommOobStrategy` first because its DIDComm-shaped URLs are unambiguous;
-// `PairingCodeStrategy` is the looser catch-all (bare alphanumeric codes) so
-// it goes last. If a future Bifold release loosens `isDidCommInvitation`, the
-// `PairingCodeStrategy.matches` test pins the assumption.
+// Ordering matters: `Array.find` returns the first matching strategy. Both
+// strategies parse URLs with disjoint shapes (DIDComm OOB vs pairingqrcode.html),
+// so order is not load-bearing today; keep DIDComm first to match the original seam.
 const DEFAULT_STRATEGIES: UriStrategy[] = [DidCommOobStrategy, PairingCodeStrategy]
 
 const useScanScreenViewModel = (options: UseScanScreenViewModelOptions) => {
-  const { onConnectionFound } = options
+  const { onConnectionFound, onPairingCodeFound } = options
   const strategies = useMemo(() => options.strategies ?? DEFAULT_STRATEGIES, [options.strategies])
   const { t } = useTranslation()
   const { agent } = useAgent()
@@ -65,6 +68,10 @@ const useScanScreenViewModel = (options: UseScanScreenViewModelOptions) => {
             // the transition (see isNavigatingRef comment above) are ignored.
             isNavigatingRef.current = true
             onConnectionFound(result.oobRecordId)
+            break
+          case 'pairing-code':
+            isNavigatingRef.current = true
+            onPairingCodeFound(result.pairingCode)
             break
           case 'unsupported':
             // BCSC v4.1 rejects OpenID and mediator URIs at the strategy layer; show a localized
@@ -107,7 +114,7 @@ const useScanScreenViewModel = (options: UseScanScreenViewModelOptions) => {
         setIsProcessing(false)
       }
     },
-    [strategies, scanError, t, agent, logger, onConnectionFound]
+    [strategies, scanError, t, agent, logger, onConnectionFound, onPairingCodeFound]
   )
 
   const dismissError = useCallback(() => setScanError(null), [])

--- a/app/src/bcsc-theme/navigators/QRCoreStack.tsx
+++ b/app/src/bcsc-theme/navigators/QRCoreStack.tsx
@@ -15,10 +15,10 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 import { createAuthHelpHeaderButton } from '../components/HelpHeaderButton'
 
-type QRCoreTabParams = {
+export type QRCoreTabParams = {
   Scanner: undefined
   Display: undefined
-  PairingCode: undefined
+  PairingCode: { pairingCode?: string } | undefined
   AccountNotVerified: undefined
 }
 

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -633,7 +633,6 @@ const translation = {
         "OpenID": "OpenID credentials aren't supported in BC Services Card.",
         "Mediator": "Mediator invitations aren't supported in BC Services Card.",
         "AgentNotReady": "Wallet isn't ready yet — please try again in a moment.",
-        "PairingCodePending": "Pairing-code scanning isn't available yet.",
       },
     },
     "ManualSerial": {

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -626,7 +626,6 @@ const translation = {
         "OpenID": "OpenID credentials aren't supported in BC Services Card. (FR)",
         "Mediator": "Mediator invitations aren't supported in BC Services Card. (FR)",
         "AgentNotReady": "Wallet isn't ready yet — please try again in a moment. (FR)",
-        "PairingCodePending": "Pairing-code scanning isn't available yet. (FR)",
       },
     },
     "ManualSerial": {

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -626,7 +626,6 @@ const translation = {
         "OpenID": "OpenID credentials aren't supported in BC Services Card. (PT-BR)",
         "Mediator": "Mediator invitations aren't supported in BC Services Card. (PT-BR)",
         "AgentNotReady": "Wallet isn't ready yet — please try again in a moment. (PT-BR)",
-        "PairingCodePending": "Pairing-code scanning isn't available yet. (PT-BR)",
       },
     },
     "ManualSerial": {


### PR DESCRIPTION

## What

Pairing QRs encode URLs like `https://idsit.gov.bc.ca/static/pairingqrcode.html#SKGAZZ`. Scanner now:

1. Recognizes the URL shape (path `pairingqrcode.html`, 6-char alphanumeric fragment)
2. Pulls the code out of the fragment
3. Hops to the PairingCode tab with the code pre-filled
4. ManualPairing's existing auto-submit takes it from there → PairingConfirmation

No new pairing mechanics — just plugs the scanner into what's already wired for typed codes.

https://github.com/user-attachments/assets/5010b285-0947-4fd0-80a3-c7f4d3021881


Closes #3838.
Follow-up to #3769/#3846 — fills in the `PairingCodeStrategy` stub.

## Notes

- Deep-link parser **not** reused. Different URL shape (`/device/{title}/{code}` vs `pairingqrcode.html#<code>`) and the QR doesn't carry a serviceTitle. Reuses pairing **mechanics** (`loginByPairingCode` → `PairingConfirmation`) instead.
- Dropped the stub's bare-6-12-char regex — pairing QRs are URLs.
- Tab keeps params consumed-and-cleared via `setParams` so re-focus doesn't re-submit a stale code.

## Test plan

- [x] `yarn typecheck`, `yarn lint`, `yarn format:check`, `yarn test` (1967 pass)
- [x] Scan demo QR `https://idsit.gov.bc.ca/static/pairingqrcode.html#SKGAZZ` → lands on PairingCode tab → auto-submits → PairingConfirmation
- [x] Scan a random `https://www.gov.bc.ca` QR → "QR code not recognized"
- [x] Scan a DIDComm OOB QR → existing connection flow still works
- [x] Type a code manually into PairingCode tab → still works

## Open questions

- Does prod use the same `pairingqrcode.html` path? If not, the match regex needs a tweak.