### PR TITLE
fix: don't rely on swift Data impl (iOS 16 device auth crash)

### DIFF
--- a/packages/bcsc-core/ios/JWECrypto.swift
+++ b/packages/bcsc-core/ios/JWECrypto.swift
@@ -73,9 +73,11 @@ class SecureRandom {
   /// - Returns: The random byte array with the given count number of bytes.
   class func nextBytes(count: Int) -> [UInt8] {
     var bytes = [UInt8](repeating: 0, count: count)
-    _ = bytes.withUnsafeMutableBytes { buffer in
+    print("[SecureRandom] nextBytes: requesting \(count) bytes")
+    let status = bytes.withUnsafeMutableBytes { buffer in
       SecRandomCopyBytes(kSecRandomDefault, count, buffer.baseAddress!)
     }
+    print("[SecureRandom] nextBytes: SecRandomCopyBytes returned \(status) for \(count) bytes")
     return bytes
   }
 }

--- a/packages/bcsc-core/ios/JWECrypto.swift
+++ b/packages/bcsc-core/ios/JWECrypto.swift
@@ -72,14 +72,11 @@ class SecureRandom {
   /// - Parameter count: the desired number of random bytes
   /// - Returns: The random byte array with the given count number of bytes.
   class func nextBytes(count: Int) -> [UInt8] {
-    var data = Data(count: count)
-    let bytes = data.withUnsafeMutableBytes({ (bytes: UnsafeMutablePointer<UInt8>) -> UnsafeMutablePointer<UInt8> in
-      return bytes
-    })
-
-    let status = SecRandomCopyBytes(kSecRandomDefault, count, bytes)
-//        print(status)
-    return data.arrayOfBytes()
+    var bytes = [UInt8](repeating: 0, count: count)
+    _ = bytes.withUnsafeMutableBytes { buffer in
+      SecRandomCopyBytes(kSecRandomDefault, count, buffer.baseAddress!)
+    }
+    return bytes
   }
 }
 


### PR DESCRIPTION
# Summary of Changes

This PR is an attempt to fix a crash on iOS 16 when a fresh install using device auth is done. More recent versions of iOS rewrote the OS Swift impl, that's why they don't crash. The only function that this bug affected was generateRandomPIN, which is why it only occurred on fresh install setup.

Note: We are unable to reproduce (we don't have the device in question) so we've tested that this fix doesn't break anything in our versions (15.8.8 and 26.3.x) and we'll let a Testflight build go out for the UAT folks to confirm.

# Testing Instructions

No noticeable change unless you are using iOS 16 or older. Crash is avoided in that case.

# Acceptance Criteria

Fixes crash.

# Screenshots, videos, or gifs

N/A

# Related Issues

#3895 