### PR TITLE
feat: handle connection invitations from browser deep links

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,4 +1,8 @@
 import Root from '@/Root'
+import {
+  ConnectionInvitationService,
+  ConnectionInvitationServiceProvider,
+} from '@/bcsc-theme/features/connection-invitation'
 import { DeepLinkService, DeepLinkViewModel } from '@/bcsc-theme/features/deep-linking'
 import { FcmService, FcmServiceProvider, FcmViewModel } from '@/bcsc-theme/features/fcm'
 import { PairingService, PairingServiceProvider } from '@/bcsc-theme/features/pairing'
@@ -57,8 +61,14 @@ initIssuer(appLogger)
 // Module-level singletons - constructors are pure (no RN bridge calls)
 // All platform interactions happen in initialize() methods
 const pairingService = new PairingService(appLogger)
+const connectionInvitationService = new ConnectionInvitationService(appLogger)
 const verificationResponseService = new VerificationResponseService(appLogger)
-const deepLinkViewModel = new DeepLinkViewModel(new DeepLinkService(), appLogger, pairingService)
+const deepLinkViewModel = new DeepLinkViewModel(
+  new DeepLinkService(),
+  appLogger,
+  pairingService,
+  connectionInvitationService
+)
 const appMode = Config.BUILD_TARGET === Mode.BCSC ? Mode.BCSC : Mode.BCWallet
 const fcmService = new FcmService(appLogger)
 const fcmViewModel = new FcmViewModel(fcmService, appLogger, pairingService, verificationResponseService, appMode)
@@ -127,32 +137,34 @@ const App = () => {
             >
               <NavigationContainerProvider>
                 <PairingServiceProvider service={pairingService}>
-                  <FcmServiceProvider service={fcmService} viewModel={fcmViewModel}>
-                    <VerificationResponseServiceProvider service={verificationResponseService}>
-                      <AnimatedComponentsProvider value={animatedComponents}>
-                        <AuthProvider>
-                          <NetworkProvider>
-                            <ThemeAwareStatusBar />
-                            <ErrorModal enableReport />
-                            <WebDisplay
-                              destinationUrl={surveyMonkeyUrl}
-                              exitUrl={surveyMonkeyExitUrl}
-                              visible={surveyVisible}
-                              onClose={() => setSurveyVisible(false)}
-                            />
-                            <TourProvider tours={tours} overlayColor={'black'} overlayOpacity={0.7}>
-                              <ErrorAlertProvider enableReport>
-                                <KeyboardProvider statusBarTranslucent={true} navigationBarTranslucent={true}>
-                                  <Root />
-                                </KeyboardProvider>
-                              </ErrorAlertProvider>
-                            </TourProvider>
-                            <Toast topOffset={15} config={toastConfig} />
-                          </NetworkProvider>
-                        </AuthProvider>
-                      </AnimatedComponentsProvider>
-                    </VerificationResponseServiceProvider>
-                  </FcmServiceProvider>
+                  <ConnectionInvitationServiceProvider service={connectionInvitationService}>
+                    <FcmServiceProvider service={fcmService} viewModel={fcmViewModel}>
+                      <VerificationResponseServiceProvider service={verificationResponseService}>
+                        <AnimatedComponentsProvider value={animatedComponents}>
+                          <AuthProvider>
+                            <NetworkProvider>
+                              <ThemeAwareStatusBar />
+                              <ErrorModal enableReport />
+                              <WebDisplay
+                                destinationUrl={surveyMonkeyUrl}
+                                exitUrl={surveyMonkeyExitUrl}
+                                visible={surveyVisible}
+                                onClose={() => setSurveyVisible(false)}
+                              />
+                              <TourProvider tours={tours} overlayColor={'black'} overlayOpacity={0.7}>
+                                <ErrorAlertProvider enableReport>
+                                  <KeyboardProvider statusBarTranslucent={true} navigationBarTranslucent={true}>
+                                    <Root />
+                                  </KeyboardProvider>
+                                </ErrorAlertProvider>
+                              </TourProvider>
+                              <Toast topOffset={15} config={toastConfig} />
+                            </NetworkProvider>
+                          </AuthProvider>
+                        </AnimatedComponentsProvider>
+                      </VerificationResponseServiceProvider>
+                    </FcmServiceProvider>
+                  </ConnectionInvitationServiceProvider>
                 </PairingServiceProvider>
               </NavigationContainerProvider>
             </ThemeProvider>

--- a/app/src/bcsc-theme/contexts/BCSCActivityContext.test.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCActivityContext.test.tsx
@@ -185,4 +185,38 @@ describe('BCSCActivityContext', () => {
 
     addEventListenerSpy.mockRestore()
   })
+
+  it('restarts pickup on a fast background→foreground flip while the stop is still in-flight', async () => {
+    mockAgentHolder.current = { didcomm: { mediationRecipient: mockMediationRecipient } }
+    let appStateHandler: ((state: AppStateStatus) => void | Promise<void>) | undefined
+    const addEventListenerSpy = jest.spyOn(AppState, 'addEventListener').mockImplementation((event, handler) => {
+      if (event === 'change') {
+        appStateHandler = handler
+      }
+      return { remove: jest.fn() } as unknown as ReturnType<typeof AppState.addEventListener>
+    })
+
+    renderHook(() => useBCSCActivity(), { wrapper })
+
+    await act(async () => {
+      await appStateHandler?.('active')
+    })
+    mockMediationRecipient.stopMessagePickup.mockClear()
+    mockMediationRecipient.initiateMessagePickup.mockClear()
+
+    // Fire background then foreground back-to-back without awaiting between them — the
+    // foreground handler runs while the background handler is still awaiting stop, so it
+    // must read the already-advanced previous state and restart pickup (regression for
+    // the stale-prevAppState race).
+    await act(async () => {
+      const background = appStateHandler?.('background')
+      const foreground = appStateHandler?.('active')
+      await Promise.all([background, foreground])
+    })
+
+    expect(mockMediationRecipient.stopMessagePickup).toHaveBeenCalledTimes(1)
+    expect(mockMediationRecipient.initiateMessagePickup).toHaveBeenCalledTimes(1)
+
+    addEventListenerSpy.mockRestore()
+  })
 })

--- a/app/src/bcsc-theme/contexts/BCSCActivityContext.test.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCActivityContext.test.tsx
@@ -31,6 +31,8 @@ describe('BCSCActivityContext', () => {
   beforeEach(() => {
     jest.useFakeTimers()
     mockLogout.mockClear()
+    mockMediationRecipient.stopMessagePickup.mockClear()
+    mockMediationRecipient.initiateMessagePickup.mockClear()
   })
 
   afterEach(() => {
@@ -152,6 +154,34 @@ describe('BCSCActivityContext', () => {
       await appStateHandler?.('active')
     })
     expect(mockMediationRecipient.initiateMessagePickup).toHaveBeenCalled()
+
+    addEventListenerSpy.mockRestore()
+  })
+
+  it('does not touch message pickup (or log) when no agent is available', async () => {
+    mockAgentHolder.current = null
+    let appStateHandler: ((state: AppStateStatus) => void | Promise<void>) | undefined
+    const addEventListenerSpy = jest.spyOn(AppState, 'addEventListener').mockImplementation((event, handler) => {
+      if (event === 'change') {
+        appStateHandler = handler
+      }
+      return { remove: jest.fn() } as unknown as ReturnType<typeof AppState.addEventListener>
+    })
+
+    renderHook(() => useBCSCActivity(), { wrapper })
+
+    await act(async () => {
+      await appStateHandler?.('active')
+    })
+    await act(async () => {
+      await appStateHandler?.('background')
+    })
+    await act(async () => {
+      await appStateHandler?.('active')
+    })
+
+    expect(mockMediationRecipient.stopMessagePickup).not.toHaveBeenCalled()
+    expect(mockMediationRecipient.initiateMessagePickup).not.toHaveBeenCalled()
 
     addEventListenerSpy.mockRestore()
   })

--- a/app/src/bcsc-theme/contexts/BCSCActivityContext.test.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCActivityContext.test.tsx
@@ -1,6 +1,6 @@
 import { BasicAppContext } from '@mocks/helpers/app'
 import { act, renderHook } from '@testing-library/react-native'
-import { Keyboard } from 'react-native'
+import { AppState, AppStateStatus, Keyboard } from 'react-native'
 
 import { BCSCActivityProvider, useBCSCActivity } from './BCSCActivityContext'
 
@@ -9,6 +9,16 @@ const mockLogout = jest.fn()
 jest.mock('@/bcsc-theme/hooks/useSecureActions', () => ({
   __esModule: true,
   default: () => ({ logout: mockLogout }),
+}))
+
+const mockMediationRecipient = {
+  stopMessagePickup: jest.fn().mockResolvedValue(undefined),
+  initiateMessagePickup: jest.fn().mockResolvedValue(undefined),
+}
+const mockAgentHolder: { current: unknown } = { current: null }
+
+jest.mock('@/bcsc-theme/features/agent/BCSCAgentProvider', () => ({
+  useBCSCAgentSafe: () => ({ agent: mockAgentHolder.current }),
 }))
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -25,6 +35,7 @@ describe('BCSCActivityContext', () => {
 
   afterEach(() => {
     jest.useRealTimers()
+    mockAgentHolder.current = null
   })
 
   it('should expose reportActivity on the context', () => {
@@ -108,5 +119,40 @@ describe('BCSCActivityContext', () => {
     expect(removeMock).toHaveBeenCalledTimes(2)
 
     addListenerSpy.mockRestore()
+  })
+
+  it('stops message pickup on background and restarts live pickup on foreground', async () => {
+    mockAgentHolder.current = { didcomm: { mediationRecipient: mockMediationRecipient } }
+    let appStateHandler: ((state: AppStateStatus) => void | Promise<void>) | undefined
+    const addEventListenerSpy = jest.spyOn(AppState, 'addEventListener').mockImplementation((event, handler) => {
+      if (event === 'change') {
+        appStateHandler = handler
+      }
+      return { remove: jest.fn() } as unknown as ReturnType<typeof AppState.addEventListener>
+    })
+
+    renderHook(() => useBCSCActivity(), { wrapper })
+
+    // Prime the previous app state to 'active' so the next transition is recognized,
+    // then clear any pickup calls priming may have produced.
+    await act(async () => {
+      await appStateHandler?.('active')
+    })
+    mockMediationRecipient.stopMessagePickup.mockClear()
+    mockMediationRecipient.initiateMessagePickup.mockClear()
+
+    // → background: the live pickup socket is torn down.
+    await act(async () => {
+      await appStateHandler?.('background')
+    })
+    expect(mockMediationRecipient.stopMessagePickup).toHaveBeenCalledTimes(1)
+
+    // → foreground: live pickup is restarted to flush anything queued while away.
+    await act(async () => {
+      await appStateHandler?.('active')
+    })
+    expect(mockMediationRecipient.initiateMessagePickup).toHaveBeenCalled()
+
+    addEventListenerSpy.mockRestore()
   })
 })

--- a/app/src/bcsc-theme/contexts/BCSCActivityContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCActivityContext.tsx
@@ -112,8 +112,17 @@ export const BCSCActivityProvider: React.FC<PropsWithChildren> = ({ children }) 
   useEffect(() => {
     // listener for backgrounding / foregrounding
     const eventSubscription = AppState.addEventListener('change', async (nextAppState) => {
+      // Snapshot the previous state and advance the ref/state synchronously, before any
+      // await below. The handler is async (it awaits pickup calls), so if the OS fires
+      // another AppState event while one is in-flight, advancing the ref up front keeps
+      // the second invocation from reading a stale previous state and mis-ordering pickup
+      // (e.g. a fast background→foreground flip would otherwise skip the pickup restart).
+      const prevAppState = prevAppStateStatusRef.current
+      prevAppStateStatusRef.current = nextAppState
+      setAppStateStatus(nextAppState)
+
       // if going into the background
-      if (['active', 'inactive'].includes(prevAppStateStatusRef.current) && nextAppState === 'background') {
+      if (['active', 'inactive'].includes(prevAppState) && nextAppState === 'background') {
         // remove timeout when backgrounded as timeout refs can be lost when app is backgrounded
         clearInactivityTimeoutIfExists()
 
@@ -133,7 +142,7 @@ export const BCSCActivityProvider: React.FC<PropsWithChildren> = ({ children }) 
       }
 
       // if coming to the foreground
-      if (prevAppStateStatusRef.current === 'background' && ['active', 'inactive'].includes(nextAppState)) {
+      if (prevAppState === 'background' && ['active', 'inactive'].includes(nextAppState)) {
         // if app was in background for longer than allowed time, log out user
         if (
           !isPausedRef.current &&
@@ -166,9 +175,6 @@ export const BCSCActivityProvider: React.FC<PropsWithChildren> = ({ children }) 
           }
         }
       }
-
-      prevAppStateStatusRef.current = nextAppState
-      setAppStateStatus(nextAppState)
     })
 
     // keyboard activity resets the inactivity timeout

--- a/app/src/bcsc-theme/contexts/BCSCActivityContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCActivityContext.tsx
@@ -1,7 +1,10 @@
+import { useBCSCAgentSafe } from '@/bcsc-theme/features/agent/BCSCAgentProvider'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { DEFAULT_AUTO_LOCK_TIME_MIN } from '@/constants'
 import { BCState } from '@/store'
 import { TOKENS, useServices, useStore } from '@bifold/core'
+import { Agent } from '@credo-ts/core'
+import { DidCommMediatorPickupStrategy } from '@credo-ts/didcomm'
 import React, {
   createContext,
   PropsWithChildren,
@@ -51,6 +54,11 @@ export const BCSCActivityProvider: React.FC<PropsWithChildren> = ({ children }) 
   const prevAppStateStatusRef = useRef(AppState.currentState)
   const [appStateStatus, setAppStateStatus] = useState<AppStateStatus>(AppState.currentState)
   const isPausedRef = useRef<boolean>(false)
+  // Read the live agent through a ref so the AppState listener (registered once)
+  // always sees the current instance without re-subscribing on every agent change.
+  const agentContext = useBCSCAgentSafe()
+  const agentRef = useRef<Agent | null>(null)
+  agentRef.current = agentContext?.agent ?? null
 
   const clearInactivityTimeoutIfExists = useCallback(() => {
     if (inactivityTimeoutRef.current) {
@@ -108,6 +116,16 @@ export const BCSCActivityProvider: React.FC<PropsWithChildren> = ({ children }) 
       if (['active', 'inactive'].includes(prevAppStateStatusRef.current) && nextAppState === 'background') {
         // remove timeout when backgrounded as timeout refs can be lost when app is backgrounded
         clearInactivityTimeoutIfExists()
+
+        // Tear down the live mediator pickup socket. The OS suspends sockets while
+        // backgrounded, leaving a dead session; pairing this with the foreground
+        // restart below is what flushes messages queued at the mediator on return.
+        try {
+          await agentRef.current?.didcomm.mediationRecipient.stopMessagePickup()
+          logger.info('BCSC Activity: Stopped agent message pickup')
+        } catch (err) {
+          logger.error(`BCSC Activity: Error stopping agent message pickup: ${err}`)
+        }
       }
 
       // if coming to the foreground
@@ -124,6 +142,20 @@ export const BCSCActivityProvider: React.FC<PropsWithChildren> = ({ children }) 
         } else {
           // app coming into the foreground is 'user activity', reset timeout
           resetInactivityTimeout(timeoutInMilliseconds.current)
+
+          // Restart live message pickup. The mediator queues inbound DIDComm
+          // messages (credential offers, proof requests, connection responses)
+          // while the socket is down; without this they stay unfetched until the
+          // next agent restart (app relaunch).
+          try {
+            await agentRef.current?.didcomm.mediationRecipient.initiateMessagePickup(
+              undefined,
+              DidCommMediatorPickupStrategy.PickUpV2LiveMode
+            )
+            logger.info('BCSC Activity: Restarted agent message pickup')
+          } catch (err) {
+            logger.error(`BCSC Activity: Error restarting agent message pickup: ${err}`)
+          }
         }
       }
 

--- a/app/src/bcsc-theme/contexts/BCSCActivityContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCActivityContext.tsx
@@ -120,11 +120,15 @@ export const BCSCActivityProvider: React.FC<PropsWithChildren> = ({ children }) 
         // Tear down the live mediator pickup socket. The OS suspends sockets while
         // backgrounded, leaving a dead session; pairing this with the foreground
         // restart below is what flushes messages queued at the mediator on return.
-        try {
-          await agentRef.current?.didcomm.mediationRecipient.stopMessagePickup()
-          logger.info('BCSC Activity: Stopped agent message pickup')
-        } catch (err) {
-          logger.error(`BCSC Activity: Error stopping agent message pickup: ${err}`)
+        // Only act when an agent exists, so the log reflects what actually happened.
+        const agent = agentRef.current
+        if (agent) {
+          try {
+            await agent.didcomm.mediationRecipient.stopMessagePickup()
+            logger.info('BCSC Activity: Stopped agent message pickup')
+          } catch (err) {
+            logger.error(`BCSC Activity: Error stopping agent message pickup: ${err}`)
+          }
         }
       }
 
@@ -147,14 +151,18 @@ export const BCSCActivityProvider: React.FC<PropsWithChildren> = ({ children }) 
           // messages (credential offers, proof requests, connection responses)
           // while the socket is down; without this they stay unfetched until the
           // next agent restart (app relaunch).
-          try {
-            await agentRef.current?.didcomm.mediationRecipient.initiateMessagePickup(
-              undefined,
-              DidCommMediatorPickupStrategy.PickUpV2LiveMode
-            )
-            logger.info('BCSC Activity: Restarted agent message pickup')
-          } catch (err) {
-            logger.error(`BCSC Activity: Error restarting agent message pickup: ${err}`)
+          // Only act when an agent exists, so the log reflects what actually happened.
+          const agent = agentRef.current
+          if (agent) {
+            try {
+              await agent.didcomm.mediationRecipient.initiateMessagePickup(
+                undefined,
+                DidCommMediatorPickupStrategy.PickUpV2LiveMode
+              )
+              logger.info('BCSC Activity: Restarted agent message pickup')
+            } catch (err) {
+              logger.error(`BCSC Activity: Error restarting agent message pickup: ${err}`)
+            }
           }
         }
       }

--- a/app/src/bcsc-theme/contexts/BCSCActivityContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCActivityContext.tsx
@@ -3,7 +3,7 @@ import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { DEFAULT_AUTO_LOCK_TIME_MIN } from '@/constants'
 import { BCState } from '@/store'
 import { TOKENS, useServices, useStore } from '@bifold/core'
-import { Agent } from '@credo-ts/core'
+import type { Agent } from '@credo-ts/core'
 import { DidCommMediatorPickupStrategy } from '@credo-ts/didcomm'
 import React, {
   createContext,

--- a/app/src/bcsc-theme/features/connection-invitation/ConnectionInvitationService.test.ts
+++ b/app/src/bcsc-theme/features/connection-invitation/ConnectionInvitationService.test.ts
@@ -1,0 +1,87 @@
+import { ConnectionInvitationService } from './ConnectionInvitationService'
+import { ConnectionInvitationPayload } from './types'
+
+describe('ConnectionInvitationService', () => {
+  const logger = { info: jest.fn(), warn: jest.fn() } as any
+  const invitation: ConnectionInvitationPayload = {
+    url: 'bcwallet://aries_connection_invitation?oob=eyJhbGciOi',
+    source: 'deep-link',
+  }
+
+  let service: ConnectionInvitationService
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    service = new ConnectionInvitationService(logger)
+  })
+
+  it('buffers an invitation when there are no listeners', () => {
+    service.handleInvitation(invitation)
+
+    expect(service.hasPending).toBe(true)
+  })
+
+  it('replays a buffered invitation to a late subscriber and clears pending', () => {
+    const listener = jest.fn()
+
+    service.handleInvitation(invitation)
+    expect(service.hasPending).toBe(true)
+
+    service.onInvitation(listener)
+
+    expect(listener).toHaveBeenCalledWith(invitation)
+    expect(service.hasPending).toBe(false)
+  })
+
+  it('emits immediately when a listener is already subscribed (warm path)', () => {
+    const listener = jest.fn()
+    service.onInvitation(listener)
+
+    service.handleInvitation(invitation)
+
+    expect(listener).toHaveBeenCalledWith(invitation)
+    // Nothing buffered because it was delivered live.
+    expect(service.hasPending).toBe(false)
+  })
+
+  it('does not deliver to a listener after it unsubscribes', () => {
+    const listener = jest.fn()
+    const unsubscribe = service.onInvitation(listener)
+
+    unsubscribe()
+    service.handleInvitation(invitation)
+
+    expect(listener).not.toHaveBeenCalled()
+    // Buffered again since there are no active listeners.
+    expect(service.hasPending).toBe(true)
+  })
+
+  it('ignores invitations without a url', () => {
+    service.handleInvitation({ url: '', source: 'deep-link' })
+
+    expect(service.hasPending).toBe(false)
+    expect(logger.warn).toHaveBeenCalled()
+  })
+
+  it('notifies pending-state subscribers as the buffer fills and drains', () => {
+    const stateListener = jest.fn()
+    service.onPendingStateChange(stateListener)
+    // Emits current state (false) on subscription.
+    expect(stateListener).toHaveBeenLastCalledWith(false)
+
+    service.handleInvitation(invitation)
+    expect(stateListener).toHaveBeenLastCalledWith(true)
+
+    service.onInvitation(jest.fn())
+    expect(stateListener).toHaveBeenLastCalledWith(false)
+  })
+
+  it('clearPending drops a buffered invitation', () => {
+    service.handleInvitation(invitation)
+    expect(service.hasPending).toBe(true)
+
+    service.clearPending()
+
+    expect(service.hasPending).toBe(false)
+  })
+})

--- a/app/src/bcsc-theme/features/connection-invitation/ConnectionInvitationService.ts
+++ b/app/src/bcsc-theme/features/connection-invitation/ConnectionInvitationService.ts
@@ -1,0 +1,95 @@
+import { AbstractBifoldLogger } from '@bifold/core'
+
+import { ConnectionInvitationListener, ConnectionInvitationPayload, PendingConnectionInvitationListener } from './types'
+
+/**
+ * Buffers out-of-band connection invitations that arrive before the agent is
+ * ready (e.g. a cold-start deep link) and hands them to a single agent-gated
+ * consumer once it subscribes.
+ *
+ * Mirrors {@link PairingService}, but with one key difference: accepting an
+ * invitation requires the live agent (to `receiveInvitation` and obtain an
+ * `oobRecordId` before navigating), so this service only transports the raw
+ * URL — acceptance and navigation happen in the consumer
+ * ({@link useConnectionInvitationDeepLink}).
+ */
+export class ConnectionInvitationService {
+  private readonly listeners = new Set<ConnectionInvitationListener>()
+  private readonly pendingStateListeners = new Set<PendingConnectionInvitationListener>()
+  private pending: ConnectionInvitationPayload | null = null
+
+  constructor(private readonly logger: AbstractBifoldLogger) {}
+
+  /**
+   * Subscribe to invitations. Any invitation buffered before subscription (a
+   * cold-start deep link) is replayed immediately to the new listener so the
+   * consumer does not miss invitations discovered during app launch.
+   */
+  public onInvitation(listener: ConnectionInvitationListener): () => void {
+    this.listeners.add(listener)
+
+    if (this.pending) {
+      const payload = this.pending
+      this.pending = null
+      this.notifyPendingStateChange()
+      listener(payload)
+    }
+
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  /**
+   * Subscribe to pending-state changes (useful for UI indicators). Emits the
+   * current state immediately on subscription.
+   */
+  public onPendingStateChange(listener: PendingConnectionInvitationListener): () => void {
+    this.pendingStateListeners.add(listener)
+    listener(this.hasPending)
+    return () => {
+      this.pendingStateListeners.delete(listener)
+    }
+  }
+
+  /** Whether an invitation is buffered waiting for a consumer. */
+  public get hasPending(): boolean {
+    return this.pending !== null
+  }
+
+  /** Clear any pending invitation without processing it. */
+  public clearPending(): void {
+    this.pending = null
+    this.notifyPendingStateChange()
+  }
+
+  /**
+   * Handle a new connection invitation from any source. Emits to a live
+   * consumer when one is subscribed, otherwise buffers it until one is.
+   */
+  public handleInvitation(payload: ConnectionInvitationPayload): void {
+    if (!payload.url) {
+      this.logger.warn(`[ConnectionInvitationService] Ignoring invitation from ${payload.source}: missing url`)
+      return
+    }
+
+    this.logger.info(`[ConnectionInvitationService] Invitation from ${payload.source}`)
+
+    if (this.listeners.size > 0) {
+      this.emit(payload)
+    } else {
+      this.logger.info('[ConnectionInvitationService] Buffering invitation (no listeners)')
+      this.pending = payload
+      this.notifyPendingStateChange()
+    }
+  }
+
+  private emit(payload: ConnectionInvitationPayload): void {
+    this.listeners.forEach((listener) => listener(payload))
+  }
+
+  private notifyPendingStateChange(): void {
+    const hasPending = this.hasPending
+    this.pendingStateListeners.forEach((listener) => listener(hasPending))
+  }
+}

--- a/app/src/bcsc-theme/features/connection-invitation/ConnectionInvitationServiceContext.tsx
+++ b/app/src/bcsc-theme/features/connection-invitation/ConnectionInvitationServiceContext.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext } from 'react'
+
+import { ConnectionInvitationService } from './ConnectionInvitationService'
+
+const ConnectionInvitationServiceContext = createContext<ConnectionInvitationService | null>(null)
+
+export const ConnectionInvitationServiceProvider: React.FC<{
+  service: ConnectionInvitationService
+  children: React.ReactNode
+}> = ({ service, children }) => {
+  return (
+    <ConnectionInvitationServiceContext.Provider value={service}>
+      {children}
+    </ConnectionInvitationServiceContext.Provider>
+  )
+}
+
+export const useConnectionInvitationService = () => {
+  const context = useContext(ConnectionInvitationServiceContext)
+  if (!context) {
+    throw new Error('useConnectionInvitationService must be used within a ConnectionInvitationServiceProvider')
+  }
+
+  return context
+}

--- a/app/src/bcsc-theme/features/connection-invitation/index.ts
+++ b/app/src/bcsc-theme/features/connection-invitation/index.ts
@@ -1,0 +1,11 @@
+export { ConnectionInvitationService } from './ConnectionInvitationService'
+export {
+  ConnectionInvitationServiceProvider,
+  useConnectionInvitationService,
+} from './ConnectionInvitationServiceContext'
+export type {
+  ConnectionInvitationListener,
+  ConnectionInvitationPayload,
+  PendingConnectionInvitationListener,
+} from './types'
+export { useConnectionInvitationDeepLink } from './useConnectionInvitationDeepLink'

--- a/app/src/bcsc-theme/features/connection-invitation/types.ts
+++ b/app/src/bcsc-theme/features/connection-invitation/types.ts
@@ -1,0 +1,13 @@
+/**
+ * An out-of-band connection invitation captured from any source, carrying the
+ * raw invitation URL for the agent to parse and accept once it is ready.
+ */
+export type ConnectionInvitationPayload = {
+  /** Raw invitation URL, e.g. `bcwallet://aries_connection_invitation?oob=<base64>` */
+  url: string
+  /** Source of the invitation, for debugging */
+  source: 'deep-link' | 'fcm' | 'qr'
+}
+
+export type ConnectionInvitationListener = (payload: ConnectionInvitationPayload) => void
+export type PendingConnectionInvitationListener = (hasPending: boolean) => void

--- a/app/src/bcsc-theme/features/connection-invitation/useConnectionInvitationDeepLink.test.ts
+++ b/app/src/bcsc-theme/features/connection-invitation/useConnectionInvitationDeepLink.test.ts
@@ -7,8 +7,11 @@ import { useConnectionInvitationDeepLink } from './useConnectionInvitationDeepLi
 const mockNavigate = jest.fn()
 const mockToastShow = jest.fn()
 const mockHandle = jest.fn()
+const mockStopPickup = jest.fn().mockResolvedValue(undefined)
 const mockInitiatePickup = jest.fn().mockResolvedValue(undefined)
-const mockAgent = { didcomm: { mediationRecipient: { initiateMessagePickup: mockInitiatePickup } } }
+const mockAgent = {
+  didcomm: { mediationRecipient: { stopMessagePickup: mockStopPickup, initiateMessagePickup: mockInitiatePickup } },
+}
 const mockAgentState: { agent: unknown; loading: boolean } = { agent: null, loading: true }
 let mockService: ConnectionInvitationService
 
@@ -62,8 +65,9 @@ describe('useConnectionInvitationDeepLink', () => {
     await waitFor(() =>
       expect(mockNavigate).toHaveBeenCalledWith(BCSCScreens.ConnectionLoading, { oobRecordId: 'rec-1' })
     )
-    // The #2288 fix: live pickup is (re)started before navigating so the
-    // inviter's response is flushed instead of stuck at the mediator.
+    // The #2288 fix: live pickup is fully restarted (stop → start) before navigating
+    // so the inviter's response is flushed instead of stuck at the mediator.
+    expect(mockStopPickup).toHaveBeenCalled()
     expect(mockInitiatePickup).toHaveBeenCalledWith(undefined, 'PickUpV2LiveMode')
     expect(mockHandle).toHaveBeenCalledWith(INVITATION_URL, expect.objectContaining({ agent: mockAgent }))
   })

--- a/app/src/bcsc-theme/features/connection-invitation/useConnectionInvitationDeepLink.test.ts
+++ b/app/src/bcsc-theme/features/connection-invitation/useConnectionInvitationDeepLink.test.ts
@@ -1,0 +1,98 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native'
+
+import { BCSCScreens } from '../../types/navigators'
+import { ConnectionInvitationService } from './ConnectionInvitationService'
+import { useConnectionInvitationDeepLink } from './useConnectionInvitationDeepLink'
+
+const mockNavigate = jest.fn()
+const mockToastShow = jest.fn()
+const mockHandle = jest.fn()
+const mockInitiatePickup = jest.fn().mockResolvedValue(undefined)
+const mockAgent = { didcomm: { mediationRecipient: { initiateMessagePickup: mockInitiatePickup } } }
+const mockAgentState: { agent: unknown; loading: boolean } = { agent: null, loading: true }
+let mockService: ConnectionInvitationService
+
+jest.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }))
+jest.mock('@react-navigation/native', () => ({ useNavigation: () => ({ navigate: mockNavigate }) }))
+jest.mock('react-native-toast-message', () => ({
+  __esModule: true,
+  default: { show: (...args: unknown[]) => mockToastShow(...args) },
+}))
+jest.mock('@bifold/core', () => ({
+  TOKENS: { UTIL_LOGGER: 'logger' },
+  useServices: () => [{ info: jest.fn(), warn: jest.fn(), error: jest.fn() }],
+}))
+jest.mock('@credo-ts/didcomm', () => ({
+  DidCommMediatorPickupStrategy: { PickUpV2LiveMode: 'PickUpV2LiveMode' },
+}))
+jest.mock('@/bcsc-theme/features/agent/BCSCAgentProvider', () => ({ useBCSCAgent: () => mockAgentState }))
+jest.mock('../qr-core/uri-strategies', () => ({
+  DidCommOobStrategy: { handle: (...args: unknown[]) => mockHandle(...args) },
+}))
+jest.mock('./ConnectionInvitationServiceContext', () => ({ useConnectionInvitationService: () => mockService }))
+
+const INVITATION_URL = 'bcwallet://aries_connection_invitation?oob=eyJhbGciOi'
+
+describe('useConnectionInvitationDeepLink', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockAgentState.agent = null
+    mockAgentState.loading = true
+    mockService = new ConnectionInvitationService({ info: jest.fn(), warn: jest.fn() } as any)
+  })
+
+  it('defers a cold-start invitation until the agent is ready, then re-kicks pickup and navigates', async () => {
+    mockHandle.mockResolvedValue({ kind: 'connection', oobRecordId: 'rec-1' })
+
+    const { rerender } = renderHook(() => useConnectionInvitationDeepLink())
+
+    // Invitation arrives while the agent is still initializing — must not process.
+    act(() => {
+      mockService.handleInvitation({ url: INVITATION_URL, source: 'deep-link' })
+    })
+    expect(mockHandle).not.toHaveBeenCalled()
+
+    // Agent becomes ready — the buffered invitation is now accepted.
+    mockAgentState.agent = mockAgent
+    mockAgentState.loading = false
+    await act(async () => {
+      rerender({})
+    })
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith(BCSCScreens.ConnectionLoading, { oobRecordId: 'rec-1' })
+    )
+    // The #2288 fix: live pickup is (re)started before navigating so the
+    // inviter's response is flushed instead of stuck at the mediator.
+    expect(mockInitiatePickup).toHaveBeenCalledWith(undefined, 'PickUpV2LiveMode')
+    expect(mockHandle).toHaveBeenCalledWith(INVITATION_URL, expect.objectContaining({ agent: mockAgent }))
+  })
+
+  it('surfaces a toast and does not navigate when the invitation is unsupported', async () => {
+    mockAgentState.agent = mockAgent
+    mockAgentState.loading = false
+    mockHandle.mockResolvedValue({ kind: 'unsupported', reason: 'OpenID' })
+
+    renderHook(() => useConnectionInvitationDeepLink())
+    await act(async () => {
+      mockService.handleInvitation({ url: INVITATION_URL, source: 'deep-link' })
+    })
+
+    await waitFor(() => expect(mockToastShow).toHaveBeenCalled())
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a toast when accepting the invitation throws', async () => {
+    mockAgentState.agent = mockAgent
+    mockAgentState.loading = false
+    mockHandle.mockRejectedValue(new Error('network'))
+
+    renderHook(() => useConnectionInvitationDeepLink())
+    await act(async () => {
+      mockService.handleInvitation({ url: INVITATION_URL, source: 'deep-link' })
+    })
+
+    await waitFor(() => expect(mockToastShow).toHaveBeenCalled())
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/bcsc-theme/features/connection-invitation/useConnectionInvitationDeepLink.ts
+++ b/app/src/bcsc-theme/features/connection-invitation/useConnectionInvitationDeepLink.ts
@@ -45,9 +45,20 @@ export const useConnectionInvitationDeepLink = (): void => {
       // agent reports ready once `initiateMessagePickup` was *awaited*, but the
       // mediator live-pickup socket may not be flushing yet — so the inviter's
       // connection response sits at the mediator and the Connection screen hangs
-      // (#2288). (Re)starting live pickup here flushes the queue, mirroring what
-      // the foreground handler does. BCSC has no foreground re-kick on cold
-      // start, so this is the deterministic fix for the deep-link path.
+      // (#2288).
+      //
+      // Mirror Bifold's proven foreground recovery (activity.js) with a full
+      // stop → start so we always land on a fresh, flushing live session. A bare
+      // `initiateMessagePickup` can be a no-op when a (stale) session already
+      // exists from agent init, which would leave the queue unflushed. BCSC has
+      // no foreground re-kick on cold start, so this is the deterministic fix for
+      // the deep-link path.
+      try {
+        await agent.didcomm.mediationRecipient.stopMessagePickup()
+      } catch (err) {
+        // Nothing to stop yet (no live session) — the (re)start below is what matters.
+        logger.info(`[ConnectionInvitationDeepLink] stopMessagePickup before restart: ${err}`)
+      }
       try {
         await agent.didcomm.mediationRecipient.initiateMessagePickup(
           undefined,

--- a/app/src/bcsc-theme/features/connection-invitation/useConnectionInvitationDeepLink.ts
+++ b/app/src/bcsc-theme/features/connection-invitation/useConnectionInvitationDeepLink.ts
@@ -1,0 +1,95 @@
+import { useBCSCAgent } from '@/bcsc-theme/features/agent/BCSCAgentProvider'
+import { TOKENS, useServices } from '@bifold/core'
+import { DidCommMediatorPickupStrategy } from '@credo-ts/didcomm'
+import { useNavigation } from '@react-navigation/native'
+import { StackNavigationProp } from '@react-navigation/stack'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import Toast from 'react-native-toast-message'
+
+import { BCSCMainStackParams, BCSCScreens } from '../../types/navigators'
+import { DidCommOobStrategy } from '../qr-core/uri-strategies'
+import { useConnectionInvitationService } from './ConnectionInvitationServiceContext'
+
+/**
+ * Drains out-of-band connection invitations captured by
+ * {@link ConnectionInvitationService} (e.g. a cold-start
+ * `bcwallet://aries_connection_invitation?oob=...` deep link), accepts them via
+ * the shared DIDComm OOB strategy once the agent is ready, and navigates to the
+ * Connection screen. Must be mounted inside the agent scope (it reads
+ * {@link useBCSCAgent}).
+ *
+ * Convergence: deep-link and QR-scanned invitations both run through
+ * {@link DidCommOobStrategy} and land on the same `ConnectionLoading` screen.
+ */
+export const useConnectionInvitationDeepLink = (): void => {
+  const service = useConnectionInvitationService()
+  const { agent, loading } = useBCSCAgent()
+  const navigation = useNavigation<StackNavigationProp<BCSCMainStackParams>>()
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const { t } = useTranslation()
+  const [invitationUrl, setInvitationUrl] = useState<string | null>(null)
+
+  useEffect(() => service.onInvitation(({ url }) => setInvitationUrl(url)), [service])
+
+  useEffect(() => {
+    // Wait for the agent to reach 'ready' (loading === false) before accepting.
+    if (!invitationUrl || !agent || loading) {
+      return
+    }
+
+    let cancelled = false
+
+    const accept = async () => {
+      // Gating on 'ready' is necessary but not sufficient on cold start: the
+      // agent reports ready once `initiateMessagePickup` was *awaited*, but the
+      // mediator live-pickup socket may not be flushing yet — so the inviter's
+      // connection response sits at the mediator and the Connection screen hangs
+      // (#2288). (Re)starting live pickup here flushes the queue, mirroring what
+      // the foreground handler does. BCSC has no foreground re-kick on cold
+      // start, so this is the deterministic fix for the deep-link path.
+      try {
+        await agent.didcomm.mediationRecipient.initiateMessagePickup(
+          undefined,
+          DidCommMediatorPickupStrategy.PickUpV2LiveMode
+        )
+      } catch (err) {
+        logger.error(`[ConnectionInvitationDeepLink] message pickup (re)start failed: ${err}`)
+      }
+
+      try {
+        const result = await DidCommOobStrategy.handle(invitationUrl, { agent, logger })
+        if (cancelled) {
+          return
+        }
+        setInvitationUrl(null)
+
+        switch (result.kind) {
+          case 'connection':
+            navigation.navigate(BCSCScreens.ConnectionLoading, { oobRecordId: result.oobRecordId })
+            break
+          case 'unsupported':
+            Toast.show({ type: 'error', text1: t(`BCSC.Scan.Unsupported.${result.reason}`) })
+            break
+          default:
+            logger.warn(`[ConnectionInvitationDeepLink] invitation not actionable: ${result.kind}`)
+            Toast.show({ type: 'error', text1: t('BCSC.Scan.InvalidConnectionInvitation') })
+            break
+        }
+      } catch (err) {
+        if (cancelled) {
+          return
+        }
+        setInvitationUrl(null)
+        logger.error(`[ConnectionInvitationDeepLink] failed to accept invitation: ${err}`)
+        Toast.show({ type: 'error', text1: t('BCSC.Scan.InvalidConnectionInvitation') })
+      }
+    }
+
+    accept()
+
+    return () => {
+      cancelled = true
+    }
+  }, [invitationUrl, agent, loading, navigation, logger, t])
+}

--- a/app/src/bcsc-theme/features/deep-linking/DeepLinkViewModel.test.ts
+++ b/app/src/bcsc-theme/features/deep-linking/DeepLinkViewModel.test.ts
@@ -3,6 +3,10 @@ import { isDidCommInvitation } from '@bifold/core'
 import { DeepLinkViewModel } from './DeepLinkViewModel'
 import { DeepLinkPayload } from './services/deep-linking'
 
+// Wholesale-mock @bifold/core (same approach as useScanScreenViewModel.test.ts):
+// the real module is heavy (React Native + Credo) and awkward to load under jest.
+// At runtime this ViewModel only uses isDidCommInvitation — AbstractBifoldLogger is
+// a type-only import and is erased — so stubbing just this export is sufficient.
 jest.mock('@bifold/core', () => ({
   isDidCommInvitation: jest.fn(),
 }))

--- a/app/src/bcsc-theme/features/deep-linking/DeepLinkViewModel.test.ts
+++ b/app/src/bcsc-theme/features/deep-linking/DeepLinkViewModel.test.ts
@@ -1,5 +1,13 @@
+import { isDidCommInvitation } from '@bifold/core'
+
 import { DeepLinkViewModel } from './DeepLinkViewModel'
 import { DeepLinkPayload } from './services/deep-linking'
+
+jest.mock('@bifold/core', () => ({
+  isDidCommInvitation: jest.fn(),
+}))
+
+const mockIsDidCommInvitation = isDidCommInvitation as jest.Mock
 
 describe('DeepLinkViewModel', () => {
   const pairingPath = '/https%3A%2F%2Fexample.com%2Fdevice%2FMy+Service%2FPAIR123'
@@ -7,6 +15,7 @@ describe('DeepLinkViewModel', () => {
   let capturedHandler: ((payload: DeepLinkPayload) => void) | undefined
   let mockService: { subscribe: jest.Mock; init: jest.Mock }
   let mockPairingService: { handlePairing: jest.Mock }
+  let mockConnectionInvitationService: { handleInvitation: jest.Mock }
   let logger: { info: jest.Mock; warn: jest.Mock }
 
   const buildPayload = (path: string = pairingPath, host: string = 'pair'): DeepLinkPayload => ({
@@ -28,10 +37,19 @@ describe('DeepLinkViewModel', () => {
     mockPairingService = {
       handlePairing: jest.fn(),
     }
+    mockConnectionInvitationService = {
+      handleInvitation: jest.fn(),
+    }
+    mockIsDidCommInvitation.mockReset()
   })
 
   it('initializes deep link service on initialize', () => {
-    const viewModel = new DeepLinkViewModel(mockService as any, logger as any, mockPairingService as any)
+    const viewModel = new DeepLinkViewModel(
+      mockService as any,
+      logger as any,
+      mockPairingService as any,
+      mockConnectionInvitationService as any
+    )
 
     viewModel.initialize()
 
@@ -40,7 +58,12 @@ describe('DeepLinkViewModel', () => {
   })
 
   it('delegates pairing deep link to PairingService', () => {
-    const viewModel = new DeepLinkViewModel(mockService as any, logger as any, mockPairingService as any)
+    const viewModel = new DeepLinkViewModel(
+      mockService as any,
+      logger as any,
+      mockPairingService as any,
+      mockConnectionInvitationService as any
+    )
 
     viewModel.initialize()
     capturedHandler?.(buildPayload())
@@ -53,7 +76,12 @@ describe('DeepLinkViewModel', () => {
   })
 
   it('uses pre-parsed pairing metadata without re-decoding', () => {
-    const viewModel = new DeepLinkViewModel(mockService as any, logger as any, mockPairingService as any)
+    const viewModel = new DeepLinkViewModel(
+      mockService as any,
+      logger as any,
+      mockPairingService as any,
+      mockConnectionInvitationService as any
+    )
 
     viewModel.initialize()
 
@@ -72,7 +100,12 @@ describe('DeepLinkViewModel', () => {
   })
 
   it('parses pairing metadata when URL.pathname is unavailable', () => {
-    const viewModel = new DeepLinkViewModel(mockService as any, logger as any, mockPairingService as any)
+    const viewModel = new DeepLinkViewModel(
+      mockService as any,
+      logger as any,
+      mockPairingService as any,
+      mockConnectionInvitationService as any
+    )
 
     viewModel.initialize()
     capturedHandler?.(buildPayload('/https%3A%2F%2Fidsit.gov.bc.ca%2Fdevice/BC+Parks+Discover+Camping/HHFBYS'))
@@ -86,7 +119,12 @@ describe('DeepLinkViewModel', () => {
   })
 
   it('logs a warning when pairing payload cannot be parsed', () => {
-    const viewModel = new DeepLinkViewModel(mockService as any, logger as any, mockPairingService as any)
+    const viewModel = new DeepLinkViewModel(
+      mockService as any,
+      logger as any,
+      mockPairingService as any,
+      mockConnectionInvitationService as any
+    )
 
     viewModel.initialize()
     capturedHandler?.(buildPayload('/%'))
@@ -96,7 +134,12 @@ describe('DeepLinkViewModel', () => {
   })
 
   it('ignores deep links for other hosts', () => {
-    const viewModel = new DeepLinkViewModel(mockService as any, logger as any, mockPairingService as any)
+    const viewModel = new DeepLinkViewModel(
+      mockService as any,
+      logger as any,
+      mockPairingService as any,
+      mockConnectionInvitationService as any
+    )
 
     viewModel.initialize()
     capturedHandler?.({ rawUrl: 'scheme://other/thing', host: 'other', path: '/thing' })
@@ -105,12 +148,69 @@ describe('DeepLinkViewModel', () => {
   })
 
   it('skips pairing payloads that do not match expected segments', () => {
-    const viewModel = new DeepLinkViewModel(mockService as any, logger as any, mockPairingService as any)
+    const viewModel = new DeepLinkViewModel(
+      mockService as any,
+      logger as any,
+      mockPairingService as any,
+      mockConnectionInvitationService as any
+    )
 
     viewModel.initialize()
     capturedHandler?.(buildPayload('/https%3A%2F%2Fexample.com%2Ffoo'))
 
     expect(mockPairingService.handlePairing).not.toHaveBeenCalled()
     expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('delegates connection-invitation deep link to ConnectionInvitationService', () => {
+    mockIsDidCommInvitation.mockReturnValue(true)
+    const viewModel = new DeepLinkViewModel(
+      mockService as any,
+      logger as any,
+      mockPairingService as any,
+      mockConnectionInvitationService as any
+    )
+
+    viewModel.initialize()
+    const rawUrl = 'bcwallet://aries_connection_invitation?oob=eyJhbGciOi'
+    capturedHandler?.({ rawUrl, host: 'aries_connection_invitation' })
+
+    expect(mockConnectionInvitationService.handleInvitation).toHaveBeenCalledWith({
+      url: rawUrl,
+      source: 'deep-link',
+    })
+    expect(mockPairingService.handlePairing).not.toHaveBeenCalled()
+  })
+
+  it('does not route non-invitation, non-pairing deep links to either service', () => {
+    mockIsDidCommInvitation.mockReturnValue(false)
+    const viewModel = new DeepLinkViewModel(
+      mockService as any,
+      logger as any,
+      mockPairingService as any,
+      mockConnectionInvitationService as any
+    )
+
+    viewModel.initialize()
+    capturedHandler?.({ rawUrl: 'bcwallet://something/else', host: 'something' })
+
+    expect(mockPairingService.handlePairing).not.toHaveBeenCalled()
+    expect(mockConnectionInvitationService.handleInvitation).not.toHaveBeenCalled()
+  })
+
+  it('prefers pairing over connection-invitation routing', () => {
+    mockIsDidCommInvitation.mockReturnValue(true)
+    const viewModel = new DeepLinkViewModel(
+      mockService as any,
+      logger as any,
+      mockPairingService as any,
+      mockConnectionInvitationService as any
+    )
+
+    viewModel.initialize()
+    capturedHandler?.(buildPayload())
+
+    expect(mockPairingService.handlePairing).toHaveBeenCalled()
+    expect(mockConnectionInvitationService.handleInvitation).not.toHaveBeenCalled()
   })
 })

--- a/app/src/bcsc-theme/features/deep-linking/DeepLinkViewModel.ts
+++ b/app/src/bcsc-theme/features/deep-linking/DeepLinkViewModel.ts
@@ -1,16 +1,19 @@
-import { AbstractBifoldLogger } from '@bifold/core'
+import { AbstractBifoldLogger, isDidCommInvitation } from '@bifold/core'
+import { ConnectionInvitationService } from '../connection-invitation/ConnectionInvitationService'
 import { PairingService } from '../pairing'
 import { DeepLinkPayload, DeepLinkService } from './services/deep-linking'
 
 /**
- * ViewModel for handling deep link URLs.
- * Parses URLs and delegates pairing requests to PairingService.
+ * ViewModel for handling deep link URLs. Parses URLs and delegates pairing
+ * requests to PairingService and out-of-band connection invitations to
+ * ConnectionInvitationService.
  */
 export class DeepLinkViewModel {
   constructor(
     private readonly deepLinkService: DeepLinkService,
     private readonly logger: AbstractBifoldLogger,
-    private readonly pairingService: PairingService
+    private readonly pairingService: PairingService,
+    private readonly connectionInvitationService: ConnectionInvitationService
   ) {}
 
   public initialize() {
@@ -28,7 +31,33 @@ export class DeepLinkViewModel {
       return
     }
 
+    if (this.handleConnectionInvitation(payload)) {
+      return
+    }
+
     // Add more routes here as needed.
+  }
+
+  /**
+   * Route an out-of-band connection invitation deep link (e.g.
+   * `bcwallet://aries_connection_invitation?oob=<base64>`) to the
+   * ConnectionInvitationService, which buffers it until the agent is ready.
+   *
+   * Detection keys off the invitation query param via Bifold's
+   * `isDidCommInvitation`, which is scheme- and host-agnostic — robust even when
+   * `parseUrl` mangles the host of `scheme://host?query` custom-scheme URLs.
+   */
+  private handleConnectionInvitation(payload: DeepLinkPayload): boolean {
+    if (!isDidCommInvitation(payload.rawUrl)) {
+      return false
+    }
+
+    this.connectionInvitationService.handleInvitation({
+      url: payload.rawUrl,
+      source: 'deep-link',
+    })
+
+    return true
   }
 
   private handlePairing(payload: DeepLinkPayload): boolean {

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -35,6 +35,7 @@ import { MainRemoveAccountConfirmationScreen } from '../features/account/RemoveA
 import { AgentReadyGate, BifoldScope, withAgentReadyGate } from '../features/agent'
 import { MainChangePINScreen } from '../features/auth/MainChangePINScreen'
 import { MainChangeSecurityScreen } from '../features/auth/MainChangeSecurityScreen'
+import { useConnectionInvitationDeepLink } from '../features/connection-invitation'
 import ContactChatScreen from '../features/contacts/ContactChatScreen'
 import ContactDetailsScreen from '../features/contacts/ContactDetailsScreen'
 import ContactJSONDetailsScreen from '../features/contacts/ContactJSONDetailsScreen'
@@ -131,6 +132,10 @@ const MainStack: React.FC = () => {
 
   useSystemChecks(SystemCheckScope.MAIN_STACK)
   useBCSCStack(BCSCStacks.Main)
+
+  // Accept connection-invitation deep links (e.g. from the showcase) once the
+  // agent is ready and route to the Connection screen (#2288).
+  useConnectionInvitationDeepLink()
 
   useEffect(() => {
     const unsubscribe = pairingService.onNavigationRequest(({ screen, params }) => {

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -695,6 +695,7 @@ const translation = {
       "TryAgain": "Try Again",
       "Connecting": "Connecting…",
       "UnrecognizedQR": "QR code not recognized.",
+      "InvalidConnectionInvitation": "This connection invitation could not be opened.",
       "FeatureUnavailable": "This action isn't available yet.",
       "Unsupported": {
         "OpenID": "OpenID credentials aren't supported in BC Services Card.",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -695,6 +695,7 @@ const translation = {
       "TryAgain": "Try Again (FR)",
       "Connecting": "Connecting… (FR)",
       "UnrecognizedQR": "QR code not recognized. (FR)",
+      "InvalidConnectionInvitation": "This connection invitation could not be opened. (FR)",
       "FeatureUnavailable": "This action isn't available yet. (FR)",
       "Unsupported": {
         "OpenID": "OpenID credentials aren't supported in BC Services Card. (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -695,6 +695,7 @@ const translation = {
       "TryAgain": "Try Again (PT-BR)",
       "Connecting": "Connecting… (PT-BR)",
       "UnrecognizedQR": "QR code not recognized. (PT-BR)",
+      "InvalidConnectionInvitation": "This connection invitation could not be opened. (PT-BR)",
       "FeatureUnavailable": "This action isn't available yet. (PT-BR)",
       "Unsupported": {
         "OpenID": "OpenID credentials aren't supported in BC Services Card. (PT-BR)",

--- a/variants/bcsc-dev/variant.env
+++ b/variants/bcsc-dev/variant.env
@@ -12,11 +12,11 @@ ANDROID_ICON_REF='ic_launcher'
 IOS_BUNDLE_ID='ca.bc.gov.iddev.servicescard'
 IOS_PRODUCT_NAME='$(TARGET_NAME)'
 
-# URL schemes (comma-separated) — replaces base didcomm scheme. 'bcwallet' is
-# retained so showcase connection-invitation deep links
-# (bcwallet://aries_connection_invitation?oob=...) open this build.
-IOS_URL_SCHEMES='ca.bc.gov.iddev.servicescard,ca.bc.gov.iddev.servicescard.v2,bcwallet'
-ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.dev,ca.bc.gov.iddev.servicescard.v2,bcwallet'
+# URL schemes (comma-separated). 'bcwallet' and 'didcomm' are retained alongside
+# the servicescard schemes so connection-invitation deep links open this build
+# (e.g. bcwallet://aries_connection_invitation?oob=... or didcomm://...?oob=...).
+IOS_URL_SCHEMES='ca.bc.gov.iddev.servicescard,ca.bc.gov.iddev.servicescard.v2,bcwallet,didcomm'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.dev,ca.bc.gov.iddev.servicescard.v2,bcwallet,didcomm'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-dev/variant.env
+++ b/variants/bcsc-dev/variant.env
@@ -12,9 +12,11 @@ ANDROID_ICON_REF='ic_launcher'
 IOS_BUNDLE_ID='ca.bc.gov.iddev.servicescard'
 IOS_PRODUCT_NAME='$(TARGET_NAME)'
 
-# URL schemes (comma-separated) — replaces base bcwallet/didcomm schemes
-IOS_URL_SCHEMES='ca.bc.gov.iddev.servicescard,ca.bc.gov.iddev.servicescard.v2'
-ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.dev,ca.bc.gov.iddev.servicescard.v2'
+# URL schemes (comma-separated) — replaces base didcomm scheme. 'bcwallet' is
+# retained so showcase connection-invitation deep links
+# (bcwallet://aries_connection_invitation?oob=...) open this build.
+IOS_URL_SCHEMES='ca.bc.gov.iddev.servicescard,ca.bc.gov.iddev.servicescard.v2,bcwallet'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.dev,ca.bc.gov.iddev.servicescard.v2,bcwallet'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-prod/variant.env
+++ b/variants/bcsc-prod/variant.env
@@ -12,9 +12,11 @@ ANDROID_ICON_REF='ic_launcher'
 IOS_BUNDLE_ID='ca.bc.gov.id.servicescard'
 IOS_PRODUCT_NAME='$(TARGET_NAME)'
 
-# URL schemes (comma-separated) — replaces base bcwallet/didcomm schemes
-IOS_URL_SCHEMES='ca.bc.gov.id.servicescard,ca.bc.gov.id.servicescard.v2'
-ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard,ca.bc.gov.id.servicescard.v2'
+# URL schemes (comma-separated) — replaces base didcomm scheme. 'bcwallet' is
+# retained so showcase connection-invitation deep links
+# (bcwallet://aries_connection_invitation?oob=...) open this build.
+IOS_URL_SCHEMES='ca.bc.gov.id.servicescard,ca.bc.gov.id.servicescard.v2,bcwallet'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard,ca.bc.gov.id.servicescard.v2,bcwallet'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-prod/variant.env
+++ b/variants/bcsc-prod/variant.env
@@ -12,11 +12,11 @@ ANDROID_ICON_REF='ic_launcher'
 IOS_BUNDLE_ID='ca.bc.gov.id.servicescard'
 IOS_PRODUCT_NAME='$(TARGET_NAME)'
 
-# URL schemes (comma-separated) — replaces base didcomm scheme. 'bcwallet' is
-# retained so showcase connection-invitation deep links
-# (bcwallet://aries_connection_invitation?oob=...) open this build.
-IOS_URL_SCHEMES='ca.bc.gov.id.servicescard,ca.bc.gov.id.servicescard.v2,bcwallet'
-ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard,ca.bc.gov.id.servicescard.v2,bcwallet'
+# URL schemes (comma-separated). 'bcwallet' and 'didcomm' are retained alongside
+# the servicescard schemes so connection-invitation deep links open this build
+# (e.g. bcwallet://aries_connection_invitation?oob=... or didcomm://...?oob=...).
+IOS_URL_SCHEMES='ca.bc.gov.id.servicescard,ca.bc.gov.id.servicescard.v2,bcwallet,didcomm'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard,ca.bc.gov.id.servicescard.v2,bcwallet,didcomm'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-qa/variant.env
+++ b/variants/bcsc-qa/variant.env
@@ -12,9 +12,11 @@ ANDROID_ICON_REF='ic_launcher'
 IOS_BUNDLE_ID='ca.bc.gov.idqa.servicescard'
 IOS_PRODUCT_NAME='$(TARGET_NAME)'
 
-# URL schemes (comma-separated) — replaces base bcwallet/didcomm schemes
-IOS_URL_SCHEMES='ca.bc.gov.idqa.servicescard,ca.bc.gov.idqa.servicescard.v2'
-ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.qa,ca.bc.gov.idqa.servicescard.v2'
+# URL schemes (comma-separated) — replaces base didcomm scheme. 'bcwallet' is
+# retained so showcase connection-invitation deep links
+# (bcwallet://aries_connection_invitation?oob=...) open this build.
+IOS_URL_SCHEMES='ca.bc.gov.idqa.servicescard,ca.bc.gov.idqa.servicescard.v2,bcwallet'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.qa,ca.bc.gov.idqa.servicescard.v2,bcwallet'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-qa/variant.env
+++ b/variants/bcsc-qa/variant.env
@@ -12,11 +12,11 @@ ANDROID_ICON_REF='ic_launcher'
 IOS_BUNDLE_ID='ca.bc.gov.idqa.servicescard'
 IOS_PRODUCT_NAME='$(TARGET_NAME)'
 
-# URL schemes (comma-separated) — replaces base didcomm scheme. 'bcwallet' is
-# retained so showcase connection-invitation deep links
-# (bcwallet://aries_connection_invitation?oob=...) open this build.
-IOS_URL_SCHEMES='ca.bc.gov.idqa.servicescard,ca.bc.gov.idqa.servicescard.v2,bcwallet'
-ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.qa,ca.bc.gov.idqa.servicescard.v2,bcwallet'
+# URL schemes (comma-separated). 'bcwallet' and 'didcomm' are retained alongside
+# the servicescard schemes so connection-invitation deep links open this build
+# (e.g. bcwallet://aries_connection_invitation?oob=... or didcomm://...?oob=...).
+IOS_URL_SCHEMES='ca.bc.gov.idqa.servicescard,ca.bc.gov.idqa.servicescard.v2,bcwallet,didcomm'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.qa,ca.bc.gov.idqa.servicescard.v2,bcwallet,didcomm'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-test/variant.env
+++ b/variants/bcsc-test/variant.env
@@ -12,9 +12,11 @@ ANDROID_ICON_REF='ic_launcher'
 IOS_BUNDLE_ID='ca.bc.gov.idtest.servicescard'
 IOS_PRODUCT_NAME='$(TARGET_NAME)'
 
-# URL schemes (comma-separated) — replaces base bcwallet/didcomm schemes
-IOS_URL_SCHEMES='ca.bc.gov.idtest.servicescard,ca.bc.gov.idtest.servicescard.v2'
-ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.test,ca.bc.gov.idtest.servicescard.v2'
+# URL schemes (comma-separated) — replaces base didcomm scheme. 'bcwallet' is
+# retained so showcase connection-invitation deep links
+# (bcwallet://aries_connection_invitation?oob=...) open this build.
+IOS_URL_SCHEMES='ca.bc.gov.idtest.servicescard,ca.bc.gov.idtest.servicescard.v2,bcwallet'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.test,ca.bc.gov.idtest.servicescard.v2,bcwallet'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'

--- a/variants/bcsc-test/variant.env
+++ b/variants/bcsc-test/variant.env
@@ -12,11 +12,11 @@ ANDROID_ICON_REF='ic_launcher'
 IOS_BUNDLE_ID='ca.bc.gov.idtest.servicescard'
 IOS_PRODUCT_NAME='$(TARGET_NAME)'
 
-# URL schemes (comma-separated) — replaces base didcomm scheme. 'bcwallet' is
-# retained so showcase connection-invitation deep links
-# (bcwallet://aries_connection_invitation?oob=...) open this build.
-IOS_URL_SCHEMES='ca.bc.gov.idtest.servicescard,ca.bc.gov.idtest.servicescard.v2,bcwallet'
-ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.test,ca.bc.gov.idtest.servicescard.v2,bcwallet'
+# URL schemes (comma-separated). 'bcwallet' and 'didcomm' are retained alongside
+# the servicescard schemes so connection-invitation deep links open this build
+# (e.g. bcwallet://aries_connection_invitation?oob=... or didcomm://...?oob=...).
+IOS_URL_SCHEMES='ca.bc.gov.idtest.servicescard,ca.bc.gov.idtest.servicescard.v2,bcwallet,didcomm'
+ANDROID_URL_SCHEMES='ca.bc.gov.id.servicescard.test,ca.bc.gov.idtest.servicescard.v2,bcwallet,didcomm'
 
 # Base variant to inherit shared assets from
 BASE_VARIANT='_bcsc-base'


### PR DESCRIPTION
## What's going on here

Oldld annoyance in #2288 — tapping a connection invite from the showcase on a fresh app launch and just... staring at the Connection screen until you flip back to Safari and come back? Fixed.

Since 4.1 brings the BC Wallet bits into BCSC, we want connections to work whether you scan a QR **or** tap a link in the browser. So BCSC now knows how to handle `bcwallet://…` connection invitations directly.


https://github.com/user-attachments/assets/452219b2-7567-4850-a8d0-310dee4b0be0


## The gist

- Tap a connection invite link in the browser → it opens and connects (previously this only worked via QR scan).
- No more cold-start hang: we wait until the wallet's actually ready and give message pickup a nudge before connecting, so the other side's reply doesn't get stuck waiting at the mediator.
- Little bonus: the wallet now refreshes its message pickup when you come back to the app, so anything that arrived while you were away comes through.

## Before this gets merged 🙏

- **It's a draft and needs a real device test.** The big one: kill the app, tap a `bcwallet://aries_connection_invitation?oob=…` link from Safari, and confirm it connects without having to tab away and back.
- We re-added the `bcwallet` URL scheme to the BCSC builds so those links actually open the app. If you've got an old BC Wallet build installed too, give it a try — there's a small chance the two could fight over the scheme.
- Worth a quick check that the showcase is sending `bcwallet://…?oob=` style links.
- This bundles two small related changes (the deep-link handling + the message-pickup refresh). Happy to split them into separate PRs if that's easier to review.

## Tests

Unit tests cover the buffering, the routing, and the cold-start "wait → ready → connect" path. The on-device check above is still to do.

Addresses #2288.