### PR TITLE
fix: first name optional

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useAuthorizationApi.test.tsx
+++ b/app/src/bcsc-theme/api/hooks/useAuthorizationApi.test.tsx
@@ -217,5 +217,17 @@ describe('useAuthorizationApi', () => {
         expect.objectContaining({ middle_name: undefined })
       )
     })
+
+    it('omits given_name when first name is empty (mononym)', async () => {
+      const apiClient = buildMockApiClient()
+      const api = renderAuthApi(apiClient)
+
+      await act(async () => {
+        await api.authorizeDeviceWithUnknownBCSC({ ...baseConfig, firstName: '' })
+      })
+      expect(BcscCore.createDeviceSignedJWT).toHaveBeenLastCalledWith(
+        expect.objectContaining({ given_name: undefined })
+      )
+    })
   })
 })

--- a/app/src/bcsc-theme/api/hooks/useAuthorizationApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useAuthorizationApi.tsx
@@ -105,7 +105,8 @@ const useAuthorizationApi = (apiClient: BCSCApiClient) => {
             iat: Math.floor(Date.now() / 1000),
             exp: Math.floor(Date.now() / 1000) + 60 * 10, // ten minutes
             family_name: config.lastName,
-            given_name: config.firstName,
+            // Omit given name if not provided or empty string (mononyms have no first name)
+            given_name: config.firstName || undefined,
             birthdate: config.birthdate,
             address: {
               street_address: config.address.streetAddress,

--- a/app/src/bcsc-theme/features/verify/non-photo/useEvidenceIDCollectionModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/non-photo/useEvidenceIDCollectionModel.test.ts
@@ -47,6 +47,19 @@ describe('useEvidenceIDCollectionModel', () => {
       expect(errors.lastName).toBe('BCSC.EvidenceIDCollection.LastNameError')
     })
 
+    it('treats a whitespace-only last name as missing', () => {
+      const validateEvidence = getValidateEvidence()
+
+      const errors = validateEvidence({
+        values: { ...baseValues, lastName: '   ' },
+        personalInfoRequired: true,
+        minimumAge: 19,
+        t,
+      })
+
+      expect(errors.lastName).toBe('BCSC.EvidenceIDCollection.LastNameError')
+    })
+
     it('skips personal info validation entirely when not required', () => {
       const validateEvidence = getValidateEvidence()
 

--- a/app/src/bcsc-theme/features/verify/non-photo/useEvidenceIDCollectionModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/non-photo/useEvidenceIDCollectionModel.test.ts
@@ -1,0 +1,63 @@
+import { renderHook } from '@testing-library/react-native'
+import useEvidenceIDCollectionModel, { EvidenceCollectionFormState } from './useEvidenceIDCollectionModel'
+
+// Minimal translation stub: echo the key back so we can assert on which error fired.
+const t = (key: string) => key
+
+// A valid baseline submission with a populated last name but an empty first name (a mononym).
+const baseValues: EvidenceCollectionFormState = {
+  documentNumber: '123456789',
+  firstName: '',
+  lastName: 'Mononym',
+  middleNames: '',
+  birthDate: '1990/01/01',
+}
+
+describe('useEvidenceIDCollectionModel', () => {
+  const getValidateEvidence = () => {
+    const { result } = renderHook(() => useEvidenceIDCollectionModel())
+    return result.current.validateEvidence
+  }
+
+  describe('validateEvidence', () => {
+    it('does not require a first name so mononyms can proceed', () => {
+      const validateEvidence = getValidateEvidence()
+
+      const errors = validateEvidence({
+        values: { ...baseValues, firstName: '' },
+        personalInfoRequired: true,
+        minimumAge: 19,
+        t,
+      })
+
+      expect(errors.firstName).toBeUndefined()
+      expect(errors).toEqual({})
+    })
+
+    it('still requires a last name', () => {
+      const validateEvidence = getValidateEvidence()
+
+      const errors = validateEvidence({
+        values: { ...baseValues, firstName: '', lastName: '' },
+        personalInfoRequired: true,
+        minimumAge: 19,
+        t,
+      })
+
+      expect(errors.lastName).toBe('BCSC.EvidenceIDCollection.LastNameError')
+    })
+
+    it('skips personal info validation entirely when not required', () => {
+      const validateEvidence = getValidateEvidence()
+
+      const errors = validateEvidence({
+        values: { documentNumber: '', firstName: '', lastName: '', middleNames: '', birthDate: '' },
+        personalInfoRequired: false,
+        minimumAge: 19,
+        t,
+      })
+
+      expect(errors).toEqual({})
+    })
+  })
+})

--- a/app/src/bcsc-theme/features/verify/non-photo/useEvidenceIDCollectionModel.ts
+++ b/app/src/bcsc-theme/features/verify/non-photo/useEvidenceIDCollectionModel.ts
@@ -85,8 +85,9 @@ const useEvidenceIDCollectionModel = () => {
       }
 
       // First name is intentionally optional to support mononyms (people with a single
-      // legal name). Only the last name is required.
-      if (!values.lastName) {
+      // legal name). Last name remains required; trim so whitespace-only input is rejected
+      // (the value is trimmed before it is persisted).
+      if (!values.lastName.trim()) {
         errors.lastName = t('BCSC.EvidenceIDCollection.LastNameError')
       }
 

--- a/app/src/bcsc-theme/features/verify/non-photo/useEvidenceIDCollectionModel.ts
+++ b/app/src/bcsc-theme/features/verify/non-photo/useEvidenceIDCollectionModel.ts
@@ -84,10 +84,8 @@ const useEvidenceIDCollectionModel = () => {
         return errors
       }
 
-      if (!values.firstName) {
-        errors.firstName = t('BCSC.EvidenceIDCollection.FirstNameError')
-      }
-
+      // First name is intentionally optional to support mononyms (people with a single
+      // legal name). Only the last name is required.
       if (!values.lastName) {
         errors.lastName = t('BCSC.EvidenceIDCollection.LastNameError')
       }


### PR DESCRIPTION
# Summary of Changes

Makes the **First name** field optional in the NonBCSC evidence collection flow so mononyms (people with a single legal name) can proceed with only a last name. This restores the v3.x behaviour, where first name was not required.

- `useEvidenceIDCollectionModel.ts` — drop the required-first-name validation; only last name is now required.
- `useAuthorizationApi.tsx` — send `given_name` as `undefined` when empty so an empty first name is omitted from the IAS device-auth JWT (matches the existing `middle_name` handling).
- `useEvidenceIDCollectionModel.test.ts` — new unit tests for `validateEvidence` covering the optional first name.

# Testing Instructions

1. Start a NonBCSC verification flow.
2. On the ID details screen, leave **First name** blank and fill in **Last name** and the remaining fields.
3. Tap **Continue** — the form proceeds with no first-name error.
4. Confirm last name is still enforced (blank last name still shows an error).
5. Run `yarn test src/bcsc-theme/features/verify/non-photo/useEvidenceIDCollectionModel.test.ts`.

# Acceptance Criteria

- A user with no first name can complete the NonBCSC flow by entering only a last name (no error), per v3.x.
- Last name remains required.

# Screenshots, videos, or gifs

N/A — validation-only change, no UI changes.

# Related Issues

N/A
