### PR TITLE
fix: consistent input casing with v3 on both platforms

### DIFF
--- a/app/src/bcsc-theme/features/account/__snapshots__/EditNicknameScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/account/__snapshots__/EditNicknameScreen.test.tsx.snap
@@ -285,6 +285,7 @@ exports[`EditNickname renders correctly 1`] = `
               >
                 <TextInput
                   accessibilityLabel="BCSC.NicknameAccount.AccountName"
+                  autoCapitalize="sentences"
                   autoCorrect={false}
                   maxLength={30}
                   onBlur={[Function]}

--- a/app/src/bcsc-theme/features/account/__snapshots__/NicknameAccountScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/account/__snapshots__/NicknameAccountScreen.test.tsx.snap
@@ -285,6 +285,7 @@ exports[`NicknameAccount renders correctly 1`] = `
               >
                 <TextInput
                   accessibilityLabel="BCSC.NicknameAccount.AccountName"
+                  autoCapitalize="sentences"
                   autoCorrect={false}
                   maxLength={30}
                   onBlur={[Function]}

--- a/app/src/bcsc-theme/features/account/components/NicknameForm.tsx
+++ b/app/src/bcsc-theme/features/account/components/NicknameForm.tsx
@@ -103,6 +103,7 @@ const NicknameForm: React.FC<NicknameFormProps> = ({ onSubmit, isRenaming }) => 
         textInputProps={{
           maxLength: formStringLengths.maximumLength,
           autoCorrect: false,
+          autoCapitalize: 'sentences',
         }}
       />
     </ScreenWrapper>

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
@@ -251,7 +251,7 @@ const EvidenceIDCollectionScreen = ({ navigation, route }: EvidenceIDCollectionS
           onChange={(value) => handleChange('documentNumber', value)}
           error={formErrors.documentNumber}
           subtext={`${t('BCSC.EvidenceIDCollection.DocumentNumberSubtext')} ${cardType.document_reference_sample}`}
-          textInputProps={{ autoCorrect: false }}
+          textInputProps={{ autoCorrect: false, autoCapitalize: 'characters' }}
           onLayout={(e) => {
             fieldYOffsets.current.documentNumber = e.nativeEvent.layout.y
           }}
@@ -266,7 +266,12 @@ const EvidenceIDCollectionScreen = ({ navigation, route }: EvidenceIDCollectionS
               onChange={(value) => handleChange('lastName', value)}
               error={formErrors.lastName}
               subtext={t('BCSC.EvidenceIDCollection.LastNameSubtext')}
-              textInputProps={{ autoCorrect: false, autoComplete: 'name-family', textContentType: 'familyName' }}
+              textInputProps={{
+                autoCorrect: false,
+                autoComplete: 'name-family',
+                textContentType: 'familyName',
+                autoCapitalize: 'characters',
+              }}
               onLayout={(e) => {
                 fieldYOffsets.current.lastName = e.nativeEvent.layout.y
               }}
@@ -279,7 +284,12 @@ const EvidenceIDCollectionScreen = ({ navigation, route }: EvidenceIDCollectionS
               onChange={(value) => handleChange('firstName', value)}
               error={formErrors.firstName}
               subtext={t('BCSC.EvidenceIDCollection.FirstNameSubtext')}
-              textInputProps={{ autoCorrect: false, autoComplete: 'name-given', textContentType: 'givenName' }}
+              textInputProps={{
+                autoCorrect: false,
+                autoComplete: 'name-given',
+                textContentType: 'givenName',
+                autoCapitalize: 'characters',
+              }}
               onLayout={(e) => {
                 fieldYOffsets.current.firstName = e.nativeEvent.layout.y
               }}
@@ -292,7 +302,12 @@ const EvidenceIDCollectionScreen = ({ navigation, route }: EvidenceIDCollectionS
               onChange={(value) => handleChange('middleNames', value)}
               error={formErrors.middleNames}
               subtext={t('BCSC.EvidenceIDCollection.MiddleNamesSubtext')}
-              textInputProps={{ autoCorrect: false, autoComplete: 'name-middle', textContentType: 'middleName' }}
+              textInputProps={{
+                autoCorrect: false,
+                autoComplete: 'name-middle',
+                textContentType: 'middleName',
+                autoCapitalize: 'characters',
+              }}
               onLayout={(e) => {
                 fieldYOffsets.current.middleNames = e.nativeEvent.layout.y
               }}

--- a/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/EvidenceIDCollectionScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/EvidenceIDCollectionScreen.test.tsx.snap
@@ -214,6 +214,7 @@ exports[`EvidenceIDCollection renders correctly 1`] = `
                 >
                   <TextInput
                     accessibilityLabel="Passport Number"
+                    autoCapitalize="characters"
                     autoCorrect={false}
                     onBlur={[Function]}
                     onChange={[Function]}


### PR DESCRIPTION
# Summary of Changes

This PR adjusts the input fields config to be more consistent with v3 across both iOS and Android

# Testing Instructions

Use nickname, names, and document number fields

# Acceptance Criteria

Consistency

# Screenshots, videos, or gifs

N/A

# Related Issues

#3892 