### PR TITLE
fix: flipped selfie camera

### DIFF
--- a/.yarn/patches/react-native-vision-camera-npm-4.7.3-dc361fe55c.patch
+++ b/.yarn/patches/react-native-vision-camera-npm-4.7.3-dc361fe55c.patch
@@ -110,3 +110,27 @@ index 23d78d1350242c1d2497b732fd77b291b9e06c3a..6c75b2802cf490bf2310fa69b1615160
            }
          }
          .addOnFailureListener { error ->
+diff --git a/ios/Core/CameraSession+Video.swift b/ios/Core/CameraSession+Video.swift
+index 8e57710f2444ac76f1f790ef98db1b6e2987a3e7..95fa82270d42eef48488e9afda7a7be3877a7eff 100644
+--- a/ios/Core/CameraSession+Video.swift
++++ b/ios/Core/CameraSession+Video.swift
+@@ -89,7 +89,18 @@ extension CameraSession {
+ 
+       do {
+         // Orientation is relative to our current output orientation
+-        let orientation = self.outputOrientation.relativeTo(orientation: videoOutput.orientation)
++        var orientation = self.outputOrientation.relativeTo(orientation: videoOutput.orientation)
++
++        // PATCH: VisionCamera only applies its compensating 180° orientation flip for the
++        // front camera when mirroring is ON (CameraSession+Orientation.swift). With mirroring
++        // OFF, the AVAssetWriter track transform lands 180° off and the file records upside
++        // down (confirmed in QuickTime; takePhoto/EXIF and outputOrientation are unaffected).
++        // Gated on the exact broken case — front camera AND un-mirrored — so the default
++        // mirrored path and the back camera are untouched. Remove if VisionCamera fixes its
++        // mirror-gated orientation handling.
++        if self.videoDeviceInput?.device.position == .front && !videoOutput.isMirrored {
++          orientation = orientation.flipped()
++        }
+ 
+         // Create RecordingSession for the temp file
+         let recordingSession = try RecordingSession(url: options.path,

--- a/app/src/bcsc-theme/components/MaskedCamera.tsx
+++ b/app/src/bcsc-theme/components/MaskedCamera.tsx
@@ -130,14 +130,9 @@ const MaskedCamera = ({
   const takePhoto = async () => {
     try {
       if (cameraRef.current && isActive) {
-        // Use takeSnapshot (captures from the video feed at video resolution)
-        // instead of takePhoto (full sensor resolution, e.g. 12MP).
-        // Xcode 26 / iOS 26 SDK changed the default photo encoding to HEIF,
-        // which takes 5-10s to decode at 12MP in RN's Image component.
-        // Snapshot at quality 90 produces a ~1080p JPEG that decodes instantly
-        // and is still well above the resolution needed for backend barcode processing.
-        const photo = await cameraRef.current.takeSnapshot({
-          quality: 90,
+        const photo = await cameraRef.current.takePhoto({
+          flash: 'off',
+          enableShutterSound: false,
         })
 
         onPhotoTaken(photo.path)
@@ -166,6 +161,8 @@ const MaskedCamera = ({
         isActive={isFocused && isActive}
         photo={true}
         video={true}
+        photoQualityBalance="speed"
+        isMirrored={false}
         onInitialized={() => setIsActive(true)}
         onError={onError}
         codeScanner={codeScanner}

--- a/app/src/bcsc-theme/features/verify/__snapshots__/TakePhotoScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/__snapshots__/TakePhotoScreen.test.tsx.snap
@@ -42,9 +42,11 @@ exports[`TakePhoto renders correctly 1`] = `
         }
       }
       isActive={false}
+      isMirrored={false}
       onError={[Function]}
       onInitialized={[Function]}
       photo={true}
+      photoQualityBalance="speed"
       ref={
         {
           "current": null,

--- a/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.tsx
@@ -197,7 +197,7 @@ const TakeVideoScreen = ({ navigation }: TakeVideoScreenProps) => {
       return
     }
 
-    const snapshot = await cameraRef.current.takeSnapshot()
+    const snapshot = await cameraRef.current.takePhoto({ flash: 'off', enableShutterSound: false })
 
     cameraRef.current.startRecording({
       fileType: 'mp4',
@@ -326,9 +326,12 @@ const TakeVideoScreen = ({ navigation }: TakeVideoScreenProps) => {
           device={device}
           format={format}
           isActive={isActive}
-          video={true}
+          video
+          photo
+          photoQualityBalance="speed"
           onInitialized={onInitialized}
           onError={onError}
+          isMirrored={false}
           audio
         />
 

--- a/app/src/bcsc-theme/features/verify/send-video/__snapshots__/TakeVideoScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/send-video/__snapshots__/TakeVideoScreen.test.tsx.snap
@@ -42,8 +42,11 @@ exports[`TakeVideoScreen renders correctly 1`] = `
         }
       }
       isActive={false}
+      isMirrored={false}
       onError={[Function]}
       onInitialized={[Function]}
+      photo={true}
+      photoQualityBalance="speed"
       ref={
         {
           "current": null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -17285,7 +17285,7 @@ __metadata:
 
 "react-native-vision-camera@patch:react-native-vision-camera@npm%3A4.7.3#~/.yarn/patches/react-native-vision-camera-npm-4.7.3-dc361fe55c.patch":
   version: 4.7.3
-  resolution: "react-native-vision-camera@patch:react-native-vision-camera@npm%3A4.7.3#~/.yarn/patches/react-native-vision-camera-npm-4.7.3-dc361fe55c.patch::version=4.7.3&hash=458fb0"
+  resolution: "react-native-vision-camera@patch:react-native-vision-camera@npm%3A4.7.3#~/.yarn/patches/react-native-vision-camera-npm-4.7.3-dc361fe55c.patch::version=4.7.3&hash=9cec31"
   peerDependencies:
     "@shopify/react-native-skia": "*"
     react: "*"
@@ -17299,7 +17299,7 @@ __metadata:
       optional: true
     react-native-worklets-core:
       optional: true
-  checksum: 10c0/bc4f4aee8d1b7a8feec94e549fd22417598f742d153d5bf713f2a2efc27b4de9e573fd474eba7bb42d3f17cfed17973f1d236707f91eb40a236394f642e29188
+  checksum: 10c0/76cd9bf254051198448f4dd9cad4bcd833479736f07e2cb758741f7f4bbccfe42e3d9f67e1b24fe740adfa3ad87fcb256c13e4e3a791150f44731b728e426225
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary of Changes

This PR fixes the "mirrored" effect on selfie video and selfie photo.

# Testing Instructions

Test camera flows on both platforms.

# Acceptance Criteria

Output no longer flipped

# Screenshots, videos, or gifs

N/A

# Related Issues

#4020 