### PR TITLE
Remove Google Play Integrity

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
@@ -48,7 +48,6 @@ jest.mock('@/bcsc-theme/utils/push-notification-tokens', () => ({
 
 jest.mock('@bifold/react-native-attestation', () => ({
   getAppStoreReceipt: jest.fn().mockResolvedValue('mock-ios-receipt'),
-  googleAttestation: jest.fn().mockResolvedValue('mock-google-attestation'),
 }))
 
 const mockApiClient = {

--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
@@ -5,7 +5,7 @@ import { AppError, ErrorRegistry } from '@/errors'
 import { ErrorDefinition } from '@/errors/errorRegistry'
 import { BCState } from '@/store'
 import { TOKENS, useServices, useStore } from '@bifold/core'
-import { getAppStoreReceipt, googleAttestation } from '@bifold/react-native-attestation'
+import { getAppStoreReceipt } from '@bifold/react-native-attestation'
 import { useCallback, useMemo } from 'react'
 import { Platform } from 'react-native'
 import {
@@ -13,7 +13,6 @@ import {
   BcscNativeErrorCodes,
   getAccount,
   getAccountSecurityMethod,
-  getDeviceId,
   getDynamicClientRegistrationBody,
   isBcscNativeError,
   setAccount,
@@ -94,9 +93,9 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
   /**
    * Retrieves platform-specific attestation for device verification.
    *
-   * On iOS, fetches App Store receipt. On Android, obtains nonce from server
-   * and generates Play Integrity attestation. Attestation failures are logged
-   * but non-blocking as per BCSC v3/v4 phase 1 specifications.
+   * On iOS, fetches App Store receipt. On other platforms, returns null.
+   * Attestation failures are logged but non-blocking as per BCSC v3/v4
+   * phase 1 specifications.
    *
    * @returns Promise resolving to attestation string or null if failed
    * @throws Error if BCSC client is not ready
@@ -112,23 +111,6 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
       if (Platform.OS === 'ios') {
         attestation = await getAppStoreReceipt()
         logger.debug('iOS App Store Receipt attestation complete')
-      } else if (Platform.OS === 'android') {
-        const deviceId = await getDeviceId()
-        const {
-          data: { nonce },
-        } = await apiClient.post<NonceResponseData>(
-          `${apiClient.baseURL}/device/nonces/${Platform.OS}`,
-          {
-            device_id: deviceId,
-          },
-          {
-            skipBearerAuth: true,
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          }
-        )
-        logger.debug('Received nonce for Android Play Integrity attestation')
-        attestation = await googleAttestation(nonce)
-        logger.debug('Android Play Integrity attestation complete')
       }
     } catch (err) {
       // attestation in BCSC v3 (and v4 phase 1) is non-blocking, so we log and continue

--- a/app/src/errors/errorRegistry.ts
+++ b/app/src/errors/errorRegistry.ts
@@ -896,7 +896,7 @@ export const ErrorRegistry = {
     appEvent: AppEventCode.ATTESTATION_GENERATION_ERROR,
     severity: ErrorSeverity.ERROR,
     category: ErrorCategory.VERIFICATION,
-    message: 'Platform attestation generation failed — Play Integrity or App Attest error',
+    message: 'Platform attestation generation failed — App Attest error',
   },
   ATTESTATION_VALIDATION_ERROR: {
     statusCode: 3104,
@@ -917,7 +917,7 @@ export const ErrorRegistry = {
     appEvent: AppEventCode.ATTESTATION_INTEGRITY_UNAVAILABLE,
     severity: ErrorSeverity.ERROR,
     category: ErrorCategory.VERIFICATION,
-    message: 'Platform integrity API (Play Integrity / App Attest) is not available on this device',
+    message: 'Platform integrity API (App Attest) is not available on this device',
   },
   ATTESTATION_GENERAL_PROOF_ERROR: {
     statusCode: 3107,

--- a/app/src/services/attestation.ts
+++ b/app/src/services/attestation.ts
@@ -8,12 +8,7 @@ import {
   BifoldError,
   removeExistingInvitationsById,
 } from '@bifold/core'
-import {
-  appleAttestation,
-  generateKey,
-  googleAttestation,
-  isPlayIntegrityAvailable,
-} from '@bifold/react-native-attestation'
+import { appleAttestation, generateKey } from '@bifold/react-native-attestation'
 import { AnonCredsCredentialOffer } from '@credo-ts/anoncreds'
 import {
   Agent,
@@ -412,8 +407,13 @@ export class AttestationMonitor implements AttestationMonitorI {
         return
       }
 
-      // 4. If no, get a new attestation credential
-      await this.requestAttestationCredential()
+      // 4. If no, get a new attestation credential.
+      try {
+        await this.requestAttestationCredential()
+      } catch {
+        await this.agent.proofs.declineRequest({ proofRecordId: proof.id })
+        this.stopWorkflow(AttestationEventTypes.FailedHandleProof)
+      }
     } catch (error) {
       this.log?.error('Failed to handle proof', error as Error)
 
@@ -569,8 +569,6 @@ export class AttestationMonitor implements AttestationMonitorI {
     switch (Platform.OS) {
       case 'ios':
         return this.generateAppleAttestation(nonce)
-      case 'android':
-        return this.generateGoogleAttestation(nonce)
 
       default:
         throw new BifoldError(
@@ -599,51 +597,6 @@ export class AttestationMonitor implements AttestationMonitorI {
     } as AttestationRequestParams
 
     this.log?.info('On-device Apple attestation complete')
-
-    return attestationRequest
-  }
-
-  private async generateGoogleAttestation(nonce: string) {
-    const common = this.commonAttestationMessageComponent()
-
-    this.log?.info('Checking if Play Integrity is available')
-
-    const available = await isPlayIntegrityAvailable()
-    if (!available) {
-      this.log?.error('Google Play Integrity is unavailable')
-
-      const error = new BifoldError(
-        'Google Play Integrity Unavailable',
-        'Google Play Integrity is required for device attestation but is not available on this device.',
-        'The device attestation process cannot be completed without Google Play Integrity services.',
-        AttestationErrorCodes.IntegrityUnavailable
-      )
-
-      throw error
-    } else {
-      this.log?.info('Google Play Integrity is available')
-    }
-
-    this.log?.info('Using Google on-device attestation')
-
-    let tokenString: string
-    try {
-      tokenString = await googleAttestation(nonce)
-    } catch (error) {
-      const bifoldError = new BifoldError(
-        'Google Attestation Error',
-        'There was a problem with the Google Integrity API.',
-        (error as Error)?.message || 'No details provided.',
-        AttestationErrorCodes.IntegrityUnavailable
-      )
-      throw bifoldError
-    }
-    const attestationRequest = {
-      ...common,
-      platform: 'google',
-      attestation_object: tokenString,
-    } as AttestationRequestParams
-    this.log?.info('On-device Google attestation complete')
 
     return attestationRequest
   }

--- a/packages/bcsc-core/android/build.gradle
+++ b/packages/bcsc-core/android/build.gradle
@@ -131,8 +131,6 @@ dependencies {
   }
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "com.google.android.gms:play-services-base:18.2.0"
-  implementation "com.google.android.play:integrity:1.2.0"
-  
   // Required: Nimbus JOSE library for JWT operations
   implementation 'com.nimbusds:nimbus-jose-jwt:9.37.3'
   

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -451,7 +451,7 @@ export const signPairingCode = async (
  * Creates the dynamic client registration body for OAuth client registration.
  * @param fcmDeviceToken The FCM device token for push notifications.
  * @param deviceToken Optional device token (APNS token for iOS).
- * @param attestation Optional attestation data (Play Integrity token for Android, App Store receipt for iOS).
+ * @param attestation Optional attestation data (App Store receipt for iOS).
  * @param nickname Optional nickname to use for client_name. If not provided, falls back to device name.
  * @returns A promise that resolves to the registration body string or null if an error occurs.
  */


### PR DESCRIPTION

## Summary

Removes Google Play Integrity remote attestation from BC Services Card App. A corresponding change will need to be made on the backend to remove the attestation credentials verification. (I’m not sure if the backend is open source; at least, I can’t find it anywhere. Otherwise I’d submit the PR myself -- sorry!)

## Motivation

There’s actually quite a few reasons why remote attestation is problematic…

### Canadian Digital Sovereignty

As a sovereign provincial identity verification system, it doesn’t make sense for users to be gated based on an American company’s approval. The only two remote attestation options currently implemented makes it mandatory for users to be on a device that is approved by either Google or Apple. This is kind of a non-starter for Canadian digital sovereingty, which since last year is now active federal and provincial policy.

Additionally, GPI introduces an infrastructural reliance on Google’s server uptime. If Google’s servers have a [2-hour service outage](https://status.play.google.com/incidents/QRUAfQgz8Zftj4QiSftu), that’s 2 hours when android users in BC could be unable access their medical data on sovereign Canadian servers through Health Gateway.

### Openness, Interop, Inclusion

Requiring users to use a Google- or Apple-approved devices goes against the principles of open source and interoperability. What’s the point in having an open interoperable standard for identity verification if I can’t actually implement it myself on my own device? How is this going to work on Linux devices? The BC [Digital Code of Practice](https://digital.gov.bc.ca/policies-standards/dcop/design/) clearly states (emphasis mine):

> Deliver equitable access to everyone who might use them, no matter their abilities, background, **device** or level of connectivity 

Yes, the BC Token functions as a stop-gap here, but it does require physically going to a BC services office, and it’s less user-friendly than mobile devices, rather inconvenient to have to carry around. I do like that there’s an alternative for people who don’t have any digital device whatsoever, but having the BC token be the only option for those using non-Google/Apple-approved devices is severely problematic. Plus, being produced by [FEITIAN technologies](https://portal.ftsafe.com/), it is, again, neither sovereign nor open source.

### Anti-Competitive

Remote attestation needlessly introduces friction for users of non-Google/Apple devices, which just makes it harder for Canadian and/or open alternative mobile OSs to get a foothold over Google and Apple’s duopoly. This contradicts the DCOP’s “[Ecosystem Approach](https://digital.gov.bc.ca/policies-standards/dcop/ecosystem/).”

It’s actually quite a common complaint I hear when I suggest people try switching to a different mobile OS like GrapheneOS, LineageOS, postmarketOS, mobian, UBPorts, SailfishOS, etc: “but it won’t work with my banking app and it won’t work with identity verification apps.” Alternative OSs are becoming increasingly popular as people are becoming weary of popular tech platforms. Valve [just reported](https://www.techpowerup.com/347961/steam-on-linux-surpasses-5-market-share-in-the-latest-survey-update) Linux now has 5% desktop market share (wow!), and I think this could become true for mobile devices as well.

By the way, GrapheneOS is the only sovereign Canadian mobile OS (they are [based in Canada and a registered not-for-profit corporation](https://ised-isde.canada.ca/cc/lgcy/fdrlCrpDtls.html?p=0&corpId=14857577&crpNm=grapheneos)), yet BCSC app is not compatible with GrapheneOS (solely due to Play Integrity!), which is a major hindrance for GrapheneOS.

### Privacy

My understanding based on Google’s [documentation](https://developer.android.com/google/play/integrity/terms#data-safety) is that GPI collects data on and sends a signal to Google’s servers any time a BC resident does provincial identity verification. (As is, it runs on startup, any time the app is opened -- this PR fixes that.) Google promises that this data is not shared and is deleted after some undicslosed period of time, but there is no reason provincial identity verification should require data to go to any third party, much less across the border.

### Security

I imagine the Google Play Integrity requirement is intended for user security somehow. To be clear, Play Integrity doesn’t store credentials, encrypt keys, or directly protect any user data. It only verifies that the device is Google-approved and unmodified. So I just don’t see the security justification here. “User carefully modded their phone to gain superuser privileges, installed BCSC app, and then ran `sudo apt install malware` by mistake”? What actual real-world threat model does this protect against which is remotely comparable to the unmitigateable security risks of a user physically handing a bad actor their unlocked device or patiently following instructions from a spam caller?

The app already uses Askar to keep user data secure, so there’s no need for this extra layer. I don’t mean to be harsh but remote attestation just seems like security theatre to me in this regard. It was invented mainly as a form of DRM to protect IP holders like Netflix from pirates recording content off their devices, not to protect users from data thieves. It doesn’t have any place in a sovereign, interoperable, open identity verification system.

Keeping users of alternative OSes and unusual hardware in mind may not be a high-priority item for most apps in the wild as it takes deliberate consideration for the benefit of a fraction of users, but for a potentially essential public service there is a duty to get this right.