### PR TITLE
fix: ios prompt text for variants

### DIFF
--- a/app/ios/BCWallet/Info.plist
+++ b/app/ios/BCWallet/Info.plist
@@ -70,9 +70,9 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Camera used for QR Code scanning and video calls</string>
 	<key>NSFaceIDUsageDescription</key>
-	<string>$(PRODUCT_NAME) wants to use your FaceID/TouchID to authenticate your identity</string>
+	<string>BC Wallet wants to use your FaceID/TouchID to authenticate your identity</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>$(PRODUCT_NAME) needs access to your microphone to enable video calls</string>
+	<string>BC Wallet needs access to your microphone to enable video calls</string>
 	<key>RCTNewArchEnabled</key>
 	<true/>
 	<key>UIAppFonts</key>

--- a/scripts/apply-variant.mjs
+++ b/scripts/apply-variant.mjs
@@ -111,6 +111,18 @@ const TEMPLATE_FILES = {
       pattern: /(<key>CFBundleDisplayName<\/key>\s*<string>)[^<]+(<\/string>)/g,
       replacement: (env) => `$1${env.APP_NAME}$2`,
     },
+    {
+      // Replace NSFaceIDUsageDescription value (drives the FaceID/TouchID prompt title)
+      pattern: /(<key>NSFaceIDUsageDescription<\/key>\s*<string>)[^<]+(<\/string>)/g,
+      replacement: (env) =>
+        `$1${env.APP_NAME} wants to use your FaceID/TouchID to authenticate your identity$2`,
+    },
+    {
+      // Replace NSMicrophoneUsageDescription value
+      pattern: /(<key>NSMicrophoneUsageDescription<\/key>\s*<string>)[^<]+(<\/string>)/g,
+      replacement: (env) =>
+        `$1${env.APP_NAME} needs access to your microphone to enable video calls$2`,
+    },
   ],
 }
 


### PR DESCRIPTION
# Summary of Changes

This PR ensures the iOS native permission prompts use the correct app name

# Testing Instructions

Run yarn convert, check Info.plist has been updated to say "*BC Services Card* needs to access your blah..."

# Acceptance Criteria

Proper prompt app name

# Screenshots, videos, or gifs

N/A

# Related Issues

#3898 