### PR TITLE
fix: prevent Settings → Contacts crash before agent is ready

### DIFF
--- a/app/src/bcsc-theme/features/agent/AgentReadyGate.test.tsx
+++ b/app/src/bcsc-theme/features/agent/AgentReadyGate.test.tsx
@@ -1,0 +1,95 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { fireEvent, render, screen } from '@testing-library/react-native'
+import React from 'react'
+import { Text } from 'react-native'
+
+import AgentReadyGate from './AgentReadyGate'
+import { useBCSCAgent } from './BCSCAgentProvider'
+
+jest.mock('./BCSCAgentProvider', () => ({
+  useBCSCAgent: jest.fn(),
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+jest.mock('@bifold/core', () => {
+  // Jest forbids referencing out-of-scope identifiers in a mock factory, so
+  // re-require React here instead of relying on the top-level import.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+  const ReactInFactory = require('react')
+  return {
+    Button: ({ title, onPress, testID }: any) =>
+      ReactInFactory.createElement('Pressable', { testID, onPress }, ReactInFactory.createElement('Text', null, title)),
+    ButtonType: { Primary: 'Primary' },
+    ThemedText: ({ children }: any) => ReactInFactory.createElement('Text', null, children),
+    testIdWithKey: (key: string) => `id/${key}`,
+    useTheme: () => ({
+      ColorPalette: { brand: { primary: '#000' } },
+      Spacing: { lg: 16 },
+    }),
+  }
+})
+
+const mockUseBCSCAgent = useBCSCAgent as jest.MockedFunction<typeof useBCSCAgent>
+
+const agentValue = (overrides: any = {}) => ({
+  agent: null,
+  loading: false,
+  error: null,
+  retry: jest.fn(),
+  resetWallet: jest.fn(),
+  ...overrides,
+})
+
+describe('AgentReadyGate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders children once the agent is ready', () => {
+    mockUseBCSCAgent.mockReturnValue(agentValue({ agent: {} as any }))
+
+    render(
+      <AgentReadyGate testID="gate">
+        <Text>child</Text>
+      </AgentReadyGate>
+    )
+
+    expect(screen.getByText('child')).toBeTruthy()
+    expect(screen.queryByTestId('id/AgentRetry')).toBeNull()
+  })
+
+  it('shows a loading indicator while the agent is still initializing', () => {
+    mockUseBCSCAgent.mockReturnValue(agentValue({ loading: true }))
+
+    render(
+      <AgentReadyGate testID="gate">
+        <Text>child</Text>
+      </AgentReadyGate>
+    )
+
+    expect(screen.getByTestId('gate')).toBeTruthy()
+    expect(screen.queryByText('child')).toBeNull()
+    expect(screen.queryByText('Init.Failed')).toBeNull()
+    expect(screen.queryByTestId('id/AgentRetry')).toBeNull()
+  })
+
+  it('shows a failure message with a working retry when initialization errors', () => {
+    const retry = jest.fn()
+    mockUseBCSCAgent.mockReturnValue(agentValue({ error: { message: 'boom' } as any, retry }))
+
+    render(
+      <AgentReadyGate testID="gate">
+        <Text>child</Text>
+      </AgentReadyGate>
+    )
+
+    expect(screen.getByText('Init.Failed')).toBeTruthy()
+    expect(screen.queryByText('child')).toBeNull()
+
+    fireEvent.press(screen.getByTestId('id/AgentRetry'))
+    expect(retry).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/src/bcsc-theme/features/agent/AgentReadyGate.tsx
+++ b/app/src/bcsc-theme/features/agent/AgentReadyGate.tsx
@@ -1,5 +1,6 @@
-import { useTheme } from '@bifold/core'
-import React, { PropsWithChildren } from 'react'
+import { Button, ButtonType, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
+import React, { ComponentType, PropsWithChildren } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, View } from 'react-native'
 
 import { useBCSCAgent } from './BCSCAgentProvider'
@@ -9,15 +10,39 @@ type Props = PropsWithChildren<{ testID?: string }>
 /**
  * Renders children only after the BCSC agent is ready. While the agent boots
  * (or after navigation state restores onto a screen that depends on Bifold's
- * agent context) a centered ActivityIndicator stands in. Lets us register
- * Bifold screens in the navigator without risking a crash if they mount
- * before the providers in BifoldScope are wired up.
+ * agent context) a centered ActivityIndicator stands in. If agent
+ * initialization fails the agent never becomes ready, so instead of spinning
+ * forever we surface the failure with a retry affordance. Lets us register
+ * screens that depend on Bifold's connection/agent context in the navigator
+ * without risking a crash if they mount before the providers in BifoldScope
+ * are wired up.
  */
 const AgentReadyGate: React.FC<Props> = ({ children, testID }) => {
-  const { agent } = useBCSCAgent()
-  const { ColorPalette } = useTheme()
+  const { agent, error, retry } = useBCSCAgent()
+  const { ColorPalette, Spacing } = useTheme()
+  const { t } = useTranslation()
 
   if (!agent) {
+    if (error) {
+      return (
+        <View
+          style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: Spacing.lg, gap: Spacing.lg }}
+          testID={testID}
+        >
+          <ThemedText variant="headingThree" style={{ textAlign: 'center' }}>
+            {t('Init.Failed')}
+          </ThemedText>
+          <Button
+            title={t('Init.Retry')}
+            buttonType={ButtonType.Primary}
+            onPress={retry}
+            accessibilityLabel={t('Init.Retry')}
+            testID={testIdWithKey('AgentRetry')}
+          />
+        </View>
+      )
+    }
+
     return (
       <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }} testID={testID}>
         <ActivityIndicator size="large" color={ColorPalette.brand.primary} />
@@ -26,6 +51,24 @@ const AgentReadyGate: React.FC<Props> = ({ children, testID }) => {
   }
 
   return <>{children}</>
+}
+
+/**
+ * Wraps a screen component in {@link AgentReadyGate} so it only mounts once the
+ * BCSC agent is ready. Use for screens that call Bifold connection hooks
+ * (e.g. useConnections / useConnectionById), which require providers that
+ * BifoldScope only mounts after the agent resolves. Build the wrapped component
+ * once at module scope so its identity stays stable and React Navigation does
+ * not remount it on every render.
+ */
+export function withAgentReadyGate<P extends object>(Wrapped: ComponentType<P>, loadingTestID?: string): React.FC<P> {
+  const Scoped: React.FC<P> = (props) => (
+    <AgentReadyGate testID={loadingTestID}>
+      <Wrapped {...props} />
+    </AgentReadyGate>
+  )
+  Scoped.displayName = `withAgentReadyGate(${Wrapped.displayName ?? Wrapped.name ?? 'Component'})`
+  return Scoped
 }
 
 export default AgentReadyGate

--- a/app/src/bcsc-theme/features/agent/index.ts
+++ b/app/src/bcsc-theme/features/agent/index.ts
@@ -1,4 +1,4 @@
-export { default as AgentReadyGate } from './AgentReadyGate'
+export { default as AgentReadyGate, withAgentReadyGate } from './AgentReadyGate'
 export { default as BCSCAgentProvider, useBCSCAgent } from './BCSCAgentProvider'
 export type { BCSCAgentContextValue } from './BCSCAgentProvider'
 export { default as BifoldScope } from './BifoldScope'

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -32,7 +32,7 @@ import { AccountRenewalFirstWarningScreen } from '../features/account/AccountRen
 import { AccountRenewalInformationScreen } from '../features/account/AccountRenewalInformationScreen'
 import EditNicknameScreen from '../features/account/EditNicknameScreen'
 import { MainRemoveAccountConfirmationScreen } from '../features/account/RemoveAccountConfirmationScreen'
-import { AgentReadyGate, BifoldScope } from '../features/agent'
+import { AgentReadyGate, BifoldScope, withAgentReadyGate } from '../features/agent'
 import { MainChangePINScreen } from '../features/auth/MainChangePINScreen'
 import { MainChangeSecurityScreen } from '../features/auth/MainChangeSecurityScreen'
 import ContactChatScreen from '../features/contacts/ContactChatScreen'
@@ -70,6 +70,16 @@ const ScopedCredentialDetails: React.FC<React.ComponentProps<typeof CredentialDe
     <CredentialDetails {...props} />
   </AgentReadyGate>
 )
+
+// Contact screens call Bifold connection hooks (useConnections / useConnectionById)
+// that require the providers BifoldScope only mounts once the agent is ready.
+// Gate them so an early mount — a cold-start quick-tap into Settings → Contacts,
+// or navigation state restoring onto a deep contact screen — shows the loading/
+// retry state instead of crashing on a missing ConnectionProvider.
+const ScopedContacts = withAgentReadyGate(ContactsScreen, testIdWithKey('Contacts.Loading'))
+const ScopedContactDetails = withAgentReadyGate(ContactDetailsScreen, testIdWithKey('ContactDetails.Loading'))
+const ScopedEditContactName = withAgentReadyGate(EditContactNameScreen, testIdWithKey('EditContactName.Loading'))
+const ScopedRemoveContact = withAgentReadyGate(RemoveContactScreen, testIdWithKey('RemoveContact.Loading'))
 
 const MainStack: React.FC = () => {
   const { currentStep } = useTour()
@@ -159,7 +169,7 @@ const MainStack: React.FC = () => {
         >
           <Stack.Screen
             name={BCSCScreens.Contacts}
-            component={ContactsScreen}
+            component={ScopedContacts}
             options={() => ({
               headerShown: true,
               title: t('BCSC.Contacts.Title'),
@@ -176,7 +186,7 @@ const MainStack: React.FC = () => {
           />
           <Stack.Screen
             name={BCSCScreens.ContactDetails}
-            component={ContactDetailsScreen}
+            component={ScopedContactDetails}
             options={() => ({
               headerShown: true,
               title: t('BCSC.Contacts.Details.Title'),
@@ -184,7 +194,7 @@ const MainStack: React.FC = () => {
           />
           <Stack.Screen
             name={BCSCScreens.EditContactName}
-            component={EditContactNameScreen}
+            component={ScopedEditContactName}
             options={() => ({
               headerShown: true,
               title: t('BCSC.Contacts.EditName.HeaderTitle'),
@@ -208,7 +218,7 @@ const MainStack: React.FC = () => {
           />
           <Stack.Screen
             name={BCSCScreens.RemoveContact}
-            component={RemoveContactScreen}
+            component={ScopedRemoveContact}
             options={() => ({
               ...getDefaultModalOptions(t('BCSC.Contacts.Remove.HeaderTitle')),
             })}

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -192,6 +192,7 @@ const translation = {
   },
   "Init": {
     "Retry": "Retry",
+    "Failed": "We couldn't load your wallet. Check your connection and try again.",
     "Starting": "Starting...",
     "CheckingOCA": "Checking for OCA updates...",
     "InitializingAgent": "Initializing agent...",

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -192,7 +192,7 @@ const translation = {
   },
   "Init": {
     "Retry": "Retry",
-    "Failed": "We couldn't load your wallet. Check your connection and try again.",
+    "Failed": "We couldn't load your wallet. Please try again.",
     "Starting": "Starting...",
     "CheckingOCA": "Checking for OCA updates...",
     "InitializingAgent": "Initializing agent...",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -186,6 +186,7 @@ const translation = {
   },
   "Init": {
     "Retry": "Réessayer",
+    "Failed": "Impossible de charger votre portefeuille. Vérifiez votre connexion et réessayez.",
     "Starting": "Démarrage...",
     "CheckingOCA": "Checking for OCA updates... (FR)",
     "InitializingAgent": "Initialisation de l'agent...",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -186,7 +186,7 @@ const translation = {
   },
   "Init": {
     "Retry": "Réessayer",
-    "Failed": "Impossible de charger votre portefeuille. Vérifiez votre connexion et réessayez.",
+    "Failed": "Impossible de charger votre portefeuille. Veuillez réessayer.",
     "Starting": "Démarrage...",
     "CheckingOCA": "Checking for OCA updates... (FR)",
     "InitializingAgent": "Initialisation de l'agent...",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -186,7 +186,7 @@ const translation = {
   },
   "Init": {
     "Retry": "Retry (PT-BR)",
-    "Failed": "We couldn't load your wallet. Check your connection and try again. (PT-BR)",
+    "Failed": "We couldn't load your wallet. Please try again. (PT-BR)",
     "Starting": "Starting... (PT-BR)",
     "CheckingOCA": "Checking for OCA updates... (PT-BR)",
     "InitializingAgent": "Initializing agent... (PT-BR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -186,6 +186,7 @@ const translation = {
   },
   "Init": {
     "Retry": "Retry (PT-BR)",
+    "Failed": "We couldn't load your wallet. Check your connection and try again. (PT-BR)",
     "Starting": "Starting... (PT-BR)",
     "CheckingOCA": "Checking for OCA updates... (PT-BR)",
     "InitializingAgent": "Initializing agent... (PT-BR)",


### PR DESCRIPTION
## Problem
Opening **Settings → Contacts** before the BCSC agent finished initializing crashed with a red box (`useConnections` render error).

The app now shows a spinner indicating it's waiting for the agent to complete initalization before displaying contacts. The second time through the agent is already initalized so no spinner is shown:

https://github.com/user-attachments/assets/3d9dffbf-8adf-4dac-88b7-bc9ed572e698


## Root cause
`ContactsScreen` calls `useConnections()`, which needs Bifold's `ConnectionProvider`. `BifoldScope` only mounts that provider once the agent is ready, but the contact screens were registered **raw** in `MainStack` (unlike `ScopedCredentialDetails`), so an early mount threw.

## Changes
- Wrap the connection-hook contact screens — `Contacts`, `ContactDetails`, `EditContactName`, `RemoveContact` — in `AgentReadyGate` via a new `withAgentReadyGate` HOC. Static screens (`WhatAreContacts`, `ContactJSONDetails`, `ContactChat`) stay raw — they use no connection hooks.
- Add an **error → retry** state to the shared `AgentReadyGate` (`Init.Failed` + existing `Init.Retry`). Previously an agent-init failure spun forever; now it shows a message + Retry. This also benefits the Wallet tab and `CredentialDetails`.
- Add `Init.Failed` copy to `en` / `fr` / `pt-br`.

Reading connections is local/offline (`agent…connections.getAll()`), so no mediator rework was needed — gating on agent-ready is sufficient.

## Testing
- New `AgentReadyGate.test.tsx`: ready → children, loading → spinner, error → message + working Retry.
- `yarn jest` (agent + contacts): **64 passed**. `yarn typecheck` ✅. ESLint ✅.
- Manual: cold-launch → sign in → immediately Settings → Contacts → spinner then list (no red box); forced agent-init failure → message + Retry.

Closes #3908