### PR TITLE
fix: pairing code 404

### DIFF
--- a/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
@@ -659,16 +659,6 @@ describe('clientErrorPolicies', () => {
         expect(emailVerificationCodeErrorPolicy.matches(error, context as any)).toBeTruthy()
       })
 
-      it('should match 400 on email verification PUT endpoint', () => {
-        const error = newError('unknown_server_error')
-        const context = {
-          statusCode: 400,
-          endpoint: `${evidenceBase}/v1/emails/349802`,
-          apiEndpoints: { evidence: evidenceBase },
-        }
-        expect(emailVerificationCodeErrorPolicy.matches(error, context as any)).toBeTruthy()
-      })
-
       it('should NOT match the email creation POST endpoint (no id in path)', () => {
         const error = newError('unknown_server_error')
         const context = {

--- a/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
@@ -19,6 +19,7 @@ import {
   invalidRegistrationRequestErrorPolicy,
   invalidUrlErrorPolicy,
   noTokensReturnedErrorPolicy,
+  pairingCodeErrorPolicy,
   unexpectedServerErrorPolicy,
   updateRequiredErrorPolicy,
   verifyDeviceAssertionErrorPolicy,
@@ -699,6 +700,55 @@ describe('clientErrorPolicies', () => {
 
         expect(loggerMock.info).toHaveBeenCalledWith(
           '[EmailVerificationCodeErrorPolicy] Suppressing global alert — confirmation screen will show inline error for invalid code'
+        )
+      })
+    })
+  })
+
+  describe('pairingCodeErrorPolicy', () => {
+    const assertionBase = 'https://idsit.gov.bc.ca'
+
+    describe('matches', () => {
+      it('should match 404 on pairing code assertion endpoint', () => {
+        const error = newError('unknown_server_error')
+        const context = {
+          statusCode: 404,
+          endpoint: `${assertionBase}/v3/mobile/assertion`,
+          apiEndpoints: {},
+        }
+        expect(pairingCodeErrorPolicy.matches(error, context as any)).toBeTruthy()
+      })
+
+      it('should NOT match other status codes on the assertion endpoint', () => {
+        const error = newError('unknown_server_error')
+        const context = {
+          statusCode: 400,
+          endpoint: `${assertionBase}/v3/mobile/assertion`,
+          apiEndpoints: {},
+        }
+        expect(pairingCodeErrorPolicy.matches(error, context as any)).toBeFalsy()
+      })
+
+      it('should NOT match 404 on unrelated endpoints', () => {
+        const error = newError('unknown_server_error')
+        const context = {
+          statusCode: 404,
+          endpoint: `${assertionBase}/v1/emails/349802`,
+          apiEndpoints: {},
+        }
+        expect(pairingCodeErrorPolicy.matches(error, context as any)).toBeFalsy()
+      })
+    })
+
+    describe('handle', () => {
+      it('should log expected info message', () => {
+        const error = newError('unknown_server_error')
+        const loggerMock = { info: jest.fn() }
+        const context = { logger: loggerMock }
+        pairingCodeErrorPolicy.handle(error, context as any)
+
+        expect(loggerMock.info).toHaveBeenCalledWith(
+          '[PairingCodeErrorPolicy] Suppressing global alert — manual pairing screen will show inline error and alert for invalid pairing code'
         )
       })
     })

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -271,11 +271,10 @@ export const emailVerificationCodeErrorPolicy: ErrorHandlingPolicy = {
   },
 }
 
-// Error policy for pairing code submission — 404 indicate a wrong or
+// Error policy for pairing code submission — 404 indicates a wrong or
 // expired code, which is a user-input error. Suppress the global modal so the
-// ManualPairing can show its own alert error instead of the misleading
+// ManualPairing screen can show its own alert error instead of the misleading
 // "App not installed correctly (error 209)" alert.
-//
 // Matches by path pattern (PUT /v1/emails/{id}) rather than the full evidence base URL,
 // because the discovery-provided evidence_endpoint can differ from the fallback (trailing
 // slash, version suffix, etc.) and we don't want this match to silently break.

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -248,7 +248,7 @@ export const attestationPollingErrorPolicy: ErrorHandlingPolicy = {
   },
 }
 
-// Error policy for email verification code submission — 400/404 indicate a wrong or
+// Error policy for email verification code submission — 404 indicates a wrong or
 // expired code, which is a user-input error. Suppress the global modal so the
 // EmailConfirmationScreen can show its own inline error instead of the misleading
 // "App not installed correctly (error 209)" alert.
@@ -259,10 +259,7 @@ export const attestationPollingErrorPolicy: ErrorHandlingPolicy = {
 const EMAIL_VERIFICATION_PATH_PATTERN = /\/v1\/emails\/[^/?#]+/
 export const emailVerificationCodeErrorPolicy: ErrorHandlingPolicy = {
   matches: (_, context) => {
-    return (
-      (context.statusCode === 400 || context.statusCode === 404) &&
-      EMAIL_VERIFICATION_PATH_PATTERN.test(context.endpoint)
-    )
+    return context.statusCode === 404 && EMAIL_VERIFICATION_PATH_PATTERN.test(context.endpoint)
   },
   handle: (_error, context) => {
     context.logger.info(
@@ -275,10 +272,10 @@ export const emailVerificationCodeErrorPolicy: ErrorHandlingPolicy = {
 // expired code, which is a user-input error. Suppress the global modal so the
 // ManualPairing screen can show its own alert error instead of the misleading
 // "App not installed correctly (error 209)" alert.
-const PAIRING_CORE_PATH_PATTERN = /\/v3\/mobile\/assertion/
+const PAIRING_CODE_PATH_PATTERN = /\/v3\/mobile\/assertion/
 export const pairingCodeErrorPolicy: ErrorHandlingPolicy = {
   matches: (_, context) => {
-    return context.statusCode === 404 && PAIRING_CORE_PATH_PATTERN.test(context.endpoint)
+    return context.statusCode === 404 && PAIRING_CODE_PATH_PATTERN.test(context.endpoint)
   },
   handle: (_error, context) => {
     context.logger.info(

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -271,6 +271,28 @@ export const emailVerificationCodeErrorPolicy: ErrorHandlingPolicy = {
   },
 }
 
+// Error policy for pairing code submission — 400/404 indicate a wrong or
+// expired code, which is a user-input error. Suppress the global modal so the
+// ManualPairing can show its own alert error instead of the misleading
+// "App not installed correctly (error 209)" alert.
+//
+// Matches by path pattern (PUT /v1/emails/{id}) rather than the full evidence base URL,
+// because the discovery-provided evidence_endpoint can differ from the fallback (trailing
+// slash, version suffix, etc.) and we don't want this match to silently break.
+const PAIRING_CORE_PATH_PATTERN = /\/v3\/mobile\/assertion/
+export const pairingCodeErrorPolicy: ErrorHandlingPolicy = {
+  matches: (_, context) => {
+    return (
+      (context.statusCode === 400 || context.statusCode === 404) && PAIRING_CORE_PATH_PATTERN.test(context.endpoint)
+    )
+  },
+  handle: (_error, context) => {
+    context.logger.info(
+      '[PairingCodeErrorPolicy] Suppressing global alert — confirmation screen will show inline error for invalid code'
+    )
+  },
+}
+
 // Error policy for unexpected server errors (http status: 500, 503)
 export const unexpectedServerErrorPolicy: ErrorHandlingPolicy = {
   matches: (_, context) => {
@@ -463,6 +485,7 @@ export const ClientErrorHandlingPolicies: ErrorHandlingPolicy[] = [
   videoSessionErrorPolicy,
   attestationPollingErrorPolicy,
   emailVerificationCodeErrorPolicy,
+  pairingCodeErrorPolicy,
   invalidClientMetadataErrorPolicy,
   iasErrorPolicy,
   // Specific polices listed above, followed by global policies

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -271,7 +271,7 @@ export const emailVerificationCodeErrorPolicy: ErrorHandlingPolicy = {
   },
 }
 
-// Error policy for pairing code submission — 400/404 indicate a wrong or
+// Error policy for pairing code submission — 404 indicate a wrong or
 // expired code, which is a user-input error. Suppress the global modal so the
 // ManualPairing can show its own alert error instead of the misleading
 // "App not installed correctly (error 209)" alert.

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -275,19 +275,14 @@ export const emailVerificationCodeErrorPolicy: ErrorHandlingPolicy = {
 // expired code, which is a user-input error. Suppress the global modal so the
 // ManualPairing screen can show its own alert error instead of the misleading
 // "App not installed correctly (error 209)" alert.
-// Matches by path pattern (PUT /v1/emails/{id}) rather than the full evidence base URL,
-// because the discovery-provided evidence_endpoint can differ from the fallback (trailing
-// slash, version suffix, etc.) and we don't want this match to silently break.
 const PAIRING_CORE_PATH_PATTERN = /\/v3\/mobile\/assertion/
 export const pairingCodeErrorPolicy: ErrorHandlingPolicy = {
   matches: (_, context) => {
-    return (
-      (context.statusCode === 400 || context.statusCode === 404) && PAIRING_CORE_PATH_PATTERN.test(context.endpoint)
-    )
+    return context.statusCode === 404 && PAIRING_CORE_PATH_PATTERN.test(context.endpoint)
   },
   handle: (_error, context) => {
     context.logger.info(
-      '[PairingCodeErrorPolicy] Suppressing global alert — confirmation screen will show inline error for invalid code'
+      '[PairingCodeErrorPolicy] Suppressing global alert — manual pairing screen will show inline error and alert for invalid pairing code'
     )
   },
 }

--- a/app/src/bcsc-theme/features/pairing/ManualPairing.test.tsx
+++ b/app/src/bcsc-theme/features/pairing/ManualPairing.test.tsx
@@ -20,6 +20,7 @@ jest.mock('@/bcsc-theme/api/hooks/useApi', () => ({
 
 describe('ManualPairing', () => {
   let mockNavigation: any
+  let alertSpy: any
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -29,6 +30,7 @@ describe('ManualPairing', () => {
 
   afterEach(() => {
     jest.useRealTimers()
+    alertSpy?.mockRestore()
   })
 
   const renderScreen = () =>
@@ -84,9 +86,9 @@ describe('ManualPairing', () => {
       })
     })
 
-    test('shows error when submission fails', async () => {
-      const alertSpy = jest.spyOn(Alert, 'alert')
-      mockLoginByPairingCode.mockRejectedValue(new Error('Network error'))
+    test('shows error when submission fails with 404', async () => {
+      alertSpy = jest.spyOn(Alert, 'alert')
+      mockLoginByPairingCode.mockRejectedValue(new Error('Not Found', { cause: { status: 404 } }))
       renderScreen()
 
       const codeInput = screen.getByTestId(testIdWithKey('ManualPairingCodeInput'))

--- a/app/src/bcsc-theme/features/pairing/ManualPairing.test.tsx
+++ b/app/src/bcsc-theme/features/pairing/ManualPairing.test.tsx
@@ -96,7 +96,7 @@ describe('ManualPairing', () => {
       fireEvent.press(screen.getByTestId(testIdWithKey('Submit')))
 
       await waitFor(() => {
-        expect(screen.getByText('BCSC.ManualPairing.FailedToSubmitPairingCodeMessage')).toBeTruthy()
+        expect(screen.getByText('BCSC.ManualPairing.CodeDoesNotMatchMessage')).toBeTruthy()
         expect(alertSpy).toHaveBeenCalledWith(
           'BCSC.ManualPairing.CouldNotVerifyPairingCodeTitle',
           'BCSC.ManualPairing.CodeDoesNotMatchMessage',

--- a/app/src/bcsc-theme/features/pairing/ManualPairing.test.tsx
+++ b/app/src/bcsc-theme/features/pairing/ManualPairing.test.tsx
@@ -87,7 +87,7 @@ describe('ManualPairing', () => {
     })
 
     test('shows error when submission fails with 404', async () => {
-      alertSpy = jest.spyOn(Alert, 'alert')
+      alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {})
       mockLoginByPairingCode.mockRejectedValue(new Error('Not Found', { cause: { status: 404 } }))
       renderScreen()
 

--- a/app/src/bcsc-theme/features/pairing/ManualPairing.test.tsx
+++ b/app/src/bcsc-theme/features/pairing/ManualPairing.test.tsx
@@ -4,6 +4,7 @@ import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native'
 import React from 'react'
+import { Alert } from 'react-native'
 import ManualPairing from './ManualPairing'
 
 const mockLoginByPairingCode = jest.fn()
@@ -84,6 +85,7 @@ describe('ManualPairing', () => {
     })
 
     test('shows error when submission fails', async () => {
+      const alertSpy = jest.spyOn(Alert, 'alert')
       mockLoginByPairingCode.mockRejectedValue(new Error('Network error'))
       renderScreen()
 
@@ -93,6 +95,11 @@ describe('ManualPairing', () => {
 
       await waitFor(() => {
         expect(screen.getByText('BCSC.ManualPairing.FailedToSubmitPairingCodeMessage')).toBeTruthy()
+        expect(alertSpy).toHaveBeenCalledWith(
+          'BCSC.ManualPairing.CouldNotVerifyPairingCodeTitle',
+          'BCSC.ManualPairing.CodeDoesNotMatchMessage',
+          expect.any(Array)
+        )
       })
     })
 

--- a/app/src/bcsc-theme/features/pairing/ManualPairing.tsx
+++ b/app/src/bcsc-theme/features/pairing/ManualPairing.tsx
@@ -56,11 +56,15 @@ const ManualPairing: React.FC<ManualPairingProps> = ({ navigation }) => {
       } catch (error) {
         logger.error(`Error submitting pairing code: ${error}`)
         setError(t('BCSC.ManualPairing.FailedToSubmitPairingCodeMessage'))
-        Alert.alert(
-          t('BCSC.ManualPairing.CouldNotVerifyPairingCodeTitle'),
-          t('BCSC.ManualPairing.CodeDoesNotMatchMessage'),
-          [{ text: t('Global.OK') }]
-        )
+
+        // Error 404 is assumed to be an incorrect pairing code
+        if ((error as any)?.cause?.status === 404) {
+          Alert.alert(
+            t('BCSC.ManualPairing.CouldNotVerifyPairingCodeTitle'),
+            t('BCSC.ManualPairing.CodeDoesNotMatchMessage'),
+            [{ text: t('Global.OK') }]
+          )
+        }
       } finally {
         setLoading(false)
       }

--- a/app/src/bcsc-theme/features/pairing/ManualPairing.tsx
+++ b/app/src/bcsc-theme/features/pairing/ManualPairing.tsx
@@ -56,9 +56,11 @@ const ManualPairing: React.FC<ManualPairingProps> = ({ navigation }) => {
       } catch (error) {
         logger.error(`Error submitting pairing code: ${error}`)
         setError(t('BCSC.ManualPairing.FailedToSubmitPairingCodeMessage'))
-        Alert.alert(t('BCSC.ManualPairing.CouldNotVerifyPairingCodeTitle'), t('BCSC.ManualPairing.CodeDoesNotMatchMessage'), [
-          { text: t('Global.OK') },
-        ])
+        Alert.alert(
+          t('BCSC.ManualPairing.CouldNotVerifyPairingCodeTitle'),
+          t('BCSC.ManualPairing.CodeDoesNotMatchMessage'),
+          [{ text: t('Global.OK') }]
+        )
       } finally {
         setLoading(false)
       }

--- a/app/src/bcsc-theme/features/pairing/ManualPairing.tsx
+++ b/app/src/bcsc-theme/features/pairing/ManualPairing.tsx
@@ -55,15 +55,17 @@ const ManualPairing: React.FC<ManualPairingProps> = ({ navigation }) => {
         })
       } catch (error) {
         logger.error(`Error submitting pairing code: ${error}`)
-        setError(t('BCSC.ManualPairing.FailedToSubmitPairingCodeMessage'))
 
         // Error 404 is assumed to be an incorrect pairing code
         if ((error as any)?.cause?.status === 404) {
+          setError(t('BCSC.ManualPairing.CodeDoesNotMatchMessage'))
           Alert.alert(
             t('BCSC.ManualPairing.CouldNotVerifyPairingCodeTitle'),
             t('BCSC.ManualPairing.CodeDoesNotMatchMessage'),
             [{ text: t('Global.OK') }]
           )
+        } else {
+          setError(t('BCSC.ManualPairing.FailedToSubmitPairingCodeMessage'))
         }
       } finally {
         setLoading(false)

--- a/app/src/bcsc-theme/features/pairing/ManualPairing.tsx
+++ b/app/src/bcsc-theme/features/pairing/ManualPairing.tsx
@@ -16,6 +16,7 @@ import {
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Alert } from 'react-native'
 
 type ManualPairingProps = StackScreenProps<BCSCMainStackParams, BCSCScreens.ManualPairingCode>
 
@@ -55,6 +56,9 @@ const ManualPairing: React.FC<ManualPairingProps> = ({ navigation }) => {
       } catch (error) {
         logger.error(`Error submitting pairing code: ${error}`)
         setError(t('BCSC.ManualPairing.FailedToSubmitPairingCodeMessage'))
+        Alert.alert(t('BCSC.ManualPairing.CouldNotVerifyPairingCodeTitle'), t('BCSC.ManualPairing.CodeDoesNotMatchMessage'), [
+          { text: t('Global.OK') },
+        ])
       } finally {
         setLoading(false)
       }

--- a/app/src/bcsc-theme/features/verify/email/EmailConfirmationScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EmailConfirmationScreen.test.tsx
@@ -128,7 +128,7 @@ describe('EmailConfirmation', () => {
 
     test('shows native alert when submission fails', async () => {
       const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {})
-      mockSendEmailVerificationCode.mockRejectedValue(new Error('API Error'))
+      mockSendEmailVerificationCode.mockRejectedValue(new Error('Not Found', { cause: { status: 404 } }))
       renderScreen()
 
       const codeInput = screen.getByTestId(testIdWithKey('EmailConfirmationCodeInput'))

--- a/app/src/bcsc-theme/features/verify/email/EmailConfirmationScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EmailConfirmationScreen.test.tsx
@@ -136,7 +136,7 @@ describe('EmailConfirmation', () => {
       fireEvent.press(screen.getByTestId('ContinueButton'))
 
       await waitFor(() => {
-        expect(screen.getByText('BCSC.EmailConfirmation.ErrorTitle')).toBeTruthy()
+        expect(screen.getByText('BCSC.EmailConfirmation.CodeDoesNotMatch')).toBeTruthy()
         expect(alertSpy).toHaveBeenCalledWith(
           'BCSC.EmailConfirmation.CouldNotVerifyTitle',
           'BCSC.EmailConfirmation.CodeDoesNotMatch',

--- a/app/src/bcsc-theme/features/verify/email/EmailConfirmationScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EmailConfirmationScreen.tsx
@@ -70,9 +70,11 @@ const EmailConfirmationScreen = ({ navigation, route }: EmailConfirmationScreenP
       )
     } catch (error) {
       setError(t('BCSC.EmailConfirmation.ErrorTitle'))
-      Alert.alert(t('BCSC.EmailConfirmation.CouldNotVerifyTitle'), t('BCSC.EmailConfirmation.CodeDoesNotMatch'), [
-        { text: t('Global.OK') },
-      ])
+      if ((error as any)?.cause?.status === 404) {
+        Alert.alert(t('BCSC.EmailConfirmation.CouldNotVerifyTitle'), t('BCSC.EmailConfirmation.CodeDoesNotMatch'), [
+          { text: t('Global.OK') },
+        ])
+      }
     } finally {
       setLoading(false)
     }

--- a/app/src/bcsc-theme/features/verify/email/EmailConfirmationScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EmailConfirmationScreen.tsx
@@ -69,11 +69,13 @@ const EmailConfirmationScreen = ({ navigation, route }: EmailConfirmationScreenP
         })
       )
     } catch (error) {
-      setError(t('BCSC.EmailConfirmation.ErrorTitle'))
       if ((error as any)?.cause?.status === 404) {
+        setError(t('BCSC.EmailConfirmation.CodeDoesNotMatch'))
         Alert.alert(t('BCSC.EmailConfirmation.CouldNotVerifyTitle'), t('BCSC.EmailConfirmation.CodeDoesNotMatch'), [
           { text: t('Global.OK') },
         ])
+      } else {
+        setError(t('BCSC.EmailConfirmation.ErrorTitle'))
       }
     } finally {
       setLoading(false)

--- a/app/src/bcsc-theme/utils/axios-error-utils.test.ts
+++ b/app/src/bcsc-theme/utils/axios-error-utils.test.ts
@@ -53,6 +53,32 @@ describe('Error Utils', () => {
       expect(appError.appEvent).toBe('unknown_server_error')
       expect(appError.code).toContain(String(ErrorRegistry.UNKNOWN_SERVER_ERROR.statusCode))
     })
+
+    it('should set url and method from error config', () => {
+      const axiosError = {
+        code: 'err_209_bad_request',
+        message: 'Bad request',
+        config: { url: 'https://example.com/device/token', method: 'post' },
+        response: { data: {}, status: 400 },
+      } as any
+
+      const appError = getAppErrorFromAxiosError(axiosError)
+
+      expect(appError.url).toBe('https://example.com/device/token')
+      expect(appError.method).toBe('POST')
+    })
+
+    it('should set url to undefined when config.url is absent', () => {
+      const axiosError = {
+        code: 'unknown_ias_code',
+        message: 'Unknown',
+        config: {},
+      } as any
+
+      const appError = getAppErrorFromAxiosError(axiosError)
+
+      expect(appError.url).toBeUndefined()
+    })
   })
 
   describe('formatIasAxiosResponseError', () => {

--- a/app/src/bcsc-theme/utils/axios-error-utils.test.ts
+++ b/app/src/bcsc-theme/utils/axios-error-utils.test.ts
@@ -54,7 +54,7 @@ describe('Error Utils', () => {
       expect(appError.code).toContain(String(ErrorRegistry.UNKNOWN_SERVER_ERROR.statusCode))
     })
 
-    it('should set url and method from error config', () => {
+    it('should set url path and method from error config', () => {
       const axiosError = {
         code: 'err_209_bad_request',
         message: 'Bad request',
@@ -64,11 +64,11 @@ describe('Error Utils', () => {
 
       const appError = getAppErrorFromAxiosError(axiosError)
 
-      expect(appError.url).toBe('https://example.com/device/token')
+      expect(appError.url).toBe('/device/token')
       expect(appError.method).toBe('POST')
     })
 
-    it('should set url to undefined when config.url is absent', () => {
+    it('should set url path to undefined when config.url is absent', () => {
       const axiosError = {
         code: 'unknown_ias_code',
         message: 'Unknown',

--- a/app/src/bcsc-theme/utils/axios-error-utils.ts
+++ b/app/src/bcsc-theme/utils/axios-error-utils.ts
@@ -152,8 +152,8 @@ export const getAppErrorFromAxiosError = (error: AxiosError): AppError => {
       cause: error,
     })
   }
-
-  appError.url = error.config?.url
+  // http://x.com is a dummy domain so relative paths still parse correctly
+  appError.url = error.config?.url ? new URL(error.config.url, 'https://x.com').pathname : undefined
   appError.method = error.config?.method?.toUpperCase()
 
   return appError

--- a/app/src/bcsc-theme/utils/axios-error-utils.ts
+++ b/app/src/bcsc-theme/utils/axios-error-utils.ts
@@ -132,14 +132,14 @@ export const getAppErrorFromAxiosError = (error: AxiosError): AppError => {
   const errorCode = error.code
   const errorDefinition = getAxiosErrorDefinition(errorCode) ?? getErrorDefinitionFromAppEventCode(errorCode)
 
+  let appError: AppError
+
   // If we have a predefined error definition for this app event code, use it to create the AppError
   if (errorDefinition) {
-    return AppError.fromErrorDefinition(errorDefinition, { cause: error })
-  }
-
-  // Create a generic AppError for known event codes that don't have a predefined error definition
-  if (isAppEventCode(errorCode)) {
-    return new AppError(
+    appError = AppError.fromErrorDefinition(errorDefinition, { cause: error })
+  } else if (isAppEventCode(errorCode)) {
+    // Create a generic AppError for known event codes that don't have a predefined error definition
+    appError = new AppError(
       `Server Error: Unregistered error code (${errorCode})`,
       {
         ...ErrorRegistry.UNKNOWN_SERVER_ERROR,
@@ -147,9 +147,14 @@ export const getAppErrorFromAxiosError = (error: AxiosError): AppError => {
       },
       { cause: error }
     )
+  } else {
+    appError = new AppError(`Server Error: Unknown error code (${errorCode})`, ErrorRegistry.UNKNOWN_SERVER_ERROR, {
+      cause: error,
+    })
   }
 
-  return new AppError(`Server Error: Unknown error code (${errorCode})`, ErrorRegistry.UNKNOWN_SERVER_ERROR, {
-    cause: error,
-  })
+  appError.url = error.config?.url
+  appError.method = error.config?.method?.toUpperCase()
+
+  return appError
 }

--- a/app/src/errors/appError.test.ts
+++ b/app/src/errors/appError.test.ts
@@ -77,6 +77,35 @@ describe('AppError', () => {
         'Something went wrong\nDebug: [general.unknown_server_error.1234] Technical details about the error'
       )
     })
+
+    it('should append URL if set', () => {
+      const identity = {
+        category: ErrorCategory.GENERAL,
+        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
+        statusCode: 1234,
+      }
+      const error = new AppError('Something went wrong', identity)
+      error.url = 'https://example.com/device/token'
+
+      expect(error.fullMessage).toBe(
+        'Something went wrong\nDebug: [general.unknown_server_error.1234]\nRequest: https://example.com/device/token'
+      )
+    })
+
+    it('should include HTTP method with URL when both are set', () => {
+      const identity = {
+        category: ErrorCategory.GENERAL,
+        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
+        statusCode: 1234,
+      }
+      const error = new AppError('Something went wrong', identity)
+      error.url = 'https://example.com/device/token'
+      error.method = 'POST'
+
+      expect(error.fullMessage).toBe(
+        'Something went wrong\nDebug: [general.unknown_server_error.1234]\nRequest: POST https://example.com/device/token'
+      )
+    })
   })
 
   describe('track', () => {
@@ -170,6 +199,8 @@ describe('AppError', () => {
         timestamp: '2024-01-01T00:00:00.000Z',
         cause: cause,
         handled: false,
+        url: undefined,
+        method: undefined,
       })
 
       jest.useRealTimers()

--- a/app/src/errors/appError.ts
+++ b/app/src/errors/appError.ts
@@ -29,6 +29,8 @@ export class AppError extends Error {
   statusCode: number // ie: 2100
   timestamp: string // ISO timestamp of when the error was created
   handled: boolean // Whether this error has been handled by a policy
+  url?: string // API endpoint URL that produced this error, if applicable
+  method?: string // HTTP method of the request that produced this error, if applicable
 
   constructor(message: string, identity: ErrorIdentity, options?: AppErrorOptions) {
     super(message, options)
@@ -40,6 +42,8 @@ export class AppError extends Error {
     this.timestamp = new Date().toISOString()
     this.handled = false
     this.tracked = false
+    this.url = undefined
+    this.method = undefined
 
     // Track the error in analytics unless explicitly disabled
     if (options?.track !== false) {
@@ -73,6 +77,11 @@ export class AppError extends Error {
 
     if (this.technicalMessage) {
       formattedMessage += ` ${this.technicalMessage}`
+    }
+
+    if (this.url) {
+      const request = this.method ? `${this.method} ${this.url}` : this.url
+      formattedMessage += `\nRequest: ${request}`
     }
 
     return formattedMessage
@@ -136,6 +145,8 @@ export class AppError extends Error {
       code: this.code,
       timestamp: this.timestamp,
       handled: this.handled,
+      url: this.url,
+      method: this.method,
       cause: this.cause,
     }
   }

--- a/app/src/errors/errorRegistry.ts
+++ b/app/src/errors/errorRegistry.ts
@@ -163,7 +163,7 @@ export const ErrorRegistry = {
     appEvent: AppEventCode.ERR_209_BAD_REQUEST,
     severity: ErrorSeverity.ERROR,
     category: ErrorCategory.NETWORK,
-    message: 'Server rejected the request with HTTP 400 — check request payload',
+    message: 'Server rejected the request — check request payload',
   },
   SERVER_OUTAGE: {
     statusCode: 2108,

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -506,6 +506,8 @@ const translation = {
       "BookmarkService": "Save link to:",
       "ToggleBookmark": "Toggle bookmark",
       "BookmarkDescription": "This adds a link to the menu in this app for easier access next time.",
+      "CouldNotVerifyPairingCodeTitle": "Could not verify pairing code",
+      "CodeDoesNotMatchMessage": "The code you entered does not match. Try again.",
     },
     "Onboarding": {
       "LearnMore": "Learn more",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -502,6 +502,8 @@ const translation = {
       "BookmarkService": "Save link to: (FR)",
       "ToggleBookmark": "Toggle bookmark (FR)",
       "BookmarkDescription": "This adds a link to the menu in this app for easier access next time. (FR)",
+      "CouldNotVerifyPairingCodeTitle": "Could not verify pairing code (FR)",
+      "CodeDoesNotMatchMessage": "The code you entered does not match. Try again. (FR)",
     },
     "Onboarding": {
       "LearnMore": "Learn more (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -502,6 +502,8 @@ const translation = {
       "BookmarkService": "Save link to: (PT-BR)",
       "ToggleBookmark": "Toggle bookmark (PT-BR)",
       "BookmarkDescription": "This adds a link to the menu in this app for easier access next time. (PT-BR)",
+      "CouldNotVerifyPairingCodeTitle": "Could not verify pairing code (PT-BR)",
+      "CodeDoesNotMatchMessage": "The code you entered does not match. Try again. (PT-BR)",
     },
     "Onboarding": {
       "LearnMore": "Learn more (PT-BR)",


### PR DESCRIPTION
# Summary of Changes

- added error policy to suppress pairing code 404s
- added system alert to inform user of incorrect pairing code
- added http and url info to error reporting

# Testing Instructions

- verify app
- attempt to login via paring code with false code (AAA-AAA)
- see system alert

# Acceptance Criteria

- incorrect pairing codes generate an alert
- global error alerts that originate from api calls show a URL path and method

# Screenshots, videos, or gifs
Screenshot of incorrect pairing code
<img width="392" height="473" alt="Screenshot 2026-06-08 at 3 13 19 PM" src="https://github.com/user-attachments/assets/dfa9a4f8-eae3-4a06-a8d3-18106d379ba4" />



Screenshot showing example of URL in global error
<img width="390" height="657" alt="Screenshot 2026-06-08 at 1 45 43 PM" src="https://github.com/user-attachments/assets/11ee3919-4179-4dd1-bfdb-fb6b070efeda" />



# Related Issues
[BC-Wallet: 3994](https://github.com/bcgov/bc-wallet-mobile/issues/3994)
