### PR TITLE
fix: error 2502 token hydration

### DIFF
--- a/app/src/bcsc-theme/api/client.test.ts
+++ b/app/src/bcsc-theme/api/client.test.ts
@@ -6,7 +6,7 @@ import { localization } from '@/localization'
 import { initLanguages } from '@bifold/core'
 import { AxiosError } from 'axios'
 import { jwtDecode } from 'jwt-decode'
-import { getAccount } from 'react-native-bcsc-core'
+import { getAccount, getToken, TokenType } from 'react-native-bcsc-core'
 
 jest.mock('jwt-decode', () => ({
   jwtDecode: jest.fn(),
@@ -140,6 +140,52 @@ describe('BCSC Client', () => {
       expect(privateFetchTokens).toHaveBeenCalledWith('refreshToken1')
       expect(client.tokens).toBe(mockTokens)
       expect(client.tokensPromise).toBeNull()
+    })
+  })
+
+  describe('recoverTokens', () => {
+    it('should return the in-memory tokens without reading storage when the cache is populated', async () => {
+      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const client = new BCSCApiClient('https://example.com', mockLogger as any)
+      const tokens = { access_token: 'a', refresh_token: 'r' }
+      client.tokens = tokens as any
+      ;(getToken as jest.Mock).mockClear()
+
+      const result = await client.recoverTokens()
+
+      expect(result).toBe(tokens)
+      expect(getToken).not.toHaveBeenCalled()
+    })
+
+    it('should rebuild the cache from the stored refresh token when empty', async () => {
+      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const client = new BCSCApiClient('https://example.com', mockLogger as any)
+      client.tokens = undefined
+      ;(getToken as jest.Mock).mockResolvedValue({ token: 'stored-refresh', type: TokenType.Refresh })
+
+      const recoveredTokens = { access_token: 'recovered-access', refresh_token: 'recovered-refresh' }
+      const privateFetchTokens = jest
+        .spyOn(BCSCApiClient.prototype as any, 'fetchTokens')
+        .mockResolvedValue(recoveredTokens)
+
+      const result = await client.recoverTokens()
+
+      expect(getToken).toHaveBeenCalledWith(TokenType.Refresh)
+      expect(privateFetchTokens).toHaveBeenCalledWith('stored-refresh')
+      expect(result).toEqual(recoveredTokens)
+      expect(client.tokens).toEqual(recoveredTokens)
+    })
+
+    it('should throw TOKEN_NULL when the cache is empty and no refresh token is stored', async () => {
+      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const client = new BCSCApiClient('https://example.com', mockLogger as any)
+      client.tokens = undefined
+      ;(getToken as jest.Mock).mockResolvedValue(null)
+
+      await expect(client.recoverTokens()).rejects.toMatchObject({
+        appEvent: AppEventCode.ERR_119_TOKEN_UNEXPECTEDLY_NULL,
+      })
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('no refresh token in secure storage'))
     })
   })
 
@@ -339,14 +385,35 @@ describe('BCSC Client', () => {
       expect(result).toEqual(mockTokens)
     })
 
-    it('should throw when tokens are missing', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+    it('should throw TOKEN_NULL when tokens are missing and unrecoverable', async () => {
+      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       client.tokens = undefined
       ;(getAccount as jest.Mock).mockResolvedValue({ issuer: 'iss', clientID: 'cid' })
+      ;(getToken as jest.Mock).mockResolvedValue(null)
 
-      await expect((client as any).ensureValidTokens()).rejects.toThrow()
-      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Missing tokens'))
+      await expect((client as any).ensureValidTokens()).rejects.toMatchObject({
+        appEvent: AppEventCode.ERR_119_TOKEN_UNEXPECTEDLY_NULL,
+      })
+    })
+
+    it('should recover tokens from secure storage when the in-memory cache is empty', async () => {
+      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const client = new BCSCApiClient('https://example.com', mockLogger as any)
+      client.tokens = undefined
+      ;(getAccount as jest.Mock).mockResolvedValue({ issuer: 'iss', clientID: 'cid' })
+      ;(getToken as jest.Mock).mockResolvedValue({ token: 'stored-refresh', type: TokenType.Refresh })
+
+      const recoveredTokens = { access_token: 'recovered-access', refresh_token: 'recovered-refresh' }
+      jest.spyOn(BCSCApiClient.prototype as any, 'fetchTokens').mockResolvedValue(recoveredTokens)
+      // Recovered tokens are freshly fetched, so neither is expired
+      ;(jwtDecode as jest.Mock).mockReturnValue({ exp: Math.floor(Date.now() / 1000) + 3600 })
+
+      const result = await (client as any).ensureValidTokens()
+
+      expect(getToken).toHaveBeenCalledWith(TokenType.Refresh)
+      expect(result).toEqual(recoveredTokens)
+      expect(client.tokens).toEqual(recoveredTokens)
     })
 
     it('should throw when refresh token is expired', async () => {

--- a/app/src/bcsc-theme/api/client.test.ts
+++ b/app/src/bcsc-theme/api/client.test.ts
@@ -2,10 +2,12 @@ import BCSCApiClient from '@/bcsc-theme/api/client'
 import { AppError } from '@/errors/appError'
 import { ErrorCategory } from '@/errors/errorRegistry'
 import { AppEventCode } from '@/events/appEventCode'
+import { BCSCEventTypes } from '@/events/eventTypes'
 import { localization } from '@/localization'
 import { initLanguages } from '@bifold/core'
 import { AxiosError } from 'axios'
 import { jwtDecode } from 'jwt-decode'
+import { DeviceEventEmitter } from 'react-native'
 import { getAccount, getToken, TokenType } from 'react-native-bcsc-core'
 
 jest.mock('jwt-decode', () => ({
@@ -174,6 +176,46 @@ describe('BCSC Client', () => {
       expect(privateFetchTokens).toHaveBeenCalledWith('stored-refresh')
       expect(result).toEqual(recoveredTokens)
       expect(client.tokens).toEqual(recoveredTokens)
+    })
+
+    it('should emit TOKENS_REFRESHED after a successful rebuild', async () => {
+      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const client = new BCSCApiClient('https://example.com', mockLogger as any)
+      client.tokens = undefined
+      ;(getToken as jest.Mock).mockResolvedValue({ token: 'stored-refresh', type: TokenType.Refresh })
+
+      const recoveredTokens = { access_token: 'recovered-access', refresh_token: 'recovered-refresh' }
+      jest.spyOn(BCSCApiClient.prototype as any, 'fetchTokens').mockResolvedValue(recoveredTokens)
+      const emitSpy = jest.spyOn(DeviceEventEmitter, 'emit').mockClear()
+
+      await client.recoverTokens()
+
+      expect(emitSpy).toHaveBeenCalledWith(BCSCEventTypes.TOKENS_REFRESHED)
+    })
+
+    it('should not emit TOKENS_REFRESHED when the cache is already populated', async () => {
+      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const client = new BCSCApiClient('https://example.com', mockLogger as any)
+      client.tokens = { access_token: 'a', refresh_token: 'r' } as any
+      const emitSpy = jest.spyOn(DeviceEventEmitter, 'emit').mockClear()
+
+      await client.recoverTokens()
+
+      expect(emitSpy).not.toHaveBeenCalledWith(BCSCEventTypes.TOKENS_REFRESHED)
+    })
+
+    it('should not emit TOKENS_REFRESHED when the rebuild fails', async () => {
+      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const client = new BCSCApiClient('https://example.com', mockLogger as any)
+      client.tokens = undefined
+      ;(getToken as jest.Mock).mockResolvedValue({ token: 'stored-refresh', type: TokenType.Refresh })
+
+      jest.spyOn(BCSCApiClient.prototype as any, 'fetchTokens').mockRejectedValue(new Error('Network Error'))
+      const emitSpy = jest.spyOn(DeviceEventEmitter, 'emit').mockClear()
+
+      await expect(client.recoverTokens()).rejects.toThrow('Network Error')
+
+      expect(emitSpy).not.toHaveBeenCalledWith(BCSCEventTypes.TOKENS_REFRESHED)
     })
 
     it('should throw TOKEN_NULL when the cache is empty and no refresh token is stored', async () => {

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -5,7 +5,7 @@ import { getUserAgentString } from '@utils/user-agent'
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { jwtDecode } from 'jwt-decode'
 import merge from 'lodash.merge'
-import { getRefreshTokenRequestBody } from 'react-native-bcsc-core'
+import { getRefreshTokenRequestBody, getToken, TokenType } from 'react-native-bcsc-core'
 import {
   formatAxiosErrorForLogger as formatIASAxiosErrorForLogger,
   formatIasAxiosResponseError,
@@ -222,26 +222,25 @@ class BCSCApiClient {
         return this.tokensPromise
       }
 
-      if (!this.tokens) {
-        // initialize tokens using `getTokensForRefreshToken`
-        this.logger.error('[BCSCApiClient] Missing tokens - call getTokensForRefreshToken to initialize tokens')
-        throw AppError.fromErrorDefinition(ErrorRegistry.TOKEN_NULL)
-      }
+      // Rebuild the in-memory cache from secure storage if it's empty (e.g. the
+      // startup hydration refresh failed transiently or ran before the client
+      // was ready). Throws TOKEN_NULL only when no refresh token is recoverable.
+      const tokens = this.tokens ?? (await this.recoverTokens())
 
-      if (this.isTokenExpired(this.tokens.refresh_token)) {
+      if (this.isTokenExpired(tokens.refresh_token)) {
         // refresh tokens should not expire
         this.logger.error('[BCSCApiClient] Refresh token expired - fatal error detected')
         throw new Error('Refresh token expired')
       }
 
-      if (!this.isTokenExpired(this.tokens.access_token)) {
+      if (!this.isTokenExpired(tokens.access_token)) {
         // access token is still valid, don't refresh
-        return this.tokens
+        return tokens
       }
 
       // access token is expired or about to expire, fetch new tokens using refresh token
       // Set tokensPromise immediately to prevent concurrent callers from starting duplicate refreshes
-      this.tokensPromise = this.fetchTokens(this.tokens.refresh_token)
+      this.tokensPromise = this.fetchTokens(tokens.refresh_token)
       try {
         this.tokens = await this.tokensPromise
       } finally {
@@ -304,6 +303,38 @@ class BCSCApiClient {
     }
 
     return this.tokens
+  }
+
+  /**
+   * Returns the in-memory token cache, rebuilding it from secure storage when it
+   * is empty.
+   *
+   * The cache (`this.tokens`) is ephemeral and is normally populated at startup
+   * by `hydrateSecureState`. That path can leave it empty without surfacing an
+   * error — for example when the startup refresh fails on a flaky network, or
+   * runs before the client finished configuring. In those cases a valid refresh
+   * token still lives in secure storage, so we lazily rebuild the cache instead
+   * of forcing the user to reinstall the app.
+   *
+   * @returns the populated tokens
+   * @throws AppError TOKEN_NULL when the cache is empty and no refresh token
+   *   exists in secure storage — the only genuinely unrecoverable case.
+   */
+  async recoverTokens(): Promise<TokenResponse> {
+    if (this.tokens) {
+      return this.tokens
+    }
+
+    const storedRefreshToken = (await getToken(TokenType.Refresh))?.token
+    if (!storedRefreshToken) {
+      this.logger.error('[BCSCApiClient] Token cache empty and no refresh token in secure storage')
+      throw AppError.fromErrorDefinition(ErrorRegistry.TOKEN_NULL, {
+        cause: new Error('Token cache empty and no stored refresh token to recover from'),
+      })
+    }
+
+    this.logger.warn('[BCSCApiClient] Token cache empty; rebuilding from stored refresh token')
+    return this.getTokensForRefreshToken(storedRefreshToken)
   }
 
   async get<T>(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -1,10 +1,12 @@
 import { AppError } from '@/errors/appError'
 import { ErrorRegistry } from '@/errors/errorRegistry'
+import { BCSCEventTypes } from '@/events/eventTypes'
 import { RemoteLogger } from '@bifold/remote-logs'
 import { getUserAgentString } from '@utils/user-agent'
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { jwtDecode } from 'jwt-decode'
 import merge from 'lodash.merge'
+import { DeviceEventEmitter } from 'react-native'
 import { getRefreshTokenRequestBody, getToken, TokenType } from 'react-native-bcsc-core'
 import {
   formatAxiosErrorForLogger as formatIASAxiosErrorForLogger,
@@ -334,7 +336,14 @@ class BCSCApiClient {
     }
 
     this.logger.warn('[BCSCApiClient] Token cache empty; rebuilding from stored refresh token')
-    return this.getTokensForRefreshToken(storedRefreshToken)
+    const tokens = await this.getTokensForRefreshToken(storedRefreshToken)
+
+    // Tokens went from missing to available (e.g. connectivity returned after a
+    // failed startup refresh) — notify listeners so data providers can reload
+    // state that failed while tokens were unavailable.
+    DeviceEventEmitter.emit(BCSCEventTypes.TOKENS_REFRESHED)
+
+    return tokens
   }
 
   async get<T>(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {

--- a/app/src/bcsc-theme/api/hooks/useTokens.test.ts
+++ b/app/src/bcsc-theme/api/hooks/useTokens.test.ts
@@ -1,5 +1,6 @@
 import { VerifyAttestationPayload } from '@/bcsc-theme/api/hooks/useDeviceAttestationApi'
 import { getIdTokenMetadata } from '@/bcsc-theme/utils/id-token'
+import { AppError, ErrorRegistry } from '@/errors'
 import { AppEventCode } from '@/events/appEventCode'
 import { renderHook } from '@testing-library/react-native'
 import { BasicAppContext } from '__mocks__/helpers/app'
@@ -63,6 +64,7 @@ describe('useTokenApi', () => {
       },
       tokens: mockTokenResponse,
       getTokensForRefreshToken: jest.fn(),
+      recoverTokens: jest.fn().mockResolvedValue(mockTokenResponse),
       logger: {
         info: jest.fn(),
         error: jest.fn(),
@@ -185,14 +187,33 @@ describe('useTokenApi', () => {
       expect(metadata).toEqual(mockMetadata)
     })
 
-    it('should throw AppError with ERR_119 when no tokens are available', async () => {
+    it('should propagate ERR_119 when tokens cannot be recovered', async () => {
       mockApiClient.tokens = null as any
+      mockApiClient.recoverTokens = jest.fn().mockRejectedValue(AppError.fromErrorDefinition(ErrorRegistry.TOKEN_NULL))
 
       const { result } = renderHook(() => useTokenApi(mockApiClient), { wrapper: BasicAppContext })
 
       await expect(result.current.getCachedIdTokenMetadata({ refreshCache: false })).rejects.toMatchObject({
         appEvent: AppEventCode.ERR_119_TOKEN_UNEXPECTEDLY_NULL,
       })
+    })
+
+    it('should rebuild the cache via recoverTokens without an extra refresh when tokens were missing', async () => {
+      const mockMetadata = { sub: 'user123', exp: 1234567890 }
+      const recoveredTokens = { ...mockTokenResponse, id_token: 'recovered_id_token' }
+      ;(getIdTokenMetadata as jest.Mock).mockReturnValue(mockMetadata)
+      // Cache empty at point of use; recoverTokens rebuilds it from secure storage
+      mockApiClient.tokens = null as any
+      mockApiClient.recoverTokens = jest.fn().mockResolvedValue(recoveredTokens)
+
+      const { result } = renderHook(() => useTokenApi(mockApiClient), { wrapper: BasicAppContext })
+      // Even with refreshCache true, a just-recovered (already fresh) cache should not refresh again
+      const metadata = await result.current.getCachedIdTokenMetadata({ refreshCache: true })
+
+      expect(mockApiClient.recoverTokens).toHaveBeenCalled()
+      expect(mockApiClient.getTokensForRefreshToken).not.toHaveBeenCalled()
+      expect(getIdTokenMetadata).toHaveBeenCalledWith('recovered_id_token', mockApiClient.logger)
+      expect(metadata).toEqual(mockMetadata)
     })
 
     it('should handle refresh token errors', async () => {

--- a/app/src/bcsc-theme/api/hooks/useTokens.tsx
+++ b/app/src/bcsc-theme/api/hooks/useTokens.tsx
@@ -1,7 +1,6 @@
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { getIdTokenMetadata } from '@/bcsc-theme/utils/id-token'
 import { throwAppError } from '@/bcsc-theme/utils/native-error-map'
-import { AppError } from '@/errors/appError'
 import { ErrorRegistry } from '@/errors/errorRegistry'
 import { useCallback, useMemo } from 'react'
 import { getDeviceCodeRequestBody } from 'react-native-bcsc-core'
@@ -87,18 +86,21 @@ const useTokenApi = (apiClient: BCSCApiClient) => {
    */
   const getCachedIdTokenMetadata = useCallback(
     async (config: IdTokenMetadataConfig) => {
-      if (!apiClient.tokens) {
-        throw AppError.fromErrorDefinition(ErrorRegistry.TOKEN_NULL, {
-          cause: new Error('apiClient.tokens is null in getCachedIdTokenMetadata'),
-        })
-      }
+      // Ensure the in-memory token cache is populated, rebuilding it from secure
+      // storage if startup hydration left it empty (e.g. a transient network
+      // failure during the startup refresh). Only a genuinely missing refresh
+      // token throws TOKEN_NULL.
+      const cacheWasEmpty = !apiClient.tokens
+      let tokens = await apiClient.recoverTokens()
 
-      if (config.refreshCache) {
+      // A freshly recovered cache already holds newly-fetched tokens, so only pay
+      // for an extra refresh when the caller wants the latest and we had a cache.
+      if (config.refreshCache && !cacheWasEmpty) {
         // Fetch new tokens to ensure we have the latest ID token
-        await apiClient.getTokensForRefreshToken(apiClient.tokens.refresh_token)
+        tokens = await apiClient.getTokensForRefreshToken(tokens.refresh_token)
       }
 
-      return getIdTokenMetadata(apiClient.tokens.id_token, apiClient.logger)
+      return getIdTokenMetadata(tokens.id_token, apiClient.logger)
     },
     [apiClient]
   )

--- a/app/src/bcsc-theme/contexts/BCSCAccountContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCAccountContext.tsx
@@ -6,6 +6,7 @@ import { createContext, PropsWithChildren, useContext, useEffect, useMemo } from
 import { DeviceEventEmitter } from 'react-native'
 import { UserInfoResponseData } from '../api/hooks/useUserApi'
 import useDataLoader from '../hooks/useDataLoader'
+import { useRetryOnReconnect } from '../hooks/useRetryOnReconnect'
 import { useUserService } from '../services/hooks/useUserService'
 
 export interface BCSCAccount extends Omit<UserInfoResponseData, 'picture'> {
@@ -51,6 +52,9 @@ export const BCSCAccountProvider = ({ children }: PropsWithChildren) => {
 
     return () => subscription.remove()
   }, [refresh, logger])
+
+  // If the load failed while offline, retry when connectivity returns
+  useRetryOnReconnect(() => !data && !isLoading, refresh)
 
   const accountContextValue = useMemo(() => {
     if (!data) {

--- a/app/src/bcsc-theme/contexts/BCSCIdTokenContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCIdTokenContext.tsx
@@ -2,7 +2,6 @@ import { CredentialMetadata } from '@/store'
 import { TOKENS, useServices } from '@bifold/core'
 import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useRef } from 'react'
 import useApi from '../api/hooks/useApi'
-import { useBCSCApiClient } from '../hooks/useBCSCApiClient'
 import useDataLoader from '../hooks/useDataLoader'
 import { IdToken } from '../utils/id-token'
 
@@ -66,7 +65,6 @@ export const BCSCIdTokenContext = createContext<BCSCIdTokenContextType<IdToken> 
  */
 export const BCSCIdTokenProvider = ({ children }: PropsWithChildren) => {
   const api = useApi()
-  const apiClient = useBCSCApiClient()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
 
   // On initial mount, use the cached tokens from hydrateSecureState or brand new verification
@@ -75,10 +73,10 @@ export const BCSCIdTokenProvider = ({ children }: PropsWithChildren) => {
 
   const { data, load, isLoading, refresh } = useDataLoader(
     async () => {
-      // On initial mount, skip the server refresh if apiClient already has tokens
-      // (populated by hydrateSecureState). If tokens are missing, force a refresh
-      // so we don't throw TOKEN_NULL in some weird scenario
-      const shouldRefresh = !isInitialLoad.current || !apiClient.tokens
+      // On initial mount, use the cached tokens (hydrated at startup, or rebuilt
+      // from secure storage on demand by getCachedIdTokenMetadata). Subsequent
+      // refreshes fetch fresh tokens from the server for the latest ID token.
+      const shouldRefresh = !isInitialLoad.current
       isInitialLoad.current = false
       return api.token.getCachedIdTokenMetadata({ refreshCache: shouldRefresh })
     },

--- a/app/src/bcsc-theme/contexts/BCSCIdTokenContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCIdTokenContext.tsx
@@ -1,8 +1,11 @@
+import { BCSCEventTypes } from '@/events/eventTypes'
 import { CredentialMetadata } from '@/store'
 import { TOKENS, useServices } from '@bifold/core'
 import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useRef } from 'react'
+import { DeviceEventEmitter } from 'react-native'
 import useApi from '../api/hooks/useApi'
 import useDataLoader from '../hooks/useDataLoader'
+import { useRetryOnReconnect } from '../hooks/useRetryOnReconnect'
 import { IdToken } from '../utils/id-token'
 
 export interface BCSCIdTokenContextType<T> {
@@ -89,18 +92,25 @@ export const BCSCIdTokenProvider = ({ children }: PropsWithChildren) => {
     load()
   }, [load])
 
-  const contextValue = useMemo(() => {
-    if (!data) {
-      return {
-        isLoading: isLoading,
-        data: null,
-        refreshData: () => {},
-      } as BCSCIdTokenContextType<IdToken>
-    }
+  // Listen for token refresh events (e.g., tokens rebuilt after a failed startup
+  // refresh) and reload from the freshly cached tokens without another refresh
+  useEffect(() => {
+    const subscription = DeviceEventEmitter.addListener(BCSCEventTypes.TOKENS_REFRESHED, () => {
+      logger.info('BCSCIdTokenProvider: Tokens refreshed, reloading ID token metadata')
+      isInitialLoad.current = true
+      refresh()
+    })
 
+    return () => subscription.remove()
+  }, [refresh, logger])
+
+  // If the load failed while offline, retry when connectivity returns
+  useRetryOnReconnect(() => !data && !isLoading, refresh)
+
+  const contextValue = useMemo(() => {
     return {
-      isLoading: false,
-      data: data,
+      isLoading: data ? false : isLoading,
+      data: data ?? null,
       refreshData: refresh,
     } as BCSCIdTokenContextType<IdToken>
   }, [data, isLoading, refresh])

--- a/app/src/bcsc-theme/hooks/useRetryOnReconnect.test.tsx
+++ b/app/src/bcsc-theme/hooks/useRetryOnReconnect.test.tsx
@@ -1,0 +1,87 @@
+import NetInfo, { NetInfoChangeHandler, NetInfoState } from '@react-native-community/netinfo'
+import { renderHook } from '@testing-library/react-native'
+import { useRetryOnReconnect } from './useRetryOnReconnect'
+
+const netInfoState = (isConnected: boolean, isInternetReachable: boolean | null = isConnected) =>
+  ({ isConnected, isInternetReachable }) as NetInfoState
+
+describe('useRetryOnReconnect', () => {
+  let netInfoListener: NetInfoChangeHandler
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(NetInfo.addEventListener as jest.Mock).mockImplementation((listener: NetInfoChangeHandler) => {
+      netInfoListener = listener
+      return jest.fn()
+    })
+  })
+
+  it('should retry when connectivity is restored and shouldRetry returns true', () => {
+    const retry = jest.fn()
+    renderHook(() => useRetryOnReconnect(() => true, retry))
+
+    netInfoListener(netInfoState(false))
+    netInfoListener(netInfoState(true))
+
+    expect(retry).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not retry when shouldRetry returns false', () => {
+    const retry = jest.fn()
+    renderHook(() => useRetryOnReconnect(() => false, retry))
+
+    netInfoListener(netInfoState(false))
+    netInfoListener(netInfoState(true))
+
+    expect(retry).not.toHaveBeenCalled()
+  })
+
+  it('should not retry without an offline-to-online transition', () => {
+    const retry = jest.fn()
+    renderHook(() => useRetryOnReconnect(() => true, retry))
+
+    // Initial state online, stays online
+    netInfoListener(netInfoState(true))
+    netInfoListener(netInfoState(true))
+
+    expect(retry).not.toHaveBeenCalled()
+  })
+
+  it('should not treat connected-but-unreachable as online', () => {
+    const retry = jest.fn()
+    renderHook(() => useRetryOnReconnect(() => true, retry))
+
+    netInfoListener(netInfoState(false))
+    // Connected to a network, but internet not reachable yet
+    netInfoListener(netInfoState(true, false))
+
+    expect(retry).not.toHaveBeenCalled()
+
+    // Internet becomes reachable
+    netInfoListener(netInfoState(true, true))
+
+    expect(retry).toHaveBeenCalledTimes(1)
+  })
+
+  it('should retry on each reconnect while shouldRetry remains true', () => {
+    const retry = jest.fn()
+    renderHook(() => useRetryOnReconnect(() => true, retry))
+
+    netInfoListener(netInfoState(false))
+    netInfoListener(netInfoState(true))
+    netInfoListener(netInfoState(false))
+    netInfoListener(netInfoState(true))
+
+    expect(retry).toHaveBeenCalledTimes(2)
+  })
+
+  it('should unsubscribe from NetInfo on unmount', () => {
+    const removeListener = jest.fn()
+    ;(NetInfo.addEventListener as jest.Mock).mockReturnValue(removeListener)
+
+    const { unmount } = renderHook(() => useRetryOnReconnect(() => true, jest.fn()))
+    unmount()
+
+    expect(removeListener).toHaveBeenCalled()
+  })
+})

--- a/app/src/bcsc-theme/hooks/useRetryOnReconnect.tsx
+++ b/app/src/bcsc-theme/hooks/useRetryOnReconnect.tsx
@@ -1,0 +1,39 @@
+import NetInfo from '@react-native-community/netinfo'
+import { useEffect, useRef } from 'react'
+
+/**
+ * Invokes `retry` when internet connectivity is restored (offline -> online
+ * transition) and `shouldRetry` returns true.
+ *
+ * Used by data providers to reload state that failed to load while the device
+ * was offline, so the app heals without requiring a restart.
+ *
+ * @param shouldRetry - Returns true when a retry is needed (e.g. data is missing and not currently loading).
+ * @param retry - The reload action to invoke.
+ */
+export const useRetryOnReconnect = (shouldRetry: () => boolean, retry: () => void) => {
+  const wasConnectedRef = useRef<boolean | null>(null)
+
+  // Refs keep the NetInfo subscription stable across renders
+  const shouldRetryRef = useRef(shouldRetry)
+  shouldRetryRef.current = shouldRetry
+
+  const retryRef = useRef(retry)
+  retryRef.current = retry
+
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener(({ isConnected, isInternetReachable }) => {
+      const connected = Boolean(isConnected) && isInternetReachable !== false
+      const cameOnline = connected && wasConnectedRef.current === false
+      wasConnectedRef.current = connected
+
+      if (cameOnline && shouldRetryRef.current()) {
+        retryRef.current()
+      }
+    })
+
+    return unsubscribe
+  }, [])
+}
+
+export default useRetryOnReconnect


### PR DESCRIPTION
# Summary of Changes

Fixes **ERR_2502 (`TOKEN_NULL`)** — the "Problem with App… reinstall (error 119)" message users hit on launch — and makes the app self-heal when the failure was transient.

`BCSCApiClient.tokens` is in-memory only and rebuilt each session by `hydrateSecureState()` via the stored refresh token. That step can fail silently (network failure during the startup refresh — e.g. airplane mode mid-unlock — or running before the client is ready), leaving the cache empty. The next read threw `TOKEN_NULL`, surfacing a misleading "reinstall the app" prompt for a fully recoverable state, and the session then stayed broken until an app restart.

**Token recovery**

- Added `BCSCApiClient.recoverTokens()` — rebuilds the in-memory token cache from the refresh token in secure storage when it's empty. Throws `TOKEN_NULL` **only** when no refresh token exists (the genuinely unrecoverable case — reinstall is then correct).
- Routed both throw sites (`ensureValidTokens()` and `getCachedIdTokenMetadata()`) through the recovery path. Recoverable cases now self-heal, or surface an accurate network error instead of a reinstall prompt.

**Post-failure healing** (offline launch previously bricked the session until restart)

- `recoverTokens()` now emits `TOKENS_REFRESHED` after a successful rebuild. The event had listeners (`BCSCAccountContext`, `useSystemChecks`) but **no emitter anywhere** — they were dead code.
- `BCSCIdTokenContext`: `refreshData` was a no-op when the first load failed; it's now always functional. Also listens for `TOKENS_REFRESHED` (parity with the account provider) and reloads from the freshly cached tokens.
- New `useRetryOnReconnect` hook: ID-token and account providers retry automatically when connectivity is restored, removing the dead `!apiClient.tokens` recovery hack that threw before it could ever recover.

# Testing Instructions

1. Onboard/verify so a refresh token is stored, then force-quit the app.
2. Launch, trigger the FaceID/PIN prompt, enable airplane mode, then complete unlock.
   - **Before:** "Problem with App… reinstall (error 119)" and the session stayed broken after reconnecting.
   - **After:** no false 119 — failures surface as network errors (`no_internet.2100`); on disabling airplane mode, ID-token and account data reload automatically (look for `Token cache empty; rebuilding from stored refresh token` then `Tokens refreshed, reloading…` in logs).
3. Confirm normal online launch and ID-token-backed screens (Services, system-check banners) still load.
4. Unit tests: `cd app && yarn typecheck && yarn test src/bcsc-theme`.

# Acceptance Criteria

- A missing in-memory token cache with a valid stored refresh token recovers transparently instead of throwing `TOKEN_NULL`.
- `TOKEN_NULL` / reinstall messaging only appears when no refresh token is recoverable.
- After an offline launch, the app heals on reconnect without a restart (account + ID token data reload).
- No regression to normal launch, token refresh, or authenticated requests; typecheck, lint, and tests pass.

# Screenshots, videos, or gifs

N/A — no UI changes.

# Related Issues

Closes #4014 (ERR_2502). Also removes the #4015 → #4014 knock-on (a missing token from a prior failed write no longer triggers a false 119). Low-disk messaging for #4015 (ERR_2600) and #4016 (ERR_2822) are out of scope.
