### PR TITLE
fix: stale wallet

### DIFF
--- a/app/src/bcsc-theme/features/agent/services/agent-service.test.ts
+++ b/app/src/bcsc-theme/features/agent/services/agent-service.test.ts
@@ -58,6 +58,7 @@ jest.mock('@credo-ts/indy-vdr', () => ({
 import {
   AgentWalletSecret,
   buildAgent,
+  initializeAgent,
   loadCachedLedgers,
   restartAgent,
   shutdownAgent,
@@ -256,5 +257,64 @@ describe('shutdownAgent', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await expect(shutdownAgent(agent as any, logger)).resolves.toBeUndefined()
     expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('shutdown boom'))
+  })
+})
+
+describe('initializeAgent', () => {
+  it('rethrows when initialize fails (so callers can surface init errors)', async () => {
+    const agent = { initialize: jest.fn().mockRejectedValue(new Error('open failed')) }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(initializeAgent(agent as any)).rejects.toThrow('open failed')
+  })
+})
+
+describe('wallet lifecycle serialization', () => {
+  it('holds a queued initialize until an in-flight shutdown finishes closing the wallet', async () => {
+    // Models sign-out → sign-in: the old agent is still closing the shared Askar
+    // wallet when the new agent tries to open it. The open must wait for the close.
+    const order: string[] = []
+    let resolveShutdown: () => void = () => undefined
+    const shutdownGate = new Promise<void>((resolve) => {
+      resolveShutdown = resolve
+    })
+
+    const oldAgent = {
+      shutdown: jest.fn(() => shutdownGate.then(() => void order.push('shutdown'))),
+    }
+    const newAgent = {
+      initialize: jest.fn(async () => void order.push('initialize')),
+    }
+
+    // Sign-out teardown begins (not awaited — fire-and-forget like the unmount path).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const shutdownPromise = shutdownAgent(oldAgent as any, logger)
+    // Sign-in build immediately tries to open the same wallet.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const initPromise = initializeAgent(newAgent as any)
+
+    // Flush microtasks/timers: the open must still be queued behind the close.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(newAgent.initialize).not.toHaveBeenCalled()
+
+    // Close finishes → the queued open is now allowed to run.
+    resolveShutdown()
+    await shutdownPromise
+    await initPromise
+
+    expect(newAgent.initialize).toHaveBeenCalled()
+    expect(order).toEqual(['shutdown', 'initialize'])
+  })
+
+  it('does not let a failed shutdown wedge the queue for the next open', async () => {
+    const failing = { shutdown: jest.fn().mockRejectedValue(new Error('close boom')) }
+    const next = { initialize: jest.fn().mockResolvedValue(undefined) }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await shutdownAgent(failing as any, logger)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await initializeAgent(next as any)
+
+    expect(next.initialize).toHaveBeenCalled()
   })
 })

--- a/app/src/bcsc-theme/features/agent/services/agent-service.ts
+++ b/app/src/bcsc-theme/features/agent/services/agent-service.ts
@@ -37,6 +37,33 @@ interface CachedGenesisTransactions {
 }
 
 /**
+ * Serializes opening and closing of the single shared Askar wallet (WALLET_ID).
+ *
+ * The BCSC agent provider unmounts on sign-out and remounts on sign-in, building
+ * a brand-new {@link Agent} each time against the same wallet file. React can
+ * mount the next agent before the previous one has finished closing, so a fresh
+ * agent's `initialize()` (wallet open) could race the prior agent's `shutdown()`
+ * (wallet close) and leave the wallet/mediator session wedged — credential
+ * issuance hangs and the mediator never reconnects until the app is restarted.
+ *
+ * Routing every open/close through this promise chain guarantees they run
+ * strictly one after another, even across separate agent instances and React
+ * mounts — a module-level lock survives component unmount; component refs do not.
+ */
+let walletLifecycle: Promise<unknown> = Promise.resolve()
+
+const enqueueWalletOp = <T>(op: () => Promise<T>): Promise<T> => {
+  // Chain onto the tail whether or not the previous op resolved, so a single
+  // failed open/close can't wedge the queue for every later one.
+  const result = walletLifecycle.then(op, op)
+  walletLifecycle = result.then(
+    () => undefined,
+    () => undefined
+  )
+  return result
+}
+
+/**
  * Loads previously cached pool genesis transactions from persistent storage.
  *
  * Used to skip live ledger discovery on subsequent agent inits. Returns `undefined`
@@ -123,12 +150,26 @@ export const buildAgent = (opts: BuildAgentOptions): Agent => {
  */
 export const restartAgent = async (agent: Agent, logger: BifoldLogger): Promise<Agent | undefined> => {
   try {
-    await agent.initialize()
+    await enqueueWalletOp(() => agent.initialize())
     return agent
   } catch (error) {
     logger.warn(`Agent restart failed: ${error}`)
     return undefined
   }
+}
+
+/**
+ * Initializes a freshly built agent.
+ *
+ * The wallet open is serialized against any in-flight open/close (see
+ * {@link enqueueWalletOp}) so a sign-in rebuild never races the previous agent's
+ * teardown on the shared wallet file. Unlike {@link restartAgent} this rethrows
+ * on failure so the caller can surface an init error.
+ *
+ * @param agent - The built (uninitialized) agent to initialize.
+ */
+export const initializeAgent = async (agent: Agent): Promise<void> => {
+  await enqueueWalletOp(() => agent.initialize())
 }
 
 /**
@@ -226,7 +267,7 @@ const refreshLedgerCache = async (poolService: IndyVdrPoolService, logger: Bifol
  */
 export const shutdownAgent = async (agent: Agent, logger: BifoldLogger): Promise<void> => {
   try {
-    await agent.shutdown()
+    await enqueueWalletOp(() => agent.shutdown())
   } catch (error) {
     logger.error(`Error shutting down agent: ${error}`)
   }

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
@@ -45,6 +45,7 @@ describe('useAgentSetupViewModel', () => {
     jest.mocked(Bifold.createLinkSecretIfRequired).mockResolvedValue(undefined as never)
     jest.mocked(agentService.loadCachedLedgers).mockResolvedValue(undefined)
     jest.mocked(agentService.buildAgent).mockReturnValue(mockAgent())
+    jest.mocked(agentService.initializeAgent).mockResolvedValue(undefined)
     jest.mocked(agentService.restartAgent).mockResolvedValue(undefined)
     jest.mocked(agentService.warmCache).mockResolvedValue(undefined)
     jest.mocked(agentService.shutdownAgent).mockResolvedValue(undefined)
@@ -121,8 +122,8 @@ describe('useAgentSetupViewModel', () => {
       resolveInit = resolve
     })
     const newAgent = mockAgent()
-    newAgent.initialize = jest.fn().mockReturnValue(initPromise)
     jest.mocked(agentService.buildAgent).mockReturnValue(newAgent)
+    jest.mocked(agentService.initializeAgent).mockReturnValue(initPromise)
 
     const store: Record<string, unknown> = {
       authentication: { didAuthenticate: true },
@@ -191,8 +192,8 @@ describe('useAgentSetupViewModel', () => {
 
   it('shuts down partially-built agent when init step throws', async () => {
     const newAgent = mockAgent()
-    newAgent.initialize = jest.fn().mockRejectedValue(new Error('initialize failed'))
     jest.mocked(agentService.buildAgent).mockReturnValue(newAgent)
+    jest.mocked(agentService.initializeAgent).mockRejectedValue(new Error('initialize failed'))
 
     const { result } = renderHook(() => useAgentSetupViewModel())
 
@@ -206,8 +207,8 @@ describe('useAgentSetupViewModel', () => {
       resolveInit = resolve
     })
     const newAgent = mockAgent()
-    newAgent.initialize = jest.fn().mockReturnValue(initPromise)
     jest.mocked(agentService.buildAgent).mockReturnValue(newAgent)
+    jest.mocked(agentService.initializeAgent).mockReturnValue(initPromise)
 
     const store: Record<string, unknown> = {
       authentication: { didAuthenticate: true },
@@ -283,5 +284,33 @@ describe('useAgentSetupViewModel', () => {
     await waitFor(() => expect(result.current.status).toBe('idle'))
     expect(agentService.shutdownAgent).toHaveBeenCalled()
     expect(result.current.agent).toBeNull()
+  })
+
+  it('shuts down the agent when the provider unmounts (the real sign-out path)', async () => {
+    // Regression test: sign-out unmounts BCSCAgentProvider (RootStack swaps in
+    // AuthStack) rather than re-rendering this hook with didAuthenticate=false.
+    // Previously nothing shut the agent down on unmount, so it lingered as a
+    // zombie holding the wallet + mediator socket and the next sign-in's agent
+    // collided with it — issuance hung until the app was force-restarted.
+    const builtAgent = mockAgent()
+    jest.mocked(agentService.buildAgent).mockReturnValue(builtAgent)
+
+    const { result, unmount } = renderHook(() => useAgentSetupViewModel())
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+
+    unmount()
+
+    expect(agentService.shutdownAgent).toHaveBeenCalledWith(builtAgent, logger)
+  })
+
+  it('does not call shutdown on unmount when no agent was ever built', async () => {
+    jest.mocked(Bifold.useStore).mockReturnValue(mockedStore({ bcscSecure: { walletKey: undefined } }) as never)
+
+    const { result, unmount } = renderHook(() => useAgentSetupViewModel())
+    await waitFor(() => expect(result.current.status).toBe('error'))
+
+    unmount()
+
+    expect(agentService.shutdownAgent).not.toHaveBeenCalled()
   })
 })

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
@@ -8,7 +8,14 @@ import { DidCommMediatorPickupStrategy } from '@credo-ts/didcomm'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Config } from 'react-native-config'
 
-import { buildAgent, loadCachedLedgers, restartAgent, shutdownAgent, warmCache } from './services/agent-service'
+import {
+  buildAgent,
+  initializeAgent,
+  loadCachedLedgers,
+  restartAgent,
+  shutdownAgent,
+  warmCache,
+} from './services/agent-service'
 
 export type AgentSetupStatus = 'idle' | 'initializing' | 'ready' | 'error'
 
@@ -37,6 +44,8 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
   const initializingRef = useRef(false)
   const statusRef = useRef<AgentSetupStatus>('idle')
   statusRef.current = status
+  const loggerRef = useRef(logger)
+  loggerRef.current = logger
 
   const didAuthenticate = store.authentication.didAuthenticate
   const walletKey = store.bcscSecure.walletKey
@@ -57,6 +66,23 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
     setError(null)
     setStatus('idle')
     setRetryCount((c) => c + 1)
+  }, [])
+
+  // Sign-out removes the authenticated navigator subtree, unmounting this
+  // provider. Tear the agent down here so it doesn't linger as a zombie holding
+  // the Askar wallet open and its mediator live-session socket alive — otherwise
+  // the next sign-in builds a second agent that the mediator and wallet fight
+  // over, which is why issuance hangs until the app is force-restarted. The
+  // wallet close is serialized in agent-service, so the next sign-in's build
+  // waits for it before reopening. Empty deps: cleanup runs only on unmount.
+  useEffect(() => {
+    return () => {
+      const liveAgent = agentRef.current
+      if (liveAgent) {
+        agentRef.current = null
+        shutdownAgent(liveAgent, loggerRef.current)
+      }
+    }
   }, [])
 
   useEffect(() => {
@@ -132,7 +158,8 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
           logger,
         })
 
-        await inFlightAgent.initialize()
+        await initializeAgent(inFlightAgent)
+
         if (cancelled) {
           return
         }
@@ -182,6 +209,8 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
         setStatus('error')
       } finally {
         if (inFlightAgent) {
+          // Cancelled or partially-built agent — close its wallet handle. The
+          // shutdown is serialized against the next build's open in agent-service.
           await shutdownAgent(inFlightAgent, logger)
         }
         if (!cancelled) {


### PR DESCRIPTION
# Summary of Changes

Fixes a stale-wallet bug where signing out and back in (without restarting the app) left the agent broken — scanned credential offers would hang and the mediator never reconnected until a full app restart.

**Root cause:** `BCSCAgentProvider` (which owns the Credo agent) is only rendered while authenticated, so signing out unmounts it — but nothing shut the agent down on unmount. It lingered as a zombie holding the shared Askar wallet open and its mediator live-session socket alive. The next sign-in built a new agent that collided with the zombie on the same wallet/mediator, so offers were delivered to the dead session.

**Fix:**
- Tear the agent down when the provider unmounts (sign-out), via a dedicated unmount-only effect.
- Serialize wallet open/close through a module-level queue in `agent-service` so a sign-in rebuild waits for the previous agent's shutdown before reopening the shared wallet. The old and new agents live in separate hook instances (unmount → remount), so this can't be coordinated with component refs.

# Testing Instructions

1. Sign in and confirm the wallet works (e.g. receive a credential).
2. Sign out via Settings.
3. Sign back in **without closing the app**.
4. Scan a QR credential offer — it should be received and the notification banner should appear, with no force-restart needed.

Unit tests: `yarn jest src/bcsc-theme/features/agent`

# Acceptance Criteria

- After sign-out → sign-in (no app restart), the agent reconnects to the mediator and can receive credentials.
- Scanning a credential offer after re-login surfaces the offer/notification without a force-restart.
- No regression to first-launch agent init, retry, or factory reset.

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A
