### PR TITLE
feat: added screen and native error messages to report

### DIFF
--- a/app/__mocks__/@react-navigation/native.ts
+++ b/app/__mocks__/@react-navigation/native.ts
@@ -42,5 +42,19 @@ const CommonActions = {
 
 const useFocusEffect = jest.fn()
 const createNavigatorFactory = jest.fn()
+const createNavigationContainerRef = jest.fn(() => ({
+  isReady: jest.fn(() => false),
+  getCurrentRoute: jest.fn(() => undefined),
+  navigate: jest.fn(),
+  dispatch: jest.fn(),
+}))
 
-export { CommonActions, createNavigatorFactory, useFocusEffect, useIsFocused, useNavigation, useRoute }
+export {
+  CommonActions,
+  createNavigationContainerRef,
+  createNavigatorFactory,
+  useFocusEffect,
+  useIsFocused,
+  useNavigation,
+  useRoute,
+}

--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
@@ -21,6 +21,10 @@ const mockLogger = {
   error: jest.fn(),
 }
 
+jest.mock('@/contexts/NavigationContainerContext', () => ({
+  navigationRef: { isReady: () => false, getCurrentRoute: () => undefined },
+}))
+
 jest.mock('@bifold/core', () => ({
   useStore: () => [
     {

--- a/app/src/bcsc-theme/hooks/useCreateSystemChecks.test.tsx
+++ b/app/src/bcsc-theme/hooks/useCreateSystemChecks.test.tsx
@@ -43,6 +43,7 @@ jest.mock('@react-navigation/native', () => ({
 }))
 
 jest.mock('@/contexts/NavigationContainerContext', () => ({
+  navigationRef: { isReady: () => false, getCurrentRoute: () => undefined },
   useNavigationContainer: () => mockUseNavigationContainer(),
 }))
 

--- a/app/src/bcsc-theme/hooks/useQuickLoginURL.test.ts
+++ b/app/src/bcsc-theme/hooks/useQuickLoginURL.test.ts
@@ -9,6 +9,10 @@ import { mockAppError } from '@mocks/helpers/error'
 import { renderHook } from '@testing-library/react-native'
 import * as BcscCore from 'react-native-bcsc-core'
 
+jest.mock('@/contexts/NavigationContainerContext', () => ({
+  navigationRef: { isReady: () => false, getCurrentRoute: () => undefined },
+}))
+
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: jest.fn() }),
   createNavigatorFactory: jest.fn(),

--- a/app/src/bcsc-theme/navigators/RootStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.test.tsx
@@ -12,6 +12,7 @@ jest.mock('@/contexts/ErrorAlertContext', () => ({
   useErrorAlert: () => ({ emitErrorModal: jest.fn() }),
 }))
 jest.mock('@/contexts/NavigationContainerContext', () => ({
+  navigationRef: { isReady: () => false, getCurrentRoute: () => undefined },
   useNavigationContainer: () => ({ isNavigationReady: true }),
 }))
 jest.mock('../api/hooks/useInitializeAccountStatus')

--- a/app/src/bcsc-theme/utils/native-error-map.test.ts
+++ b/app/src/bcsc-theme/utils/native-error-map.test.ts
@@ -3,6 +3,10 @@ import { ErrorRegistry } from '@/errors/errorRegistry'
 
 import { throwAppError, toAppError } from './native-error-map'
 
+jest.mock('@/contexts/NavigationContainerContext', () => ({
+  navigationRef: { isReady: () => false, getCurrentRoute: () => undefined },
+}))
+
 jest.mock('react-native', () => ({
   DeviceEventEmitter: { emit: jest.fn() },
   Platform: { OS: 'ios', select: jest.fn((obj: Record<string, unknown>) => obj.ios ?? obj.default) },

--- a/app/src/contexts/ErrorAlertContext.test.tsx
+++ b/app/src/contexts/ErrorAlertContext.test.tsx
@@ -9,6 +9,10 @@ import { Analytics } from '../utils/analytics/analytics-singleton'
 import { appLogger } from '../utils/logger'
 import { ErrorAlertProvider, useErrorAlert } from './ErrorAlertContext'
 
+jest.mock('@/contexts/NavigationContainerContext', () => ({
+  navigationRef: { isReady: () => false, getCurrentRoute: () => undefined },
+}))
+
 const mockBCSCErrorModal = jest.fn()
 jest.mock('@/errors/components/ErrorModal', () => ({
   BCSCErrorModal: (props: any) => mockBCSCErrorModal(props),

--- a/app/src/errors/appError.test.ts
+++ b/app/src/errors/appError.test.ts
@@ -122,6 +122,20 @@ describe('AppError', () => {
         'Something went wrong\nDebug: [general.unknown_server_error.1234]\nRequest: POST https://example.com/device/token'
       )
     })
+
+    it('should append screen name when screen is set', () => {
+      const identity = {
+        category: ErrorCategory.GENERAL,
+        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
+        statusCode: 1234,
+      }
+      const error = new AppError('Something went wrong', identity)
+      error.screen = 'HomeScreen'
+
+      expect(error.fullMessage).toBe(
+        'Something went wrong\nDebug: [general.unknown_server_error.1234]\nScreen: HomeScreen'
+      )
+    })
   })
 
   describe('track', () => {

--- a/app/src/errors/appError.test.ts
+++ b/app/src/errors/appError.test.ts
@@ -50,6 +50,18 @@ describe('AppError', () => {
 
       expect(error.technicalMessage).toBeNull()
     })
+
+    it('should prefix the native error code when present on the cause', () => {
+      const identity = {
+        category: ErrorCategory.GENERAL,
+        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
+        statusCode: 1234,
+      }
+      const cause = Object.assign(new Error("Key pair with alias 'abc' not found."), { code: 'E_KEY_NOT_FOUND' })
+      const error = new AppError('Something went wrong', identity, { cause })
+
+      expect(error.technicalMessage).toBe("E_KEY_NOT_FOUND: Key pair with alias 'abc' not found.")
+    })
   })
 
   describe('fullMessage', () => {

--- a/app/src/errors/appError.test.ts
+++ b/app/src/errors/appError.test.ts
@@ -3,6 +3,10 @@ import { Analytics } from '@/utils/analytics/analytics-singleton'
 import { AppError, isAppError, isHandledAppError } from './appError'
 import { ErrorCategory, ErrorRegistry, ErrorSeverity } from './errorRegistry'
 
+jest.mock('@/contexts/NavigationContainerContext', () => ({
+  navigationRef: { isReady: () => false, getCurrentRoute: () => undefined },
+}))
+
 describe('AppError', () => {
   beforeEach(() => {
     jest.clearAllMocks()

--- a/app/src/errors/appError.ts
+++ b/app/src/errors/appError.ts
@@ -1,3 +1,4 @@
+import { navigationRef } from '@/contexts/NavigationContainerContext'
 import { AppEventCode } from '@/events/appEventCode'
 import { Analytics } from '@/utils/analytics/analytics-singleton'
 import { ErrorCategory, ErrorDefinition } from './errorRegistry'
@@ -54,6 +55,7 @@ export class AppError extends Error {
   statusCode: number // ie: 2100
   timestamp: string // ISO timestamp of when the error was created
   handled: boolean // Whether this error has been handled by a policy
+  screen: string | undefined // Active screen name at the time the error was created
   url?: string // API endpoint URL that produced this error, if applicable
   method?: string // HTTP method of the request that produced this error, if applicable
 
@@ -67,6 +69,7 @@ export class AppError extends Error {
     this.timestamp = new Date().toISOString()
     this.handled = false
     this.tracked = false
+    this.screen = navigationRef.isReady() ? navigationRef.getCurrentRoute()?.name : undefined
     this.url = undefined
     this.method = undefined
 
@@ -83,7 +86,11 @@ export class AppError extends Error {
    */
   get technicalMessage(): string | null {
     // QUESTION (MD): Should we have a max length? Or detect HTML strings or other non-user-friendly content and truncate/remove it?
-    return this.cause instanceof Error ? this.cause.message : null
+    if (!(this.cause instanceof Error)) {
+      return null
+    }
+    const nativeCode = (this.cause as { code?: string }).code
+    return [nativeCode, this.cause.message].filter(Boolean).join(': ')
   }
 
   /**
@@ -102,6 +109,10 @@ export class AppError extends Error {
 
     if (this.technicalMessage) {
       formattedMessage += ` ${this.technicalMessage}`
+    }
+
+    if (this.screen) {
+      formattedMessage += `\nScreen: ${this.screen}`
     }
 
     if (this.url) {
@@ -177,6 +188,7 @@ export class AppError extends Error {
       code: this.code,
       timestamp: this.timestamp,
       handled: this.handled,
+      screen: this.screen,
       url: this.url,
       method: this.method,
       cause: summarizeCause(this.cause),

--- a/app/src/errors/appError.ts
+++ b/app/src/errors/appError.ts
@@ -91,7 +91,13 @@ export class AppError extends Error {
     }
 
     const cause = this.cause as Error & { code?: unknown; isAxiosError?: boolean }
+
+    // AxiosErrors have their error code written into cause.code
+    // That value is already captured in appEvent, so excluding it here
+    // keeps technicalMessage as server description, which error policies policies match against
     const isAxiosError = Boolean(cause.isAxiosError) || cause.name === 'AxiosError'
+
+    // For non-Axios errors (e.g. native module errors), cause.code is a meaningful prefix like "E_KEY_NOT_FOUND"
     const code = !isAxiosError && typeof cause.code === 'string' ? cause.code : undefined
 
     return [code, cause.message].filter(Boolean).join(': ')

--- a/app/src/errors/appError.ts
+++ b/app/src/errors/appError.ts
@@ -89,8 +89,12 @@ export class AppError extends Error {
     if (!(this.cause instanceof Error)) {
       return null
     }
-    const nativeCode = (this.cause as { code?: string }).code
-    return [nativeCode, this.cause.message].filter(Boolean).join(': ')
+
+    const cause = this.cause as Error & { code?: unknown; isAxiosError?: boolean }
+    const isAxiosError = Boolean(cause.isAxiosError) || cause.name === 'AxiosError'
+    const code = !isAxiosError && typeof cause.code === 'string' ? cause.code : undefined
+
+    return [code, cause.message].filter(Boolean).join(': ')
   }
 
   /**

--- a/app/src/errors/components/ErrorBoundary.test.tsx
+++ b/app/src/errors/components/ErrorBoundary.test.tsx
@@ -3,6 +3,10 @@ import React from 'react'
 import { Text } from 'react-native'
 import { ErrorBoundaryWrapper } from './ErrorBoundary'
 
+jest.mock('@/contexts/NavigationContainerContext', () => ({
+  navigationRef: { isReady: () => false, getCurrentRoute: () => undefined },
+}))
+
 jest.mock('react-native-device-info', () => ({
   getVersion: () => '1.0.0',
   getBuildNumber: () => '42',


### PR DESCRIPTION
# Summary of Changes

In an effort to help identify more issues I've added more logging to our error reports

- added react navigation route to error report
- added native messages along with key to error report

# Testing Instructions

- trigger an error report from the developer settings
- see updated message in loki

# Acceptance Criteria

- app still functions as you'd expect
- new logging information appears in reporting tools

# Screenshots, videos, or gifs
See `Screen` and `E_TEST_EXCEPTION: ...`
I wired a test button to the home screen, that's why both error reports originated from `Home`

<img width="1008" height="200" alt="Screenshot 2026-06-11 at 4 54 17 PM" src="https://github.com/user-attachments/assets/369cffdd-b6d7-41da-affc-51926f494cf5" />

<img width="997" height="215" alt="Screenshot 2026-06-11 at 4 57 46 PM" src="https://github.com/user-attachments/assets/188f9125-0bdd-414f-bfa0-9e91e7cd8f85" />

# Related Issues

[BC-Wallet: 4016](https://github.com/bcgov/bc-wallet-mobile/issues/4016)
