### PR TITLE
fix: email confirmation error dialog

### DIFF
--- a/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
@@ -11,6 +11,7 @@ import {
   birthdateLockoutErrorPolicy,
   cardExpiredErrorPolicy,
   ClientErrorHandlingPolicies,
+  emailVerificationCodeErrorPolicy,
   failedToRetrieveStringResourceErrorPolicy,
   globalAlertErrorPolicy,
   iasErrorPolicy,
@@ -644,6 +645,75 @@ describe('clientErrorPolicies', () => {
     })
   })
 
+  describe('emailVerificationCodeErrorPolicy', () => {
+    const evidenceBase = 'https://idsit.gov.bc.ca/evidence'
+
+    describe('matches', () => {
+      it('should match 404 on email verification PUT endpoint', () => {
+        const error = newError('unknown_server_error')
+        const context = {
+          statusCode: 404,
+          endpoint: `${evidenceBase}/v1/emails/349802`,
+          apiEndpoints: { evidence: evidenceBase },
+        }
+        expect(emailVerificationCodeErrorPolicy.matches(error, context as any)).toBeTruthy()
+      })
+
+      it('should match 400 on email verification PUT endpoint', () => {
+        const error = newError('unknown_server_error')
+        const context = {
+          statusCode: 400,
+          endpoint: `${evidenceBase}/v1/emails/349802`,
+          apiEndpoints: { evidence: evidenceBase },
+        }
+        expect(emailVerificationCodeErrorPolicy.matches(error, context as any)).toBeTruthy()
+      })
+
+      it('should NOT match the email creation POST endpoint (no id in path)', () => {
+        const error = newError('unknown_server_error')
+        const context = {
+          statusCode: 400,
+          endpoint: `${evidenceBase}/v1/emails`,
+          apiEndpoints: { evidence: evidenceBase },
+        }
+        expect(emailVerificationCodeErrorPolicy.matches(error, context as any)).toBeFalsy()
+      })
+
+      it('should NOT match other status codes on the verification endpoint', () => {
+        const error = newError('unknown_server_error')
+        const context = {
+          statusCode: 500,
+          endpoint: `${evidenceBase}/v1/emails/349802`,
+          apiEndpoints: { evidence: evidenceBase },
+        }
+        expect(emailVerificationCodeErrorPolicy.matches(error, context as any)).toBeFalsy()
+      })
+
+      it('should NOT match 404 on unrelated endpoints', () => {
+        const error = newError('unknown_server_error')
+        const context = {
+          statusCode: 404,
+          endpoint: `${evidenceBase}/v1/photos/123`,
+          apiEndpoints: { evidence: evidenceBase },
+        }
+        expect(emailVerificationCodeErrorPolicy.matches(error, context as any)).toBeFalsy()
+      })
+    })
+
+    describe('handle', () => {
+      it('should log expected info message', () => {
+        const error = newError('unknown_server_error')
+        const loggerMock = { info: jest.fn() }
+        const context = { logger: loggerMock }
+        emailVerificationCodeErrorPolicy.handle(error, context as any)
+
+        expect(loggerMock.info).toHaveBeenCalledWith(
+          '[EmailVerificationCodeErrorPolicy] Suppressing global alert — confirmation screen will show inline error for invalid code'
+        )
+      })
+    })
+  })
+
   describe('failedToRetrieveStringResourceErrorPolicy', () => {
     describe('matches', () => {
       it('should match ERR_400_FAILED_TO_RETRIEVE_STRING_RESOURCE', () => {
@@ -781,6 +851,13 @@ describe('clientErrorPolicies', () => {
         expect(indexOfStringResource).toBeLessThan(indexOfGlobalAlert)
         expect(indexOfInvalidUrl).toBeLessThan(indexOfGlobalAlert)
         expect(indexOfInvalidRegistration).toBeLessThan(indexOfGlobalAlert)
+      })
+
+      it('should have emailVerificationCodeErrorPolicy before iasErrorPolicy so 400/404 do not route to the err_209 alert', () => {
+        const indexOfEmailVerification = ClientErrorHandlingPolicies.indexOf(emailVerificationCodeErrorPolicy)
+        const indexOfIas = ClientErrorHandlingPolicies.indexOf(iasErrorPolicy)
+
+        expect(indexOfEmailVerification).toBeLessThan(indexOfIas)
       })
 
       it('should prefer alreadyRegisteredErrorPolicy for ERR_501 with "client is in invalid" on deviceAuthorization', () => {

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -248,6 +248,29 @@ export const attestationPollingErrorPolicy: ErrorHandlingPolicy = {
   },
 }
 
+// Error policy for email verification code submission — 400/404 indicate a wrong or
+// expired code, which is a user-input error. Suppress the global modal so the
+// EmailConfirmationScreen can show its own inline error instead of the misleading
+// "App not installed correctly (error 209)" alert.
+//
+// Matches by path pattern (PUT /v1/emails/{id}) rather than the full evidence base URL,
+// because the discovery-provided evidence_endpoint can differ from the fallback (trailing
+// slash, version suffix, etc.) and we don't want this match to silently break.
+const EMAIL_VERIFICATION_PATH_PATTERN = /\/v1\/emails\/[^/?#]+/
+export const emailVerificationCodeErrorPolicy: ErrorHandlingPolicy = {
+  matches: (_, context) => {
+    return (
+      (context.statusCode === 400 || context.statusCode === 404) &&
+      EMAIL_VERIFICATION_PATH_PATTERN.test(context.endpoint)
+    )
+  },
+  handle: (_error, context) => {
+    context.logger.info(
+      '[EmailVerificationCodeErrorPolicy] Suppressing global alert — confirmation screen will show inline error for invalid code'
+    )
+  },
+}
+
 // Error policy for unexpected server errors (http status: 500, 503)
 export const unexpectedServerErrorPolicy: ErrorHandlingPolicy = {
   matches: (_, context) => {
@@ -439,6 +462,7 @@ export const ClientErrorHandlingPolicies: ErrorHandlingPolicy[] = [
   invalidRegistrationRequestErrorPolicy,
   videoSessionErrorPolicy,
   attestationPollingErrorPolicy,
+  emailVerificationCodeErrorPolicy,
   invalidClientMetadataErrorPolicy,
   iasErrorPolicy,
   // Specific polices listed above, followed by global policies

--- a/app/src/bcsc-theme/features/verify/email/EmailConfirmationScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EmailConfirmationScreen.test.tsx
@@ -5,6 +5,7 @@ import { BasicAppContext } from '@mocks/helpers/app'
 import { CommonActions } from '@react-navigation/native'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native'
 import React from 'react'
+import { Alert } from 'react-native'
 import Toast from 'react-native-toast-message'
 import EmailConfirmationScreen from './EmailConfirmationScreen'
 
@@ -125,7 +126,8 @@ describe('EmailConfirmation', () => {
       })
     })
 
-    test('shows error when submission fails', async () => {
+    test('shows native alert when submission fails', async () => {
+      const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {})
       mockSendEmailVerificationCode.mockRejectedValue(new Error('API Error'))
       renderScreen()
 
@@ -135,7 +137,14 @@ describe('EmailConfirmation', () => {
 
       await waitFor(() => {
         expect(screen.getByText('BCSC.EmailConfirmation.ErrorTitle')).toBeTruthy()
+        expect(alertSpy).toHaveBeenCalledWith(
+          'BCSC.EmailConfirmation.CouldNotVerifyTitle',
+          'BCSC.EmailConfirmation.CodeDoesNotMatch',
+          [{ text: 'Global.OK' }]
+        )
       })
+
+      alertSpy.mockRestore()
     })
   })
 

--- a/app/src/bcsc-theme/features/verify/email/EmailConfirmationScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EmailConfirmationScreen.tsx
@@ -70,6 +70,9 @@ const EmailConfirmationScreen = ({ navigation, route }: EmailConfirmationScreenP
       )
     } catch (error) {
       setError(t('BCSC.EmailConfirmation.ErrorTitle'))
+      Alert.alert(t('BCSC.EmailConfirmation.CouldNotVerifyTitle'), t('BCSC.EmailConfirmation.CodeDoesNotMatch'), [
+        { text: t('Global.OK') },
+      ])
     } finally {
       setLoading(false)
     }

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -742,6 +742,8 @@ const translation = {
     },
     "EmailConfirmation": {
       "ErrorTitle": "Error verifying confirmation code",
+      "CouldNotVerifyTitle": "Could not verify your email",
+      "CodeDoesNotMatch": "The code you entered does not match. Try again.",
       "EmailError": "Please enter a valid email address (name@host.com).",
       "CodeError": "Please enter a six digit verification code",
       "ErrorResendingCode": "Error resending code",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -736,6 +736,8 @@ const translation = {
     },
     "EmailConfirmation": {
       "ErrorTitle": "Error verifying confirmation code (FR)",
+      "CouldNotVerifyTitle": "Could not verify your email (FR)",
+      "CodeDoesNotMatch": "The code you entered does not match. Try again. (FR)",
       "EmailError": "Please enter a valid email address (name@host.com). (FR)",
       "CodeError": "Please enter a six digit verification code (FR)",
       "ErrorResendingCode": "Error resending code (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -736,6 +736,8 @@ const translation = {
     },
     "EmailConfirmation": {
       "ErrorTitle": "Error verifying confirmation code (PT-BR)",
+      "CouldNotVerifyTitle": "Could not verify your email (PT-BR)",
+      "CodeDoesNotMatch": "The code you entered does not match. Try again. (PT-BR)",
       "EmailError": "Please enter a valid email address (name@host.com). (PT-BR)",
       "CodeError": "Please enter a six digit verification code (PT-BR)",
       "ErrorResendingCode": "Error resending code (PT-BR)",


### PR DESCRIPTION
# Summary of Changes

Remove large error modal with incorrect information during email confirmation screen. Added basic native alert to follow v3. 

# Testing Instructions

Enter incorrect code to email confirmation. 

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

<img width="460" height="994" alt="image" src="https://github.com/user-attachments/assets/d9ca1152-7c63-4ed5-939a-9de47e2f3874" />
<img width="460" height="994" alt="image" src="https://github.com/user-attachments/assets/2e7aa723-b2d7-4af6-b4c5-c987e1c20452" />


# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
