### PR TITLE
feat: notification style update

### DIFF
--- a/app/src/bcsc-theme/features/notifications/CredentialNotification.tsx
+++ b/app/src/bcsc-theme/features/notifications/CredentialNotification.tsx
@@ -165,7 +165,8 @@ const BasicMessageNotification = ({ notification }: CredentialNotificationProps)
       description={
         label ? t('Notification.BasicMessage.SentMessage', { label }) : t('Notification.BasicMessage.ReceivedMessage')
       }
-      icon="chat"
+      icon="tray-arrow-down"
+      logoUrl={connection?.imageUrl}
       status={isRead ? NotificationCardStatus.Read : NotificationCardStatus.Unread}
       onPress={() => {
         markRead()
@@ -234,7 +235,8 @@ const CredentialOfferNotification = ({ notification }: CredentialNotificationPro
     <NotificationCard
       title={t('Notification.CredentialOffer.Title')}
       description={description}
-      icon="card-membership"
+      icon="tray-arrow-down"
+      logoUrl={connection?.imageUrl}
       status={getTimeSensitiveStatus(isRead, expiresTime)}
       onPress={() => {
         markOfferSeen()
@@ -338,7 +340,8 @@ const ProofRequestNotification = ({ notification }: CredentialNotificationProps)
     <NotificationCard
       title={t('Notification.ProofRequest.Title')}
       description={description}
-      icon="assignment"
+      icon="file-download"
+      logoUrl={connection?.imageUrl}
       status={getTimeSensitiveStatus(isRead, effectiveExpiry)}
       onPress={handlePress}
       onClose={handleClose}
@@ -359,6 +362,7 @@ const RevocationNotification = ({ notification }: CredentialNotificationProps) =
   const { agent } = useBCSCAgent()
   const navigation = useNavigation<StackNavigationProp<BCSCMainStackParams>>()
   const credential = notification as DidCommCredentialExchangeRecord
+  const connection = useConnectionById(credential.connectionId ?? '')
   const { name, version } = parsedSchema(credential)
 
   const handleClose = async () => {
@@ -375,7 +379,8 @@ const RevocationNotification = ({ notification }: CredentialNotificationProps) =
     <NotificationCard
       title={t('Notification.Revocation.Title')}
       description={version ? `${name} v${version}` : name}
-      icon="error"
+      icon="alert-circle"
+      logoUrl={connection?.imageUrl}
       // Revoked credentials require immediate attention, per the designs
       status={NotificationCardStatus.Warning}
       onPress={() => navigation.navigate(Screens.CredentialDetails, { credentialId: credential.id })}

--- a/app/src/bcsc-theme/features/notifications/CredentialNotification.tsx
+++ b/app/src/bcsc-theme/features/notifications/CredentialNotification.tsx
@@ -26,7 +26,6 @@ import {
   DidCommProofExchangeRecord,
   DidCommProofExchangeRepository,
   DidCommProofState,
-  DidCommRequestPresentationV2Message,
 } from '@credo-ts/didcomm'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -161,10 +160,10 @@ const BasicMessageNotification = ({ notification }: CredentialNotificationProps)
 
   return (
     <NotificationCard
-      title={t('Notification.BasicMessage.Title')}
-      description={
-        label ? t('Notification.BasicMessage.SentMessage', { label }) : t('Notification.BasicMessage.ReceivedMessage')
-      }
+      // Per the designs, message notifications are titled with the connection's name
+      // and show the message itself as the content
+      title={label || t('Notification.BasicMessage.Title')}
+      description={basicMessage.content}
       icon="tray-arrow-down"
       logoUrl={connection?.imageUrl}
       status={isRead ? NotificationCardStatus.Read : NotificationCardStatus.Unread}
@@ -263,37 +262,27 @@ const ProofRequestNotification = ({ notification }: CredentialNotificationProps)
   const proof = notification as DidCommProofExchangeRecord
   const connection = useConnectionById(proof.connectionId ?? '')
   const label = getConnectionName(connection, store.preferences.alternateContactNames)
-  const [proofName, setProofName] = useState('')
   const [expiresTime, setExpiresTime] = useState<Date>()
 
   useEffect(() => {
-    const fetchProofDetails = async () => {
+    const fetchTiming = async () => {
       try {
         const message = await agent?.didcomm.proofs.findRequestMessage(proof.id)
         if (message?.timing?.expiresTime) {
           setExpiresTime(message.timing.expiresTime)
         }
-        if (message instanceof DidCommRequestPresentationV2Message) {
-          const attachment = message.requestAttachments.find((a) => a.id === 'indy')
-          const name = attachment?.getDataAsJson<{ name?: string }>()?.name
-          if (name) {
-            setProofName(name)
-            return
-          }
-        }
-        if (message?.comment) {
-          setProofName(message.comment)
-        }
-      } catch (err) {
-        agent?.config.logger.error(`Failed to fetch proof request details: ${err}`)
+      } catch {
+        // timing is optional, ignore errors
       }
     }
-    fetchProofDetails()
+    fetchTiming()
   }, [agent, proof.id])
 
-  const description =
-    proofName ||
-    (label ? t('Notification.ProofRequest.Description', { label }) : t('Notification.ProofRequest.DefaultDescription'))
+  // Per the designs: verifier name when the request comes from a connection,
+  // otherwise the generic connectionless wording
+  const description = label
+    ? t('Notification.ProofRequest.Description', { label })
+    : t('Notification.ProofRequest.DefaultDescription')
 
   const isDone = proof.state === DidCommProofState.Done || proof.state === DidCommProofState.PresentationReceived
   const declineProofRequest = useDeclineProofRequest(proof)
@@ -364,6 +353,7 @@ const RevocationNotification = ({ notification }: CredentialNotificationProps) =
   const credential = notification as DidCommCredentialExchangeRecord
   const connection = useConnectionById(credential.connectionId ?? '')
   const { name, version } = parsedSchema(credential)
+  const credentialDisplayName = version ? `${name} v${version}` : name
 
   const handleClose = async () => {
     if (!agent) {
@@ -378,7 +368,7 @@ const RevocationNotification = ({ notification }: CredentialNotificationProps) =
   return (
     <NotificationCard
       title={t('Notification.Revocation.Title')}
-      description={version ? `${name} v${version}` : name}
+      description={t('Notification.Revocation.Description', { credential: credentialDisplayName })}
       icon="alert-circle"
       logoUrl={connection?.imageUrl}
       // Revoked credentials require immediate attention, per the designs

--- a/app/src/bcsc-theme/features/notifications/CredentialNotification.tsx
+++ b/app/src/bcsc-theme/features/notifications/CredentialNotification.tsx
@@ -295,7 +295,8 @@ const ProofRequestNotification = ({ notification }: CredentialNotificationProps)
   // passes (see useNotifications), so warn about the protocol expiry or the app-imposed
   // removal time, whichever comes first. Expiry is moot once the proof is done.
   const removalTime = new Date(new Date(proof.createdAt).getTime() + PROOF_REQUEST_NOTIFICATION_TTL_MS)
-  const effectiveExpiry = isDone ? undefined : expiresTime && expiresTime < removalTime ? expiresTime : removalTime
+  const soonestExpiry = expiresTime && expiresTime < removalTime ? expiresTime : removalTime
+  const effectiveExpiry = isDone ? undefined : soonestExpiry
 
   // Flip the notification from unread to read once the user opens it
   const markRequestSeen = async () => {

--- a/app/src/bcsc-theme/features/notifications/CredentialNotification.tsx
+++ b/app/src/bcsc-theme/features/notifications/CredentialNotification.tsx
@@ -1,6 +1,6 @@
 import { useBCSCAgent } from '@/bcsc-theme/features/agent/BCSCAgentProvider'
 import { BCSCMainStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
-import { CredentialNotificationRecord } from '@/hooks/notifications'
+import { CredentialNotificationRecord, PROOF_REQUEST_NOTIFICATION_TTL_MS } from '@/hooks/notifications'
 import { useDeclineCredentialOffer } from '@/hooks/useDeclineCredentialOffer'
 import { useDeclineProofRequest } from '@/hooks/useDeclineProofRequest'
 import { getCredentialNotificationType, NotificationType } from '@/utils/credentials'
@@ -10,20 +10,19 @@ import {
   credentialCustomMetadata,
   CredentialMetadata,
   getConnectionName,
-  InfoBoxType,
   parsedSchema,
   Screens,
   useStore,
-  useTheme,
 } from '@bifold/core'
 import { useConnectionById } from '@bifold/react-hooks'
-import { markProofAsViewed } from '@bifold/verifier'
+import { markProofAsViewed, ProofCustomMetadata, ProofMetadata } from '@bifold/verifier'
 import {
   DidCommBasicMessageRecord,
   DidCommBasicMessageRepository,
   DidCommCredentialExchangeRecord,
   DidCommCredentialExchangeRepository,
   DidCommProofExchangeRecord,
+  DidCommProofExchangeRepository,
   DidCommProofState,
   DidCommRequestPresentationV2Message,
 } from '@credo-ts/didcomm'
@@ -31,7 +30,7 @@ import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import NotificationCard from './NotificationCard'
+import NotificationCard, { NotificationCardStatus } from './NotificationCard'
 
 interface CredentialNotificationProps {
   notification: CredentialNotificationRecord
@@ -104,6 +103,37 @@ function formatExpiryBadge(expiresTime: Date): string | undefined {
 }
 
 /**
+ * Notifications within this window of expiring (or already expired) show the yellow
+ * "attention" state to warn the user before the item becomes unusable / is removed.
+ */
+const EXPIRY_WARNING_WINDOW_MS = 60 * 60 * 1000 // 1 hour
+
+/** App-level additions to bifold's credential custom metadata for notification read tracking. */
+interface NotificationCredentialMetadata extends credentialCustomMetadata {
+  offer_seen?: boolean
+}
+
+/** App-level additions to bifold's proof custom metadata for notification read tracking. */
+interface NotificationProofMetadata extends ProofCustomMetadata {
+  request_seen?: boolean
+}
+
+/**
+ * Resolve the card status for time-sensitive notifications: items at or near expiry need
+ * attention regardless of read state, otherwise blue when unread and white when read.
+ *
+ * @param {boolean} read Whether the user has opened the notification
+ * @param {Date} [expiresTime] When the notification expires, if it does
+ * @return {*}  {NotificationCardStatus}
+ */
+function getTimeSensitiveStatus(read: boolean, expiresTime?: Date): NotificationCardStatus {
+  if (expiresTime && expiresTime.getTime() - Date.now() <= EXPIRY_WARNING_WINDOW_MS) {
+    return NotificationCardStatus.Attention
+  }
+  return read ? NotificationCardStatus.Read : NotificationCardStatus.Unread
+}
+
+/**
  * Basic Message Notifications
  *
  * @param {CredentialNotificationProps} { notification }
@@ -155,7 +185,8 @@ const BasicMessageNotification = ({ notification }: CredentialNotificationProps)
         label ? t('Notification.BasicMessage.SentMessage', { label }) : t('Notification.BasicMessage.ReceivedMessage')
       }
       icon="chat"
-      cardType={InfoBoxType.Info}
+      // Only unseen messages appear in the notifications list, so this is always unread
+      status={NotificationCardStatus.Unread}
       onPress={() => {
         handleClose()
         navigation.navigate(BCSCScreens.ContactChat, { connectionId: basicMessage.connectionId })
@@ -176,7 +207,6 @@ const BasicMessageNotification = ({ notification }: CredentialNotificationProps)
 const CredentialOfferNotification = ({ notification }: CredentialNotificationProps) => {
   const { t } = useTranslation()
   const { agent } = useBCSCAgent()
-  const { ColorPalette } = useTheme()
   const [store] = useStore()
   const navigation = useNavigation<StackNavigationProp<BCSCMainStackParams>>()
   const credential = notification as DidCommCredentialExchangeRecord
@@ -184,6 +214,9 @@ const CredentialOfferNotification = ({ notification }: CredentialNotificationPro
   const { name, version } = parsedSchema(credential)
   const label = getConnectionName(connection, store.preferences.alternateContactNames)
   const [expiresTime, setExpiresTime] = useState<Date>()
+
+  const offerMeta = credential.metadata.get(CredentialMetadata.customMetadata) as NotificationCredentialMetadata | null
+  const isRead = Boolean(offerMeta?.offer_seen)
 
   useEffect(() => {
     const fetchTiming = async () => {
@@ -204,6 +237,17 @@ const CredentialOfferNotification = ({ notification }: CredentialNotificationPro
     ? t('Notification.CredentialOffer.Description', { label, credential: credentialDisplayName })
     : credentialDisplayName
 
+  // Flip the notification from unread to read once the user opens it
+  const markOfferSeen = async () => {
+    if (!agent || isRead) {
+      return
+    }
+    const meta = credential.metadata.get(CredentialMetadata.customMetadata) as NotificationCredentialMetadata
+    credential.metadata.set(CredentialMetadata.customMetadata, { ...meta, offer_seen: true })
+    const repo = agent.context.dependencyManager.resolve(DidCommCredentialExchangeRepository)
+    await repo.update(agent.context, credential)
+  }
+
   const handleClose = useDeclineCredentialOffer(credential)
 
   return (
@@ -211,9 +255,11 @@ const CredentialOfferNotification = ({ notification }: CredentialNotificationPro
       title={t('Notification.CredentialOffer.Title')}
       description={description}
       icon="card-membership"
-      cardType={InfoBoxType.Info}
-      backgroundColor={ColorPalette.grayscale.white}
-      onPress={() => navigation.navigate(BCSCScreens.ConnectionLoading, { credentialId: credential.id })}
+      status={getTimeSensitiveStatus(isRead, expiresTime)}
+      onPress={() => {
+        markOfferSeen()
+        navigation.navigate(BCSCScreens.ConnectionLoading, { credentialId: credential.id })
+      }}
       onClose={handleClose}
       badge={expiresTime ? formatExpiryBadge(expiresTime) : undefined}
       timestamp={formatTimestamp(notification.createdAt)}
@@ -270,9 +316,32 @@ const ProofRequestNotification = ({ notification }: CredentialNotificationProps)
   const isDone = proof.state === DidCommProofState.Done || proof.state === DidCommProofState.PresentationReceived
   const declineProofRequest = useDeclineProofRequest(proof)
 
+  const proofMeta = proof.metadata.get(ProofMetadata.customMetadata) as NotificationProofMetadata | null
+  // Done proofs only stay in the list until their outcome has been viewed, so treat them as unread
+  const isRead = !isDone && Boolean(proofMeta?.request_seen)
+
+  // Pending proof requests are short-lived: they are removed from the list once their TTL
+  // passes (see useNotifications), so warn about the protocol expiry or the app-imposed
+  // removal time, whichever comes first. Expiry is moot once the proof is done.
+  const removalTime = new Date(new Date(proof.createdAt).getTime() + PROOF_REQUEST_NOTIFICATION_TTL_MS)
+  const effectiveExpiry = isDone ? undefined : expiresTime && expiresTime < removalTime ? expiresTime : removalTime
+
+  // Flip the notification from unread to read once the user opens it
+  const markRequestSeen = async () => {
+    if (!agent || isRead) {
+      return
+    }
+    const meta = proof.metadata.get(ProofMetadata.customMetadata) as NotificationProofMetadata
+    proof.metadata.set(ProofMetadata.customMetadata, { ...meta, request_seen: true })
+    const repo = agent.context.dependencyManager.resolve(DidCommProofExchangeRepository)
+    await repo.update(agent.context, proof)
+  }
+
   const handlePress = () => {
     if (isDone && agent) {
       markProofAsViewed(agent, proof)
+    } else {
+      markRequestSeen()
     }
     navigation.navigate(BCSCScreens.ConnectionLoading, { proofId: proof.id })
   }
@@ -290,10 +359,10 @@ const ProofRequestNotification = ({ notification }: CredentialNotificationProps)
       title={t('Notification.ProofRequest.Title')}
       description={description}
       icon="assignment"
-      cardType={InfoBoxType.Info}
+      status={getTimeSensitiveStatus(isRead, effectiveExpiry)}
       onPress={handlePress}
       onClose={handleClose}
-      badge={expiresTime ? formatExpiryBadge(expiresTime) : undefined}
+      badge={effectiveExpiry ? formatExpiryBadge(effectiveExpiry) : undefined}
       timestamp={formatTimestamp(notification.createdAt)}
     />
   )
@@ -327,7 +396,8 @@ const RevocationNotification = ({ notification }: CredentialNotificationProps) =
       title={t('Notification.Revocation.Title')}
       description={version ? `${name} v${version}` : name}
       icon="error"
-      cardType={InfoBoxType.Error}
+      // Revoked credentials require immediate attention, per the designs
+      status={NotificationCardStatus.Warning}
       onPress={() => navigation.navigate(Screens.CredentialDetails, { credentialId: credential.id })}
       onClose={handleClose}
       timestamp={formatTimestamp(notification.updatedAt ?? notification.createdAt)}

--- a/app/src/bcsc-theme/features/notifications/CredentialNotification.tsx
+++ b/app/src/bcsc-theme/features/notifications/CredentialNotification.tsx
@@ -16,7 +16,7 @@ import {
   Screens,
   useStore,
 } from '@bifold/core'
-import { useConnectionById } from '@bifold/react-hooks'
+import { useBasicMessages, useConnectionById } from '@bifold/react-hooks'
 import { markProofAsViewed, ProofCustomMetadata, ProofMetadata } from '@bifold/verifier'
 import {
   DidCommBasicMessageRecord,
@@ -30,7 +30,7 @@ import {
 } from '@credo-ts/didcomm'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import NotificationCard, { NotificationCardStatus } from './NotificationCard'
 
@@ -59,6 +59,11 @@ const CredentialNotification = (props: CredentialNotificationProps) => {
     default:
       return null
   }
+}
+
+/** App-level additions to bifold's basic message custom metadata for notification read tracking. */
+interface NotificationBasicMessageMetadata extends basicMessageCustomMetadata {
+  notification_read?: boolean
 }
 
 /** App-level additions to bifold's credential custom metadata for notification read tracking. */
@@ -100,34 +105,57 @@ const BasicMessageNotification = ({ notification }: CredentialNotificationProps)
   const basicMessage = notification as DidCommBasicMessageRecord
   const connection = useConnectionById(basicMessage.connectionId)
   const label = getConnectionName(connection, store.preferences.alternateContactNames)
-  const [unseenCount, setUnseenCount] = useState(0)
+  const { records: basicMessages } = useBasicMessages()
 
-  useEffect(() => {
+  // Messages for this contact the user hasn't dismissed — the list shows one
+  // notification per contact, so this card represents all of them
+  const unseenMessages = useMemo(
+    () =>
+      basicMessages.filter((msg) => {
+        if (msg.connectionId !== basicMessage.connectionId) {
+          return false
+        }
+        const meta = msg.metadata.get(BasicMessageMetadata.customMetadata) as NotificationBasicMessageMetadata
+        return !meta?.seen
+      }),
+    [basicMessages, basicMessage.connectionId]
+  )
+
+  // Read (white) once the user has opened the chat for every message in this card —
+  // a new incoming message flips the notification back to unread (blue)
+  const isRead =
+    unseenMessages.length > 0 &&
+    unseenMessages.every(
+      (msg) =>
+        (msg.metadata.get(BasicMessageMetadata.customMetadata) as NotificationBasicMessageMetadata)?.notification_read
+    )
+
+  // Flip the notification from unread to read once the user opens the chat;
+  // the notification stays in the list until dismissed
+  const markRead = async () => {
     if (!agent) {
       return
     }
     const repo = agent.context.dependencyManager.resolve(DidCommBasicMessageRepository)
-    repo.findByQuery(agent.context, { connectionId: basicMessage.connectionId }).then((messages) => {
-      const count = messages.filter((msg) => {
-        const meta = msg.metadata.get(BasicMessageMetadata.customMetadata) as basicMessageCustomMetadata
-        return !meta?.seen
-      }).length
-      setUnseenCount(count)
-    })
-  }, [agent, basicMessage.connectionId])
+    for (const msg of unseenMessages) {
+      const meta = msg.metadata.get(BasicMessageMetadata.customMetadata) as NotificationBasicMessageMetadata
+      if (!meta?.notification_read) {
+        msg.metadata.set(BasicMessageMetadata.customMetadata, { ...meta, notification_read: true })
+        await repo.update(agent.context, msg)
+      }
+    }
+  }
 
+  // Dismissing the notification marks the messages seen, which removes it from the list
   const handleClose = async () => {
     if (!agent) {
       return
     }
     const repo = agent.context.dependencyManager.resolve(DidCommBasicMessageRepository)
-    const allMessages = await repo.findByQuery(agent.context, { connectionId: basicMessage.connectionId })
-    for (const msg of allMessages) {
-      const meta = msg.metadata.get(BasicMessageMetadata.customMetadata) as basicMessageCustomMetadata
-      if (!meta?.seen) {
-        msg.metadata.set(BasicMessageMetadata.customMetadata, { ...meta, seen: true })
-        await repo.update(agent.context, msg)
-      }
+    for (const msg of unseenMessages) {
+      const meta = msg.metadata.get(BasicMessageMetadata.customMetadata) as NotificationBasicMessageMetadata
+      msg.metadata.set(BasicMessageMetadata.customMetadata, { ...meta, seen: true })
+      await repo.update(agent.context, msg)
     }
   }
 
@@ -138,14 +166,13 @@ const BasicMessageNotification = ({ notification }: CredentialNotificationProps)
         label ? t('Notification.BasicMessage.SentMessage', { label }) : t('Notification.BasicMessage.ReceivedMessage')
       }
       icon="chat"
-      // Only unseen messages appear in the notifications list, so this is always unread
-      status={NotificationCardStatus.Unread}
+      status={isRead ? NotificationCardStatus.Read : NotificationCardStatus.Unread}
       onPress={() => {
-        handleClose()
+        markRead()
         navigation.navigate(BCSCScreens.ContactChat, { connectionId: basicMessage.connectionId })
       }}
       onClose={handleClose}
-      badge={unseenCount > 1 ? `${unseenCount} messages` : undefined}
+      badge={unseenMessages.length > 1 ? `${unseenMessages.length} messages` : undefined}
       timestamp={formatTimestamp(notification.createdAt)}
     />
   )

--- a/app/src/bcsc-theme/features/notifications/CredentialNotification.tsx
+++ b/app/src/bcsc-theme/features/notifications/CredentialNotification.tsx
@@ -1,6 +1,8 @@
 import { useBCSCAgent } from '@/bcsc-theme/features/agent/BCSCAgentProvider'
 import { BCSCMainStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
-import { CredentialNotificationRecord, PROOF_REQUEST_NOTIFICATION_TTL_MS } from '@/hooks/notifications'
+import { formatExpiryBadge, formatTimestamp } from '@/bcsc-theme/utils/datetime-utils'
+import { NOTIFICATION_EXPIRY_WARNING_WINDOW_MS, PROOF_REQUEST_NOTIFICATION_TTL_MS } from '@/constants'
+import { CredentialNotificationRecord } from '@/hooks/notifications'
 import { useDeclineCredentialOffer } from '@/hooks/useDeclineCredentialOffer'
 import { useDeclineProofRequest } from '@/hooks/useDeclineProofRequest'
 import { getCredentialNotificationType, NotificationType } from '@/utils/credentials'
@@ -59,55 +61,6 @@ const CredentialNotification = (props: CredentialNotificationProps) => {
   }
 }
 
-/**
- * Helper function to format timestamps in a user-friendly way (e.g., "Just now", "5 minutes ago", "Today at 3:45 PM").
- *
- * @param {Date} date
- * @return {*}  {string}
- */
-function formatTimestamp(date: Date): string {
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffMin = Math.floor(diffMs / 60_000)
-
-  if (diffMin < 1) {
-    return 'Just now'
-  }
-  if (diffMin < 60) {
-    return `${diffMin} minute${diffMin === 1 ? '' : 's'} ago`
-  }
-
-  const diffHours = Math.floor(diffMin / 60)
-  if (diffHours < 24) {
-    return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
-  }
-
-  return date.toLocaleDateString([], { month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit' })
-}
-
-function formatExpiryBadge(expiresTime: Date): string | undefined {
-  const diffMs = expiresTime.getTime() - Date.now()
-  if (diffMs <= 0) {
-    return 'Expired'
-  }
-  const diffMin = Math.floor(diffMs / 60_000)
-  if (diffMin < 60) {
-    return `Expires in ${diffMin} min`
-  }
-  const diffHours = Math.floor(diffMin / 60)
-  if (diffHours < 24) {
-    return `Expires in ${diffHours} hour${diffHours === 1 ? '' : 's'}`
-  }
-  const diffDays = Math.floor(diffHours / 24)
-  return `Expires in ${diffDays} day${diffDays === 1 ? '' : 's'}`
-}
-
-/**
- * Notifications within this window of expiring (or already expired) show the yellow
- * "attention" state to warn the user before the item becomes unusable / is removed.
- */
-const EXPIRY_WARNING_WINDOW_MS = 60 * 60 * 1000 // 1 hour
-
 /** App-level additions to bifold's credential custom metadata for notification read tracking. */
 interface NotificationCredentialMetadata extends credentialCustomMetadata {
   offer_seen?: boolean
@@ -127,7 +80,7 @@ interface NotificationProofMetadata extends ProofCustomMetadata {
  * @return {*}  {NotificationCardStatus}
  */
 function getTimeSensitiveStatus(read: boolean, expiresTime?: Date): NotificationCardStatus {
-  if (expiresTime && expiresTime.getTime() - Date.now() <= EXPIRY_WARNING_WINDOW_MS) {
+  if (expiresTime && expiresTime.getTime() - Date.now() <= NOTIFICATION_EXPIRY_WARNING_WINDOW_MS) {
     return NotificationCardStatus.Attention
   }
   return read ? NotificationCardStatus.Read : NotificationCardStatus.Unread

--- a/app/src/bcsc-theme/features/notifications/NotificationCard.test.tsx
+++ b/app/src/bcsc-theme/features/notifications/NotificationCard.test.tsx
@@ -1,0 +1,39 @@
+import { GrayscaleColors, NotificationColors } from '@bcwallet-theme/theme'
+import { testIdWithKey } from '@bifold/core'
+import { BasicAppContext } from '@mocks/helpers/app'
+import { render } from '@testing-library/react-native'
+import React from 'react'
+import NotificationCard, { NotificationCardStatus } from './NotificationCard'
+
+describe('NotificationCard', () => {
+  const baseProps = {
+    title: 'Notification title',
+    description: 'Content of notification goes here',
+    onPress: jest.fn(),
+  }
+
+  const renderCard = (status: NotificationCardStatus) =>
+    render(
+      <BasicAppContext>
+        <NotificationCard {...baseProps} status={status} />
+      </BasicAppContext>
+    )
+
+  // Per the designs: blue when unread, white when read, red for warnings and yellow for attention
+  it.each([
+    [NotificationCardStatus.Unread, NotificationColors.info],
+    [NotificationCardStatus.Read, GrayscaleColors.white],
+    [NotificationCardStatus.Warning, NotificationColors.error],
+    [NotificationCardStatus.Attention, NotificationColors.warn],
+  ])('renders the %s status with the correct background color', (status, backgroundColor) => {
+    const tree = renderCard(status)
+
+    expect(tree.getByTestId(testIdWithKey('NotificationListItem'))).toHaveStyle({ backgroundColor })
+  })
+
+  it('renders correctly', () => {
+    const tree = renderCard(NotificationCardStatus.Unread)
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/app/src/bcsc-theme/features/notifications/NotificationCard.test.tsx
+++ b/app/src/bcsc-theme/features/notifications/NotificationCard.test.tsx
@@ -31,6 +31,20 @@ describe('NotificationCard', () => {
     expect(tree.getByTestId(testIdWithKey('NotificationListItem'))).toHaveStyle({ backgroundColor })
   })
 
+  it('renders the connection logo in place of the icon when one is available', () => {
+    const tree = render(
+      <BasicAppContext>
+        <NotificationCard
+          {...baseProps}
+          status={NotificationCardStatus.Unread}
+          logoUrl="https://example.com/logo.png"
+        />
+      </BasicAppContext>
+    )
+
+    expect(tree.getByTestId(testIdWithKey('NotificationLogo'))).toBeTruthy()
+  })
+
   it('renders correctly', () => {
     const tree = renderCard(NotificationCardStatus.Unread)
 

--- a/app/src/bcsc-theme/features/notifications/NotificationCard.tsx
+++ b/app/src/bcsc-theme/features/notifications/NotificationCard.tsx
@@ -1,5 +1,5 @@
 import { hitSlop } from '@/constants'
-import { Button, ButtonType, IColorPalette, InfoBoxType, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
+import { Button, ButtonType, IColorPalette, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Pressable, StyleSheet, TouchableOpacity, View } from 'react-native'
@@ -9,17 +9,31 @@ const ICON_CIRCLE_SIZE = 36
 const ICON_INNER_SIZE = 20
 const CLOSE_ICON_SIZE = 24
 
+/**
+ * Display states for notification cards, matching the BCSC notification designs:
+ * blue for unread, white for read, red for warnings and yellow for attention.
+ */
+export enum NotificationCardStatus {
+  /** Notifications the user has not opened yet (blue). */
+  Unread = 'Unread',
+  /** Notifications the user has already opened (white). */
+  Read = 'Read',
+  /** Revoked notifications or anything requiring immediate attention (red). */
+  Warning = 'Warning',
+  /** Notifications needing moderate attention, e.g. expiring soon (yellow). */
+  Attention = 'Attention',
+}
+
 interface NotificationCardProps {
   title: string
   description: string
-  cardType: InfoBoxType
+  status: NotificationCardStatus
   onPress: () => void
   onClose?: () => void
   buttonTitle?: string
   timestamp?: string
   badge?: string
   icon?: string
-  backgroundColor?: string
 }
 
 /**
@@ -32,7 +46,7 @@ interface NotificationCardProps {
 const NotificationCard: React.FC<NotificationCardProps> = (props) => {
   const { t } = useTranslation()
   const { ColorPalette, Spacing } = useTheme()
-  const cardStyle = getCardStyle(props.cardType, ColorPalette)
+  const cardStyle = getCardStyle(props.status, ColorPalette)
   const iconColor = ColorPalette.grayscale.mediumGrey
 
   const isV1 = !!props.buttonTitle
@@ -41,9 +55,7 @@ const NotificationCard: React.FC<NotificationCardProps> = (props) => {
     container: {
       paddingHorizontal: Spacing.lg,
       paddingVertical: Spacing.md,
-      backgroundColor: isV1
-        ? ColorPalette.brand.modalTertiaryBackground
-        : (props.backgroundColor ?? cardStyle.backgroundColor),
+      backgroundColor: isV1 ? ColorPalette.brand.modalTertiaryBackground : cardStyle.backgroundColor,
       ...(isV1 && {
         borderWidth: 1,
         borderColor: ColorPalette.notification.infoBorder,
@@ -165,29 +177,30 @@ interface CardStyle {
 }
 
 /**
- * getCardStyle returns the appropriate background color and default icon for a given notification type, based on the app's color palette.
+ * getCardStyle returns the appropriate background color and default icon for a given notification status, based on the app's color palette.
  *
- * @param {InfoBoxType} cardType
+ * @param {NotificationCardStatus} status
  * @param {IColorPalette} palette
  * @return {*}  {CardStyle}
  */
-function getCardStyle(cardType: InfoBoxType, palette: IColorPalette): CardStyle {
-  switch (cardType) {
-    case InfoBoxType.Success:
+function getCardStyle(status: NotificationCardStatus, palette: IColorPalette): CardStyle {
+  switch (status) {
+    case NotificationCardStatus.Read:
       return {
-        backgroundColor: palette.notification.success,
-        defaultIcon: 'check-circle',
+        backgroundColor: palette.grayscale.white,
+        defaultIcon: 'info',
       }
-    case InfoBoxType.Warn:
-      return {
-        backgroundColor: palette.notification.warn,
-        defaultIcon: 'warning',
-      }
-    case InfoBoxType.Error:
+    case NotificationCardStatus.Warning:
       return {
         backgroundColor: palette.notification.error,
         defaultIcon: 'error',
       }
+    case NotificationCardStatus.Attention:
+      return {
+        backgroundColor: palette.notification.warn,
+        defaultIcon: 'warning',
+      }
+    case NotificationCardStatus.Unread:
     default:
       return {
         backgroundColor: palette.notification.info,

--- a/app/src/bcsc-theme/features/notifications/NotificationCard.tsx
+++ b/app/src/bcsc-theme/features/notifications/NotificationCard.tsx
@@ -2,8 +2,8 @@ import { hitSlop } from '@/constants'
 import { Button, ButtonType, IColorPalette, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Pressable, StyleSheet, TouchableOpacity, View } from 'react-native'
-import Icon from 'react-native-vector-icons/MaterialIcons'
+import { Image, Pressable, StyleSheet, TouchableOpacity, View } from 'react-native'
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
 const ICON_CIRCLE_SIZE = 36
 const ICON_INNER_SIZE = 20
@@ -34,6 +34,12 @@ interface NotificationCardProps {
   timestamp?: string
   badge?: string
   icon?: string
+  /**
+   * Connection logo to display in place of the icon. Per the designs, notifications
+   * from connections show the connection's logo when one is available, and fall back
+   * to an icon matching the purpose of the notification otherwise.
+   */
+  logoUrl?: string
 }
 
 /**
@@ -75,6 +81,12 @@ const NotificationCard: React.FC<NotificationCardProps> = (props) => {
       alignItems: 'center',
       marginRight: 12,
     },
+    logoImage: {
+      width: ICON_CIRCLE_SIZE,
+      height: ICON_CIRCLE_SIZE,
+      borderRadius: ICON_CIRCLE_SIZE / 2,
+      marginRight: 12,
+    },
     bodyContainer: {
       marginLeft: ICON_CIRCLE_SIZE + 12,
       marginTop: 4,
@@ -113,9 +125,18 @@ const NotificationCard: React.FC<NotificationCardProps> = (props) => {
   const content = (
     <View style={styles.container} testID={testIdWithKey('NotificationListItem')}>
       <View style={styles.headerContainer}>
-        <View style={styles.iconCircle}>
-          <Icon accessible={false} name={iconName} size={ICON_INNER_SIZE} color="#FFFFFF" />
-        </View>
+        {props.logoUrl ? (
+          <Image
+            accessible={false}
+            source={{ uri: props.logoUrl }}
+            style={styles.logoImage}
+            testID={testIdWithKey('NotificationLogo')}
+          />
+        ) : (
+          <View style={styles.iconCircle}>
+            <Icon accessible={false} name={iconName} size={ICON_INNER_SIZE} color="#FFFFFF" />
+          </View>
+        )}
         <ThemedText variant="bold" style={styles.headerText} testID={testIdWithKey('HeaderText')}>
           {props.title}
         </ThemedText>

--- a/app/src/bcsc-theme/features/notifications/NotificationCard.tsx
+++ b/app/src/bcsc-theme/features/notifications/NotificationCard.tsx
@@ -209,23 +209,23 @@ function getCardStyle(status: NotificationCardStatus, palette: IColorPalette): C
     case NotificationCardStatus.Read:
       return {
         backgroundColor: palette.grayscale.white,
-        defaultIcon: 'info',
+        defaultIcon: 'information',
       }
     case NotificationCardStatus.Warning:
       return {
         backgroundColor: palette.notification.error,
-        defaultIcon: 'error',
+        defaultIcon: 'alert-circle',
       }
     case NotificationCardStatus.Attention:
       return {
         backgroundColor: palette.notification.warn,
-        defaultIcon: 'warning',
+        defaultIcon: 'alert',
       }
     case NotificationCardStatus.Unread:
     default:
       return {
         backgroundColor: palette.notification.info,
-        defaultIcon: 'info',
+        defaultIcon: 'information',
       }
   }
 }

--- a/app/src/bcsc-theme/features/notifications/StartVerificationNotification.tsx
+++ b/app/src/bcsc-theme/features/notifications/StartVerificationNotification.tsx
@@ -1,9 +1,9 @@
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { computeSetupStepCompletion } from '@/bcsc-theme/utils/setup-step-completion'
 import { BCState } from '@/store'
-import { InfoBoxType, useStore } from '@bifold/core'
+import { useStore } from '@bifold/core'
 import { useTranslation } from 'react-i18next'
-import NotificationCard from './NotificationCard'
+import NotificationCard, { NotificationCardStatus } from './NotificationCard'
 
 interface StartVerificationNotificationProps {
   onClose: () => void
@@ -35,7 +35,7 @@ const StartVerificationNotification = (props: StartVerificationNotificationProps
         secureActions.continueVerificationProcess()
       }}
       onClose={props.onClose}
-      cardType={InfoBoxType.Info}
+      status={NotificationCardStatus.Unread}
     />
   )
 }

--- a/app/src/bcsc-theme/features/notifications/StartVerificationNotification.tsx
+++ b/app/src/bcsc-theme/features/notifications/StartVerificationNotification.tsx
@@ -31,6 +31,7 @@ const StartVerificationNotification = (props: StartVerificationNotificationProps
       title={t('Notification.StartVerification.Title')}
       description={t('Notification.StartVerification.Description')}
       buttonTitle={buttonTitle}
+      icon="alert-circle"
       onPress={() => {
         secureActions.continueVerificationProcess()
       }}

--- a/app/src/bcsc-theme/features/notifications/__snapshots__/NotificationCard.test.tsx.snap
+++ b/app/src/bcsc-theme/features/notifications/__snapshots__/NotificationCard.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`NotificationCard renders correctly 1`] = `
             ]
           }
         >
-          ?
+          󰋼
         </Text>
       </View>
       <Text

--- a/app/src/bcsc-theme/features/notifications/__snapshots__/NotificationCard.test.tsx.snap
+++ b/app/src/bcsc-theme/features/notifications/__snapshots__/NotificationCard.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`NotificationCard renders correctly 1`] = `
               },
               undefined,
               {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -85,7 +85,7 @@ exports[`NotificationCard renders correctly 1`] = `
             ]
           }
         >
-          
+          ?
         </Text>
       </View>
       <Text

--- a/app/src/bcsc-theme/features/notifications/__snapshots__/NotificationCard.test.tsx.snap
+++ b/app/src/bcsc-theme/features/notifications/__snapshots__/NotificationCard.test.tsx.snap
@@ -1,0 +1,141 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotificationCard renders correctly 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  testID="com.ariesbifold:id/NotificationCardPressable"
+>
+  <View
+    style={
+      {
+        "backgroundColor": "#D9EAF7",
+        "paddingHorizontal": 24,
+        "paddingVertical": 16,
+      }
+    }
+    testID="com.ariesbifold:id/NotificationListItem"
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#606060",
+            "borderRadius": 18,
+            "height": 36,
+            "justifyContent": "center",
+            "marginRight": 12,
+            "width": 36,
+          }
+        }
+      >
+        <Text
+          accessible={false}
+          allowFontScaling={false}
+          selectable={false}
+          style={
+            [
+              {
+                "color": "#FFFFFF",
+                "fontSize": 20,
+              },
+              undefined,
+              {
+                "fontFamily": "Material Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <Text
+        maxFontSizeMultiplier={2}
+        style={
+          [
+            {
+              "color": "#313132",
+              "fontFamily": "BCSans-Regular",
+              "fontSize": 18,
+              "fontWeight": "bold",
+            },
+            {
+              "flex": 1,
+            },
+          ]
+        }
+        testID="com.ariesbifold:id/HeaderText"
+      >
+        Notification title
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "marginLeft": 48,
+          "marginTop": 4,
+        }
+      }
+    >
+      <Text
+        maxFontSizeMultiplier={2}
+        style={
+          [
+            {
+              "color": "#313132",
+              "fontFamily": "BCSans-Regular",
+              "fontSize": 18,
+              "fontWeight": "normal",
+            },
+            {
+              "marginTop": 4,
+            },
+          ]
+        }
+        testID="com.ariesbifold:id/BodyText"
+      >
+        Content of notification goes here
+      </Text>
+    </View>
+  </View>
+</View>
+`;

--- a/app/src/bcsc-theme/features/qr-core/ConnectionLoadingScreen.test.tsx
+++ b/app/src/bcsc-theme/features/qr-core/ConnectionLoadingScreen.test.tsx
@@ -3,6 +3,7 @@ import { Connection } from '@bifold/core'
 import { CommonActions } from '@react-navigation/native'
 import { render } from '@testing-library/react-native'
 import React from 'react'
+import { BackHandler } from 'react-native'
 
 import ConnectionLoadingScreen from './ConnectionLoadingScreen'
 
@@ -21,9 +22,15 @@ jest.mock('@react-navigation/native', () => ({
 
 const ConnectionMock = Connection as jest.MockedFunction<typeof Connection>
 
-const mkProps = () => {
-  const navigation = { dispatch: jest.fn(), navigate: jest.fn(), getParent: jest.fn() } as any
-  const route = { params: { oobRecordId: 'oob-1' } } as any
+const mkProps = (params: Record<string, string | undefined> = { oobRecordId: 'oob-1' }) => {
+  const navigation = {
+    dispatch: jest.fn(),
+    navigate: jest.fn(),
+    getParent: jest.fn(),
+    canGoBack: jest.fn().mockReturnValue(true),
+    goBack: jest.fn(),
+  } as any
+  const route = { params } as any
   return { navigation, route }
 }
 
@@ -67,5 +74,45 @@ describe('ConnectionLoadingScreen', () => {
         routes: [{ name: BCSCStacks.Tab, state: { routes: [{ name: BCSCScreens.Home }] } }],
       })
     )
+  })
+
+  // Bifold's Connection screen blocks the Android hardware back button. For
+  // notification-opened offers / proof requests the header shows a back button
+  // (see MainStack), so the wrapper registers its own higher-priority handler
+  // to make the hardware button match.
+  describe('hardware back handling', () => {
+    it.each([{ credentialId: 'cred-1' }, { proofId: 'proof-1' }])(
+      'pops the screen on hardware back when opened with %o',
+      (params) => {
+        const spy = jest.spyOn(BackHandler, 'addEventListener')
+        const { navigation, route } = mkProps(params)
+        render(<ConnectionLoadingScreen navigation={navigation} route={route} />)
+
+        expect(spy).toHaveBeenCalledWith('hardwareBackPress', expect.any(Function))
+        const handler = spy.mock.calls.at(-1)![1] as () => boolean
+        expect(handler()).toBe(true)
+        expect(navigation.goBack).toHaveBeenCalled()
+      }
+    )
+
+    it('leaves hardware back alone for QR-scan (oobRecordId) entries', () => {
+      const spy = jest.spyOn(BackHandler, 'addEventListener')
+      const { navigation, route } = mkProps({ oobRecordId: 'oob-1' })
+      render(<ConnectionLoadingScreen navigation={navigation} route={route} />)
+
+      expect(spy).not.toHaveBeenCalled()
+      expect(navigation.goBack).not.toHaveBeenCalled()
+    })
+
+    it('swallows hardware back instead of popping when there is nowhere to go back to', () => {
+      const spy = jest.spyOn(BackHandler, 'addEventListener')
+      const { navigation, route } = mkProps({ credentialId: 'cred-1' })
+      navigation.canGoBack.mockReturnValue(false)
+      render(<ConnectionLoadingScreen navigation={navigation} route={route} />)
+
+      const handler = spy.mock.calls.at(-1)![1] as () => boolean
+      expect(handler()).toBe(true)
+      expect(navigation.goBack).not.toHaveBeenCalled()
+    })
   })
 })

--- a/app/src/bcsc-theme/features/qr-core/ConnectionLoadingScreen.tsx
+++ b/app/src/bcsc-theme/features/qr-core/ConnectionLoadingScreen.tsx
@@ -2,8 +2,9 @@ import { BCSCMainStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { Connection } from '@bifold/core'
 import { NavigationContext } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack'
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { BackHandler } from 'react-native'
 
 import { createBifoldNavigationAdapter } from './BifoldNavigationAdapter'
 
@@ -22,6 +23,26 @@ type Props = StackScreenProps<BCSCMainStackParams, BCSCScreens.ConnectionLoading
 const ConnectionLoadingScreen: React.FC<Props> = ({ navigation, route }) => {
   const { t } = useTranslation()
   const adaptedNavigation = useMemo(() => createBifoldNavigationAdapter(navigation, { t }), [navigation, t])
+  const { credentialId, proofId } = route.params
+
+  // Bifold's Connection screen blocks the Android hardware back button for its
+  // entire lifetime (it assumes a locked QR handshake flow). Offers / proof
+  // requests opened from a home notification show a header back button instead
+  // (see MainStack), so honour the hardware button for them too: child effects
+  // run before parent effects, so this handler registers after Bifold's blocker
+  // and BackHandler gives it priority.
+  useEffect(() => {
+    if (!credentialId && !proofId) {
+      return
+    }
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+      if (navigation.canGoBack()) {
+        navigation.goBack()
+      }
+      return true
+    })
+    return () => subscription.remove()
+  }, [credentialId, proofId, navigation])
   const bifoldRoute = useMemo(
     () => ({
       ...route,

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -240,11 +240,27 @@ const MainStack: React.FC = () => {
           <Stack.Screen
             name={BCSCScreens.ConnectionLoading}
             component={ConnectionLoadingScreen}
-            options={{
-              headerShown: true,
-              headerLeft: () => null,
-              gestureEnabled: false,
-              title: t('BCSC.Scan.Connecting'),
+            options={({ route }) => {
+              // Offers / proof requests opened from a home notification land directly on
+              // the offer / request view, so keep the default back button — backing out
+              // leaves the notification pending (in its read state) instead of forcing
+              // an accept / decline. QR-scan entries (oobRecordId) run the connection
+              // handshake, where backing out mid-exchange isn't supported — the loading
+              // placeholder has its own cancel affordance.
+              const { credentialId, proofId } = route.params
+              if (credentialId || proofId) {
+                return {
+                  headerShown: true,
+                  title: credentialId ? t('Screens.CredentialOffer') : t('Screens.ProofRequest'),
+                }
+              }
+
+              return {
+                headerShown: true,
+                headerLeft: () => null,
+                gestureEnabled: false,
+                title: t('BCSC.Scan.Connecting'),
+              }
             }}
           />
           <Stack.Screen

--- a/app/src/bcsc-theme/utils/datetime-utils.test.ts
+++ b/app/src/bcsc-theme/utils/datetime-utils.test.ts
@@ -1,0 +1,65 @@
+import { formatExpiryBadge, formatTimestamp } from './datetime-utils'
+
+const NOW = new Date('2026-06-04T12:00:00.000Z')
+const minutes = (n: number) => n * 60_000
+const hours = (n: number) => n * 3_600_000
+const days = (n: number) => n * 86_400_000
+
+describe('formatTimestamp', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(NOW)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('returns "Just now" for timestamps less than a minute old', () => {
+    expect(formatTimestamp(new Date(NOW.getTime() - 30_000))).toBe('Just now')
+  })
+
+  it('returns minutes ago for timestamps less than an hour old', () => {
+    expect(formatTimestamp(new Date(NOW.getTime() - minutes(1)))).toBe('1 minute ago')
+    expect(formatTimestamp(new Date(NOW.getTime() - minutes(5)))).toBe('5 minutes ago')
+    expect(formatTimestamp(new Date(NOW.getTime() - minutes(59)))).toBe('59 minutes ago')
+  })
+
+  it('returns a time of day for timestamps less than a day old', () => {
+    // Locale-dependent output (e.g. "9:00 AM"), so assert the shape rather than the exact string
+    expect(formatTimestamp(new Date(NOW.getTime() - hours(3)))).toMatch(/\d{1,2}:\d{2}/)
+  })
+
+  it('returns a date for timestamps a day or more old', () => {
+    expect(formatTimestamp(new Date(NOW.getTime() - days(2)))).toMatch(/June 2/)
+  })
+})
+
+describe('formatExpiryBadge', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(NOW)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('returns "Expired" once the expiry time has passed', () => {
+    expect(formatExpiryBadge(new Date(NOW.getTime() - 1))).toBe('Expired')
+    expect(formatExpiryBadge(NOW)).toBe('Expired')
+  })
+
+  it('returns minutes for expiries less than an hour away', () => {
+    expect(formatExpiryBadge(new Date(NOW.getTime() + minutes(5)))).toBe('Expires in 5 min')
+    expect(formatExpiryBadge(new Date(NOW.getTime() + minutes(59)))).toBe('Expires in 59 min')
+  })
+
+  it('returns hours for expiries less than a day away', () => {
+    expect(formatExpiryBadge(new Date(NOW.getTime() + hours(1)))).toBe('Expires in 1 hour')
+    expect(formatExpiryBadge(new Date(NOW.getTime() + hours(23)))).toBe('Expires in 23 hours')
+  })
+
+  it('returns days for expiries a day or more away', () => {
+    expect(formatExpiryBadge(new Date(NOW.getTime() + days(1)))).toBe('Expires in 1 day')
+    expect(formatExpiryBadge(new Date(NOW.getTime() + days(3)))).toBe('Expires in 3 days')
+  })
+})

--- a/app/src/bcsc-theme/utils/datetime-utils.ts
+++ b/app/src/bcsc-theme/utils/datetime-utils.ts
@@ -1,0 +1,50 @@
+/**
+ * Format a timestamp in a user-friendly way (e.g., "Just now", "5 minutes ago", "3:45 PM",
+ * "June 4, 3:45 PM"), as used by the home screen notification cards.
+ *
+ * @param {Date} date The timestamp to format
+ * @return {*}  {string}
+ */
+export function formatTimestamp(date: Date): string {
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMin = Math.floor(diffMs / 60_000)
+
+  if (diffMin < 1) {
+    return 'Just now'
+  }
+  if (diffMin < 60) {
+    return `${diffMin} minute${diffMin === 1 ? '' : 's'} ago`
+  }
+
+  const diffHours = Math.floor(diffMin / 60)
+  if (diffHours < 24) {
+    return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+  }
+
+  return date.toLocaleDateString([], { month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit' })
+}
+
+/**
+ * Format an expiry time as a short badge label counting down until the item expires
+ * (e.g., "Expires in 5 min", "Expires in 3 hours", "Expired").
+ *
+ * @param {Date} expiresTime When the item expires
+ * @return {*}  {string}
+ */
+export function formatExpiryBadge(expiresTime: Date): string {
+  const diffMs = expiresTime.getTime() - Date.now()
+  if (diffMs <= 0) {
+    return 'Expired'
+  }
+  const diffMin = Math.floor(diffMs / 60_000)
+  if (diffMin < 60) {
+    return `Expires in ${diffMin} min`
+  }
+  const diffHours = Math.floor(diffMin / 60)
+  if (diffHours < 24) {
+    return `Expires in ${diffHours} hour${diffHours === 1 ? '' : 's'}`
+  }
+  const diffDays = Math.floor(diffHours / 24)
+  return `Expires in ${diffDays} day${diffDays === 1 ? '' : 's'}`
+}

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -95,6 +95,21 @@ export const ACCOUNT_EXPIRATION_DATE_FORMAT = 'MMMM D, YYYY'
 export const ACCOUNT_EXPIRATION_WARNING_DAYS = 30
 export const FIVE_MINUTES_IN_SECONDS = 5 * 60
 export const SERVER_STATUS_RECHECK_INTERVAL_MS = 60 * 1000
+
+// Notification constants
+/**
+ * How long a pending proof request notification stays in the notifications list. Users who hit
+ * a problem often scan a new QR code and abandon the previous proof request, so old requests
+ * are removed rather than left to pile up. (Duration is tentative, per the designs.)
+ */
+export const PROOF_REQUEST_NOTIFICATION_TTL_MS = 60 * 60 * 1000 // 1 hour
+/**
+ * Notifications within this window of expiring (or already expired) show the yellow
+ * "attention" state to warn the user before the item becomes unusable / is removed.
+ */
+export const NOTIFICATION_EXPIRY_WARNING_WINDOW_MS = 60 * 60 * 1000 // 1 hour
+/** How often the notifications list re-evaluates time-based rules (TTL removal, expiry warnings). */
+export const NOTIFICATION_REFRESH_INTERVAL_MS = 60_000
 export const enum DaysOfTheWeek {
   MONDAY = 'MONDAY',
   TUESDAY = 'TUESDAY',
@@ -121,7 +136,7 @@ export const enum LIVE_CALL_UNAVAILABLE_REASONS {
 // File chunking constants
 export const DEFAULT_CHUNK_SIZE = 1024 * 1024 // 1 MB
 
-// Styling contants
+// Styling constants
 export const DEFAULT_HEADER_TITLE_CONTAINER_STYLE: ViewStyle = { flexShrink: 1, maxWidth: '68%' }
 
 // Barcode scanner constants

--- a/app/src/hooks/notifications.ts
+++ b/app/src/hooks/notifications.ts
@@ -1,5 +1,9 @@
 import { showPersonCredentialSelector } from '@/bcwallet-theme/features/person-flow/utils/BCIDHelper'
-import { AttestationRestrictions, NOTIFICATION_REFRESH_INTERVAL_MS, PROOF_REQUEST_NOTIFICATION_TTL_MS } from '@/constants'
+import {
+  AttestationRestrictions,
+  NOTIFICATION_REFRESH_INTERVAL_MS,
+  PROOF_REQUEST_NOTIFICATION_TTL_MS,
+} from '@/constants'
 import { BCState } from '@/store'
 import {
   BasicMessageMetadata,

--- a/app/src/hooks/notifications.ts
+++ b/app/src/hooks/notifications.ts
@@ -1,5 +1,5 @@
 import { showPersonCredentialSelector } from '@/bcwallet-theme/features/person-flow/utils/BCIDHelper'
-import { AttestationRestrictions } from '@/constants'
+import { AttestationRestrictions, NOTIFICATION_REFRESH_INTERVAL_MS, PROOF_REQUEST_NOTIFICATION_TTL_MS } from '@/constants'
 import { BCState } from '@/store'
 import {
   BasicMessageMetadata,
@@ -23,16 +23,6 @@ import { BCAgent } from '@utils/bc-agent-modules'
 import { useEffect, useMemo, useState } from 'react'
 
 export type CredentialNotificationRecord = DidCommBasicMessageRecord | CredentialRecord | DidCommProofExchangeRecord
-
-/**
- * How long a pending proof request notification stays in the notifications list. Users who hit
- * a problem often scan a new QR code and abandon the previous proof request, so old requests
- * are removed rather than left to pile up. (Duration is tentative, per the designs.)
- */
-export const PROOF_REQUEST_NOTIFICATION_TTL_MS = 60 * 60 * 1000 // 1 hour
-
-/** How often the notifications list re-evaluates time-based rules (TTL removal, expiry warnings). */
-const NOTIFICATION_REFRESH_INTERVAL_MS = 60_000
 
 export const useNotifications = (): Array<CredentialNotificationRecord> => {
   const { agent } = useAgent<BCAgent>()

--- a/app/src/hooks/notifications.ts
+++ b/app/src/hooks/notifications.ts
@@ -24,6 +24,16 @@ import { useEffect, useMemo, useState } from 'react'
 
 export type CredentialNotificationRecord = DidCommBasicMessageRecord | CredentialRecord | DidCommProofExchangeRecord
 
+/**
+ * How long a pending proof request notification stays in the notifications list. Users who hit
+ * a problem often scan a new QR code and abandon the previous proof request, so old requests
+ * are removed rather than left to pile up. (Duration is tentative, per the designs.)
+ */
+export const PROOF_REQUEST_NOTIFICATION_TTL_MS = 60 * 60 * 1000 // 1 hour
+
+/** How often the notifications list re-evaluates time-based rules (TTL removal, expiry warnings). */
+const NOTIFICATION_REFRESH_INTERVAL_MS = 60_000
+
 export const useNotifications = (): Array<CredentialNotificationRecord> => {
   const { agent } = useAgent<BCAgent>()
   const [store] = useStore<BCState>()
@@ -39,6 +49,14 @@ export const useNotifications = (): Array<CredentialNotificationRecord> => {
     []
   )
   const proofsDone = useProofByState(doneStates)
+  const [now, setNow] = useState(() => Date.now())
+
+  // Tick periodically so time-based rules (proof request TTL, expiry warnings) are
+  // re-evaluated while the notifications list stays mounted
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), NOTIFICATION_REFRESH_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [])
 
   useEffect(() => {
     // get all unseen messages
@@ -76,8 +94,16 @@ export const useNotifications = (): Array<CredentialNotificationRecord> => {
         : []
 
     const proofs = nonAttestationProofs.filter((proof) => {
+      const isDone = [DidCommProofState.Done, DidCommProofState.PresentationReceived].includes(proof.state)
+
+      // Pending proof requests are usually abandoned once they get old (e.g. the user scanned
+      // a new QR code), so they are removed from the list after their TTL passes
+      if (!isDone && new Date(proof.createdAt).getTime() + PROOF_REQUEST_NOTIFICATION_TTL_MS <= now) {
+        return false
+      }
+
       return (
-        ![DidCommProofState.Done, DidCommProofState.PresentationReceived].includes(proof.state) ||
+        !isDone ||
         (proof.isVerified !== undefined &&
           !(proof.metadata.data[ProofMetadata.customMetadata] as ProofCustomMetadata)?.details_seen)
       )
@@ -94,6 +120,7 @@ export const useNotifications = (): Array<CredentialNotificationRecord> => {
     basicMessages,
     nonAttestationProofs,
     store.dismissPersonCredentialOffer.personCredentialOfferDismissed,
+    now,
   ])
 
   useEffect(() => {

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -96,21 +96,20 @@ const translation = {
     },
     "BasicMessage": {
       "Title": "New message",
-      "SentMessage": "{{ label }} sent a message",
-      "ReceivedMessage": "You received a new message",
       "ButtonTitle": "View message"
     },
     "CredentialOffer": {
       "Title": "Credential offer",
-      "Description": "{{ label }} is offering you a credential"
+      "Description": "{{ label }} is offering you a {{ credential }}."
     },
     "ProofRequest": {
       "Title": "Proof request",
-      "Description": "{{ label }} is requesting information",
-      "DefaultDescription": "You received a proof request"
+      "Description": "{{ label }} is requesting for information.",
+      "DefaultDescription": "You're being asked to share information."
     },
     "Revocation": {
-      "Title": "Credential revoked"
+      "Title": "Credential revoked",
+      "Description": "{{ credential }} was revoked."
     }
   },
   "PersonCredential": {

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -96,21 +96,20 @@ const translation = {
     },
     "BasicMessage": {
       "Title": "New message (FR)",
-      "SentMessage": "{{ label }} sent a message (FR)",
-      "ReceivedMessage": "You received a new message (FR)",
       "ButtonTitle": "View message (FR)"
     },
     "CredentialOffer": {
       "Title": "Credential offer (FR)",
-      "Description": "{{ label }} is offering you a credential (FR)"
+      "Description": "{{ label }} is offering you a {{ credential }}. (FR)"
     },
     "ProofRequest": {
       "Title": "Proof request (FR)",
-      "Description": "{{ label }} is requesting information (FR)",
-      "DefaultDescription": "You received a proof request (FR)"
+      "Description": "{{ label }} is requesting for information. (FR)",
+      "DefaultDescription": "You're being asked to share information. (FR)"
     },
     "Revocation": {
-      "Title": "Credential revoked (FR)"
+      "Title": "Credential revoked (FR)",
+      "Description": "{{ credential }} was revoked. (FR)"
     }
   },
   "PersonCredential": {

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -96,21 +96,20 @@ const translation = {
     },
     "BasicMessage": {
       "Title": "New message (PT-BR)",
-      "SentMessage": "{{ label }} sent a message (PT-BR)",
-      "ReceivedMessage": "You received a new message (PT-BR)",
       "ButtonTitle": "View message (PT-BR)"
     },
     "CredentialOffer": {
       "Title": "Credential offer (PT-BR)",
-      "Description": "{{ label }} is offering you a credential (PT-BR)"
+      "Description": "{{ label }} is offering you a {{ credential }}. (PT-BR)"
     },
     "ProofRequest": {
       "Title": "Proof request (PT-BR)",
-      "Description": "{{ label }} is requesting information (PT-BR)",
-      "DefaultDescription": "You received a proof request (PT-BR)"
+      "Description": "{{ label }} is requesting for information. (PT-BR)",
+      "DefaultDescription": "You're being asked to share information. (PT-BR)"
     },
     "Revocation": {
-      "Title": "Credential revoked (PT-BR)"
+      "Title": "Credential revoked (PT-BR)",
+      "Description": "{{ credential }} was revoked. (PT-BR)"
     }
   },
   "PersonCredential": {


### PR DESCRIPTION
# Summary of Changes

Aligns the BCSC home-screen notifications with the Figma designs.

- **Card states:** new `NotificationCardStatus` on `NotificationCard` — blue (unread), white (read), red (warning/revoked), yellow (attention/expiring soon).
- **Read tracking:** opening a notification marks it read (`offer_seen` / `request_seen` / `notification_read` metadata) instead of dismissing it; only the X (or completing the flow) removes it. Fixes message notifications disappearing on open; new incoming messages flip the card back to unread.
- **Expiry:** pending proof requests are removed from the list 1 hour after creation (TTL constant), with a yellow "Expires in …" warning state during the final hour. List re-evaluates on a 60s tick.
- **Back button:** offers/proofs opened from a notification get a header back button, swipe-back, and Android hardware-back support on the `ConnectionLoading` screen; QR-scan handshake flow stays locked.
- **Logo + icons:** cards show the connection's logo when available, with MaterialCommunityIcons fallbacks per type (`tray-arrow-down`, `file-download`, `alert-circle`).
- **Content:** copy matches the Figma spec — e.g. "_{issuer}_ is offering you a _{credential}_.", messages titled with the contact name showing the message text, "_{credential}_ was revoked." Updated in en/fr/pt-br.
- **Refactors:** timestamp/expiry formatters moved to `bcsc-theme/utils/datetime-utils.ts` (with tests); timing constants moved to `@/constants`.

# Testing Instructions

With an issuer/verifier (e.g. local Traction) connected:

1. Send a message / credential offer / proof request → blue card with the expected copy. Open it, go back → card turns white and stays in the list. X dismisses/declines.
2. Offer/proof screens opened from a notification can be backed out of (header arrow, iOS swipe, Android hardware back).
3. Proof request with <1h expiry (or default TTL) renders yellow with an "Expires in X min" badge and drops off the list after ~1 hour.
4. Revoke a credential → red "Credential revoked" card.
5. Connection with an `imageUrl` → its cards show the logo instead of the icon.

Automated: `yarn test --testPathPattern "(NotificationCard|ConnectionLoadingScreen|datetime-utils)"`, `yarn typecheck`, `yarn lint:ts`.

# Acceptance Criteria

- [x] Card colors match the Figma states (unread/read/warning/attention).
- [x] Opening marks a notification read without removing it; X or completing the flow removes it.
- [x] Logos, fallback icons, and content copy match the designs (all locales).
- [x] Notification-opened offer/proof screens can be backed out of on both platforms; QR flow unchanged.
- [x] Proof requests expire out of the list after the TTL with a prior warning state.

# Screenshots, videos, or gifs

<img width="351" height="756" alt="image" src="https://github.com/user-attachments/assets/3a4f9ad3-f3ed-4d0d-a521-6d7c083e7a3d" />


# Related Issues

N/A
