### PR TITLE
fix: disk space error

### DIFF
--- a/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.test.tsx
@@ -13,6 +13,7 @@ jest.mock('react-native-vision-camera', () => ({
   useMicrophonePermission: jest.fn().mockReturnValue({ hasPermission: true, requestPermission: jest.fn() }),
   useCameraFormat: jest.fn().mockReturnValue({ videoWidth: 640, videoHeight: 480, fps: 24 }),
   CameraRuntimeError: class extends Error {},
+  CameraCaptureError: class extends Error {},
 }))
 
 const storeWithPrompts = {

--- a/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.tsx
@@ -21,7 +21,9 @@ import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 import {
   Camera,
+  CameraCaptureError,
   CameraRuntimeError,
+  PhotoFile,
   useCameraDevice,
   useCameraFormat,
   useCameraPermission,
@@ -194,7 +196,29 @@ const TakeVideoScreen = ({ navigation }: TakeVideoScreenProps) => {
       return
     }
 
-    const snapshot = await cameraRef.current.takeSnapshot()
+    let snapshot: PhotoFile
+    try {
+      snapshot = await cameraRef.current.takeSnapshot()
+    } catch (error) {
+      // Without this catch a failure here (e.g. device out of disk space) is an unhandled
+      // rejection that leaves the screen stuck on the countdown with no controls.
+      stopTimer()
+      setRecordingInProgress(false)
+      logger.error(`Error capturing video thumbnail snapshot: ${error}`)
+
+      if (error instanceof CameraCaptureError && error.code === 'capture/file-io-error') {
+        failedToWriteToLocalStorageAlert(error)
+      } else {
+        Alert.alert(
+          t('BCSC.SendVideo.TakeVideo.RecordingError'),
+          t('BCSC.SendVideo.TakeVideo.RecordingErrorDescription')
+        )
+      }
+
+      // Back to the previous screen so the user can retry once the issue is resolved
+      navigation.goBack()
+      return
+    }
 
     cameraRef.current.startRecording({
       fileType: 'mp4',

--- a/app/src/errors/errorHandler.test.ts
+++ b/app/src/errors/errorHandler.test.ts
@@ -80,7 +80,9 @@ describe('errorHandler', () => {
     })
 
     it('should detect the Android/POSIX ENOSPC message', () => {
-      const error = new Error('An unexpected File IO error occurred! Error: write failed: ENOSPC (No space left on device).')
+      const error = new Error(
+        'An unexpected File IO error occurred! Error: write failed: ENOSPC (No space left on device).'
+      )
       expect(isDeviceStorageFullError(error)).toBe(true)
     })
 

--- a/app/src/errors/errorHandler.test.ts
+++ b/app/src/errors/errorHandler.test.ts
@@ -6,6 +6,7 @@ import {
   extractErrorMessage,
   getErrorDefinition,
   getErrorDefinitionFromAppEventCode,
+  isDeviceStorageFullError,
   toBifoldError,
 } from './errorHandler'
 import { ErrorCategory, ErrorRegistry, ErrorSeverity } from './errorRegistry'
@@ -67,6 +68,59 @@ describe('errorHandler', () => {
       const circular: Record<string, unknown> = { name: 'test' }
       circular.self = circular
       expect(extractErrorMessage(circular)).toBe('[Non-serializable object]')
+    })
+  })
+
+  describe('isDeviceStorageFullError', () => {
+    it('should detect the iOS NSFileWriteOutOfSpaceError message from vision-camera (ERR_2600 report)', () => {
+      const error = new Error(
+        'An unexpected File IO error occurred! Error: You can\'t save the file "ABC123.jpg" because the volume "User" is out of space.'
+      )
+      expect(isDeviceStorageFullError(error)).toBe(true)
+    })
+
+    it('should detect the Android/POSIX ENOSPC message', () => {
+      const error = new Error('An unexpected File IO error occurred! Error: write failed: ENOSPC (No space left on device).')
+      expect(isDeviceStorageFullError(error)).toBe(true)
+    })
+
+    it('should detect an ENOSPC error code even with an unrelated message', () => {
+      const error = new Error('write failed') as Error & { code: string }
+      error.code = 'ENOSPC'
+      expect(isDeviceStorageFullError(error)).toBe(true)
+    })
+
+    it('should detect a SQLite disk-full message', () => {
+      expect(isDeviceStorageFullError(new Error('database or disk is full (code 13 SQLITE_FULL)'))).toBe(true)
+    })
+
+    it('should detect a disk-full cause nested inside an AppError', () => {
+      const cause = new Error('You can\'t save the file "x.jpg" because the volume "User" is out of space.')
+      const appError = AppError.fromErrorDefinition(ErrorRegistry.STORAGE_WRITE_ERROR, { cause, track: false })
+      expect(isDeviceStorageFullError(appError)).toBe(true)
+    })
+
+    it('should detect a plain string error', () => {
+      expect(isDeviceStorageFullError('No space left on device')).toBe(true)
+    })
+
+    it('should return false for a generic write failure', () => {
+      const appError = AppError.fromErrorDefinition(ErrorRegistry.STORAGE_WRITE_ERROR, {
+        cause: new Error('keychain unavailable'),
+        track: false,
+      })
+      expect(isDeviceStorageFullError(appError)).toBe(false)
+    })
+
+    it('should return false for null and undefined', () => {
+      expect(isDeviceStorageFullError(null)).toBe(false)
+      expect(isDeviceStorageFullError(undefined)).toBe(false)
+    })
+
+    it('should not hang on a circular cause chain', () => {
+      const error = new Error('generic failure')
+      error.cause = error
+      expect(isDeviceStorageFullError(error)).toBe(false)
     })
   })
 

--- a/app/src/errors/errorHandler.ts
+++ b/app/src/errors/errorHandler.ts
@@ -34,6 +34,51 @@ export function extractErrorMessage(error: unknown): string {
 }
 
 /**
+ * Signatures emitted by the OS when a write fails because the disk is full.
+ *
+ * - iOS (NSFileWriteOutOfSpaceError): `You can't save the file "x.jpg" because the volume "User" is out of space.`
+ * - POSIX/Android (ENOSPC): `write failed: ENOSPC (No space left on device)`
+ * - SQLite (SQLITE_FULL): `database or disk is full`
+ */
+const OUT_OF_STORAGE_PATTERNS: RegExp[] = [
+  /out of space/i,
+  /no space left on device/i,
+  /\bENOSPC\b/,
+  /\bSQLITE_FULL\b/i,
+  /database or disk is full/i,
+  /not enough (?:free |disk |storage )?space/i,
+]
+
+/**
+ * Detect whether an error (or anything in its cause chain) was ultimately caused by
+ * the device running out of disk space, so callers can show actionable "free up space"
+ * guidance instead of a generic storage failure message.
+ *
+ * @param error - The error to inspect, including its nested `cause` chain
+ * @returns True if any error in the chain matches a known out-of-disk-space signature
+ */
+export function isDeviceStorageFullError(error: unknown): boolean {
+  let current: unknown = error
+
+  // Bounded walk of the cause chain to guard against cycles
+  for (let depth = 0; current != null && depth < 10; depth++) {
+    const code = (current as { code?: unknown }).code
+    if (typeof code === 'string' && code.toUpperCase() === 'ENOSPC') {
+      return true
+    }
+
+    const message = extractErrorMessage(current)
+    if (OUT_OF_STORAGE_PATTERNS.some((pattern) => pattern.test(message))) {
+      return true
+    }
+
+    current = (current as { cause?: unknown }).cause
+  }
+
+  return false
+}
+
+/**
  * Get error definition by key (useful for custom error handling)
  *
  * @param errorKey - The key of the error definition to retrieve from the ErrorRegistry.

--- a/app/src/errors/errorRegistry.ts
+++ b/app/src/errors/errorRegistry.ts
@@ -570,6 +570,13 @@ export const ErrorRegistry = {
     category: ErrorCategory.STORAGE,
     message: 'Object toJSONString() serialization threw an exception',
   },
+  DEVICE_STORAGE_FULL: {
+    statusCode: 2609,
+    appEvent: AppEventCode.DEVICE_STORAGE_FULL,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.STORAGE,
+    message: 'Storage write failed because the device is out of disk space',
+  },
 
   // ============================================
   // Device Errors (2700-2799)

--- a/app/src/events/appEventCode.ts
+++ b/app/src/events/appEventCode.ts
@@ -66,6 +66,7 @@ export enum AppEventCode {
   VERIFY_NOT_COMPLETE = 'verify_not_complete',
   VERIFY_COMPLETE_FEEDBACK = 'verify_complete_feedback',
   ERR_100_FAILED_TO_WRITE_LOCAL_STORAGE = 'err_100_failed_to_write_local_storage',
+  DEVICE_STORAGE_FULL = 'device_storage_full', // Non-IAS error code
   ERR_101_FAILED_TO_READ_LOCAL_STORAGE = 'err_101_failed_to_read_local_storage',
   ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL = 'err_102_client_registration_unexpectedly_null',
   // ERR_103_AUTHORIZATION_REQUEST_UNEXPECTEDLY_NULL deprecated in V4

--- a/app/src/hooks/useAlerts.test.tsx
+++ b/app/src/hooks/useAlerts.test.tsx
@@ -810,6 +810,67 @@ describe('useAlerts', () => {
         expect.objectContaining({ appEvent: AppEventCode.ERR_100_FAILED_TO_WRITE_LOCAL_STORAGE })
       )
     })
+
+    it('should keep the generic copy for a write failure unrelated to disk space', () => {
+      const mockNavigation = { navigate: jest.fn() }
+      const mockEmitErrorModal = jest.fn()
+      jest
+        .spyOn(ErrorAlertContext, 'useErrorAlert')
+        .mockReturnValue({ emitAlert: jest.fn(), emitErrorModal: mockEmitErrorModal } as any)
+
+      const { result } = renderHook(() => useAlerts(mockNavigation as any))
+
+      result.current.failedToWriteToLocalStorageAlert(new Error('keychain unavailable'))
+
+      expect(mockEmitErrorModal).toHaveBeenCalledWith(
+        'Alerts.ProblemWithApp.Title',
+        'Alerts.ProblemWithApp.Description',
+        expect.objectContaining({ appEvent: AppEventCode.ERR_100_FAILED_TO_WRITE_LOCAL_STORAGE })
+      )
+    })
+
+    it('should show actionable storage-full copy when the device is out of disk space (iOS)', () => {
+      const mockNavigation = { navigate: jest.fn() }
+      const mockEmitErrorModal = jest.fn()
+      jest
+        .spyOn(ErrorAlertContext, 'useErrorAlert')
+        .mockReturnValue({ emitAlert: jest.fn(), emitErrorModal: mockEmitErrorModal } as any)
+
+      const { result } = renderHook(() => useAlerts(mockNavigation as any))
+
+      // Message shape thrown by react-native-vision-camera on iOS when the volume is full
+      result.current.failedToWriteToLocalStorageAlert(
+        new Error(
+          'An unexpected File IO error occurred! Error: You can\'t save the file "photo.jpg" because the volume "User" is out of space.'
+        )
+      )
+
+      expect(mockEmitErrorModal).toHaveBeenCalledWith(
+        'Alerts.DeviceStorageFull.Title',
+        'Alerts.DeviceStorageFull.Description',
+        expect.objectContaining({ appEvent: AppEventCode.DEVICE_STORAGE_FULL })
+      )
+    })
+
+    it('should show actionable storage-full copy when the device is out of disk space (Android ENOSPC)', () => {
+      const mockNavigation = { navigate: jest.fn() }
+      const mockEmitErrorModal = jest.fn()
+      jest
+        .spyOn(ErrorAlertContext, 'useErrorAlert')
+        .mockReturnValue({ emitAlert: jest.fn(), emitErrorModal: mockEmitErrorModal } as any)
+
+      const { result } = renderHook(() => useAlerts(mockNavigation as any))
+
+      result.current.failedToWriteToLocalStorageAlert(
+        new Error('An unexpected File IO error occurred! Error: write failed: ENOSPC (No space left on device).')
+      )
+
+      expect(mockEmitErrorModal).toHaveBeenCalledWith(
+        'Alerts.DeviceStorageFull.Title',
+        'Alerts.DeviceStorageFull.Description',
+        expect.objectContaining({ appEvent: AppEventCode.DEVICE_STORAGE_FULL })
+      )
+    })
   })
 
   describe('failedToSerializeJsonAlert', () => {

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -118,7 +118,7 @@ export const useAlerts = (navigation: NavigationProp<any>) => {
    * up space will fix it. Detect that case and show actionable copy instead.
    */
   const failedToWriteToLocalStorageAlert = useCallback(
-    (error?: AppError | unknown) => {
+    (error?: unknown) => {
       if (isDeviceStorageFullError(error)) {
         // Re-wrap as DEVICE_STORAGE_FULL (preserving the original as cause) so analytics and
         // problem reports can distinguish disk-full failures from other storage write errors.

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -3,7 +3,8 @@ import { useBCSCStack } from '@/bcsc-theme/contexts/BCSCStackContext'
 import { BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
 import { useErrorAlert } from '@/contexts/ErrorAlertContext'
 import { AppError } from '@/errors'
-import { ensureAppError } from '@/errors/errorHandler'
+import { isAppError } from '@/errors/appError'
+import { ensureAppError, getRegistryAppError, isDeviceStorageFullError } from '@/errors/errorHandler'
 import { AppEventCode } from '@/events/appEventCode'
 import { getBCSCAppStoreUrl } from '@/utils/links'
 import { TOKENS, useServices } from '@bifold/core'
@@ -108,6 +109,34 @@ export const useAlerts = (navigation: NavigationProp<any>) => {
       }
     },
     [emitErrorModal, logger, navigation, stack, t]
+  )
+
+  /**
+   * ERR_100 (storage write failure) normally shows the generic "Problem with App" copy, but
+   * when the underlying cause is the device being out of disk space (e.g. the camera failing
+   * to save an evidence photo or video), reinstalling/retrying can't succeed — only freeing
+   * up space will fix it. Detect that case and show actionable copy instead.
+   */
+  const failedToWriteToLocalStorageAlert = useCallback(
+    (error?: AppError | unknown) => {
+      if (isDeviceStorageFullError(error)) {
+        // Re-wrap as DEVICE_STORAGE_FULL (preserving the original as cause) so analytics and
+        // problem reports can distinguish disk-full failures from other storage write errors.
+        const appError = isAppError(error, AppEventCode.DEVICE_STORAGE_FULL)
+          ? error
+          : getRegistryAppError(AppEventCode.DEVICE_STORAGE_FULL, error)
+
+        emitErrorModal(t('Alerts.DeviceStorageFull.Title'), t('Alerts.DeviceStorageFull.Description'), appError)
+        return
+      }
+
+      emitErrorModal(
+        t('Alerts.ProblemWithApp.Title', { errorCode: '100' }),
+        t('Alerts.ProblemWithApp.Description', { errorCode: '100' }),
+        ensureAppError(error, AppEventCode.ERR_100_FAILED_TO_WRITE_LOCAL_STORAGE)
+      )
+    },
+    [emitErrorModal, t]
   )
 
   const unknownErrorModal = useCallback(
@@ -306,7 +335,7 @@ export const useAlerts = (navigation: NavigationProp<any>) => {
       alreadyVerifiedAlert: _createBasicErrorModal(AppEventCode.ALREADY_VERIFIED, 'AlreadyVerified'),
       fileUploadErrorAlert: _createBasicErrorModal(AppEventCode.FILE_UPLOAD_ERROR, 'FileUploadError'),
       loginSameDeviceInvalidPairingCodeAlert: _createBasicErrorModal(AppEventCode.LOGIN_SAME_DEVICE_INVALID_PAIRING_CODE, 'InvalidPairingCodeSameDevice'),
-      failedToWriteToLocalStorageAlert: _createBasicErrorModal(AppEventCode.ERR_100_FAILED_TO_WRITE_LOCAL_STORAGE, 'ProblemWithApp', { errorCode: '100' }),
+      failedToWriteToLocalStorageAlert,
       failedToReadFromLocalStorageAlert: _createBasicErrorModal(AppEventCode.ERR_101_FAILED_TO_READ_LOCAL_STORAGE, 'ProblemWithApp', { errorCode: '101' }),
       clientRegistrationNullAlert: _createBasicErrorModal(AppEventCode.ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL, 'ProblemWithApp', { errorCode: '102' }),
       unableToDecryptIdTokenAlert: _createBasicErrorModal(AppEventCode.ERR_105_UNABLE_TO_DECRYPT_AND_VERIFY_ID_TOKEN, 'ProblemWithApp', { errorCode: '105' }),
@@ -362,6 +391,7 @@ export const useAlerts = (navigation: NavigationProp<any>) => {
       _createBasicAlert,
       unknownErrorModal,
       factoryResetErrorModal,
+      failedToWriteToLocalStorageAlert,
       _createBasicErrorModal,
       _createProblemWithAccountErrorModal,
     ]

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -1278,6 +1278,10 @@ const translation = {
       "Title": "Problem with App",
       "Description": "The app does not appear to be installed correctly. Please remove the app from your device and add it again. (error {{ errorCode }})"
     },
+    "DeviceStorageFull": {
+      "Title": "Not Enough Storage",
+      "Description": "Your device is out of storage space, so the app can't save your information. Free up space on your device, then try again."
+    },
     "ProblemWithService": {
       "Title": "Problem with Service",
       "Description": "Please try again later. (error {{ errorCode }})"

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -1283,6 +1283,10 @@ const translation = {
       "Title": "Problem with App (FR)",
       "Description": "The app does not appear to be installed correctly. Please remove the app from your device and add it again. (error {{ errorCode }}) (FR)"
     },
+    "DeviceStorageFull": {
+      "Title": "Not Enough Storage (FR)",
+      "Description": "Your device is out of storage space, so the app can't save your information. Free up space on your device, then try again. (FR)"
+    },
     "ProblemWithService": {
       "Title": "Problem with Service (FR)",
       "Description": "Please try again later. (error {{ errorCode }}) (FR)"

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -1283,6 +1283,10 @@ const translation = {
       "Title": "Problem with App (PT-BR)",
       "Description": "The app does not appear to be installed correctly. Please remove the app from your device and add it again. (error {{ errorCode }}) (PT-BR)"
     },
+    "DeviceStorageFull": {
+      "Title": "Not Enough Storage (PT-BR)",
+      "Description": "Your device is out of storage space, so the app can't save your information. Free up space on your device, then try again. (PT-BR)"
+    },
     "ProblemWithService": {
       "Title": "Problem with Service (PT-BR)",
       "Description": "Please try again later. (error {{ errorCode }}) (PT-BR)"

--- a/app/src/screens/ErrorAlertTest.tsx
+++ b/app/src/screens/ErrorAlertTest.tsx
@@ -217,6 +217,33 @@ const ErrorAlertTest: React.FC<ErrorAlertTestProps> = ({ onBack }) => {
     econnaborted: () => injectErrorCodeIntoAxiosResponse(client, 'ECONNABORTED'),
   }
 
+  /**
+   * Simulated platform write-failure errors (ERR_100 / disk full), routed through the real
+   * `failedToWriteToLocalStorageAlert` handler — the same path the camera screens use for
+   * `capture/file-io-error` — so disk-full detection is exercised end to end. The two
+   * disk-full messages replicate what react-native-vision-camera produces on each platform.
+   */
+  const storageWriteFailureCallbacks: Record<string, () => void> = {
+    disk_full_ios_camera: () => {
+      onBack()
+      alerts.failedToWriteToLocalStorageAlert(
+        new Error(
+          'An unexpected File IO error occurred! Error: You can\'t save the file "BCSC-dev-test.jpg" because the volume "User" is out of space.'
+        )
+      )
+    },
+    disk_full_android_camera: () => {
+      onBack()
+      alerts.failedToWriteToLocalStorageAlert(
+        new Error('An unexpected File IO error occurred! Error: write failed: ENOSPC (No space left on device).')
+      )
+    },
+    generic_write_failure: () => {
+      onBack()
+      alerts.failedToWriteToLocalStorageAlert(new Error('Simulated storage write failure unrelated to disk space.'))
+    },
+  }
+
   const getCategoryIcon = (category: ErrorCategory): string => {
     const icons: Record<ErrorCategory, string> = {
       [ErrorCategory.CAMERA]: 'camera-alt',
@@ -339,6 +366,26 @@ const ErrorAlertTest: React.FC<ErrorAlertTestProps> = ({ onBack }) => {
               </View>
             )
           })}
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionHeader}>{'Storage write failures (error 100 / disk full)'}</Text>
+          <Text style={styles.description}>
+            {'Simulates camera/storage write errors through failedToWriteToLocalStorageAlert. ' +
+              'The disk-full variants should show the "Not Enough Storage" modal (2609); ' +
+              'the generic one should show "Problem with App" (error 100 / 2600).'}
+          </Text>
+          {Object.keys(storageWriteFailureCallbacks).map((key) => (
+            <View key={key} style={styles.buttonRow}>
+              <Button
+                title={key}
+                accessibilityLabel={`Trigger storage write failure ${key}`}
+                testID={`storage-error-${key}`}
+                buttonType={ButtonType.Secondary}
+                onPress={storageWriteFailureCallbacks[key]}
+              />
+            </View>
+          ))}
         </View>
 
         <View style={styles.section}>


### PR DESCRIPTION
# Summary of Changes

Fixes ERR_2600 (#4015): when a storage write failed because the device was out of disk space (e.g. the camera saving an evidence photo), users saw the misleading "remove the app and add it again (error 100)" message — reinstalling can't fix a full disk.

- Add `isDeviceStorageFullError()`, which walks the error cause chain for platform disk-full signatures (iOS `NSFileWriteOutOfSpaceError` "out of space", POSIX/Android `ENOSPC`, `SQLITE_FULL`)
- Route `failedToWriteToLocalStorageAlert` through it: disk-full failures now show actionable "Not Enough Storage — free up space, then try again" copy and report as `DEVICE_STORAGE_FULL` (2609), so analytics can distinguish them from other ERR_100/2600 write failures. All other write failures keep the existing "Problem with App" (error 100) behavior
- Fix an unhandled `takeSnapshot()` rejection in `TakeVideoScreen.startRecording`: a disk-full thumbnail snapshot left the screen stuck on the countdown with no controls; it now alerts and returns to the previous screen
- Add developer-screen triggers to test these cases end to end

# Testing Instructions

1. Enable developer mode, then go to **Settings → Developer → Error Alert Test → "Storage write failures (error 100 / disk full)"**
2. Tap `disk_full_ios_camera` or `disk_full_android_camera` → expect the **"Not Enough Storage"** modal (2609)
3. Tap `generic_write_failure` → expect the existing **"Problem with App" (error 100)** modal (2600)
4. (Optional, real device) Fill device storage, then take an evidence photo or record the selfie video → expect the "Not Enough Storage" modal instead of the reinstall message

Unit tests cover the detection patterns (`errorHandler.test.ts`) and alert routing (`useAlerts.test.tsx`).

# Acceptance Criteria

- Storage writes that fail due to a full disk show "Not Enough Storage" guidance instead of "remove the app and add it again"
- Disk-full failures are reported as `DEVICE_STORAGE_FULL` (2609); other storage write failures still report as ERR_100 (2600) with unchanged copy
- A failed video thumbnail snapshot no longer leaves the selfie-video screen stuck with no controls

# Screenshots, videos, or gifs

N/A

# Related Issues

#4015 (possibly related: #4014 — a disk-full write in a prior session could leave a token unwritten)
