### PR TITLE
feat: key probing and pruning on key mismatch

### DIFF
--- a/app/src/bcsc-theme/hooks/useSecureActions.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.tsx
@@ -42,6 +42,7 @@ import { TokenResponse } from '../api/hooks/useTokens'
 import { ProvinceCode } from '../utils/address-utils'
 import { createMinimalCredential, getCredentialVerificationStatus } from '../utils/bcsc-credential'
 import { isCardEvidenceComplete } from '../utils/card-utils'
+import { performKeyRecovery } from '../utils/key-recovery'
 import { useBCSCApiClientState } from './useBCSCApiClient'
 
 /**
@@ -779,31 +780,34 @@ export const useSecureActions = () => {
         logger.warn('[IsVerified] No credential found but refresh token exists — treating as not verified.')
       }
 
-      if (account && (!account.issuer || !account.clientID)) {
+      let issuer = account?.issuer
+      let clientID = account?.clientID
+
+      if (account && (!issuer || !clientID)) {
         // Account is missing issuer or clientID - this prevents token refresh from working.
         // Recover from authRequest, which preserves these fields from older v3 storage during migration.
         logger.warn(
-          `[hydrateSecureState] Account missing required fields: issuer=${!account.issuer ? 'MISSING' : 'OK'}, clientID=${!account.clientID ? 'MISSING' : 'OK'}. Attempting recovery from authorization request.`
+          `[hydrateSecureState] Account missing required fields: issuer=${!issuer ? 'MISSING' : 'OK'}, clientID=${!clientID ? 'MISSING' : 'OK'}. Attempting recovery from authorization request.`
         )
 
         if (authRequest) {
           try {
-            const recoveredIssuer = account.issuer || authRequest.issuer
-            const recoveredClientID = account.clientID || authRequest.clientID
+            issuer = issuer || authRequest.issuer
+            clientID = clientID || authRequest.clientID
 
-            if (recoveredIssuer && recoveredClientID) {
+            if (issuer && clientID) {
               const securityMethod = await getAccountSecurityMethod()
               const updatedAccount = {
                 ...account,
-                issuer: recoveredIssuer,
-                clientID: recoveredClientID,
+                issuer,
+                clientID,
                 securityMethod,
               }
               logger.info('[hydrateSecureState] Recovered issuer/clientID from authorization request; updating account')
               await setAccount(updatedAccount)
             } else {
               logger.warn(
-                `[hydrateSecureState] Could not recover account fields from authorization request: issuer=${recoveredIssuer ? 'OK' : 'MISSING'}, clientID=${recoveredClientID ? 'OK' : 'MISSING'}`
+                `[hydrateSecureState] Could not recover account fields from authorization request: issuer=${issuer ? 'OK' : 'MISSING'}, clientID=${clientID ? 'OK' : 'MISSING'}`
               )
             }
           } catch (error) {
@@ -821,6 +825,21 @@ export const useSecureActions = () => {
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error)
           logger.error(`[hydrateSecureState] Failed to refresh tokens with stored refresh token: ${message}`)
+          if (clientID && registrationAccessToken) {
+            logger.info('[hydrateSecureState] Attempting key recovery in case of signing key mismatch...')
+            const recovered = await performKeyRecovery(apiClient, clientID, registrationAccessToken, logger)
+            if (recovered) {
+              try {
+                freshTokens = await apiClient.getTokensForRefreshToken(refreshToken)
+                logger.info('[hydrateSecureState] token refresh succeeded after key recovery')
+              } catch (retryError) {
+                const retryMessage = retryError instanceof Error ? retryError.message : String(retryError)
+                logger.error(`[hydrateSecureState] token refresh still failed after key recovery: ${retryMessage}`)
+              }
+            } else {
+              logger.warn('[hydrateSecureState] Key recovery did not occur or did not succeed; tokens remain stale.')
+            }
+          }
         }
       }
 

--- a/app/src/bcsc-theme/utils/key-recovery.test.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.test.ts
@@ -1,15 +1,21 @@
 /**
- * Unit tests for the 401-triggered key-recovery helpers exported from
- * useSecureActions.tsx. These cover the conservative-realignment flow
- * described in the v3-account-reset incident:
+ * Unit tests for the 401-triggered key-recovery helper in ./key-recovery.ts.
+ * These cover the conservative-realignment flow described in the
+ * v3-account-reset incident:
  *
  *   - happy path: server returns a kid that matches a local rsa\d+ alias
  *     → setActiveKeyAlias is called for the match and other local kids
  *     not in the server set are pruned via deleteKey
  *   - safety guard: empty serverKids must NOT prune or reassign
  *   - no-match: server kids exist but none align locally → no mutation
- *   - mutex: concurrent recoverActiveKid invocations share one in-flight
- *     promise (one probe, one result)
+ *   - orphan-is-keychain-newest (iOS-shaped regression): the only
+ *     unmatched local kid happens to be the keychain-newest. The JS layer
+ *     must still ask native to prune it — the native self-delete guard
+ *     was relaxed to "refuse only when deleting would leave zero keys"
+ *     precisely so this case succeeds.
+ *   - native delete refusal is non-fatal: if native throws (e.g.
+ *     E_KEY_DELETE_REFUSED_LAST), the prune loop swallows it and recovery
+ *     still reports success because setActiveKeyAlias already landed.
  */
 
 jest.mock('react-native-bcsc-core', () => ({
@@ -139,7 +145,37 @@ describe('performKeyRecovery', () => {
     expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('recovery probe failed'))
   })
 
-  it('swallows per-key prune failures and still reports success', async () => {
+  it('prunes the unmatched local kid even when it is the keychain-newest', async () => {
+    // Regression test for the iOS native self-delete-refusal bug. Pre-fix,
+    // the native deleteKey on iOS refused any alias whose kSecAttrCreationDate
+    // was the newest, which blocked exactly the case where a stale post-reset
+    // alias was sitting in the keychain as the most-recent entry. The fix
+    // relaxed the native guard to "refuse only when this would leave zero
+    // keys", and this test pins the behaviour: JS must still call deleteKey
+    // on the unmatched newer alias.
+    const apiClient = makeApiClient({ keys: [{ kid: 'rsa1' }] })
+    mockedGetAllKeys.mockResolvedValueOnce([
+      { id: 'rsa1', algorithm: 'RSA', size: 4096, created: 1000 } as any,
+      { id: 'rsa2', algorithm: 'RSA', size: 4096, created: 2000 } as any, // keychain-newest
+    ])
+    // Post-prune verification re-fetches; pretend rsa2 has been removed.
+    mockedGetAllKeys.mockResolvedValueOnce([{ id: 'rsa1', algorithm: 'RSA', size: 4096, created: 1000 } as any])
+    mockedSetActive.mockResolvedValue(undefined as any)
+    mockedDeleteKey.mockResolvedValue(undefined as any)
+    const logger = makeLogger()
+
+    const ok = await performKeyRecovery(apiClient, CLIENT_ID, REG_TOKEN, logger)
+
+    expect(ok).toBe(true)
+    expect(mockedSetActive).toHaveBeenCalledWith('rsa1')
+    expect(mockedDeleteKey).toHaveBeenCalledTimes(1)
+    expect(mockedDeleteKey).toHaveBeenCalledWith('rsa2')
+    // No post-prune mismatch error should fire since the verification mock
+    // reports rsa1 as the sole (and therefore newest) key after prune.
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('swallows per-key prune failures (incl. native E_KEY_DELETE_REFUSED_LAST) and still reports success', async () => {
     const apiClient = makeApiClient({ keys: [{ kid: 'rsa1' }] })
     mockedGetAllKeys.mockResolvedValue([
       { id: 'rsa1', algorithm: 'RSA', size: 4096 } as any,
@@ -149,7 +185,14 @@ describe('performKeyRecovery', () => {
     mockedSetActive.mockResolvedValue(undefined as any)
     mockedDeleteKey.mockImplementation(async (alias: string) => {
       if (alias === 'rsa2') {
-        throw new Error('keystore busy')
+        // Shape mirrors what the native module rejects with — confirms the
+        // prune loop treats the native last-line-of-defence guard as a
+        // soft warning rather than a recovery-blocking failure.
+        const err: Error & { code?: string } = new Error(
+          "Refusing to delete 'rsa2': would leave the keystore with no private keys"
+        )
+        err.code = 'E_KEY_DELETE_REFUSED_LAST'
+        throw err
       }
       return undefined as any
     })

--- a/app/src/bcsc-theme/utils/key-recovery.test.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for the 401-triggered key-recovery helpers exported from
+ * useSecureActions.tsx. These cover the conservative-realignment flow
+ * described in the v3-account-reset incident:
+ *
+ *   - happy path: server returns a kid that matches a local rsa\d+ alias
+ *     → setActiveKeyAlias is called for the match and other local kids
+ *     not in the server set are pruned via deleteKey
+ *   - safety guard: empty serverKids must NOT prune or reassign
+ *   - no-match: server kids exist but none align locally → no mutation
+ *   - mutex: concurrent recoverActiveKid invocations share one in-flight
+ *     promise (one probe, one result)
+ */
+
+jest.mock('react-native-bcsc-core', () => ({
+  getAllKeys: jest.fn(),
+  setActiveKeyAlias: jest.fn(),
+  deleteKey: jest.fn(),
+}))
+
+import { deleteKey, getAllKeys, setActiveKeyAlias } from 'react-native-bcsc-core'
+import { performKeyRecovery } from './key-recovery'
+
+const mockedGetAllKeys = getAllKeys as jest.MockedFunction<typeof getAllKeys>
+const mockedSetActive = setActiveKeyAlias as jest.MockedFunction<typeof setActiveKeyAlias>
+const mockedDeleteKey = deleteKey as jest.MockedFunction<typeof deleteKey>
+
+const makeLogger = () =>
+  ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }) as any
+
+const CLIENT_ID = 'client-abc'
+const REG_TOKEN = 'rat-xyz'
+
+const makeApiClient = (jwks: { keys: { kid: string }[] } | undefined, opts: { throws?: boolean } = {}) => {
+  const get = jest.fn(async () => {
+    if (opts.throws) {
+      throw new Error('network down')
+    }
+    return { data: { client_id: CLIENT_ID, jwks } }
+  })
+  return {
+    endpoints: { registration: 'https://example.test/device/register' },
+    get,
+  } as any
+}
+
+describe('performKeyRecovery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('matches a local kid and prunes other non-server kids (happy path)', async () => {
+    const apiClient = makeApiClient({ keys: [{ kid: 'rsa1' }] })
+    mockedGetAllKeys.mockResolvedValue([
+      { id: 'rsa1', algorithm: 'RSA', size: 4096 } as any,
+      { id: 'rsa2', algorithm: 'RSA', size: 4096 } as any,
+    ])
+    mockedSetActive.mockResolvedValue(undefined as any)
+    mockedDeleteKey.mockResolvedValue(undefined as any)
+    const logger = makeLogger()
+
+    const ok = await performKeyRecovery(apiClient, CLIENT_ID, REG_TOKEN, logger)
+
+    expect(ok).toBe(true)
+    expect(apiClient.get).toHaveBeenCalledWith(
+      `${apiClient.endpoints.registration}/${CLIENT_ID}`,
+      expect.objectContaining({
+        skipBearerAuth: true,
+        headers: { Authorization: `Bearer ${REG_TOKEN}` },
+      })
+    )
+    expect(mockedSetActive).toHaveBeenCalledWith('rsa1')
+    expect(mockedDeleteKey).toHaveBeenCalledTimes(1)
+    expect(mockedDeleteKey).toHaveBeenCalledWith('rsa2')
+  })
+
+  it('preserves local kids that ARE in the server set (no prune)', async () => {
+    const apiClient = makeApiClient({ keys: [{ kid: 'rsa1' }, { kid: 'rsa2' }] })
+    mockedGetAllKeys.mockResolvedValue([
+      { id: 'rsa1', algorithm: 'RSA', size: 4096 } as any,
+      { id: 'rsa2', algorithm: 'RSA', size: 4096 } as any,
+    ])
+    mockedSetActive.mockResolvedValue(undefined as any)
+    const logger = makeLogger()
+
+    const ok = await performKeyRecovery(apiClient, CLIENT_ID, REG_TOKEN, logger)
+
+    expect(ok).toBe(true)
+    // First-listed local kid that intersects wins; the other server kid
+    // remains untouched (not deleted).
+    expect(mockedSetActive).toHaveBeenCalledWith('rsa1')
+    expect(mockedDeleteKey).not.toHaveBeenCalled()
+  })
+
+  it('refuses to reassign or prune when server returns empty jwks', async () => {
+    const apiClient = makeApiClient({ keys: [] })
+    mockedGetAllKeys.mockResolvedValue([{ id: 'rsa1', algorithm: 'RSA', size: 4096 } as any])
+    const logger = makeLogger()
+
+    const ok = await performKeyRecovery(apiClient, CLIENT_ID, REG_TOKEN, logger)
+
+    expect(ok).toBe(false)
+    expect(mockedSetActive).not.toHaveBeenCalled()
+    expect(mockedDeleteKey).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('refusing to prune'))
+  })
+
+  it('returns false (and does not mutate) when no local kid matches', async () => {
+    const apiClient = makeApiClient({ keys: [{ kid: 'rsa9' }] })
+    mockedGetAllKeys.mockResolvedValue([
+      { id: 'rsa1', algorithm: 'RSA', size: 4096 } as any,
+      { id: 'rsa2', algorithm: 'RSA', size: 4096 } as any,
+    ])
+    const logger = makeLogger()
+
+    const ok = await performKeyRecovery(apiClient, CLIENT_ID, REG_TOKEN, logger)
+
+    expect(ok).toBe(false)
+    expect(mockedSetActive).not.toHaveBeenCalled()
+    expect(mockedDeleteKey).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('no local key matches server kids'))
+  })
+
+  it('returns false when the registration probe throws', async () => {
+    const apiClient = makeApiClient(undefined, { throws: true })
+    const logger = makeLogger()
+
+    const ok = await performKeyRecovery(apiClient, CLIENT_ID, REG_TOKEN, logger)
+
+    expect(ok).toBe(false)
+    expect(mockedGetAllKeys).not.toHaveBeenCalled()
+    expect(mockedSetActive).not.toHaveBeenCalled()
+    expect(mockedDeleteKey).not.toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('recovery probe failed'))
+  })
+
+  it('swallows per-key prune failures and still reports success', async () => {
+    const apiClient = makeApiClient({ keys: [{ kid: 'rsa1' }] })
+    mockedGetAllKeys.mockResolvedValue([
+      { id: 'rsa1', algorithm: 'RSA', size: 4096 } as any,
+      { id: 'rsa2', algorithm: 'RSA', size: 4096 } as any,
+      { id: 'rsa3', algorithm: 'RSA', size: 4096 } as any,
+    ])
+    mockedSetActive.mockResolvedValue(undefined as any)
+    mockedDeleteKey.mockImplementation(async (alias: string) => {
+      if (alias === 'rsa2') {
+        throw new Error('keystore busy')
+      }
+      return undefined as any
+    })
+    const logger = makeLogger()
+
+    const ok = await performKeyRecovery(apiClient, CLIENT_ID, REG_TOKEN, logger)
+
+    expect(ok).toBe(true)
+    expect(mockedDeleteKey).toHaveBeenCalledWith('rsa2')
+    expect(mockedDeleteKey).toHaveBeenCalledWith('rsa3')
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining(`failed to prune 'rsa2'`))
+  })
+})

--- a/app/src/bcsc-theme/utils/key-recovery.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.ts
@@ -1,0 +1,117 @@
+import { BifoldLogger } from '@bifold/core'
+import { deleteKey, getAllKeys, setActiveKeyAlias } from 'react-native-bcsc-core'
+import BCSCApiClient from '../api/client'
+
+interface ServerJwk {
+  kid: string
+  kty?: string
+}
+
+interface ServerClientRegistrationView {
+  client_id: string
+  jwks?: { keys?: ServerJwk[] }
+}
+
+/**
+ * Probe the BCSC server for its current view of registered signing keys and
+ * realign local key state to match. Called when /device/token returns 401,
+ * which (after the conservative reconcile) is overwhelmingly caused by the
+ * wallet signing with a kid the server no longer recognises (e.g. post-v3-
+ * reset, post-keystore-restore, or post-rotation desync).
+ *
+ * Steps:
+ *  1. GET /device/register/{client_id} with the registration_access_token
+ *     to read jwks.keys[].kid (the server's source of truth).
+ *  2. Enumerate every rsa\d+ key in the local keystore via getAllKeys().
+ *  3. Intersect by kid string. If a local kid matches, mark it active via
+ *     setActiveKeyAlias() so the next sign uses it.
+ *  4. Prune local keys whose kid is NOT in the server set. Guarded by
+ *     `serverKids.length >= 1` so an unexpectedly empty jwks response never
+ *     wipes the device; the native delete additionally refuses to remove
+ *     the currently-active alias.
+ *
+ * @returns true if recovery completed and the caller should retry token
+ *   refresh once; false if no recovery occurred (no token, no match,
+ *   network/probe failure, or empty server jwks).
+ */
+export async function performKeyRecovery(
+  apiClient: BCSCApiClient,
+  clientId: string,
+  registrationAccessToken: string,
+  logger: BifoldLogger
+): Promise<boolean> {
+  try {
+    const { data } = await apiClient.get<ServerClientRegistrationView>(
+      `${apiClient.endpoints.registration}/${clientId}`,
+      {
+        skipBearerAuth: true,
+        headers: { Authorization: `Bearer ${registrationAccessToken}` },
+      }
+    )
+    const serverKids = (data?.jwks?.keys ?? [])
+      .map((k) => k?.kid)
+      .filter((k): k is string => typeof k === 'string' && k.length > 0)
+    if (serverKids.length === 0) {
+      logger.warn('[performKeyRecovery] event=failed_empty_jwks server returned no jwks; refusing to prune or reassign')
+      return false
+    }
+    const localKeys = await getAllKeys()
+    const localIds = localKeys.map((k) => k.id)
+    const matched = localKeys.find((k) => serverKids.includes(k.id))
+    if (!matched) {
+      logger.warn(
+        `[performKeyRecovery] event=failed_no_match no local key matches server kids (server=${JSON.stringify(serverKids)}, local=${JSON.stringify(localIds)})`
+      )
+      return false
+    }
+    logger.info(`[performKeyRecovery] matched local kid '${matched.id}' against server jwks`)
+    await setActiveKeyAlias(matched.id)
+    let prunedCount = 0
+    let pruneFailures = 0
+    for (const k of localKeys) {
+      if (k.id === matched.id) {
+        continue
+      }
+      if (serverKids.includes(k.id)) {
+        continue
+      }
+      try {
+        await deleteKey(k.id)
+        prunedCount++
+        logger.info(`[performKeyRecovery] pruned local kid '${k.id}'`)
+      } catch (err) {
+        pruneFailures++
+        const m = err instanceof Error ? err.message : String(err)
+        logger.warn(`[performKeyRecovery] failed to prune '${k.id}': ${m}`)
+      }
+    }
+    // Post-prune invariant check. On iOS, setActiveKeyAlias is validate-only
+    // (kSecAttrCreationDate is read-only) — the matched alias only becomes
+    // de-facto active once everything newer is gone. On Android, the active
+    // alias is whichever has the newest createdAt. Either way, after recovery
+    // the highest-created entry returned by getAllKeys() should be `matched`.
+    // If it isn't, signing will still hit the wrong kid and we'll just loop
+    // back into recovery on the next request — loud log is preferable to
+    // silent loop.
+    try {
+      const post = await getAllKeys()
+      const newest = post.slice().sort((a, b) => (b.created ?? 0) - (a.created ?? 0))[0]
+      if (newest && newest.id !== matched.id) {
+        logger.error(
+          `[performKeyRecovery] event=post_prune_active_mismatch expected newest='${matched.id}' but got '${newest.id}' (remaining=${JSON.stringify(post.map((k) => k.id))})`
+        )
+      }
+    } catch (verifyErr) {
+      const m = verifyErr instanceof Error ? verifyErr.message : String(verifyErr)
+      logger.warn(`[performKeyRecovery] post-prune verification failed: ${m}`)
+    }
+    logger.info(
+      `[performKeyRecovery] event=succeeded active='${matched.id}' pruned=${prunedCount} prune_failures=${pruneFailures}`
+    )
+    return true
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    logger.error(`[performKeyRecovery] event=failed_probe recovery probe failed: ${message}`)
+    return false
+  }
+}

--- a/app/src/bcsc-theme/utils/key-recovery.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.ts
@@ -27,8 +27,10 @@ interface ServerClientRegistrationView {
  *     setActiveKeyAlias() so the next sign uses it.
  *  4. Prune local keys whose kid is NOT in the server set. Guarded by
  *     `serverKids.length >= 1` so an unexpectedly empty jwks response never
- *     wipes the device; the native delete additionally refuses to remove
- *     the currently-active alias.
+ *     wipes the device; this loop additionally skips `matched.id` so the
+ *     just-selected active alias is never a prune target. The native delete
+ *     has its own last-line-of-defence guard that refuses to remove the
+ *     final remaining alias.
  *
  * @returns true if recovery completed and the caller should retry token
  *   refresh once; false if no recovery occurred (no token, no match,

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -222,26 +222,94 @@ class BcscCoreModule(
                 return
             }
 
-            // Get the current key pair (this will create one if none exists)
-            val currentKeyPair = keyPairSource.getCurrentBcscKeyPair()
+            // Enumerate every rsa\d+ alias the keystore actually holds. This is the
+            // source of truth for the recovery flow: matching local keys against the
+            // server's jwks requires visibility into orphan aliases that metadata
+            // may not yet track.
+            val infos = keyPairSource.getAllBcscKeyPairInfos()
 
             val privateKeys: WritableArray = Arguments.createArray()
-            val keyInfo: WritableMap = Arguments.createMap()
-
-            // Add the current key pair info
-            val info = currentKeyPair.getKeyInfo()
-            keyInfo.putString("id", info.getAlias())
-            keyInfo.putString("keyType", "RSA") // bcsc-keypair-port uses RSA keys
-            keyInfo.putInt("keySize", 4096) // bcsc-keypair-port uses 4096-bit RSA keys
-            keyInfo.putDouble("created", info.getCreatedAt().toDouble())
-
-            privateKeys.pushMap(keyInfo)
+            for (info in infos) {
+                val keyInfo: WritableMap = Arguments.createMap()
+                keyInfo.putString("id", info.getAlias())
+                keyInfo.putString("keyType", "RSA")
+                keyInfo.putInt("keySize", 4096)
+                keyInfo.putDouble("created", info.getCreatedAt().toDouble())
+                privateKeys.pushMap(keyInfo)
+            }
 
             promise.resolve(privateKeys)
         } catch (e: BcscException) {
             promise.reject("E_KEYSTORE_ERROR", "Error accessing keystore: ${e.devMessage}", e)
         } catch (e: Exception) {
             promise.reject("E_KEYSTORE_ERROR", "Unexpected error accessing keystore: ${e.message}", e)
+        }
+    }
+
+    /**
+     * Mark a keystore alias as the active (newest) key. Called by the recovery
+     * flow after the server confirms which kid it accepts. Refuses if the alias
+     * is not present in the keystore so the app never points at a missing key.
+     */
+    @ReactMethod
+    fun setActiveKeyAlias(
+        alias: String,
+        promise: Promise,
+    ) {
+        try {
+            if (!keyPairSource.isAvailable()) {
+                promise.reject("E_KEYSTORE_UNAVAILABLE", "Android KeyStore is not available on this device")
+                return
+            }
+            val present = keyPairSource.getAllBcscKeyPairInfos().any { it.getAlias() == alias }
+            if (!present) {
+                promise.reject("E_KEY_NOT_FOUND", "Alias '$alias' is not present in the keystore")
+                return
+            }
+            keyPairSource.markActiveBcscKeyPair(alias)
+            promise.resolve(null)
+        } catch (e: BcscException) {
+            promise.reject("E_KEYSTORE_ERROR", "Error marking active alias: ${e.devMessage}", e)
+        } catch (e: Exception) {
+            promise.reject("E_KEYSTORE_ERROR", "Unexpected error marking active alias: ${e.message}", e)
+        }
+    }
+
+    /**
+     * Permanently delete a keystore alias and its metadata entry. Called by the
+     * recovery flow to prune local keys the server does not recognise. Refuses
+     * to delete the currently-active alias as a defence in depth against the
+     * recovery flow accidentally orphaning the signing key.
+     */
+    @ReactMethod
+    fun deleteKey(
+        alias: String,
+        promise: Promise,
+    ) {
+        try {
+            if (!keyPairSource.isAvailable()) {
+                promise.reject("E_KEYSTORE_UNAVAILABLE", "Android KeyStore is not available on this device")
+                return
+            }
+            val current =
+                try {
+                    keyPairSource.getCurrentBcscKeyPair().getKeyInfo().getAlias()
+                } catch (_: Exception) {
+                    null
+                }
+            if (current != null && current == alias) {
+                promise.reject(
+                    "E_KEY_DELETE_REFUSED_SELF",
+                    "Refusing to delete the currently-active alias '$alias'",
+                )
+                return
+            }
+            keyPairSource.deleteBcscKeyPair(alias)
+            promise.resolve(null)
+        } catch (e: BcscException) {
+            promise.reject("E_KEYSTORE_ERROR", "Error deleting key: ${e.devMessage}", e)
+        } catch (e: Exception) {
+            promise.reject("E_KEYSTORE_ERROR", "Unexpected error deleting key: ${e.message}", e)
         }
     }
 

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -277,9 +277,13 @@ class BcscCoreModule(
 
     /**
      * Permanently delete a keystore alias and its metadata entry. Called by the
-     * recovery flow to prune local keys the server does not recognise. Refuses
-     * to delete the currently-active alias as a defence in depth against the
-     * recovery flow accidentally orphaning the signing key.
+     * recovery flow to prune local keys the server does not recognise.
+     *
+     * Defence-in-depth: refuses to delete the alias if doing so would leave the
+     * keystore with zero rsa\d+ aliases, which would brick signing entirely.
+     * The JS recovery layer is authoritative for never deleting the matched
+     * alias; this guard exists so that a buggy caller (or future regression)
+     * cannot wipe the device's last private key. Mirrors the iOS guard.
      */
     @ReactMethod
     fun deleteKey(
@@ -291,16 +295,16 @@ class BcscCoreModule(
                 promise.reject("E_KEYSTORE_UNAVAILABLE", "Android KeyStore is not available on this device")
                 return
             }
-            val current =
+            val remainingCount =
                 try {
-                    keyPairSource.getCurrentBcscKeyPair().getKeyInfo().getAlias()
+                    keyPairSource.getAllBcscKeyPairInfos().count { it.getAlias() != alias }
                 } catch (_: Exception) {
-                    null
+                    -1
                 }
-            if (current != null && current == alias) {
+            if (remainingCount == 0) {
                 promise.reject(
-                    "E_KEY_DELETE_REFUSED_SELF",
-                    "Refusing to delete the currently-active alias '$alias'",
+                    "E_KEY_DELETE_REFUSED_LAST",
+                    "Refusing to delete '$alias': would leave the keystore with no private keys",
                 )
                 return
             }

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/core/interfaces/BcscKeyPairSource.java
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/core/interfaces/BcscKeyPairSource.java
@@ -3,10 +3,12 @@ package com.bcsccore.keypair.core.interfaces;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.bcsccore.keypair.core.models.BcscKeyPair;
+import com.bcsccore.keypair.core.models.KeyPairInfo;
 import com.bcsccore.keypair.core.exceptions.BcscException;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import java.util.List;
 
 /**
  * Interface for BC Services Card key pair operations.
@@ -53,6 +55,26 @@ public interface BcscKeyPairSource {
    * @throws BcscException if deletion fails
    */
   void deleteBcscKeyPair(@NonNull String alias) throws BcscException;
+
+  /**
+   * Enumerate every key pair backed by an entry in the platform keystore.
+   * The createdAt on each result reflects metadata when present, or 0 when
+   * the alias exists in the keystore but has no metadata entry yet.
+   * Used by the recovery flow to match local keys against the server jwks.
+   * @return list of KeyPairInfo entries; empty list if the keystore is empty.
+   * @throws BcscException if the keystore cannot be read
+   */
+  @NonNull
+  List<KeyPairInfo> getAllBcscKeyPairInfos() throws BcscException;
+
+  /**
+   * Mark the given alias as the active (newest) key by stamping its
+   * createdAt to now. Creates a metadata entry if none exists. Does not
+   * touch the keystore.
+   * @param alias the alias to mark active
+   * @throws BcscException if metadata cannot be written
+   */
+  void markActiveBcscKeyPair(@NonNull String alias) throws BcscException;
 
   /**
    * Clean up old key pairs to manage storage.

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
@@ -35,8 +35,10 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.UnrecoverableEntryException;
 import java.security.interfaces.RSAPublicKey;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -282,51 +284,90 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
   }
 
   /**
-   * Make sure every rsa\d+ key sitting in the AndroidKeyStore also has a
-   * KeyPairInfo entry in our SharedPreferences-backed metadata.
+   * Conservative bootstrap for KeyPairInfo metadata when nothing is tracked yet.
    *
-   * Why this exists: users upgrading from v3 ias-android keep their keystore
-   * (same applicationId) but lose their v3 metadata (v3 stored it in an
-   * encrypted file, v4 stores it in SharedPreferences). Without this step,
-   * v4 would ignore the keys IAS actually has registered and sign with a
-   * fresh rsa1 instead, producing a 401 on /device/token.
+   * Source of truth for "which kid is active" is the server (validated via
+   * GET /device/register/{client_id} and the recovery flow in the app layer).
+   * This method exists only to bootstrap metadata when we have no other
+   * information at all: e.g. a v3 user upgraded in place, keystore preserved,
+   * but SharedPreferences empty.
    *
-   * Approach: any keystore alias matching rsa\d+ that isn't already tracked
-   * gets a KeyPairInfo with a synthetic createdAt. The createdAt values are
-   * chosen so a higher-numbered alias is newer than a lower-numbered one --
-   * that's all getNewestKeyPairInfo / getOldestKeyPairInfo care about.
-   *
-   * Safe to call on every access: if nothing is missing, this is a no-op.
+   * Behaviour:
+   *   - If metadata already has any entry, this is a no-op. We trust metadata;
+   *     orphaned keystore aliases (e.g. left over from a v3 account reset) are
+   *     intentionally NOT promoted to "newest" here. The recovery flow will
+   *     prune them once the server confirms which kid is real.
+   *   - If metadata is empty AND keystore has rsa\d+ aliases, backfill them
+   *     with synthetic createdAt values so the highest-numbered alias becomes
+   *     newest. This is a last-resort guess (numeric ordering is wrong after
+   *     a v3 account reset that restarts at rsa1); the recovery flow corrects
+   *     it on the first 401.
    */
   private void reconcileKeyPairInfoWithKeyStore(@NonNull KeyStore keyStore) throws BcscException {
-    // 1. Find every rsa\d+ alias the keystore knows about, sorted by number.
+    HashMap<String, KeyPairInfo> existing = keyPairInfoSource.getKeyPairInfo();
+    if (!existing.isEmpty()) {
+      SimpleLog.d(TAG, "reconcile: metadata non-empty; trusting existing entries (" + existing.keySet() + ")");
+      return;
+    }
+
     java.util.TreeMap<Integer, String> keystoreAliases = findRsaAliasesInKeyStore(keyStore);
     if (keystoreAliases.isEmpty()) {
+      SimpleLog.d(TAG, "reconcile: metadata empty and no rsa\\d+ aliases in keystore; nothing to do");
       return;
     }
 
-    // 2. Drop the ones we already have metadata for.
-    HashMap<String, KeyPairInfo> existing = keyPairInfoSource.getKeyPairInfo();
-    java.util.TreeMap<Integer, String> missing = new java.util.TreeMap<>();
-    for (java.util.Map.Entry<Integer, String> entry : keystoreAliases.entrySet()) {
-      if (!existing.containsKey(entry.getValue())) {
-        missing.put(entry.getKey(), entry.getValue());
-      }
-    }
-    if (missing.isEmpty()) {
-      return;
-    }
-
-    // 3. Backfill metadata for the rest. The newest alias gets "now"; older
-    //    aliases get progressively earlier timestamps so ordering is right.
     long now = System.currentTimeMillis();
-    int highestId = missing.lastKey();
-    for (java.util.Map.Entry<Integer, String> entry : missing.entrySet()) {
+    int highestId = keystoreAliases.lastKey();
+    for (java.util.Map.Entry<Integer, String> entry : keystoreAliases.entrySet()) {
       long createdAt = now - (long) (highestId - entry.getKey());
       keyPairInfoSource.saveKeyPairInfo(new KeyPairInfo(entry.getValue(), createdAt));
     }
-    SimpleLog.d(TAG, "Reconciled KeyPairInfo with keystore; backfilled aliases "
-        + missing.values() + " (keystore had " + keystoreAliases.values() + ")");
+    SimpleLog.d(TAG, "reconcile: bootstrapped empty metadata from keystore aliases "
+        + keystoreAliases.values() + " (synthetic timestamps; will be corrected on first 401 recovery)");
+  }
+
+  /**
+   * Enumerate every rsa\d+ alias that exists in the AndroidKeyStore, augmented
+   * with the createdAt from metadata when present. This is the source of truth
+   * for "what private keys does this device actually hold" — used by the
+   * recovery flow to match local keys against the server's jwks.
+   *
+   * @return list of KeyPairInfo, one per keystore alias matching rsa\d+. The
+   *         createdAt is 0 for aliases not yet tracked in metadata. Empty list
+   *         (never null) if the keystore can't be read.
+   */
+  @NonNull
+  @Override
+  public List<KeyPairInfo> getAllBcscKeyPairInfos() throws BcscException {
+    try {
+      KeyStore keyStore = loadAndroidKeyStore();
+      java.util.TreeMap<Integer, String> keystoreAliases = findRsaAliasesInKeyStore(keyStore);
+      HashMap<String, KeyPairInfo> metadata = keyPairInfoSource.getKeyPairInfo();
+      List<KeyPairInfo> result = new ArrayList<>(keystoreAliases.size());
+      for (String alias : keystoreAliases.values()) {
+        KeyPairInfo tracked = metadata.get(alias);
+        result.add(tracked != null ? tracked : new KeyPairInfo(alias, 0L));
+      }
+      return result;
+    } catch (BcscException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new BcscException("Failed to enumerate keystore aliases: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Mark the given alias as the active (newest) key in metadata. Called by
+   * the recovery flow after the server confirms which kid it accepts.
+   *
+   * Updates createdAt = now so getNewestKeyPairInfo returns this alias on
+   * subsequent calls. If the alias has no metadata entry yet (e.g. it was a
+   * keystore-only orphan before recovery), an entry is created.
+   */
+  @Override
+  public void markActiveBcscKeyPair(@NonNull String alias) throws BcscException {
+    keyPairInfoSource.saveKeyPairInfo(new KeyPairInfo(alias, System.currentTimeMillis()));
+    SimpleLog.d(TAG, "markActiveBcscKeyPair: " + alias + " stamped as newest");
   }
 
   /**

--- a/packages/bcsc-core/android/src/test/java/com/bcsccore/keypair/repos/key/BcscKeyPairRepoSeedingTest.kt
+++ b/packages/bcsc-core/android/src/test/java/com/bcsccore/keypair/repos/key/BcscKeyPairRepoSeedingTest.kt
@@ -177,6 +177,94 @@ class BcscKeyPairRepoSeedingTest {
     }
 
     // -----------------------------------------------------------------------
+    // (3b) Conservative reconcile: when metadata already exists, the keystore
+    //      is NOT used to backfill orphan aliases.
+    //
+    //      This guards against the v3-account-reset case where the keystore
+    //      retains an orphan (e.g. rsa2) from a previous identity while
+    //      metadata correctly points at rsa1 — synthetic timestamps used to
+    //      misrank rsa2 as newest and cause a 401. The server-driven recovery
+    //      flow is the only path that may now reassign the active alias.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `reconcile preserves existing metadata and ignores orphan keystore aliases`() {
+        val now = System.currentTimeMillis()
+        val infoSource =
+            InMemoryKeyPairInfoSource(
+                mapOf("rsa1" to KeyPairInfo("rsa1", now)),
+            )
+        val repo = BcscKeyPairRepo(infoSource)
+
+        // Keystore holds an orphan rsa2 left over from a v3 account reset.
+        reconcile(repo, keystoreWith(listOf("rsa1", "rsa2")))
+
+        val saved = infoSource.store
+        assertEquals(
+            "metadata must not gain an entry for the orphan rsa2 alias",
+            1,
+            saved.size,
+        )
+        assertTrue("the original rsa1 entry must remain", saved.containsKey("rsa1"))
+        assertFalse(
+            "orphan rsa2 must NOT be backfilled when metadata is non-empty — only the recovery flow may add it",
+            saved.containsKey("rsa2"),
+        )
+        assertEquals(
+            "the original rsa1 createdAt must not be rewritten by reconcile",
+            now,
+            saved["rsa1"]!!.createdAt,
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // (3c) markActiveBcscKeyPair stamps the given alias as the newest entry
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `markActiveBcscKeyPair creates a metadata entry with the current timestamp`() {
+        val infoSource = InMemoryKeyPairInfoSource()
+        val repo = BcscKeyPairRepo(infoSource)
+
+        val before = System.currentTimeMillis()
+        repo.markActiveBcscKeyPair("rsa3")
+        val after = System.currentTimeMillis()
+
+        val saved = infoSource.store["rsa3"]
+        assertNotNull("markActiveBcscKeyPair must create an entry when none exists", saved)
+        assertTrue(
+            "createdAt must be stamped with the current time",
+            saved!!.createdAt in before..after,
+        )
+    }
+
+    @Test
+    fun `markActiveBcscKeyPair promotes an existing alias to newest`() {
+        // rsa1 is stamped in the distant past so a same-millisecond execution of
+        // markActiveBcscKeyPair still produces a strictly-greater timestamp.
+        val rsa1CreatedAt = System.currentTimeMillis() - 60_000L
+        val infoSource =
+            InMemoryKeyPairInfoSource(
+                mapOf(
+                    "rsa1" to KeyPairInfo("rsa1", rsa1CreatedAt), // currently newest
+                    "rsa2" to KeyPairInfo("rsa2", rsa1CreatedAt - 10_000L), // orphan, older
+                ),
+            )
+        val repo = BcscKeyPairRepo(infoSource)
+
+        val before = System.currentTimeMillis()
+        repo.markActiveBcscKeyPair("rsa2")
+
+        val rsa1 = infoSource.store["rsa1"]!!
+        val rsa2 = infoSource.store["rsa2"]!!
+        assertEquals("rsa1's timestamp must not be touched", rsa1CreatedAt, rsa1.createdAt)
+        assertTrue(
+            "rsa2 must now be newer than rsa1 after markActiveBcscKeyPair",
+            rsa2.createdAt >= before && rsa2.createdAt > rsa1.createdAt,
+        )
+    }
+
+    // -----------------------------------------------------------------------
     // (4) signClaimsSet – kid in JWS header matches the active key alias, and
     //     the alias identifies the key that actually produced the signature.
     // -----------------------------------------------------------------------

--- a/packages/bcsc-core/ios/BcscCore.m
+++ b/packages/bcsc-core/ios/BcscCore.m
@@ -4,6 +4,12 @@
 
 RCT_EXTERN_METHOD(getAllKeys : (RCTPromiseResolveBlock)resolve reject : (RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(setActiveKeyAlias : (NSString *)alias resolve : (RCTPromiseResolveBlock)
+                      resolve reject : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(deleteKey : (NSString *)alias resolve : (RCTPromiseResolveBlock)
+                      resolve reject : (RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(getKeyPair : (NSString *)label resolve : (RCTPromiseResolveBlock)
                       resolve reject : (RCTPromiseRejectBlock)reject)
 

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -216,6 +216,61 @@ class BcscCore: NSObject {
     resolve(result)
   }
 
+  /**
+   * Mark a keychain alias as the active (newest) signing key.
+   *
+   * iOS picks the active key by `kSecAttrCreationDate` (newest-first), which is
+   * read-only at the keychain level. The recovery flow's contract is that
+   * setActiveKeyAlias is followed immediately by deleteKey() on every other
+   * alias — once the unmatched aliases are pruned, the matched alias becomes
+   * de-facto active by elimination. This method therefore only verifies the
+   * alias actually exists; the prune step does the heavy lifting.
+   */
+  @objc(setActiveKeyAlias:resolve:reject:)
+  func setActiveKeyAlias(
+    _ alias: String,
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    let keyPairManager = KeyPairManager()
+    let keys = keyPairManager.findAllPrivateKeys()
+    guard keys.contains(where: { $0.tag == alias }) else {
+      reject("E_KEY_NOT_FOUND", "Alias '\(alias)' is not present in the keychain", nil)
+      return
+    }
+    resolve(nil)
+  }
+
+  /**
+   * Permanently delete a keychain alias. Used by the 401 key-recovery flow to
+   * prune local keys the server does not recognise. Refuses to delete the
+   * currently-active alias (the keychain-newest) as a defence in depth.
+   */
+  @objc(deleteKey:resolve:reject:)
+  func deleteKey(
+    _ alias: String,
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    let keyPairManager = KeyPairManager()
+    let keys = keyPairManager.findAllPrivateKeys()
+    let activeAlias = keys.sorted(by: { $0.created > $1.created }).first?.tag
+    if let active = activeAlias, active == alias {
+      reject(
+        "E_KEY_DELETE_REFUSED_SELF",
+        "Refusing to delete the currently-active alias '\(alias)'",
+        nil
+      )
+      return
+    }
+    let deleted = keyPairManager.deleteKey(withLabel: alias)
+    if deleted {
+      resolve(nil)
+    } else {
+      reject("E_KEYSTORE_ERROR", "Failed to delete key '\(alias)' from keychain", nil)
+    }
+  }
+
   func getKeyPair(
     _ label: String, resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -243,8 +243,15 @@ class BcscCore: NSObject {
 
   /**
    * Permanently delete a keychain alias. Used by the 401 key-recovery flow to
-   * prune local keys the server does not recognise. Refuses to delete the
-   * currently-active alias (the keychain-newest) as a defence in depth.
+   * prune local keys the server does not recognise.
+   *
+   * Defence-in-depth: refuses to delete the alias if doing so would leave the
+   * keychain with zero private keys, which would brick signing entirely. The
+   * JS recovery layer is authoritative for never deleting the matched/active
+   * alias — we deliberately do NOT guard "active" here, because on iOS
+   * kSecAttrCreationDate is read-only and the matched alias only becomes
+   * keychain-newest after the unmatched newer alias is pruned (see
+   * setActiveKeyAlias). Guarding by "newest" would block the recovery path.
    */
   @objc(deleteKey:resolve:reject:)
   func deleteKey(
@@ -254,11 +261,11 @@ class BcscCore: NSObject {
   ) {
     let keyPairManager = KeyPairManager()
     let keys = keyPairManager.findAllPrivateKeys()
-    let activeAlias = keys.sorted(by: { $0.created > $1.created }).first?.tag
-    if let active = activeAlias, active == alias {
+    let remaining = keys.filter { $0.tag != alias }
+    if remaining.isEmpty {
       reject(
-        "E_KEY_DELETE_REFUSED_SELF",
-        "Refusing to delete the currently-active alias '\(alias)'",
+        "E_KEY_DELETE_REFUSED_LAST",
+        "Refusing to delete '\(alias)': would leave the keychain with no private keys",
         nil
       )
       return

--- a/packages/bcsc-core/src/NativeBcscCore.ts
+++ b/packages/bcsc-core/src/NativeBcscCore.ts
@@ -246,6 +246,16 @@ export type NativeSavedService = {
 
 export interface Spec extends TurboModule {
   getAllKeys(): Promise<PrivateKeyInfo[]>;
+  /**
+   * Mark a keystore alias as the active (newest) signing key. Rejects with
+   * E_KEY_NOT_FOUND if the alias is not present in the keystore.
+   */
+  setActiveKeyAlias(alias: string): Promise<void>;
+  /**
+   * Permanently delete a keystore alias and its metadata entry. Rejects with
+   * E_KEY_DELETE_REFUSED_SELF if the alias is currently active.
+   */
+  deleteKey(alias: string): Promise<void>;
   getKeyPair(label: string): Promise<KeyPair>;
   getToken(tokenType: number): Promise<NativeToken | null>;
 

--- a/packages/bcsc-core/src/NativeBcscCore.ts
+++ b/packages/bcsc-core/src/NativeBcscCore.ts
@@ -253,7 +253,7 @@ export interface Spec extends TurboModule {
   setActiveKeyAlias(alias: string): Promise<void>;
   /**
    * Permanently delete a keystore alias and its metadata entry. Rejects with
-   * E_KEY_DELETE_REFUSED_SELF if the alias is currently active.
+   * E_KEY_DELETE_REFUSED_LAST if deleting would leave zero private keys.
    */
   deleteKey(alias: string): Promise<void>;
   getKeyPair(label: string): Promise<KeyPair>;

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -276,7 +276,8 @@ export const setActiveKeyAlias = (alias: string): Promise<void> => {
 /**
  * Permanently deletes a keystore alias and its metadata entry. Used by the
  * 401 key-recovery flow to prune local keys the server does not recognise.
- * Rejects with `E_KEY_DELETE_REFUSED_SELF` if the alias is currently active.
+ * Rejects with `E_KEY_DELETE_REFUSED_LAST` if deleting the alias would leave
+ * the device with no private keys (defence-in-depth against bricking signing).
  */
 export const deleteKey = (alias: string): Promise<void> => {
   return BcscCore.deleteKey(alias);

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -265,6 +265,24 @@ export const getAllKeys = (): Promise<PrivateKeyInfo[]> => {
 };
 
 /**
+ * Marks a keystore alias as the active (newest) signing key. Used by the 401
+ * key-recovery flow to point the wallet at the kid the server confirms it
+ * accepts. Rejects with `E_KEY_NOT_FOUND` if the alias is not in the keystore.
+ */
+export const setActiveKeyAlias = (alias: string): Promise<void> => {
+  return BcscCore.setActiveKeyAlias(alias);
+};
+
+/**
+ * Permanently deletes a keystore alias and its metadata entry. Used by the
+ * 401 key-recovery flow to prune local keys the server does not recognise.
+ * Rejects with `E_KEY_DELETE_REFUSED_SELF` if the alias is currently active.
+ */
+export const deleteKey = (alias: string): Promise<void> => {
+  return BcscCore.deleteKey(alias);
+};
+
+/**
  * Retrieves a key pair (public and optionally private) for a given label.
  * @param label The identifier for the key pair.
  * @returns A promise that resolves to a KeyPair object.


### PR DESCRIPTION
# Summary of Changes

Key probing and pruning on key mismatch token failure.

# Testing Instructions

Test path:
- v3, verify, key rotation, expiry, reverify in v3, update to v4 main pre-last-fix-PR, update to v4 main, update to this branch, recovery happens, fixed

# Acceptance Criteria

Proper key recovery works

# Screenshots, videos, or gifs

N/A

# Related Issues

#3870 