### PR TITLE
fix: handle missing video prompts in selfie video verification

### DIFF
--- a/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.test.ts
@@ -9,6 +9,7 @@ import {
   formatServiceHours,
   isLiveCallAvailable,
 } from '@/bcsc-theme/utils/service-hours-formatter'
+import { useAlerts } from '@/hooks/useAlerts'
 import { BCDispatchAction, IASEnvironment } from '@/store'
 import * as Bifold from '@bifold/core'
 import { act, renderHook } from '@testing-library/react-native'
@@ -17,6 +18,7 @@ import { BCSCCardType } from 'react-native-bcsc-core'
 jest.mock('@/bcsc-theme/api/hooks/useApi')
 jest.mock('@/bcsc-theme/utils/file-info')
 jest.mock('@/bcsc-theme/utils/service-hours-formatter')
+jest.mock('@/hooks/useAlerts')
 jest.mock('@/bcsc-theme/features/verify/send-video/VideoReviewScreen', () => ({
   VerificationVideoCache: {
     clearCache: jest.fn(),
@@ -42,6 +44,7 @@ describe('useVerificationMethodModel', () => {
   const mockNavigation = {
     navigate: jest.fn(),
   } as any
+  const mockFileUploadErrorAlert = jest.fn()
 
   const mockStore: any = {
     bcsc: {
@@ -72,6 +75,7 @@ describe('useVerificationMethodModel', () => {
 
   const mockEvidenceApi = {
     createVerificationRequest: jest.fn(),
+    getVerificationRequestPrompts: jest.fn(),
   }
 
   const mockVideoCallApi = {
@@ -91,6 +95,8 @@ describe('useVerificationMethodModel', () => {
     const bifoldMock = jest.mocked(Bifold)
     bifoldMock.useStore.mockReturnValue([mockStore, mockDispatch])
     bifoldMock.useServices.mockReturnValue([mockLogger] as any)
+
+    jest.mocked(useAlerts).mockReturnValue({ fileUploadErrorAlert: mockFileUploadErrorAlert } as any)
   })
 
   describe('Initial state', () => {
@@ -170,7 +176,7 @@ describe('useVerificationMethodModel', () => {
         resolveRequest!({
           sha256: 'test-sha256',
           id: 'test-id',
-          prompts: [],
+          prompts: [{ id: 1, prompt: 'Say your name' }],
         })
         await requestPromise
       })
@@ -198,7 +204,7 @@ describe('useVerificationMethodModel', () => {
       const mockVerificationRequest = {
         sha256: 'test-sha256',
         id: 'test-id',
-        prompts: [],
+        prompts: [{ id: 1, prompt: 'Say your name' }],
       }
 
       mockEvidenceApi.createVerificationRequest.mockResolvedValue(mockVerificationRequest)
@@ -215,6 +221,53 @@ describe('useVerificationMethodModel', () => {
       // (Promise.allSettled is used so rejections don't stop the flow)
       expect(mockDispatch).toHaveBeenCalled()
       expect(mockNavigation.navigate).toHaveBeenCalled()
+    })
+
+    it('refetches prompts when the store holds an empty prompts array and a request id exists', async () => {
+      // Regression for #4018: an empty array is truthy, so the old `!store.bcsc.prompts` guard skipped
+      // the refetch and stranded the user. `?.length` must re-trigger the fetch.
+      const storeWithEmptyPrompts = {
+        ...mockStore,
+        bcsc: { ...mockStore.bcsc, prompts: [] },
+        bcscSecure: { ...mockStore.bcscSecure, verificationRequestId: 'existing-id' },
+      }
+      jest.mocked(Bifold).useStore.mockReturnValue([storeWithEmptyPrompts, mockDispatch])
+
+      const fetched = { id: 'existing-id', sha256: 'sha', prompts: [{ id: 1, prompt: 'Say your name' }] }
+      mockEvidenceApi.getVerificationRequestPrompts.mockResolvedValue(fetched)
+      jest.mocked(removeFileSafely).mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => useVerificationMethodModel({ navigation: mockNavigation }))
+
+      await act(async () => {
+        await result.current.handlePressSendVideo()
+      })
+
+      expect(mockEvidenceApi.getVerificationRequestPrompts).toHaveBeenCalledWith('existing-id')
+      expect(mockEvidenceApi.createVerificationRequest).not.toHaveBeenCalled()
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_VIDEO_PROMPTS,
+        payload: [fetched.prompts],
+      })
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.InformationRequired)
+      expect(mockFileUploadErrorAlert).not.toHaveBeenCalled()
+    })
+
+    it('aborts with a retryable alert and no navigation when no prompts are returned', async () => {
+      // Regression for #4018: the server can return an empty prompt set; never walk the user into
+      // TakeVideoScreen (which hard-stops) — show a retryable alert and stay put instead.
+      mockEvidenceApi.createVerificationRequest.mockResolvedValue({ id: 'test-id', sha256: 'sha', prompts: [] })
+      jest.mocked(removeFileSafely).mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => useVerificationMethodModel({ navigation: mockNavigation }))
+
+      await act(async () => {
+        await result.current.handlePressSendVideo()
+      })
+
+      expect(mockFileUploadErrorAlert).toHaveBeenCalledTimes(1)
+      expect(mockNavigation.navigate).not.toHaveBeenCalled()
+      expect(result.current.sendVideoLoading).toBe(false)
     })
   })
 

--- a/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.test.ts
@@ -44,7 +44,7 @@ describe('useVerificationMethodModel', () => {
   const mockNavigation = {
     navigate: jest.fn(),
   } as any
-  const mockFileUploadErrorAlert = jest.fn()
+  const mockVideoPromptsMissingAlert = jest.fn()
 
   const mockStore: any = {
     bcsc: {
@@ -96,7 +96,7 @@ describe('useVerificationMethodModel', () => {
     bifoldMock.useStore.mockReturnValue([mockStore, mockDispatch])
     bifoldMock.useServices.mockReturnValue([mockLogger] as any)
 
-    jest.mocked(useAlerts).mockReturnValue({ fileUploadErrorAlert: mockFileUploadErrorAlert } as any)
+    jest.mocked(useAlerts).mockReturnValue({ videoPromptsMissingAlert: mockVideoPromptsMissingAlert } as any)
   })
 
   describe('Initial state', () => {
@@ -250,7 +250,7 @@ describe('useVerificationMethodModel', () => {
         payload: [fetched.prompts],
       })
       expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.InformationRequired)
-      expect(mockFileUploadErrorAlert).not.toHaveBeenCalled()
+      expect(mockVideoPromptsMissingAlert).not.toHaveBeenCalled()
     })
 
     it('aborts with a retryable alert and no navigation when no prompts are returned', async () => {
@@ -265,7 +265,7 @@ describe('useVerificationMethodModel', () => {
         await result.current.handlePressSendVideo()
       })
 
-      expect(mockFileUploadErrorAlert).toHaveBeenCalledTimes(1)
+      expect(mockVideoPromptsMissingAlert).toHaveBeenCalledTimes(1)
       expect(mockNavigation.navigate).not.toHaveBeenCalled()
       expect(result.current.sendVideoLoading).toBe(false)
     })

--- a/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.tsx
@@ -2,6 +2,7 @@ import useApi from '@/bcsc-theme/api/hooks/useApi'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { removeFileSafely } from '@/bcsc-theme/utils/file-info'
 import { formatServiceAndUnavailableHours, isLiveCallAvailable } from '@/bcsc-theme/utils/service-hours-formatter'
+import { useAlerts } from '@/hooks/useAlerts'
 import { BCDispatchAction, BCState } from '@/store'
 import { BCSCScreens, BCSCVerifyStackParams } from '@bcsc-theme/types/navigators'
 import { TOKENS, useServices, useStore } from '@bifold/core'
@@ -21,6 +22,7 @@ const useVerificationMethodModel = ({ navigation }: useVerificationMethodModelPr
   const { evidence, video: videoCallApi } = useApi()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const { updateVerificationRequest } = useSecureActions()
+  const { fileUploadErrorAlert } = useAlerts(navigation)
 
   const handlePressSendVideo = useCallback(async () => {
     try {
@@ -32,7 +34,9 @@ const useVerificationMethodModel = ({ navigation }: useVerificationMethodModelPr
         verificationRequest = await evidence.createVerificationRequest()
       }
 
-      if (store.bcscSecure.verificationRequestId && !store.bcsc.prompts) {
+      // Use `?.length` (not just `!prompts`): an empty array is truthy, so a leftover/empty `[]` would
+      // otherwise skip this refetch and strand the user with no prompts on TakeVideoScreen.
+      if (store.bcscSecure.verificationRequestId && !store.bcsc.prompts?.length) {
         // NOTE: Making this request too many times will be rate limited by the server.
         verificationRequest = await evidence.getVerificationRequestPrompts(store.bcscSecure.verificationRequestId)
       }
@@ -40,6 +44,15 @@ const useVerificationMethodModel = ({ navigation }: useVerificationMethodModelPr
       if (verificationRequest) {
         updateVerificationRequest(verificationRequest.id, verificationRequest.sha256)
         dispatch({ type: BCDispatchAction.UPDATE_VIDEO_PROMPTS, payload: [verificationRequest.prompts] })
+      }
+
+      // Never advance into the video flow without prompts. The server can return an empty prompt set,
+      // and TakeVideoScreen hard-stops when prompts are missing — surface a retryable alert here instead.
+      const resolvedPrompts = verificationRequest?.prompts ?? store.bcsc.prompts
+      if (!resolvedPrompts?.length) {
+        logger.error('[useVerificationMethodModel] No verification prompts available; aborting Send Video')
+        fileUploadErrorAlert()
+        return
       }
 
       await Promise.allSettled([
@@ -70,6 +83,7 @@ const useVerificationMethodModel = ({ navigation }: useVerificationMethodModelPr
     navigation,
     evidence,
     updateVerificationRequest,
+    fileUploadErrorAlert,
   ])
 
   const handlePressLiveCall = useCallback(async () => {

--- a/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.tsx
@@ -22,7 +22,7 @@ const useVerificationMethodModel = ({ navigation }: useVerificationMethodModelPr
   const { evidence, video: videoCallApi } = useApi()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const { updateVerificationRequest } = useSecureActions()
-  const { fileUploadErrorAlert } = useAlerts(navigation)
+  const { videoPromptsMissingAlert } = useAlerts(navigation)
 
   const handlePressSendVideo = useCallback(async () => {
     try {
@@ -51,7 +51,7 @@ const useVerificationMethodModel = ({ navigation }: useVerificationMethodModelPr
       const resolvedPrompts = verificationRequest?.prompts ?? store.bcsc.prompts
       if (!resolvedPrompts?.length) {
         logger.error('[useVerificationMethodModel] No verification prompts available; aborting Send Video')
-        fileUploadErrorAlert()
+        videoPromptsMissingAlert()
         return
       }
 
@@ -83,7 +83,7 @@ const useVerificationMethodModel = ({ navigation }: useVerificationMethodModelPr
     navigation,
     evidence,
     updateVerificationRequest,
-    fileUploadErrorAlert,
+    videoPromptsMissingAlert,
   ])
 
   const handlePressLiveCall = useCallback(async () => {

--- a/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.test.tsx
@@ -1,4 +1,5 @@
 import { BCSCLoadingProvider } from '@/bcsc-theme/contexts/BCSCLoadingContext'
+import { AppError } from '@/errors'
 import { BasicAppContext } from '@mocks/helpers/app'
 import { useNavigation } from '@react-navigation/native'
 import { render, waitFor } from '@testing-library/react-native'
@@ -81,5 +82,25 @@ describe('TakeVideoScreen', () => {
     await waitFor(() => {
       expect(getByText('BCSC.PermissionDisabled.CameraAndMicrophoneTitle')).toBeTruthy()
     })
+  })
+
+  test('throws a coded AppError (2412) when prompts are missing', () => {
+    // Regression for #4018: the backstop should report a specific code (2412) via the ErrorBoundary
+    // instead of the catch-all 9999.
+    const navigation = useNavigation()
+    let caught: unknown
+
+    try {
+      render(
+        <BasicAppContext initialStateOverride={{ bcsc: { prompts: [] } } as any}>
+          <TakeVideoScreen navigation={navigation as never} />
+        </BasicAppContext>
+      )
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toBeInstanceOf(AppError)
+    expect((caught as AppError).statusCode).toBe(2412)
   })
 })

--- a/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.tsx
@@ -1,6 +1,7 @@
 import { PermissionDisabled } from '@/bcsc-theme/components/PermissionDisabled'
 import { LoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
+import { toAppError } from '@/bcsc-theme/utils/native-error-map'
 import {
   hitSlop,
   MAX_SELFIE_VIDEO_DURATION_SECONDS,
@@ -8,6 +9,7 @@ import {
   SELFIE_VIDEO_FRAME_RATE,
   VIDEO_RESOLUTION_480P,
 } from '@/constants'
+import { ErrorRegistry } from '@/errors/errorRegistry'
 import { useAlerts } from '@/hooks/useAlerts'
 import { useAutoRequestPermission } from '@/hooks/useAutoRequestPermission'
 import { BCState } from '@/store'
@@ -73,8 +75,10 @@ const TakeVideoScreen = ({ navigation }: TakeVideoScreenProps) => {
   }, [prompts, prompt])
 
   if (!prompts.length) {
-    // Developer error - prompts must be persisted before reaching this screen.
-    throw new Error('[TakeVideoScreen] No prompts found in store')
+    // Defensive backstop — upstream guards in useVerificationMethodModel should prevent reaching this
+    // screen without prompts. Throw a coded AppError so the ErrorBoundary reports 2412 instead of the
+    // catch-all 9999, giving this condition a specific signal in analytics/Loki.
+    throw toAppError(new Error('[TakeVideoScreen] No prompts found in store'), ErrorRegistry.VIDEO_PROMPTS_MISSING)
   }
 
   const styles = useMemo(

--- a/app/src/errors/errorRegistry.ts
+++ b/app/src/errors/errorRegistry.ts
@@ -394,6 +394,13 @@ export const ErrorRegistry = {
     category: ErrorCategory.VERIFICATION,
     message: 'Verification request is still pending — agent has yet to verify request',
   },
+  VIDEO_PROMPTS_MISSING: {
+    statusCode: 2412,
+    appEvent: AppEventCode.VIDEO_PROMPTS_MISSING,
+    severity: ErrorSeverity.WARNING,
+    category: ErrorCategory.VERIFICATION,
+    message: 'Video prompts were missing or empty when entering the capture screen',
+  },
 
   // ============================================
   // Token/Crypto Errors (2500-2599)

--- a/app/src/events/appEventCode.ts
+++ b/app/src/events/appEventCode.ts
@@ -135,6 +135,7 @@ export enum AppEventCode {
   FILE_UPLOAD_ERROR = 'file_upload_error',
   NO_DOCUMENT_NUMBER_ENTERED_ERROR = 'no_document_number_entered_error',
   VIDEO_VERIFY_NOT_COMPLETE = 'video_verify_not_complete',
+  VIDEO_PROMPTS_MISSING = 'video_prompts_missing',
   REMOVE_UNVERIFIED_CARD = 'remove_unverified_card',
   REMOVE_VERIFIED_CARD = 'remove_verified_card',
   ALREADY_VERIFIED = 'already_verified',

--- a/app/src/hooks/useAlerts.test.tsx
+++ b/app/src/hooks/useAlerts.test.tsx
@@ -231,6 +231,27 @@ describe('useAlerts', () => {
     })
   })
 
+  describe('videoPromptsMissingAlert', () => {
+    it('should show an error modal with the correct title and message', () => {
+      const mockNavigation = { navigate: jest.fn() }
+      const mockEmitAlert = jest.fn()
+      const mockEmitErrorModal = jest.fn()
+      jest
+        .spyOn(ErrorAlertContext, 'useErrorAlert')
+        .mockReturnValue({ emitAlert: mockEmitAlert, emitErrorModal: mockEmitErrorModal } as any)
+
+      const { result } = renderHook(() => useAlerts(mockNavigation as any))
+
+      result.current.videoPromptsMissingAlert()
+
+      expect(mockEmitErrorModal).toHaveBeenCalledWith(
+        'Alerts.VideoPromptsMissing.Title',
+        'Alerts.VideoPromptsMissing.Description',
+        expect.objectContaining({ appEvent: AppEventCode.VIDEO_PROMPTS_MISSING })
+      )
+    })
+  })
+
   describe('loginSameDeviceInvalidPairingCodeAlert', () => {
     it('should show an error modal with the correct title and message', () => {
       const mockNavigation = { navigate: jest.fn() }

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -305,6 +305,7 @@ export const useAlerts = (navigation: NavigationProp<any>) => {
       invalidPairingCodeAlert: _createBasicErrorModal(AppEventCode.INVALID_PAIRING_CODE, 'InvalidPairingCode'),
       alreadyVerifiedAlert: _createBasicErrorModal(AppEventCode.ALREADY_VERIFIED, 'AlreadyVerified'),
       fileUploadErrorAlert: _createBasicErrorModal(AppEventCode.FILE_UPLOAD_ERROR, 'FileUploadError'),
+      videoPromptsMissingAlert: _createBasicErrorModal(AppEventCode.VIDEO_PROMPTS_MISSING, 'VideoPromptsMissing'),
       loginSameDeviceInvalidPairingCodeAlert: _createBasicErrorModal(AppEventCode.LOGIN_SAME_DEVICE_INVALID_PAIRING_CODE, 'InvalidPairingCodeSameDevice'),
       failedToWriteToLocalStorageAlert: _createBasicErrorModal(AppEventCode.ERR_100_FAILED_TO_WRITE_LOCAL_STORAGE, 'ProblemWithApp', { errorCode: '100' }),
       failedToReadFromLocalStorageAlert: _createBasicErrorModal(AppEventCode.ERR_101_FAILED_TO_READ_LOCAL_STORAGE, 'ProblemWithApp', { errorCode: '101' }),

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -1239,6 +1239,10 @@ const translation = {
       "Title": "Problem with Connection",
       "Description": "Please try again."
     },
+    "VideoPromptsMissing": {
+      "Title": "Problem Starting Video",
+      "Description": "We couldn't load your verification steps. Please try again."
+    },
     "FactoryReset": {
       "Title": "Problem with App",
       "Description": "The app needs to be reset to factory settings to continue. This will delete all information in the app and you will have to set it up again.",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -1231,6 +1231,10 @@ const translation = {
       "Title": "Problem with Connection (FR)",
       "Description": "Please try again. (FR)"
     },
+    "VideoPromptsMissing": {
+      "Title": "Problem Starting Video (FR)",
+      "Description": "We couldn't load your verification steps. Please try again. (FR)"
+    },
     "FactoryReset": {
       "Title": "Problem with App (FR)",
       "Description": "The app needs to be reset to factory settings to continue. This will delete all information in the app and you will have to set it up again. (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -1231,6 +1231,10 @@ const translation = {
       "Title": "Problem with Connection (PT-BR)",
       "Description": "Please try again. (PT-BR)"
     },
+    "VideoPromptsMissing": {
+      "Title": "Problem Starting Video (PT-BR)",
+      "Description": "We couldn't load your verification steps. Please try again. (PT-BR)"
+    },
     "FactoryReset": {
       "Title": "Problem with App (PT-BR)",
       "Description": "The app needs to be reset to factory settings to continue. This will delete all information in the app and you will have to set it up again. (PT-BR)",


### PR DESCRIPTION
A problem report came in via Loki: the **Send Video** identity verification reached `TakeVideoScreen` with no prompts in the store and showed the generic "Something went wrong" screen (error **9999**).

Fixes #4018

## Root cause
`TakeVideoScreen` stops hard when `store.bcsc.prompts` is empty. Two gaps let that happen:

- The refetch check used `!store.bcsc.prompts`, but an empty array `[]` is truthy — so an empty/leftover prompt set **skipped the refetch**.
- Nothing checked for empty prompts on the way into the screen. Guards agains the server sending an empty prompt array because of a server side issue.

## Fix (small + layered)
1. **Refetch on empty** — `!store.bcsc.prompts` → `!store.bcsc.prompts?.length`, so an empty set re-fetches.
2. **Don't advance without prompts** — if none come back, show a retryable alert and stay put instead of sending the user into the dead-end screen.
3. **Specific code as a backstop** — if the screen is ever reached without prompts, throw a coded `AppError` (**2412**) so it reports as a specific code instead of the catch-all 9999.

Prompts remain un-persisted (no change); the refetch covers app restarts.

## Testing
- `yarn typecheck` ✅, eslint on changed files ✅
- Affected jest suites ✅ — 17 tests, existing snapshot unchanged
- Added tests: empty array → refetch; empty server response → alert + no navigation; missing prompts → coded 2412

## Files
- `events/appEventCode.ts`, `errors/errorRegistry.ts` — new `VIDEO_PROMPTS_MISSING` (2412)
- `verify/_models/useVerificationMethodModel.tsx` — refetch + empty guard
- `verify/send-video/TakeVideoScreen.tsx` — coded backstop
- tests for both

## Manual Testing
The empty-prompts condition is server-driven, so to trigger it on demand drop in a temporary `__DEV__`-guarded flag (intentionally **not** committed — paste it in locally, revert when done).

In `app/src/bcsc-theme/api/hooks/useEvidenceApi.tsx`:

**1.** Add the flag after the imports:
```ts
// TEMPORARY — simulate the server returning an empty prompt set (#4018). Revert before committing.
const DEBUG_FORCE_EMPTY_PROMPTS = __DEV__ && true
```

**2.** Force empty prompts on both fetch paths — in `createVerificationRequest` and `getVerificationRequestPrompts`, swap `return data` for:
```ts
return DEBUG_FORCE_EMPTY_PROMPTS ? { ...data, prompts: [] } : data
```

Then run **Send Video** from the verification method screen:

| Build | Expected |
| --- | --- |
| this branch | "Problem Starting Video" alert, stays on the method-selection screen, no 9999 |
| `main` (pre-fix) | walks forward → "Something went wrong" / **9999** → Report → Loki |

`__DEV__ &&` keeps it a no-op in release builds even if left enabled. When finished: `git restore app/src/bcsc-theme/api/hooks/useEvidenceApi.tsx`.
