### PR TITLE
fix: camera formatting bug

### DIFF
--- a/app/src/bcsc-theme/components/utils/camera.ts
+++ b/app/src/bcsc-theme/components/utils/camera.ts
@@ -49,6 +49,12 @@ export const CameraFormat = {
    * Higher FPS and resolution for better barcode recognition
    */
   MaskedWithBarcodeDetection: [
+    // Prefer non-HDR (8-bit) formats. Some devices only expose a 10-bit HDR
+    // pixel format (e.g. "btp2") on their max-resolution/60fps formats, which
+    // VisionCamera's default 8-bit pipeline can't use → "pixel-format-not-supported".
+    {
+      videoHdr: false,
+    },
     // Target 60 FPS for smoother camera preview and better barcode detection
     {
       fps: 60,
@@ -72,6 +78,11 @@ export const CameraFormat = {
    * - PDF417: ~50mm x 9mm
    */
   SmallBarcodeScanning: [
+    // Prefer non-HDR (8-bit) formats to avoid 10-bit-only HDR formats whose
+    // pixel format (e.g. "btp2") is incompatible with VisionCamera's pipeline.
+    {
+      videoHdr: false,
+    },
     // High FPS for better real-time detection
     {
       fps: 60,


### PR DESCRIPTION
# Summary of Changes

This PR addresses #4003 

The fix matches what we already do for ScanSerial's CodeScanningCamera, where the user did not encounter the bug. 

# Testing Instructions

It is device specific, so hard to reproduce. Just check card scanning and evidence photo camera still work.

# Acceptance Criteria

Card scanning and evidence photo still works.

# Screenshots, videos, or gifs

N/A

# Related Issues

#4003