### PR TITLE
fix: error codes 4xx

### DIFF
--- a/app/src/bcsc-theme/api/client.test.ts
+++ b/app/src/bcsc-theme/api/client.test.ts
@@ -234,6 +234,95 @@ describe('BCSC Client', () => {
     })
   })
 
+  describe('401 recovery', () => {
+    // A bearer request with locally-valid tokens: handleRequest attaches the bearer and won't refresh
+    // on its own, so the only refresh is the interceptor's force-refresh-and-retry.
+    const setupBearerClient = (mockLogger: any) => {
+      const client = new BCSCApiClient('https://example.com', mockLogger)
+      client.tokens = { access_token: 'access-1', refresh_token: 'refresh-1' } as any
+      ;(getAccount as jest.Mock).mockResolvedValue({ issuer: 'iss', clientID: 'cid' })
+      ;(jwtDecode as jest.Mock).mockReturnValue({ exp: Math.floor(Date.now() / 1000) + 3600 })
+      return client
+    }
+
+    const reject401 = (config: any) =>
+      Promise.reject(
+        new AxiosError('Unauthorized', 'ERR_BAD_REQUEST', config, null, {
+          status: 401,
+          data: {},
+          statusText: 'Unauthorized',
+          headers: {} as any,
+          config,
+        })
+      )
+
+    it('should refresh tokens and retry once on a 401, then succeed', async () => {
+      const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+      const client = setupBearerClient(mockLogger)
+
+      const forceRefreshSpy = jest
+        .spyOn(BCSCApiClient.prototype as any, 'forceRefreshTokens')
+        .mockResolvedValue({ access_token: 'access-2', refresh_token: 'refresh-2' })
+
+      let callCount = 0
+      client.client.defaults.adapter = (config: any) => {
+        callCount += 1
+        return callCount === 1
+          ? reject401(config)
+          : Promise.resolve({ status: 200, data: { ok: true }, statusText: 'OK', headers: {} as any, config })
+      }
+
+      const response = await client.get('/protected')
+
+      expect(forceRefreshSpy).toHaveBeenCalledTimes(1)
+      expect(callCount).toBe(2) // original + one retry
+      expect(response.status).toBe(200)
+      expect(response.data).toEqual({ ok: true })
+
+      forceRefreshSpy.mockRestore()
+    })
+
+    it('should not retry a 401 on a skipBearerAuth request', async () => {
+      const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+      const client = new BCSCApiClient('https://example.com', mockLogger as any)
+
+      const forceRefreshSpy = jest.spyOn(BCSCApiClient.prototype as any, 'forceRefreshTokens')
+
+      let callCount = 0
+      client.client.defaults.adapter = (config: any) => {
+        callCount += 1
+        return reject401(config)
+      }
+
+      await expect(client.get('/token', { skipBearerAuth: true })).rejects.toBeInstanceOf(AppError)
+      expect(forceRefreshSpy).not.toHaveBeenCalled()
+      expect(callCount).toBe(1)
+
+      forceRefreshSpy.mockRestore()
+    })
+
+    it('should retry a 401 only once, then surface the error', async () => {
+      const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+      const client = setupBearerClient(mockLogger)
+
+      const forceRefreshSpy = jest
+        .spyOn(BCSCApiClient.prototype as any, 'forceRefreshTokens')
+        .mockResolvedValue({ access_token: 'access-2', refresh_token: 'refresh-2' })
+
+      let callCount = 0
+      client.client.defaults.adapter = (config: any) => {
+        callCount += 1
+        return reject401(config)
+      }
+
+      await expect(client.get('/protected')).rejects.toBeInstanceOf(AppError)
+      expect(forceRefreshSpy).toHaveBeenCalledTimes(1)
+      expect(callCount).toBe(2) // original + one retry, then surfaced
+
+      forceRefreshSpy.mockRestore()
+    })
+  })
+
   describe('fetchEndpointsAndConfig', () => {
     it('should merge server config and endpoints into client', async () => {
       const mockLogger = { info: jest.fn(), error: jest.fn() }

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -26,6 +26,8 @@ declare module 'axios' {
     skipBearerAuth?: boolean
     // Note: Useful for endpoints that return expected error codes
     suppressStatusCodeLogs?: number[]
+    // Internal: marks a request already retried once after a 401, to prevent refresh/retry loops
+    _retriedAfter401?: boolean
   }
 }
 
@@ -136,6 +138,25 @@ class BCSCApiClient {
         throw _error
       }
 
+      // 401 recovery: a bearer-authed request can fail with 401 when its access token is rejected
+      // server-side despite still looking valid locally (revoked token, or device clock skew). Refresh
+      // the tokens once and retry the request a single time before surfacing the error. Guards: only
+      // bearer requests (skipBearerAuth is excluded so the refresh call itself can't loop) and only once.
+      const originalConfig = _error.config
+      if (
+        _error.response?.status === 401 &&
+        originalConfig &&
+        !originalConfig.skipBearerAuth &&
+        !originalConfig._retriedAfter401
+      ) {
+        originalConfig._retriedAfter401 = true
+        this.logger.info('[BCSCApiClient] Access token rejected (401); refreshing tokens and retrying once')
+        // On refresh failure the error is already handled by its own interceptor pass and propagates;
+        // on success the retry's own interceptor pass handles any further failure (no double-handling).
+        await this.forceRefreshTokens()
+        return this.client.request(originalConfig)
+      }
+
       // 1. Format the error - update error code and message properties from IAS response
       const error = formatIasAxiosResponseError(_error)
 
@@ -241,6 +262,38 @@ class BCSCApiClient {
 
       // access token is expired or about to expire, fetch new tokens using refresh token
       // Set tokensPromise immediately to prevent concurrent callers from starting duplicate refreshes
+      this.tokensPromise = this.fetchTokens(this.tokens.refresh_token)
+      try {
+        this.tokens = await this.tokensPromise
+      } finally {
+        this.tokensPromise = null
+      }
+      return this.tokens
+    })
+  }
+
+  /**
+   * Forces a token refresh regardless of the local access-token expiry, then returns the new tokens.
+   * Used to recover from a server-side 401 on an access token that still looked valid locally (revoked
+   * token, or device clock skew). Concurrent callers share the in-flight refresh via `tokensPromise`.
+   */
+  private async forceRefreshTokens(): Promise<TokenResponse> {
+    return withAccount(async () => {
+      if (this.tokensPromise) {
+        // share the in-flight refresh if one is already running
+        return this.tokensPromise
+      }
+
+      if (!this.tokens) {
+        this.logger.error('[BCSCApiClient] Cannot refresh after 401 - no tokens present')
+        throw AppError.fromErrorDefinition(ErrorRegistry.TOKEN_NULL)
+      }
+
+      if (this.isTokenExpired(this.tokens.refresh_token)) {
+        this.logger.error('[BCSCApiClient] Cannot refresh after 401 - refresh token expired')
+        throw new Error('Refresh token expired')
+      }
+
       this.tokensPromise = this.fetchTokens(this.tokens.refresh_token)
       try {
         this.tokens = await this.tokensPromise

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -70,7 +70,8 @@ const _getVerifyDeviceAssertionAlertMap = (alerts?: AppAlerts) => {
   ])
 }
 
-// Alert map for IAS errors 201–300 (add_card_*, err_206–213, err_299, err_300)
+// Alert map for IAS errors 201–300 (add_card_*, err_206–213, err_299, err_300) plus
+// status-mapped HTTP client errors (403 forbidden, 404 not found) that share the same modal style.
 const _getIasErrorAlertMap = (alerts?: AppAlerts) => {
   return new Map([
     [AppEventCode.ADD_CARD_SERVER_CONFIGURATION, alerts?.serverConfigurationAlert],
@@ -83,6 +84,8 @@ const _getIasErrorAlertMap = (alerts?: AppAlerts) => {
     [AppEventCode.ERR_208_UNEXPECTED_NETWORK_CALL_EXCEPTION, alerts?.unexpectedNetworkCallAlert],
     [AppEventCode.ERR_209_BAD_REQUEST, alerts?.badRequestAlert],
     [AppEventCode.ERR_210_UNAUTHORIZED, alerts?.unauthorizedAlert],
+    [AppEventCode.FORBIDDEN, alerts?.forbiddenAlert],
+    [AppEventCode.NOT_FOUND, alerts?.notFoundAlert],
     [AppEventCode.ERR_211_SERVER_OUTAGE, alerts?.serverOutageAlert],
     [AppEventCode.ERR_212_RETRY_LATER, alerts?.retryLaterAlert],
     [AppEventCode.ERR_213_FAILED_CREATING_CLIENT_REGISTRATION, alerts?.creatingClientRegistrationFailedAlert],

--- a/app/src/bcsc-theme/utils/axios-error-utils.test.ts
+++ b/app/src/bcsc-theme/utils/axios-error-utils.test.ts
@@ -133,11 +133,27 @@ describe('Error Utils', () => {
       expect(errorDefinition?.appEvent).toBe('server_timeout')
     })
 
-    it('BAD_REQUEST should resolve to BAD_REQUEST AppError', () => {
+    it('BAD_REQUEST without a status should resolve to BAD_REQUEST AppError', () => {
       const errorDefinition = getAxiosErrorDefinition('ERR_BAD_REQUEST')
 
       expect(errorDefinition).toBeDefined()
       expect(errorDefinition?.appEvent).toBe('err_209_bad_request')
+    })
+
+    // Axios collapses every 4xx into ERR_BAD_REQUEST; we disambiguate by the real HTTP status so
+    // 401/403/404/429 no longer masquerade as the "HTTP 400 / error 209" bad-request error.
+    it.each([
+      [400, 'err_209_bad_request'],
+      [401, 'err_210_unauthorized'],
+      [403, 'forbidden'],
+      [404, 'not_found'],
+      [429, 'err_212_retry_later'],
+      [409, 'err_209_bad_request'], // unmapped 4xx falls back to BAD_REQUEST
+    ])('BAD_REQUEST with status %s should resolve to appEvent "%s"', (status, expectedAppEvent) => {
+      const errorDefinition = getAxiosErrorDefinition('ERR_BAD_REQUEST', status)
+
+      expect(errorDefinition).toBeDefined()
+      expect(errorDefinition?.appEvent).toBe(expectedAppEvent)
     })
 
     it('BAD_RESPONSE should resolve to SERVER_ERROR AppError', () => {

--- a/app/src/bcsc-theme/utils/axios-error-utils.ts
+++ b/app/src/bcsc-theme/utils/axios-error-utils.ts
@@ -102,19 +102,50 @@ export const isNetworkError = (error: unknown): boolean => {
 }
 
 /**
+ * Disambiguates a 4xx client error by its real HTTP status.
+ *
+ * Axios collapses *every* 4xx response into a single `ERR_BAD_REQUEST` code — see axios
+ * `settle.js`: `[ERR_BAD_REQUEST, ERR_BAD_RESPONSE][Math.floor(status / 100) - 4]`. Without this,
+ * 401/403/404/429 all resolve to BAD_REQUEST (2107), which both misclassifies them (the user sees
+ * the "app not installed correctly (error 209)" modal) and surfaces a misleading "HTTP 400" message.
+ * Mapping by status gives each its own error code, modal, and analytics event.
+ *
+ * Note: this only applies when the IAS response body did NOT carry an `error`/`error_description`
+ * (those are reclassified earlier by {@link formatIasAxiosResponseError} and take precedence).
+ *
+ * @param status - The HTTP status code from the Axios response (undefined when unavailable)
+ * @returns The ErrorDefinition for the specific status, falling back to BAD_REQUEST for HTTP 400 and any other unmapped 4xx
+ */
+const getClientErrorDefinitionFromStatus = (status?: number): ErrorDefinition => {
+  switch (status) {
+    case 401:
+      return ErrorRegistry.UNAUTHORIZED
+    case 403:
+      return ErrorRegistry.FORBIDDEN
+    case 404:
+      return ErrorRegistry.NOT_FOUND
+    case 429:
+      return ErrorRegistry.RETRY_LATER
+    default:
+      return ErrorRegistry.BAD_REQUEST
+  }
+}
+
+/**
  * Maps Axios error codes to predefined AppError definitions based on the application's error registry.
  *
  * @param errorCode - The error code from an AxiosError to map to an AppError definition
+ * @param status - The HTTP response status, used to disambiguate the collapsed `ERR_BAD_REQUEST` (4xx) code
  * @returns An ErrorDefinition from the ErrorRegistry if a mapping exists, or null if no mapping is found
  */
-export const getAxiosErrorDefinition = (errorCode?: string): ErrorDefinition | null => {
+export const getAxiosErrorDefinition = (errorCode?: string, status?: number): ErrorDefinition | null => {
   switch (errorCode) {
     case AxiosErrorCode.ECONNABORTED:
       return ErrorRegistry.SERVER_TIMEOUT
     case AxiosErrorCode.NETWORK_ERROR:
       return ErrorRegistry.NO_INTERNET
     case AxiosErrorCode.BAD_REQUEST:
-      return ErrorRegistry.BAD_REQUEST
+      return getClientErrorDefinitionFromStatus(status)
     case AxiosErrorCode.BAD_RESPONSE:
       return ErrorRegistry.SERVER_ERROR
   }
@@ -130,7 +161,8 @@ export const getAxiosErrorDefinition = (errorCode?: string): ErrorDefinition | n
  */
 export const getAppErrorFromAxiosError = (error: AxiosError): AppError => {
   const errorCode = error.code
-  const errorDefinition = getAxiosErrorDefinition(errorCode) ?? getErrorDefinitionFromAppEventCode(errorCode)
+  const errorDefinition =
+    getAxiosErrorDefinition(errorCode, error.response?.status) ?? getErrorDefinitionFromAppEventCode(errorCode)
 
   let appError: AppError
 

--- a/app/src/errors/appError.test.ts
+++ b/app/src/errors/appError.test.ts
@@ -126,6 +126,27 @@ describe('AppError', () => {
         message: `[${error.code}] ${error.message}`,
       })
     })
+
+    it('should include the HTTP status and endpoint in the tracked message when present', () => {
+      const trackErrorEventSpy = jest.spyOn(Analytics, 'trackErrorEvent')
+
+      const identity = {
+        category: ErrorCategory.NETWORK,
+        appEvent: AppEventCode.NOT_FOUND,
+        statusCode: 2113,
+      }
+      // track: false so the constructor's auto-track doesn't fire before url/method are set
+      const error = new AppError('Not found', identity, { cause: { response: { status: 404 } }, track: false })
+      error.url = '/device/userinfo'
+      error.method = 'GET'
+
+      error.track()
+
+      expect(trackErrorEventSpy).toHaveBeenCalledWith({
+        code: AppEventCode.NOT_FOUND,
+        message: `[${error.code}] HTTP 404 GET /device/userinfo Not found`,
+      })
+    })
   })
 
   describe('fromErrorDefinition', () => {

--- a/app/src/errors/appError.ts
+++ b/app/src/errors/appError.ts
@@ -97,6 +97,13 @@ export class AppError extends Error {
       return
     }
 
+    // Surface the HTTP context (status + endpoint) when the cause is an HTTP/Axios error. Axios collapses
+    // every 4xx into a single code, so without this the dashboard cannot tell 400/401/403/404 apart — nor
+    // which endpoint produced the error.
+    const httpStatus = (this.cause as { response?: { status?: number } } | undefined)?.response?.status
+    const request = [this.method, this.url].filter(Boolean).join(' ')
+    const context = [httpStatus ? `HTTP ${httpStatus}` : undefined, request || undefined].filter(Boolean).join(' ')
+
     Analytics.trackErrorEvent({
       /**
        * NOTE: We use AppEventCode as the error code for backwards compatibility with V3 and the
@@ -105,9 +112,9 @@ export class AppError extends Error {
        */
       code: this.appEvent,
       /**
-       * TEMP: Inject the error code into the message to provide additional context.
+       * TEMP: Inject the error code (plus HTTP status + endpoint when present) into the message for context.
        */
-      message: `[${this.code}] ${this.message}`,
+      message: context ? `[${this.code}] ${context} ${this.message}` : `[${this.code}] ${this.message}`,
     })
 
     this.tracked = true

--- a/app/src/errors/errorRegistry.ts
+++ b/app/src/errors/errorRegistry.ts
@@ -200,6 +200,13 @@ export const ErrorRegistry = {
     category: ErrorCategory.AUTHENTICATION,
     message: 'Maximum retry/attempt count exceeded — request throttled',
   },
+  NOT_FOUND: {
+    statusCode: 2113,
+    appEvent: AppEventCode.NOT_FOUND,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.NETWORK,
+    message: 'Server returned 404 — requested resource or endpoint was not found',
+  },
 
   // ============================================
   // Authentication/Login Errors (2200-2299)
@@ -273,6 +280,13 @@ export const ErrorRegistry = {
     severity: ErrorSeverity.WARNING,
     category: ErrorCategory.AUTHENTICATION,
     message: 'Account limit reached — user has too many active registrations',
+  },
+  FORBIDDEN: {
+    statusCode: 2210,
+    appEvent: AppEventCode.FORBIDDEN,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.AUTHENTICATION,
+    message: 'HTTP 403 — authenticated but not permitted to access this resource',
   },
 
   // ============================================

--- a/app/src/events/appEventCode.ts
+++ b/app/src/events/appEventCode.ts
@@ -100,6 +100,8 @@ export enum AppEventCode {
   ERR_208_UNEXPECTED_NETWORK_CALL_EXCEPTION = 'err_208_unexpected_network_call_exception', //being tracked
   ERR_209_BAD_REQUEST = 'err_209_bad_request',
   ERR_210_UNAUTHORIZED = 'err_210_unauthorized',
+  FORBIDDEN = 'forbidden',
+  NOT_FOUND = 'not_found',
   ERR_212_RETRY_LATER = 'err_212_retry_later',
   ERR_211_SERVER_OUTAGE = 'err_211_server_outage',
   ERR_213_FAILED_CREATING_CLIENT_REGISTRATION = 'err_213_failed_creating_client_registration',

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -343,6 +343,8 @@ export const useAlerts = (navigation: NavigationProp<any>) => {
       unexpectedNetworkCallAlert: _createBasicErrorModal(AppEventCode.ERR_208_UNEXPECTED_NETWORK_CALL_EXCEPTION, 'ProblemWithApp', { errorCode: '208' }),
       badRequestAlert: _createBasicErrorModal(AppEventCode.ERR_209_BAD_REQUEST, 'ProblemWithApp', { errorCode: '209' }),
       unauthorizedAlert: _createBasicErrorModal(AppEventCode.ERR_210_UNAUTHORIZED, 'ProblemWithApp', { errorCode: '210' }),
+      forbiddenAlert: _createBasicErrorModal(AppEventCode.FORBIDDEN, 'ProblemWithApp', { errorCode: '403' }),
+      notFoundAlert: _createBasicErrorModal(AppEventCode.NOT_FOUND, 'ProblemWithApp', { errorCode: '404' }),
       serverOutageAlert: _createBasicErrorModal(AppEventCode.ERR_211_SERVER_OUTAGE, 'ProblemWithApp', { errorCode: '211' }),
       retryLaterAlert: _createBasicErrorModal(AppEventCode.ERR_212_RETRY_LATER, 'ProblemWithApp', { errorCode: '212' }),
       creatingClientRegistrationFailedAlert: _createBasicErrorModal(AppEventCode.ERR_213_FAILED_CREATING_CLIENT_REGISTRATION, 'ProblemWithApp', { errorCode: '213' }),

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -343,8 +343,10 @@ export const useAlerts = (navigation: NavigationProp<any>) => {
       unexpectedNetworkCallAlert: _createBasicErrorModal(AppEventCode.ERR_208_UNEXPECTED_NETWORK_CALL_EXCEPTION, 'ProblemWithApp', { errorCode: '208' }),
       badRequestAlert: _createBasicErrorModal(AppEventCode.ERR_209_BAD_REQUEST, 'ProblemWithApp', { errorCode: '209' }),
       unauthorizedAlert: _createBasicErrorModal(AppEventCode.ERR_210_UNAUTHORIZED, 'ProblemWithApp', { errorCode: '210' }),
-      forbiddenAlert: _createBasicErrorModal(AppEventCode.FORBIDDEN, 'ProblemWithApp', { errorCode: '403' }),
-      notFoundAlert: _createBasicErrorModal(AppEventCode.NOT_FOUND, 'ProblemWithApp', { errorCode: '404' }),
+      // 403/404 are server/permission/resource issues, not a broken install — use the neutral
+      // "Problem with Service / please try again later" copy rather than "reinstall the app".
+      forbiddenAlert: _createBasicErrorModal(AppEventCode.FORBIDDEN, 'ProblemWithService', { errorCode: '403' }),
+      notFoundAlert: _createBasicErrorModal(AppEventCode.NOT_FOUND, 'ProblemWithService', { errorCode: '404' }),
       serverOutageAlert: _createBasicErrorModal(AppEventCode.ERR_211_SERVER_OUTAGE, 'ProblemWithApp', { errorCode: '211' }),
       retryLaterAlert: _createBasicErrorModal(AppEventCode.ERR_212_RETRY_LATER, 'ProblemWithApp', { errorCode: '212' }),
       creatingClientRegistrationFailedAlert: _createBasicErrorModal(AppEventCode.ERR_213_FAILED_CREATING_CLIENT_REGISTRATION, 'ProblemWithApp', { errorCode: '213' }),

--- a/app/src/screens/ErrorAlertTest.tsx
+++ b/app/src/screens/ErrorAlertTest.tsx
@@ -96,6 +96,8 @@ const ErrorAlertTest: React.FC<ErrorAlertTestProps> = ({ onBack }) => {
     { key: 'SERVER_TIMEOUT', description: 'Request timeout error' },
     { key: 'INVALID_QR_CODE', description: 'QR code scanning error' },
     { key: 'LOGIN_REJECTED_401', description: 'Authentication unauthorized' },
+    { key: 'FORBIDDEN', description: 'HTTP 403 — authenticated but not permitted' },
+    { key: 'NOT_FOUND', description: 'HTTP 404 — resource or endpoint not found' },
     { key: 'CARD_EXPIRED_WILL_REMOVE', description: 'Credential expiration warning' },
     { key: 'WALLET_SECRET_NOT_FOUND', description: 'Critical wallet error' },
     { key: 'ATTESTATION_CONNECTION_ERROR', description: 'Attestation flow error' },

--- a/app/src/screens/ErrorAlertTest.tsx
+++ b/app/src/screens/ErrorAlertTest.tsx
@@ -215,6 +215,11 @@ const ErrorAlertTest: React.FC<ErrorAlertTestProps> = ({ onBack }) => {
     err_bad_request: () => injectErrorCodeIntoAxiosResponse(client, 'ERR_BAD_REQUEST'),
     err_bad_response: () => injectErrorCodeIntoAxiosResponse(client, 'ERR_BAD_RESPONSE'),
     econnaborted: () => injectErrorCodeIntoAxiosResponse(client, 'ECONNABORTED'),
+    // Bare HTTP 4xx (no IAS error body): verifies axios' collapsed ERR_BAD_REQUEST is disambiguated by status
+    http_401_unauthorized: () => injectErrorCodeIntoAxiosResponse(client, 'ERR_BAD_REQUEST', undefined, 401),
+    http_403_forbidden: () => injectErrorCodeIntoAxiosResponse(client, 'ERR_BAD_REQUEST', undefined, 403),
+    http_404_not_found: () => injectErrorCodeIntoAxiosResponse(client, 'ERR_BAD_REQUEST', undefined, 404),
+    http_429_retry_later: () => injectErrorCodeIntoAxiosResponse(client, 'ERR_BAD_REQUEST', undefined, 429),
   }
 
   const getCategoryIcon = (category: ErrorCategory): string => {
@@ -241,7 +246,7 @@ const ErrorAlertTest: React.FC<ErrorAlertTestProps> = ({ onBack }) => {
     emitErrorModal('Error Modal Triggered', description, AppError.fromErrorDefinition(ErrorRegistry[key]))
   }
 
-  const triggerErrorAsAlert = (key: ErrorRegistryKey, description: string) => {
+  const triggerErrorAsAlert = (description: string) => {
     emitAlert('Native alert triggered', description, {
       actions: [
         { text: t('Global.Cancel'), style: 'cancel' },
@@ -369,7 +374,7 @@ const ErrorAlertTest: React.FC<ErrorAlertTestProps> = ({ onBack }) => {
                 accessibilityLabel={`Trigger ${key} as native alert`}
                 testID={`error-alert-${key}`}
                 buttonType={ButtonType.Secondary}
-                onPress={() => triggerErrorAsAlert(key, description)}
+                onPress={() => triggerErrorAsAlert(description)}
               />
             </View>
           ))}


### PR DESCRIPTION
# Summary of Changes

Fixes BCSC v4 surfacing real **HTTP 401 and 404** errors as the generic **error 2107 / "error 209 — the app
does not appear to be installed correctly, please reinstall"** modal, with a self-contradicting message
(`HTTP 400` in the text, `status code 401/404` in the debug line).

**Root cause:** axios collapses _every_ 4xx response into a single `ERR_BAD_REQUEST` code, which the app
mapped unconditionally to `BAD_REQUEST` (2107). A bare 401/404 (no IAS `error`/`error_description` body)
therefore fell through to the misleading "reinstall" modal.

**This PR** maps 4xx by the real HTTP status so each gets its own error code, modal, and analytics event:

| Status          | Now maps to                                                   |
| --------------- | ------------------------------------------------------------- |
| 401             | refresh + retry once → `UNAUTHORIZED` (2208) if still failing |
| 403             | `FORBIDDEN` (2210, new)                                       |
| 404             | `NOT_FOUND` (2113, new)                                       |
| 429             | `RETRY_LATER` (2109)                                          |
| 400 / other 4xx | `BAD_REQUEST` (2107, unchanged catch-all)                     |

Also:

- **401 recovery:** the response interceptor force-refreshes tokens and retries the request once on a 401
  (bearer requests only, guarded against loops), recovering revoked / clock-skewed access tokens before any
  error surfaces.
- Adds the failing endpoint (`HTTP <status> <method> <url>`) to the analytics event so 400/401/403/404 — and
  _which_ endpoint produced them — are distinguishable on the dashboard.
- `notFoundAlert` / `forbiddenAlert` use the existing neutral `ProblemWithService` copy ("please try again
  later"), **not** "reinstall the app" — no new strings.
- IAS semantic errors (`error`/`error_description`) still take precedence — unchanged.
- Dev: `ErrorAlertTest` injection triggers + curated modal buttons for the new statuses; removed an unused param.

> Builds on `#4000` (pairing/email 404 → inline errors, already on `main`); those endpoint-specific
> suppressions run before this generic status mapping, so user-input 404s stay inline.

# Testing Instructions

- **Automated:** `cd app && yarn jest src/errors src/bcsc-theme/utils/axios-error-utils.test.ts src/bcsc-theme/api/clientErrorPolicies.test.ts src/bcsc-theme/api/client.test.ts && yarn typecheck`
- **Manual:** Developer menu → **Error Alert Test** → **Server error codes** → trigger
  `http_403_forbidden` / `http_404_not_found` / `http_429_retry_later`. Each shows its own error number
  (403 / 404 / 212) with the "Problem with Service" copy, **not** "error 209 / reinstall". (A recoverable
  401 is retried transparently after a token refresh, so it won't surface a modal.)

# Acceptance Criteria

- A bare HTTP 401 is transparently recovered by a single token refresh + retry when the access token was
  merely revoked / clock-skewed; only a still-failing 401 surfaces an error.
- A bare HTTP 403/404 no longer shows "error 209 / reinstall the app" — it shows the correct status-specific
  code with the neutral "Problem with Service" copy.
- The debug message no longer claims "HTTP 400" for a 401/404; analytics distinguish 400/401/403/404 and
  include the failing endpoint.
- IAS-bodied errors and existing 404 inline flows (pairing, email) are unchanged.

# Screenshots, videos, or gifs

N/A — no new screens. 403/404 are routed to the existing "Problem with Service" modal (copy unchanged, only
the error code routed to it).

# Related Issues

N/A
