### PR TITLE
fix: discriminate scanned cards via barcodes API

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useAuthorizationApi.test.tsx
+++ b/app/src/bcsc-theme/api/hooks/useAuthorizationApi.test.tsx
@@ -230,4 +230,64 @@ describe('useAuthorizationApi', () => {
       )
     })
   })
+
+  describe('authorizeDeviceWithBarcodes', () => {
+    const BARCODES_ENDPOINT = 'https://mock-api.example.com/device/barcodes'
+
+    const buildBarcodeApiClient = () => ({
+      post: jest.fn().mockResolvedValue({ data: {} }),
+      endpoints: { barcodes: BARCODES_ENDPOINT },
+    })
+
+    it('posts the barcodes to /device/barcodes/{clientID} as JSON with skipBearerAuth', async () => {
+      const apiClient = buildBarcodeApiClient()
+      const api = renderAuthApi(apiClient as any)
+      const barcodes = [
+        { type: 'CODE_128', value: 'A06198657' },
+        { type: 'PDF_417', content_type: 'AAMVA_3TRACK_PDF417', iso_iin: '636028', birthdate: '2005-06-07' },
+      ]
+
+      await act(async () => {
+        await api.authorizeDeviceWithBarcodes(barcodes as any)
+      })
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        `${BARCODES_ENDPOINT}/${FAKE_CLIENT_ID}`,
+        { barcodes },
+        { headers: { 'Content-Type': 'application/json' }, skipBearerAuth: true }
+      )
+    })
+
+    it('returns the device authorization response from IAS', async () => {
+      const apiClient = buildBarcodeApiClient()
+      const mockResponse = {
+        device_code: 'dev-abc',
+        user_code: 'USER1234',
+        verification_options: 'video_call',
+        process: 'photo',
+        expires_in: 600,
+      }
+      apiClient.post.mockResolvedValueOnce({ data: mockResponse })
+      const api = renderAuthApi(apiClient as any)
+
+      let result: any
+      await act(async () => {
+        result = await api.authorizeDeviceWithBarcodes([{ type: 'CODE_128', value: 'A06198657' }] as any)
+      })
+
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('propagates backend errors (e.g. card_not_found) so the caller can continue as evidence', async () => {
+      const apiClient = buildBarcodeApiClient()
+      apiClient.post.mockRejectedValue(new Error('card_not_found'))
+      const api = renderAuthApi(apiClient as any)
+
+      await act(async () => {
+        await expect(
+          api.authorizeDeviceWithBarcodes([{ type: 'CODE_128', value: 'A06198657' }] as any)
+        ).rejects.toThrow('card_not_found')
+      })
+    })
+  })
 })

--- a/app/src/bcsc-theme/api/hooks/useAuthorizationApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useAuthorizationApi.tsx
@@ -1,6 +1,7 @@
 import { ProvinceCode } from '@/bcsc-theme/utils/address-utils'
 import moment from 'moment'
 import { useCallback, useMemo } from 'react'
+import type { BarcodePayload } from 'react-native-bcsc-core'
 import { BCSCCardProcess, createDeviceSignedJWT } from 'react-native-bcsc-core'
 import BCSCApiClient from '../client'
 import { withAccount } from './withAccountGuard'
@@ -137,12 +138,44 @@ const useAuthorizationApi = (apiClient: BCSCApiClient) => {
     [apiClient]
   )
 
+  /**
+   * Authorize a device from scanned card barcodes. Posts the decoded barcodes
+   * (CODE_128 serial + PDF_417/AAMVA) to the backend, which determines whether
+   * they belong to an active BC Services Card and, if so, returns a device
+   * authorization. Used by the Non-BCSC evidence flow to let the backend — not
+   * the client — discriminate the card type (matches v3's `/device/barcodes`).
+   *
+   * The backend returns an error (handled by the caller as "not a BCSC,
+   * continue") when the barcodes don't match an active card.
+   *
+   * @param {BarcodePayload[]} barcodes - Decoded barcodes from the scanned card.
+   * @returns {Promise<DeviceAuthorizationResponse>}
+   */
+  const authorizeDeviceWithBarcodes = useCallback(
+    async (barcodes: BarcodePayload[]): Promise<DeviceAuthorizationResponse> => {
+      return withAccount<DeviceAuthorizationResponse>(async (account) => {
+        const { data } = await apiClient.post<DeviceAuthorizationResponse>(
+          `${apiClient.endpoints.barcodes}/${account.clientID}`,
+          { barcodes },
+          {
+            headers: { 'Content-Type': 'application/json' },
+            skipBearerAuth: true,
+          }
+        )
+
+        return data
+      })
+    },
+    [apiClient]
+  )
+
   return useMemo(
     () => ({
       authorizeDevice,
       authorizeDeviceWithUnknownBCSC,
+      authorizeDeviceWithBarcodes,
     }),
-    [authorizeDevice, authorizeDeviceWithUnknownBCSC]
+    [authorizeDevice, authorizeDeviceWithUnknownBCSC, authorizeDeviceWithBarcodes]
   )
 }
 

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.flow.test.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.flow.test.tsx
@@ -122,12 +122,20 @@ const mockCardType = {
   image_sides: [{ side: 'FRONT', image_side_name: 'FRONT_SIDE', image_side_tip: 'tip', image_side_label: 'Front' }],
 }
 
-const renderScreen = (navigation: any) =>
+const mockTwoSidedCardType = {
+  evidence_type: 'pr_card',
+  image_sides: [
+    { side: 'FRONT', image_side_name: 'FRONT_SIDE', image_side_tip: 'tip', image_side_label: 'Front' },
+    { side: 'BACK', image_side_name: 'BACK_SIDE', image_side_tip: 'tip', image_side_label: 'Back' },
+  ],
+}
+
+const renderScreen = (navigation: any, cardType: any = mockCardType) =>
   render(
     <BasicAppContext
       initialStateOverride={{ bcscSecure: { ...initialState.bcscSecure, cardProcess: BCSCCardProcess.NonBCSC } } as any}
     >
-      <EvidenceCaptureScreen navigation={navigation} route={{ params: { cardType: mockCardType } } as never} />
+      <EvidenceCaptureScreen navigation={navigation} route={{ params: { cardType } } as never} />
     </BasicAppContext>
   )
 
@@ -183,6 +191,39 @@ describe('EvidenceCaptureScreen — Non-BCSC barcode flow', () => {
     expect(barcodes).toEqual(
       expect.arrayContaining([expect.objectContaining({ type: 'CODE_128', value: 'S00023254' })])
     )
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      BCSCScreens.EvidenceIDCollection,
+      expect.objectContaining({ documentNumber: '123' })
+    )
+  })
+
+  it('asks /device/barcodes only once across a multi-sided card', async () => {
+    mockHandleScanBarcodes.mockResolvedValue(false)
+    const navigation = { navigate: jest.fn(), reset: jest.fn() }
+    const utils = renderScreen(navigation, mockTwoSidedCardType)
+
+    // Front side: scan, photo, accept.
+    await waitFor(() => utils.getByTestId('sim-scan'))
+    await act(async () => {
+      fireEvent.press(utils.getByTestId('sim-scan'))
+    })
+    await act(async () => {
+      fireEvent.press(utils.getByTestId('sim-photo'))
+    })
+    await act(async () => {
+      fireEvent.press(await utils.findByTestId('sim-accept'))
+    })
+
+    // Back side: photo, accept — the barcodes are already captured, so no rescan.
+    await act(async () => {
+      fireEvent.press(await utils.findByTestId('sim-photo'))
+    })
+    await act(async () => {
+      fireEvent.press(await utils.findByTestId('sim-accept'))
+    })
+
+    // The backend is asked once for the card, not once per side.
+    expect(mockHandleScanBarcodes).toHaveBeenCalledTimes(1)
     expect(navigation.navigate).toHaveBeenCalledWith(
       BCSCScreens.EvidenceIDCollection,
       expect.objectContaining({ documentNumber: '123' })

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.flow.test.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.flow.test.tsx
@@ -1,0 +1,191 @@
+import { BCSCScreens } from '@/bcsc-theme/types/navigators'
+import { initialState } from '@/store'
+import { BasicAppContext } from '@mocks/helpers/app'
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native'
+import React from 'react'
+import { BCSCCardProcess } from 'react-native-bcsc-core'
+import EvidenceCaptureScreen from './EvidenceCaptureScreen'
+
+// Module-level mock fns (must be `mock`-prefixed to be referenced inside jest.mock factories).
+const mockHandleScanBarcodes = jest.fn()
+const mockHandleScanDriversLicense = jest.fn()
+const mockClearAdditionalEvidence = jest.fn()
+const mockUpdateEvidenceMetadata = jest.fn()
+
+jest.mock('react-native-vision-camera', () => ({
+  useCameraPermission: () => ({ hasPermission: true, requestPermission: jest.fn() }),
+  // Pass the config straight through so the mocked camera can invoke onCodeScanned.
+  useCodeScanner: (config: any) => config,
+}))
+
+jest.mock('@/hooks/useAutoRequestPermission', () => ({
+  useAutoRequestPermission: () => ({ isLoading: false }),
+}))
+
+jest.mock('@/hooks/useAlerts', () => ({
+  useAlerts: () => ({ failedToReadFromLocalStorageAlert: jest.fn() }),
+}))
+
+jest.mock('@/utils/alert', () => ({
+  withAlert: (fn: any) => fn,
+}))
+
+jest.mock('@/bcsc-theme/utils/file-info', () => ({
+  getPhotoMetadata: jest.fn(async () => ({
+    label: '',
+    content_type: 'image/jpeg',
+    content_length: 1,
+    date: 0,
+    sha256: 'hash',
+  })),
+}))
+
+jest.mock('@/bcsc-theme/hooks/useCardScanner', () => ({
+  useCardScanner: () => ({
+    // scanCard immediately resolves the scanned serial + licence so the screen's
+    // refs are populated (simulating a combo/AAMVA card in the Non-BCSC flow).
+    scanCard: jest.fn(async (_codes: any, cb: any) => {
+      await cb('S00023254', { birthDate: new Date('1970-01-01'), licenseNumber: '123' })
+    }),
+    startScan: jest.fn(),
+    completeScan: jest.fn(),
+    handleScanComboCard: jest.fn(),
+    handleScanBarcodes: mockHandleScanBarcodes,
+    handleScanBCServicesCard: jest.fn(),
+    handleScanDriversLicense: mockHandleScanDriversLicense,
+    codeTypes: ['code-39', 'code-128', 'pdf-417'],
+  }),
+}))
+
+jest.mock('@/bcsc-theme/hooks/useSecureActions', () => ({
+  __esModule: true,
+  default: () => ({
+    clearAdditionalEvidence: mockClearAdditionalEvidence,
+    updateEvidenceMetadata: mockUpdateEvidenceMetadata,
+  }),
+  useSecureActions: () => ({
+    clearAdditionalEvidence: mockClearAdditionalEvidence,
+    updateEvidenceMetadata: mockUpdateEvidenceMetadata,
+  }),
+}))
+
+jest.mock('@/bcsc-theme/components/MaskedCamera', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const ReactMock = require('react')
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { Pressable, Text } = require('react-native')
+  return {
+    __esModule: true,
+    default: ({ onPhotoTaken, codeScanner }: any) =>
+      ReactMock.createElement(
+        ReactMock.Fragment,
+        null,
+        ReactMock.createElement(
+          Pressable,
+          {
+            testID: 'sim-scan',
+            onPress: () =>
+              codeScanner.onCodeScanned([
+                { type: 'code-39', value: 'S00023254' },
+                { type: 'pdf-417', value: 'dl-barcode' },
+              ]),
+          },
+          ReactMock.createElement(Text, null, 'scan')
+        ),
+        ReactMock.createElement(
+          Pressable,
+          { testID: 'sim-photo', onPress: () => onPhotoTaken('/tmp/photo.jpg') },
+          ReactMock.createElement(Text, null, 'photo')
+        )
+      ),
+  }
+})
+
+jest.mock('@/bcsc-theme/components/PhotoReview', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const ReactMock = require('react')
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { Pressable, Text } = require('react-native')
+  return {
+    __esModule: true,
+    default: ({ onAccept }: any) =>
+      ReactMock.createElement(
+        Pressable,
+        { testID: 'sim-accept', onPress: onAccept },
+        ReactMock.createElement(Text, null, 'accept')
+      ),
+  }
+})
+
+const mockCardType = {
+  evidence_type: 'pr_card',
+  image_sides: [{ side: 'FRONT', image_side_name: 'FRONT_SIDE', image_side_tip: 'tip', image_side_label: 'Front' }],
+}
+
+const renderScreen = (navigation: any) =>
+  render(
+    <BasicAppContext
+      initialStateOverride={{ bcscSecure: { ...initialState.bcscSecure, cardProcess: BCSCCardProcess.NonBCSC } } as any}
+    >
+      <EvidenceCaptureScreen navigation={navigation} route={{ params: { cardType: mockCardType } } as never} />
+    </BasicAppContext>
+  )
+
+const driveScanPhotoAccept = async (utils: ReturnType<typeof render>) => {
+  await waitFor(() => utils.getByTestId('sim-scan'))
+  await act(async () => {
+    fireEvent.press(utils.getByTestId('sim-scan'))
+  })
+  await act(async () => {
+    fireEvent.press(utils.getByTestId('sim-photo'))
+  })
+  const accept = await utils.findByTestId('sim-accept')
+  await act(async () => {
+    fireEvent.press(accept)
+  })
+}
+
+describe('EvidenceCaptureScreen — Non-BCSC barcode flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('reroutes into setup and clears evidence when the backend confirms a BC Services Card', async () => {
+    mockHandleScanBarcodes.mockResolvedValue(true)
+    const navigation = { navigate: jest.fn(), reset: jest.fn() }
+
+    await driveScanPhotoAccept(renderScreen(navigation))
+
+    await waitFor(() =>
+      expect(mockHandleScanBarcodes).toHaveBeenCalledWith(
+        'S00023254',
+        expect.objectContaining({ licenseNumber: '123' })
+      )
+    )
+    expect(mockClearAdditionalEvidence).toHaveBeenCalled()
+    // Switched to the BCSC flow — does not continue to evidence ID collection.
+    expect(navigation.navigate).not.toHaveBeenCalled()
+  })
+
+  it('continues capturing as evidence (keeping the scanned barcode) when it is not a BC Services Card', async () => {
+    mockHandleScanBarcodes.mockResolvedValue(false)
+    const navigation = { navigate: jest.fn(), reset: jest.fn() }
+
+    await driveScanPhotoAccept(renderScreen(navigation))
+
+    await waitFor(() => expect(mockHandleScanBarcodes).toHaveBeenCalled())
+    expect(mockClearAdditionalEvidence).not.toHaveBeenCalled()
+
+    // Falls through to evidence capture; the scanned CODE_128 serial is preserved
+    // in the upload (no longer dropped) and the user proceeds to ID collection.
+    await waitFor(() => expect(mockUpdateEvidenceMetadata).toHaveBeenCalled())
+    const barcodes = mockUpdateEvidenceMetadata.mock.calls[0][2]
+    expect(barcodes).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'CODE_128', value: 'S00023254' })])
+    )
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      BCSCScreens.EvidenceIDCollection,
+      expect.objectContaining({ documentNumber: '123' })
+    )
+  })
+})

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.tsx
@@ -55,6 +55,10 @@ const EvidenceCaptureScreen = ({ navigation, route }: EvidenceCaptureScreenProps
   const scanner = useCardScanner()
   const bcscSerialRef = useRef<string | null>(null)
   const licenseRef = useRef<DriversLicenseMetadata | null>(null)
+  // Guards against re-hitting /device/barcodes on every photo of a multi-sided
+  // card — the scanned barcodes can't change once both refs are set (scanning
+  // stops below), so the backend only needs to be asked once per card.
+  const barcodesCheckedRef = useRef(false)
   const { isLoading: isCameraLoading } = useAutoRequestPermission(hasPermission, requestPermission)
   const { failedToReadFromLocalStorageAlert } = useAlerts(navigation)
   const codeScanner = useCodeScanner({
@@ -136,7 +140,8 @@ const EvidenceCaptureScreen = ({ navigation, route }: EvidenceCaptureScreenProps
      * In the Non-Photo BCSC flow we've already done authorizeDevice, so we skip.
      */
     if (isNonBCSCFlow) {
-      if (bcscSerialRef.current && licenseRef.current) {
+      if (bcscSerialRef.current && licenseRef.current && !barcodesCheckedRef.current) {
+        barcodesCheckedRef.current = true
         const switchedToBcsc = await scanner.handleScanBarcodes(bcscSerialRef.current, licenseRef.current)
         if (switchedToBcsc) {
           await clearAdditionalEvidence()

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.tsx
@@ -143,9 +143,6 @@ const EvidenceCaptureScreen = ({ navigation, route }: EvidenceCaptureScreenProps
           return
         }
       }
-      // Not a BC Services Card — drop any (possibly false-positive) serial so it
-      // isn't treated as one, then continue capturing this card as evidence.
-      bcscSerialRef.current = null
     }
 
     /**

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.tsx
@@ -125,40 +125,27 @@ const EvidenceCaptureScreen = ({ navigation, route }: EvidenceCaptureScreenProps
     }
 
     /**
-     * Short-circuit paths: only applicable in the Non-BCSC flow.
-     * In the Non-Photo BCSC flow we've already done authorizeDevice,
-     * so we skip these and continue to evidence photo capture.
+     * Non-BCSC flow only: the user may have scanned a real BC Services Card.
+     * Let the backend decide via POST /device/barcodes rather than guessing
+     * client-side. Only a card presenting BOTH a serial (1D) and an AAMVA (2D)
+     * barcode can match, so that's the only case we ask about. A real BCSC
+     * reroutes into setup; anything else — a lone serial (e.g. a PR card's 1D
+     * barcode), a passport, a DL — falls through to evidence capture with no
+     * error (matching v3 behaviour).
      *
-     * handleScanComboCard returns `false` when authorization fails in the
-     * Non-BCSC flow (e.g. a code-128 barcode on a DL is not a real BCSC
-     * serial).  In that case we clear the serial and fall through to the
-     * normal evidence-capture path (matching v3 iOS behaviour).
+     * In the Non-Photo BCSC flow we've already done authorizeDevice, so we skip.
      */
     if (isNonBCSCFlow) {
-      /**
-       * Both BCSC serial and DL barcode scanned
-       * Next Step: Navigate to setup steps verification (if authorization succeeds)
-       */
       if (bcscSerialRef.current && licenseRef.current) {
-        const [, success] = await Promise.all([
-          clearAdditionalEvidence(),
-          scanner.handleScanComboCard(bcscSerialRef.current, licenseRef.current),
-        ])
-        if (success) {
+        const switchedToBcsc = await scanner.handleScanBarcodes(bcscSerialRef.current, licenseRef.current)
+        if (switchedToBcsc) {
+          await clearAdditionalEvidence()
           return
         }
-        // Authorization failed — not a real BCSC serial. Clear it and continue.
-        bcscSerialRef.current = null
       }
-
-      /**
-       * Only BCSC serial scanned
-       * Next Step: Navigate to birthdate entry -> setup steps verification
-       */
-      if (bcscSerialRef.current) {
-        await Promise.all([clearAdditionalEvidence(), scanner.handleScanBCServicesCard(bcscSerialRef.current)])
-        return
-      }
+      // Not a BC Services Card — drop any (possibly false-positive) serial so it
+      // isn't treated as one, then continue capturing this card as evidence.
+      bcscSerialRef.current = null
     }
 
     /**

--- a/app/src/bcsc-theme/hooks/useCardScanner.test.tsx
+++ b/app/src/bcsc-theme/hooks/useCardScanner.test.tsx
@@ -439,4 +439,94 @@ describe('useCardScanner', () => {
       })
     })
   })
+
+  describe('handleScanBarcodes', () => {
+    const mockLicense: any = {
+      birthDate: new Date('1970-01-01'),
+      isoIIN: '636028',
+      licenseNumber: '2222222',
+    }
+
+    it('should authorize via /device/barcodes and reroute to setup when the barcodes match a BC Services Card', async () => {
+      const useApiMock = jest.mocked(useApi)
+      const bifoldMock = jest.mocked(Bifold)
+      const navigationMock = jest.mocked(navigation)
+      const useSecureActionsMock = jest.mocked(useSecureActions)
+
+      const mockState: any = { bcscSecure: {} }
+      const mockUpdateDeviceCodes = jest.fn()
+      const mockUpdateCardProcess = jest.fn()
+      const mockUpdateVerificationOptions = jest.fn()
+      const mockNavigationReset = jest.fn()
+      const mockAuthorizeDeviceWithBarcodes = jest.fn().mockResolvedValue({
+        device_code: 'test-device-code',
+        user_code: 'ABCD1234',
+        verified_email: 'test@example.com',
+        expires_in: 3600,
+        verification_options: 'video_call back_check',
+        process: 'IDIM L3 Remote BCSC Photo Identity Verification',
+      })
+
+      useApiMock.mockReturnValue({
+        authorization: { authorizeDeviceWithBarcodes: mockAuthorizeDeviceWithBarcodes },
+      } as any)
+      useSecureActionsMock.mockReturnValue({
+        updateUserInfo: jest.fn(),
+        updateDeviceCodes: mockUpdateDeviceCodes,
+        updateCardProcess: mockUpdateCardProcess,
+        updateVerificationOptions: mockUpdateVerificationOptions,
+      } as any)
+      bifoldMock.useStore.mockReturnValue([mockState, mockDispatch])
+      navigationMock.useNavigation = jest.fn().mockReturnValue({ reset: mockNavigationReset })
+      bifoldMock.useServices.mockReturnValue([{ debug: jest.fn(), info: jest.fn() } as any])
+
+      const hook = renderHook(() => useCardScanner())
+
+      const result = await hook.result.current.handleScanBarcodes('S00023254', mockLicense)
+
+      expect(result).toBe(true)
+      expect(mockAuthorizeDeviceWithBarcodes).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'CODE_128', value: 'S00023254' }),
+          expect.objectContaining({ type: 'PDF_417', iso_iin: '636028' }),
+        ])
+      )
+      expect(mockUpdateCardProcess).toHaveBeenCalledWith('IDIM L3 Remote BCSC Photo Identity Verification')
+      expect(mockUpdateVerificationOptions).toHaveBeenCalledWith(['video_call', 'back_check'])
+      expect(mockNavigationReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: BCSCScreens.SetupSteps }],
+      })
+    })
+
+    it('should return false and not surface an error when the barcodes are not a BC Services Card', async () => {
+      const useApiMock = jest.mocked(useApi)
+      const bifoldMock = jest.mocked(Bifold)
+      const navigationMock = jest.mocked(navigation)
+      const useSecureActionsMock = jest.mocked(useSecureActions)
+
+      const mockState: any = { bcscSecure: {} }
+      const mockNavigationReset = jest.fn()
+
+      useApiMock.mockReturnValue({
+        authorization: { authorizeDeviceWithBarcodes: jest.fn().mockRejectedValue(new Error('card_not_found')) },
+      } as any)
+      useSecureActionsMock.mockReturnValue({
+        updateUserInfo: jest.fn(),
+        updateDeviceCodes: jest.fn(),
+        updateCardProcess: jest.fn(),
+        updateVerificationOptions: jest.fn(),
+      } as any)
+      bifoldMock.useStore.mockReturnValue([mockState, mockDispatch])
+      navigationMock.useNavigation = jest.fn().mockReturnValue({ reset: mockNavigationReset })
+      bifoldMock.useServices.mockReturnValue([{ debug: jest.fn(), info: jest.fn() } as any])
+
+      const hook = renderHook(() => useCardScanner())
+
+      const result = await hook.result.current.handleScanBarcodes('A06198657', mockLicense)
+
+      expect(result).toBe(false)
+      expect(mockNavigationReset).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/app/src/bcsc-theme/hooks/useCardScanner.tsx
+++ b/app/src/bcsc-theme/hooks/useCardScanner.tsx
@@ -12,6 +12,7 @@ import useApi from '../api/hooks/useApi'
 import { DeviceVerificationOption } from '../api/hooks/useAuthorizationApi'
 import { VerificationCardError } from '../features/verify/verificationCardError'
 import { BCSCScreens, BCSCVerifyStackParams } from '../types/navigators'
+import { buildBarcodePayload } from '../utils/barcode'
 import {
   DecodedCodeKind,
   decodeScannedCode,
@@ -126,6 +127,58 @@ export const useCardScanner = () => {
       navigation,
       store.bcscSecure.cardProcess,
     ]
+  )
+
+  /**
+   * Non-BCSC flow handler: ask the backend whether the scanned barcodes belong
+   * to a real BC Services Card via POST `/device/barcodes`. The backend owns the
+   * discrimination (matching v3): a real BCSC is authorized and the user is
+   * rerouted into setup; any other card (PR card, passport, …) resolves to
+   * `false` so the caller keeps capturing it as evidence — no "Card not found".
+   *
+   * Only call this when the card presents BOTH a serial (1D) and AAMVA (2D)
+   * barcode — the only combination the backend can match.
+   *
+   * @param bcscSerial - The serial decoded from the card's 1D (CODE_128) barcode.
+   * @param license - The metadata decoded from the card's 2D (PDF-417) barcode.
+   * @returns `true` if authorized as a BCSC and rerouted, `false` to continue as evidence.
+   */
+  const handleScanBarcodes = useCallback(
+    async (bcscSerial: string, license: DriversLicenseMetadata): Promise<boolean> => {
+      try {
+        const deviceAuth = await authorization.authorizeDeviceWithBarcodes(buildBarcodePayload(bcscSerial, license))
+
+        await updateUserInfo({
+          serial: bcscSerial,
+          birthdate: license.birthDate,
+          email: deviceAuth.verified_email,
+          isEmailVerified: !!deviceAuth.verified_email,
+        })
+        await updateDeviceCodes({
+          deviceCode: deviceAuth.device_code,
+          userCode: deviceAuth.user_code,
+          deviceCodeExpiresAt: new Date(Date.now() + deviceAuth.expires_in * 1000),
+        })
+        await updateCardProcess(deviceAuth.process)
+        await updateVerificationOptions(deviceAuth.verification_options.split(' ') as DeviceVerificationOption[])
+
+        navigation.reset({ index: 0, routes: [{ name: BCSCScreens.SetupSteps }] })
+        return true
+      } catch (error) {
+        if (isHandledAppError(error)) {
+          return true
+        }
+
+        // Not a BC Services Card (or the endpoint was unreachable). Stay in the
+        // evidence-capture flow rather than surfacing an error — matches v3's
+        // `card_not_found → continue with non-bcsc`.
+        logger.info('[CardScanner] Barcodes did not match a BC Services Card; continuing as evidence', {
+          error: String(error),
+        })
+        return false
+      }
+    },
+    [authorization, updateUserInfo, updateDeviceCodes, updateCardProcess, updateVerificationOptions, navigation, logger]
   )
 
   /**
@@ -259,10 +312,11 @@ export const useCardScanner = () => {
       startScan,
       completeScan,
       handleScanComboCard,
+      handleScanBarcodes,
       handleScanBCServicesCard,
       handleScanDriversLicense,
       codeTypes: [BC_SERVICES_CARD_BARCODE, OLD_BC_SERVICES_CARD_BARCODE, DRIVERS_LICENSE_BARCODE] satisfies CodeType[],
     }),
-    [handleCardScan, handleScanBCServicesCard, handleScanComboCard, handleScanDriversLicense]
+    [handleCardScan, handleScanBarcodes, handleScanBCServicesCard, handleScanComboCard, handleScanDriversLicense]
   )
 }

--- a/app/src/bcsc-theme/hooks/useCardScanner.tsx
+++ b/app/src/bcsc-theme/hooks/useCardScanner.tsx
@@ -9,7 +9,7 @@ import { useCallback, useMemo, useRef } from 'react'
 import { BCSCCardProcess } from 'react-native-bcsc-core'
 import { CodeType } from 'react-native-vision-camera'
 import useApi from '../api/hooks/useApi'
-import { DeviceVerificationOption } from '../api/hooks/useAuthorizationApi'
+import { DeviceAuthorizationResponse, DeviceVerificationOption } from '../api/hooks/useAuthorizationApi'
 import { VerificationCardError } from '../features/verify/verificationCardError'
 import { BCSCScreens, BCSCVerifyStackParams } from '../types/navigators'
 import { buildBarcodePayload } from '../utils/barcode'
@@ -54,6 +54,34 @@ export const useCardScanner = () => {
     useSecureActions()
 
   /**
+   * Applies a successful device authorization to secure storage and reroutes the
+   * user into the setup flow. Shared by the combo (serial + birthdate) and the
+   * barcodes (`/device/barcodes`) authorization paths.
+   *
+   * @param deviceAuth - The device authorization response from the backend.
+   */
+  const applyDeviceAuthorization = useCallback(
+    async (deviceAuth: DeviceAuthorizationResponse) => {
+      await updateUserInfo({
+        email: deviceAuth.verified_email,
+        isEmailVerified: !!deviceAuth.verified_email,
+      })
+
+      await updateDeviceCodes({
+        deviceCode: deviceAuth.device_code,
+        userCode: deviceAuth.user_code,
+        deviceCodeExpiresAt: new Date(Date.now() + deviceAuth.expires_in * 1000),
+      })
+
+      await updateCardProcess(deviceAuth.process)
+      await updateVerificationOptions(deviceAuth.verification_options.split(' ') as DeviceVerificationOption[])
+
+      navigation.reset({ index: 0, routes: [{ name: BCSCScreens.SetupSteps }] })
+    },
+    [updateUserInfo, updateDeviceCodes, updateCardProcess, updateVerificationOptions, navigation]
+  )
+
+  /**
    * Default handler for combo card scanning (both BCSC serial and driver's license metadata).
    *
    * @param bcscSerial - The BCSC card serial number.
@@ -71,22 +99,7 @@ export const useCardScanner = () => {
 
       try {
         const deviceAuth = await authorization.authorizeDevice(bcscSerial, license.birthDate)
-
-        await updateUserInfo({
-          email: deviceAuth.verified_email,
-          isEmailVerified: !!deviceAuth.verified_email,
-        })
-
-        await updateDeviceCodes({
-          deviceCode: deviceAuth.device_code,
-          userCode: deviceAuth.user_code,
-          deviceCodeExpiresAt: new Date(Date.now() + deviceAuth.expires_in * 1000),
-        })
-
-        await updateCardProcess(deviceAuth.process)
-        await updateVerificationOptions(deviceAuth.verification_options.split(' ') as DeviceVerificationOption[])
-
-        navigation.reset({ index: 0, routes: [{ name: BCSCScreens.SetupSteps }] })
+        await applyDeviceAuthorization(deviceAuth)
         return true
       } catch (error) {
         if (isHandledAppError(error)) {
@@ -117,16 +130,7 @@ export const useCardScanner = () => {
         return true
       }
     },
-    [
-      authorization,
-      updateUserInfo,
-      updateDeviceCodes,
-      updateCardProcess,
-      updateVerificationOptions,
-      logger,
-      navigation,
-      store.bcscSecure.cardProcess,
-    ]
+    [authorization, updateUserInfo, applyDeviceAuthorization, logger, navigation, store.bcscSecure.cardProcess]
   )
 
   /**
@@ -147,38 +151,20 @@ export const useCardScanner = () => {
     async (bcscSerial: string, license: DriversLicenseMetadata): Promise<boolean> => {
       try {
         const deviceAuth = await authorization.authorizeDeviceWithBarcodes(buildBarcodePayload(bcscSerial, license))
-
-        await updateUserInfo({
-          serial: bcscSerial,
-          birthdate: license.birthDate,
-          email: deviceAuth.verified_email,
-          isEmailVerified: !!deviceAuth.verified_email,
-        })
-        await updateDeviceCodes({
-          deviceCode: deviceAuth.device_code,
-          userCode: deviceAuth.user_code,
-          deviceCodeExpiresAt: new Date(Date.now() + deviceAuth.expires_in * 1000),
-        })
-        await updateCardProcess(deviceAuth.process)
-        await updateVerificationOptions(deviceAuth.verification_options.split(' ') as DeviceVerificationOption[])
-
-        navigation.reset({ index: 0, routes: [{ name: BCSCScreens.SetupSteps }] })
+        await updateUserInfo({ serial: bcscSerial, birthdate: license.birthDate })
+        await applyDeviceAuthorization(deviceAuth)
         return true
       } catch (error) {
-        if (isHandledAppError(error)) {
-          return true
-        }
-
-        // Not a BC Services Card (or the endpoint was unreachable). Stay in the
-        // evidence-capture flow rather than surfacing an error — matches v3's
-        // `card_not_found → continue with non-bcsc`.
+        // Any failure — including a handled app error — means we could not confirm
+        // a BC Services Card, so stay in the evidence-capture flow rather than
+        // surfacing an error (matches v3's `card_not_found → continue with non-bcsc`).
         logger.info('[CardScanner] Barcodes did not match a BC Services Card; continuing as evidence', {
           error: String(error),
         })
         return false
       }
     },
-    [authorization, updateUserInfo, updateDeviceCodes, updateCardProcess, updateVerificationOptions, navigation, logger]
+    [authorization, updateUserInfo, applyDeviceAuthorization, logger]
   )
 
   /**

--- a/app/src/bcsc-theme/hooks/useCardScanner.tsx
+++ b/app/src/bcsc-theme/hooks/useCardScanner.tsx
@@ -149,10 +149,15 @@ export const useCardScanner = () => {
    */
   const handleScanBarcodes = useCallback(
     async (bcscSerial: string, license: DriversLicenseMetadata): Promise<boolean> => {
+      logger.info(
+        '[CardScanner] Non-BCSC flow: querying /device/barcodes to check if the scanned card is a BC Services Card'
+      )
+
       try {
         const deviceAuth = await authorization.authorizeDeviceWithBarcodes(buildBarcodePayload(bcscSerial, license))
         await updateUserInfo({ serial: bcscSerial, birthdate: license.birthDate })
         await applyDeviceAuthorization(deviceAuth)
+        logger.info('[CardScanner] Scanned card matched a BC Services Card; switching to setup')
         return true
       } catch (error) {
         // Any failure — including a handled app error — means we could not confirm

--- a/app/src/bcsc-theme/utils/barcode.test.ts
+++ b/app/src/bcsc-theme/utils/barcode.test.ts
@@ -12,6 +12,7 @@ const makeLicense = (overrides?: Partial<DriversLicenseMetadata>): DriversLicens
   city: 'VICTORIA',
   province: 'BC',
   postalCode: 'V8W 3Y8',
+  isoIIN: '636028',
   ...overrides,
 })
 
@@ -39,7 +40,7 @@ describe('buildBarcodePayload', () => {
       content_type: 'AAMVA_3TRACK_PDF417',
       version: '',
       jurisdiction_version: '',
-      iso_iin: '',
+      iso_iin: '636028',
       customer_id: '',
       document_number: '2222222',
       family_name: 'SPECIMEN',
@@ -93,5 +94,11 @@ describe('buildBarcodePayload', () => {
     expect(payload.address.locality).toBe('')
     expect(payload.address.province).toBe('')
     expect(payload.address.postal_code).toBe('')
+  })
+
+  it('should fall back to empty iso_iin when the license has none', () => {
+    const result = buildBarcodePayload(null, makeLicense({ isoIIN: '' }))
+
+    expect(result[0]).toMatchObject({ iso_iin: '' })
   })
 })

--- a/app/src/bcsc-theme/utils/barcode.ts
+++ b/app/src/bcsc-theme/utils/barcode.ts
@@ -20,7 +20,7 @@ export const buildBarcodePayload = (
       content_type: 'AAMVA_3TRACK_PDF417',
       version: '',
       jurisdiction_version: '',
-      iso_iin: '',
+      iso_iin: license.isoIIN ?? '',
       customer_id: '',
       document_number: license.licenseNumber ?? '',
       family_name: license.lastName ?? '',

--- a/app/src/bcsc-theme/utils/decoder-strategy/BCComboCardBarcodeDecoder.test.ts
+++ b/app/src/bcsc-theme/utils/decoder-strategy/BCComboCardBarcodeDecoder.test.ts
@@ -74,6 +74,7 @@ describe('BCComboCardBarcodeDecoder', () => {
       expect(decoded).toEqual({
         kind: 'BCServicesComboCardCardBarcode',
         bcscSerial: 'S00023254',
+        isoIIN: '636028',
         licenseNumber: '2222222',
         firstName: 'test',
         middleNames: 'card',

--- a/app/src/bcsc-theme/utils/decoder-strategy/BCComboCardBarcodeDecoder.ts
+++ b/app/src/bcsc-theme/utils/decoder-strategy/BCComboCardBarcodeDecoder.ts
@@ -55,6 +55,7 @@ export class BCComboCardBarcodeDecoder implements DecoderStrategy {
     return {
       kind: DecodedCodeKind.BCServicesComboCardCardBarcode,
       bcscSerial: bcscSerial,
+      isoIIN: decodedDriversLicense.isoIIN,
       licenseNumber: decodedDriversLicense.licenseNumber,
       firstName: decodedDriversLicense.firstName,
       middleNames: decodedDriversLicense.middleNames,

--- a/app/src/bcsc-theme/utils/decoder-strategy/DecoderStrategy.ts
+++ b/app/src/bcsc-theme/utils/decoder-strategy/DecoderStrategy.ts
@@ -68,6 +68,8 @@ export interface DriversLicenseMetadata {
   city: string
   province: string
   postalCode: string
+  /** Issuer Identification Number from AAMVA track 2 (e.g. BC = '636028'). */
+  isoIIN: string
 }
 
 export interface DriversLicenseDecodedBarcode extends DriversLicenseMetadata {

--- a/app/src/bcsc-theme/utils/decoder-strategy/DriversLicenseBarcodeDecoder.test.ts
+++ b/app/src/bcsc-theme/utils/decoder-strategy/DriversLicenseBarcodeDecoder.test.ts
@@ -67,6 +67,7 @@ describe('DriversLicenseBarcodeDecoder', () => {
 
       expect(decoded).toEqual({
         kind: 'DriversLicenseBarcode',
+        isoIIN: '636028',
         licenseNumber: '2222222',
         firstName: 'test',
         middleNames: 'card',
@@ -91,6 +92,7 @@ describe('DriversLicenseBarcodeDecoder', () => {
 
       expect(decoded).toEqual({
         kind: 'DriversLicenseBarcode',
+        isoIIN: '636028',
         licenseNumber: '2222222',
         firstName: 'test',
         middleNames: 'card',
@@ -115,6 +117,7 @@ describe('DriversLicenseBarcodeDecoder', () => {
 
       expect(decoded).toEqual({
         kind: 'DriversLicenseBarcode',
+        isoIIN: '636028',
         licenseNumber: '2222222',
         firstName: 'test',
         middleNames: 'card',
@@ -150,6 +153,7 @@ describe('DriversLicenseBarcodeDecoder', () => {
 
       expect(decoded).toEqual({
         kind: 'DriversLicenseBarcode',
+        isoIIN: '636028',
         licenseNumber: '004023964',
         firstName: 'standalone',
         middleNames: 'citz four',

--- a/app/src/bcsc-theme/utils/decoder-strategy/DriversLicenseBarcodeDecoder.ts
+++ b/app/src/bcsc-theme/utils/decoder-strategy/DriversLicenseBarcodeDecoder.ts
@@ -50,10 +50,12 @@ export class DriversLicenseBarcodeDecoder implements DecoderStrategy {
     const address = this.parseLicenseAddress(barcode.value)
     const dates = this.parseLicenseDates(barcode.value)
     const licenseNumber = this.parseLicenseNumber(barcode.value)
+    const isoIIN = this.parseIsoIIN(barcode.value)
 
     return {
       kind: DecodedCodeKind.DriversLicenseBarcode,
       licenseNumber: licenseNumber,
+      isoIIN: isoIIN,
       firstName: names.firstName,
       middleNames: names.middleNames,
       lastName: names.lastName,
@@ -143,5 +145,15 @@ export class DriversLicenseBarcodeDecoder implements DecoderStrategy {
       throw new Error('Failed to parse license number from AAMVA track 2')
     }
     return match[1].trim()
+  }
+
+  /**
+   * Extract the Issuer Identification Number (IIN) from AAMVA track 2.
+   * Track 2 format: `;[IIN(6)][license#]=...` — the IIN is the first 6 digits
+   * (BC = '636028'). Returns '' when absent so decoding never fails on it.
+   */
+  private parseIsoIIN(value: string): string {
+    const match = value.match(/;(\d{6})\d+=/)
+    return match ? match[1] : ''
   }
 }


### PR DESCRIPTION
## Problem

Issue #4001: in the **Non-BCSC** verification flow, photographing a **Permanent Residency (PR)** card during evidence capture fails with **"Card not found"** (reported on PROD, build #6575). Expected: no error for cards whose barcodes aren't Combo/DL/BCSC.

## Root cause

v4 decides "is this scanned card a BCSC?" **client-side**. `isBCSCSerial` uses a loose regex (`/^[A-Za-z]+\d+$/`, ≤9 chars) that a PR card's 1D barcode false-matches. The Non-BCSC evidence flow then routes the user into the BCSC serial path → birthdate entry → `authorizeDevice`, which rejects the bogus serial → **"Card not found"**.

v3 never had this: it did **server-side** discrimination by POSTing scanned barcodes to `/device/barcodes`, where the backend decided BCSC-or-not (a non-match was a normal "continue", not an error). v4 already wires that endpoint (`endpoints.barcodes`) and already builds the exact request body (`buildBarcodePayload`) — but **nothing calls it**; the payload only rides along in the evidence upload.

## Fix

Restore v3's server-side discrimination in the Non-BCSC flow:

- **`authorizeDeviceWithBarcodes()`** — POSTs the decoded barcodes to `/device/barcodes/{client_id}` (JSON, pre-auth).
- Parse AAMVA **`iso_iin`** from track 2 and populate it in the payload — required for the backend match (was hardcoded `''`).
- In `EvidenceCaptureScreen`, when a card presents **both** a 1D serial and a 2D AAMVA barcode (the only combination the backend can match), call `/device/barcodes`:
  - **match** → authorize + reroute into setup (as today's combo path),
  - **no match / error** → continue capturing as evidence, **no error**.
- Removes the serial-only → birthdate-entry derailment that produced the error for PR cards.

Net effect: a PR card's lone 1D barcode no longer triggers BCSC authorization; it's captured as evidence. A real combo card still auto-switches into BCSC setup, now validated by the backend.

## Testing

- `yarn typecheck` ✅ · eslint ✅ · prettier ✅
- New/updated unit + RTL tests; `verify` + `hooks` + `api` sweep: **54 suites / 320 tests passing** (incl. `authorizeDeviceWithBarcodes`, `handleScanBarcodes`, `iso_iin` decoder/payload, and existing `ScanSerialScreen` / `EvidenceCapture` regressions).

## Manual Testing

Start the Non-BCSC verification (the same "no BC Services Card" path you used for the PR card) → at the document/evidence capture step, photograph the combo card. Because a combo card has both a serial (1D) and a driver's-licence barcode (2D), it'll fire [POST] …/device/barcodes/<clientID> on the first photo accept — and since this card is an active BCSC, the backend should match and reroute you into BCSC setup.

```text
hoto taken and saved temporarily: /data/user/0/ca.bc.gov.id.servicescard.dev/cache/mrousavy4937849989672890778.jpg  
console.js:661 [POST] https://idsit.gov.bc.ca/device/barcodes/5ed24ad4-97eb-4371-af32-4e211ee51887  
```

<img width="256" alt="Screenshot_20260609-213029" src="https://github.com/user-attachments/assets/2b646563-b632-4cb6-a8a9-9556741cbb93" />



### Still needs runtime verification
- [x] Confirm the IAS `/device/barcodes` endpoint is enabled / contract-matched in the target environment.
- [ ] Device repro: Non-BCSC flow → add DL (camera) → add PR card (camera) → no "Card not found"; PR card captured as evidence.