### PR TITLE
fix: corrupted token file

### DIFF
--- a/app/src/bcsc-theme/features/auth/SessionRecoveryScreen.test.tsx
+++ b/app/src/bcsc-theme/features/auth/SessionRecoveryScreen.test.tsx
@@ -1,0 +1,87 @@
+import { SessionRecoveryScreen } from '@/bcsc-theme/features/auth/SessionRecoveryScreen'
+import { BasicAppContext } from '@mocks/helpers/app'
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
+import React from 'react'
+
+const mockFactoryReset = jest.fn()
+jest.mock('@/bcsc-theme/api/hooks/useFactoryReset', () => ({
+  useFactoryReset: () => mockFactoryReset,
+}))
+
+const mockFactoryResetAlert = jest.fn()
+jest.mock('@/hooks/useAlerts', () => ({
+  useAlerts: () => ({ factoryResetAlert: mockFactoryResetAlert }),
+}))
+
+const mockStopLoading = jest.fn()
+jest.mock('../../contexts/BCSCLoadingContext', () => ({
+  useLoadingScreen: () => ({ startLoading: jest.fn(() => mockStopLoading) }),
+}))
+
+const RESET_BUTTON = 'com.ariesbifold:id/SessionRecoveryReset'
+
+describe('SessionRecoveryScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders correctly', () => {
+    const tree = render(
+      <BasicAppContext>
+        <SessionRecoveryScreen />
+      </BasicAppContext>
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('shows the reset explanation and primary action', () => {
+    const tree = render(
+      <BasicAppContext>
+        <SessionRecoveryScreen />
+      </BasicAppContext>
+    )
+
+    expect(tree.getByText('BCSC.SessionRecovery.Header')).toBeTruthy()
+    expect(tree.getByText('BCSC.SessionRecovery.Body')).toBeTruthy()
+    expect(tree.getByText('BCSC.SessionRecovery.BodyAction')).toBeTruthy()
+    expect(tree.getByTestId(RESET_BUTTON)).toBeTruthy()
+  })
+
+  it('performs a factory reset and surfaces no alert on success', async () => {
+    mockFactoryReset.mockResolvedValue({ success: true })
+
+    const tree = render(
+      <BasicAppContext>
+        <SessionRecoveryScreen />
+      </BasicAppContext>
+    )
+
+    fireEvent.press(tree.getByTestId(RESET_BUTTON))
+
+    await waitFor(() => {
+      expect(mockFactoryReset).toHaveBeenCalledTimes(1)
+    })
+    expect(mockFactoryResetAlert).not.toHaveBeenCalled()
+    expect(mockStopLoading).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces the factory reset alert when the reset fails', async () => {
+    const error = new Error('reset failed')
+    mockFactoryReset.mockResolvedValue({ success: false, error })
+
+    const tree = render(
+      <BasicAppContext>
+        <SessionRecoveryScreen />
+      </BasicAppContext>
+    )
+
+    fireEvent.press(tree.getByTestId(RESET_BUTTON))
+
+    await waitFor(() => {
+      expect(mockFactoryResetAlert).toHaveBeenCalledWith(error)
+    })
+    // Loading is always stopped, even on failure
+    expect(mockStopLoading).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/src/bcsc-theme/features/auth/SessionRecoveryScreen.tsx
+++ b/app/src/bcsc-theme/features/auth/SessionRecoveryScreen.tsx
@@ -1,0 +1,62 @@
+import { useFactoryReset } from '@/bcsc-theme/api/hooks/useFactoryReset'
+import { useAlerts } from '@/hooks/useAlerts'
+import {
+  Button,
+  ButtonType,
+  ScreenWrapper,
+  testIdWithKey,
+  ThemedText,
+  TOKENS,
+  useServices,
+  useTheme,
+} from '@bifold/core'
+import { NavigationProp, ParamListBase, useNavigation } from '@react-navigation/core'
+import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useLoadingScreen } from '../../contexts/BCSCLoadingContext'
+
+/**
+ * Shown when an account exists but both its registration and refresh tokens are unrecoverable
+ */
+export const SessionRecoveryScreen = (): React.ReactElement => {
+  const { t } = useTranslation()
+  const { Spacing } = useTheme()
+  const navigation = useNavigation<NavigationProp<ParamListBase>>()
+  const factoryReset = useFactoryReset()
+  const { factoryResetAlert } = useAlerts(navigation)
+  const loadingScreen = useLoadingScreen()
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
+
+  const onPressPrimaryAction = useCallback(async () => {
+    const stopLoading = loadingScreen.startLoading(t('BCSC.SessionRecovery.Resetting'))
+    try {
+      const result = await factoryReset()
+      if (!result.success) {
+        logger.error('[SessionRecovery] Factory reset failed during lost-session recovery', result.error)
+        factoryResetAlert(result.error)
+      }
+    } finally {
+      stopLoading()
+    }
+  }, [loadingScreen, t, factoryReset, factoryResetAlert, logger])
+
+  const controls = (
+    <Button
+      title={t('BCSC.SessionRecovery.PrimaryAction')}
+      buttonType={ButtonType.Primary}
+      testID={testIdWithKey('SessionRecoveryReset')}
+      accessibilityLabel={t('BCSC.SessionRecovery.PrimaryAction')}
+      onPress={onPressPrimaryAction}
+    />
+  )
+
+  return (
+    <ScreenWrapper controls={controls} scrollViewContainerStyle={{ gap: Spacing.md }}>
+      <ThemedText variant="headingThree">{t('BCSC.SessionRecovery.Header')}</ThemedText>
+      <ThemedText>{t('BCSC.SessionRecovery.Body')}</ThemedText>
+      <ThemedText>{t('BCSC.SessionRecovery.BodyAction')}</ThemedText>
+    </ScreenWrapper>
+  )
+}
+
+export default SessionRecoveryScreen

--- a/app/src/bcsc-theme/features/auth/__snapshots__/SessionRecoveryScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/auth/__snapshots__/SessionRecoveryScreen.test.tsx.snap
@@ -1,0 +1,180 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SessionRecoveryScreen renders correctly 1`] = `
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "additive",
+      "right": "additive",
+      "top": "off",
+    }
+  }
+  style={
+    [
+      {
+        "backgroundColor": "#F2F2F2",
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <RCTScrollView
+    contentContainerStyle={
+      [
+        {
+          "padding": 16,
+        },
+        {
+          "gap": 16,
+        },
+      ]
+    }
+    showsVerticalScrollIndicator={false}
+  >
+    <View>
+      <Text
+        maxFontSizeMultiplier={2}
+        style={
+          [
+            {
+              "color": "#313132",
+              "fontFamily": "BCSans-Regular",
+              "fontSize": 26,
+              "fontWeight": "bold",
+            },
+            undefined,
+          ]
+        }
+      >
+        BCSC.SessionRecovery.Header
+      </Text>
+      <Text
+        maxFontSizeMultiplier={2}
+        style={
+          [
+            {
+              "color": "#313132",
+              "fontFamily": "BCSans-Regular",
+              "fontSize": 18,
+              "fontWeight": "normal",
+            },
+            undefined,
+          ]
+        }
+      >
+        BCSC.SessionRecovery.Body
+      </Text>
+      <Text
+        maxFontSizeMultiplier={2}
+        style={
+          [
+            {
+              "color": "#313132",
+              "fontFamily": "BCSans-Regular",
+              "fontSize": 18,
+              "fontWeight": "normal",
+            },
+            undefined,
+          ]
+        }
+      >
+        BCSC.SessionRecovery.BodyAction
+      </Text>
+    </View>
+  </RCTScrollView>
+  <View
+    style={
+      [
+        {
+          "gap": 16,
+        },
+        {
+          "paddingBottom": 16,
+          "paddingHorizontal": 16,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      accessibilityLabel="BCSC.SessionRecovery.PrimaryAction"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "backgroundColor": "#003366",
+          "borderRadius": 4,
+          "opacity": 1,
+          "padding": 16,
+        }
+      }
+      testID="com.ariesbifold:id/SessionRecoveryReset"
+    >
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <Text
+          maxFontSizeMultiplier={2}
+          style={
+            [
+              {
+                "color": "#313132",
+                "fontFamily": "BCSans-Regular",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              [
+                {
+                  "color": "#FFFFFF",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                  "textAlign": "center",
+                },
+                false,
+                false,
+              ],
+            ]
+          }
+        >
+          BCSC.SessionRecovery.PrimaryAction
+        </Text>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaView>
+`;

--- a/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
@@ -16,6 +16,7 @@ import {
   setAccountFlags,
   setAuthorizationRequest,
   setEvidence,
+  TokenType,
 } from 'react-native-bcsc-core'
 import * as useBCSCApiClientModule from './useBCSCApiClient'
 import { useSecureActions } from './useSecureActions'
@@ -307,6 +308,75 @@ describe('useSecureActions', () => {
           clientID: 'recovered-client-id',
         })
       )
+    })
+
+    const captureSessionRecoveryRequired = () => {
+      const hydrateCall = mockDispatch.mock.calls.find(
+        ([action]) => action.type === BCDispatchAction.HYDRATE_SECURE_STATE
+      )
+      return hydrateCall?.[0]?.payload?.[0]?.sessionRecoveryRequired
+    }
+
+    it('flags sessionRecoveryRequired when an account exists but no refresh or registration token survives', async () => {
+      // beforeEach mocks getToken -> null for all token types (the 0-byte tokens-file signature)
+      jest.mocked(getAccount).mockResolvedValue(baseAccount as any)
+      jest.mocked(getAuthorizationRequest).mockResolvedValue(null as any)
+
+      const { result } = renderHook(() => useSecureActions())
+      await act(async () => {
+        await result.current.hydrateSecureState()
+      })
+
+      expect(captureSessionRecoveryRequired()).toBe(true)
+    })
+
+    it('does not flag sessionRecoveryRequired when a registration token still exists (in-progress verification)', async () => {
+      jest.mocked(getAccount).mockResolvedValue(baseAccount as any)
+      jest.mocked(getAuthorizationRequest).mockResolvedValue(null as any)
+      jest
+        .mocked(getToken)
+        .mockImplementation(async (type: any) =>
+          type === TokenType.Registration ? ({ token: 'reg-token', type } as any) : null
+        )
+
+      const { result } = renderHook(() => useSecureActions())
+      await act(async () => {
+        await result.current.hydrateSecureState()
+      })
+
+      expect(captureSessionRecoveryRequired()).toBe(false)
+    })
+
+    it('flags sessionRecoveryRequired when a verified user has a registration token but no refresh token', async () => {
+      jest.mocked(getAccount).mockResolvedValue(baseAccount as any)
+      jest.mocked(getAuthorizationRequest).mockResolvedValue(null as any)
+      // Verified: a credential exists (no cancel/expire event → VERIFIED)
+      jest.mocked(getCredential).mockResolvedValue({} as any)
+      // Registration token present (e.g. recovered from the V3 providers file), refresh token gone
+      jest
+        .mocked(getToken)
+        .mockImplementation(async (type: any) =>
+          type === TokenType.Registration ? ({ token: 'reg-token', type } as any) : null
+        )
+
+      const { result } = renderHook(() => useSecureActions())
+      await act(async () => {
+        await result.current.hydrateSecureState()
+      })
+
+      expect(captureSessionRecoveryRequired()).toBe(true)
+    })
+
+    it('does not flag sessionRecoveryRequired when no account exists (fresh install)', async () => {
+      jest.mocked(getAccount).mockResolvedValue(null as any)
+      jest.mocked(getAuthorizationRequest).mockResolvedValue(null as any)
+
+      const { result } = renderHook(() => useSecureActions())
+      await act(async () => {
+        await result.current.hydrateSecureState()
+      })
+
+      expect(captureSessionRecoveryRequired()).toBe(false)
     })
   })
 

--- a/app/src/bcsc-theme/hooks/useSecureActions.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.tsx
@@ -878,6 +878,11 @@ export const useSecureActions = () => {
       }
 
       const verificationStatus = getCredentialVerificationStatus(credential)
+      const verified = verificationStatus === VerificationStatus.VERIFIED
+
+      // A verified account with no refresh token is unrecoverable
+      // An unverified account with no registration token is unrecoverable
+      const sessionRecoveryRequired = !!account && !refreshToken && (!registrationAccessToken || verified)
 
       // Extract bookmarked service IDs from native client metadata
       const savedServices = (nativeSavedServices ?? [])
@@ -907,7 +912,7 @@ export const useSecureActions = () => {
         registrationAccessToken,
         accessToken,
 
-        verified: verificationStatus === VerificationStatus.VERIFIED,
+        verified,
         verifiedStatus: verificationStatus,
 
         userSkippedEmailVerification: accountFlags.userSkippedEmailVerification,
@@ -924,6 +929,8 @@ export const useSecureActions = () => {
         additionalEvidenceData: cleanedEvidence,
         userMetadata,
         savedServices,
+
+        sessionRecoveryRequired,
       }
 
       logger.debug(`Hydrated secure data: ${JSON.stringify(secureData, null, 2)}`)

--- a/app/src/bcsc-theme/navigators/RootStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.test.tsx
@@ -199,6 +199,24 @@ describe('BCSCRootStack', () => {
     expect(toJSON()).toBe('MainStack')
   })
 
+  it('renders VerifyStack when sessionRecoveryRequired is set, overriding the verified→Home routing', () => {
+    const mockDispatch = jest.fn()
+    jest.mocked(Bifold.useStore).mockReturnValue([
+      mockStore({
+        bcsc: { hasAccount: true, nicknames: [] },
+        authentication: { didAuthenticate: true },
+        // verified:true would normally route to MainStack — recovery must take precedence.
+        // (VerifyStack starts on the SessionRecovery screen when sessionRecoveryRequired is set.)
+        bcscSecure: { verified: true, sessionRecoveryRequired: true },
+      }),
+      mockDispatch,
+    ] as any)
+
+    const { toJSON } = render(<BCSCRootStack />)
+
+    expect(toJSON()).toBe('VerifyStack')
+  })
+
   it('renders AuthStack as fallback when verified is undefined', () => {
     const mockDispatch = jest.fn()
     jest.mocked(Bifold.useStore).mockReturnValue([

--- a/app/src/bcsc-theme/navigators/RootStack.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.tsx
@@ -65,7 +65,7 @@ const BCSCRootStack: React.FC = () => {
     return <AuthStack />
   }
 
-  if (store.bcscSecure.verified === false) {
+  if (store.bcscSecure.sessionRecoveryRequired === true || store.bcscSecure.verified === false) {
     return (
       <BCSCActivityProvider>
         <VerifyStack />

--- a/app/src/bcsc-theme/navigators/VerifyStack.tsx
+++ b/app/src/bcsc-theme/navigators/VerifyStack.tsx
@@ -16,6 +16,7 @@ import TransferInstructionsScreen from '../features/account-transfer/transferee/
 import TransferQRScannerScreen from '../features/account-transfer/transferee/TransferQRScannerScreen'
 import NicknameAccountScreen from '../features/account/NicknameAccountScreen'
 import { VerifyRemoveAccountConfirmationScreen } from '../features/account/RemoveAccountConfirmationScreen'
+import SessionRecoveryScreen from '../features/auth/SessionRecoveryScreen'
 import { VerifyChangePINScreen } from '../features/auth/VerifyChangePINScreen'
 import { VerifyChangeSecurityScreen } from '../features/auth/VerifyChangeSecurityScreen'
 import { InternetDisconnected } from '../features/modal/InternetDisconnected'
@@ -77,8 +78,13 @@ const VerifyStack = () => {
 
   return (
     <Stack.Navigator
-      // If the user has a refresh token, they have completed setup and should go to success screen. Otherwise, start at setup steps.
-      initialRouteName={isUserVerified(store.bcscSecure) ? BCSCScreens.VerificationSuccess : BCSCScreens.SetupSteps}
+      initialRouteName={
+        store.bcscSecure.sessionRecoveryRequired
+          ? BCSCScreens.SessionRecovery
+          : isUserVerified(store.bcscSecure)
+            ? BCSCScreens.VerificationSuccess
+            : BCSCScreens.SetupSteps
+      }
       screenOptions={{
         ...defaultStackOptions,
         headerShown: true,
@@ -99,6 +105,11 @@ const VerifyStack = () => {
           headerRight: createVerifyHelpHeaderButton({ helpCentreUrl: HelpCentreUrl.HOW_TO_SETUP }),
           headerLeft: createVerifySettingsHeaderButton(),
         }}
+      />
+      <Stack.Screen
+        name={BCSCScreens.SessionRecovery}
+        component={SessionRecoveryScreen}
+        options={{ headerLeft: () => null, gestureEnabled: false }}
       />
       <Stack.Screen name={BCSCScreens.NicknameAccount} component={NicknameAccountScreen} />
       <Stack.Screen name={BCSCScreens.IdentitySelection} component={IdentitySelectionScreen} />

--- a/app/src/bcsc-theme/types/navigators.ts
+++ b/app/src/bcsc-theme/types/navigators.ts
@@ -124,6 +124,7 @@ export enum BCSCScreens {
   AccountRenewalInformation = 'Renewal ID requirements',
   AccountRenewalFirstWarning = 'Renewal Instructions',
   AccountRenewalFinalWarning = 'Renewal Warning',
+  SessionRecovery = 'Session Recovery',
   AccountSelector = 'Account Select',
   EnterPIN = 'Enter/Verify PIN',
   DeviceAuthInfo = 'Device Authentication Prep',
@@ -157,6 +158,7 @@ export type BCSCOnboardingStackParams = {
 }
 
 export type BCSCVerifyStackParams = {
+  [BCSCScreens.SessionRecovery]: undefined
   [BCSCScreens.VerifyWebView]: { url: string; title: string }
   [BCSCScreens.SetupSteps]: undefined
   [BCSCScreens.IdentitySelection]: undefined

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -453,6 +453,13 @@ const translation = {
       "WarningContentB": "This includes logging into services like Health Gateway or Canada Revenue Agency (CRA).",
       "WarningRenewButton": "Renew"
     },
+    "SessionRecovery": {
+      "Header": "Reset your app",
+      "Body": "Some of your saved data on this device couldn't be read.",
+      "BodyAction": "To keep using the app, you'll need to re-verify or transfer from another device to use your identity again.",
+      "PrimaryAction": "Reset",
+      "Resetting": "Resetting…"
+    },
     "ForgetAllPairings": {
       "Title": "Forget all pairings?",
       "Description1": "When you use this app to log in on another computer, you are asked if you want to remember this device to skip the pairing step.",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -449,6 +449,13 @@ const translation = {
       "WarningContentB": "This includes logging into services like Health Gateway or Canada Revenue Agency (CRA). (FR)",
       "WarningRenewButton": "Renew (FR)"
     },
+    "SessionRecovery": {
+      "Header": "Reset your app (FR)",
+      "Body": "Some of your saved data on this device couldn't be read. (FR)",
+      "BodyAction": "To keep using the app, you'll need to re-verify or transfer from another device to use your identity again. (FR)",
+      "PrimaryAction": "Reset (FR)",
+      "Resetting": "Resetting… (FR)"
+    },
     "ForgetAllPairings": {
       "Title": "Forget all pairings? (FR)",
       "Description1": "When you use this app to log in on another computer, you are asked if you want to remember this device to skip the pairing step. (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -449,6 +449,13 @@ const translation = {
       "WarningContentB": "This includes logging into services like Health Gateway or Canada Revenue Agency (CRA). (PT-BR)",
       "WarningRenewButton": "Renew (PT-BR)"
     },
+    "SessionRecovery": {
+      "Header": "Reset your app (PT-BR)",
+      "Body": "Some of your saved data on this device couldn't be read. (PT-BR)",
+      "BodyAction": "To keep using the app, you'll need to re-verify or transfer from another device to use your identity again. (PT-BR)",
+      "PrimaryAction": "Reset (PT-BR)",
+      "Resetting": "Resetting… (PT-BR)"
+    },
     "ForgetAllPairings": {
       "Title": "Forget all pairings? (PT-BR)",
       "Description1": "When you use this app to log in on another computer, you are asked if you want to remember this device to skip the pairing step. (PT-BR)",

--- a/app/src/store.tsx
+++ b/app/src/store.tsx
@@ -178,6 +178,12 @@ export interface BCSCSecureState {
   walletKey?: string
 
   hasDismissedExpiryAlert?: boolean
+
+  /**
+   * Set during hydration when a native account record exists but its tokens file is
+   * unreadable/corrupt — i.e. neither a refresh nor a registration token survived
+   */
+  sessionRecoveryRequired?: boolean
 }
 
 /** Initial secure state - unhydrated with no data */

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -463,12 +463,20 @@ class BcscCoreModule(
 
                             promise.resolve(null)
                         } catch (e: Exception) {
-                            Log.e(NAME, "Failed to parse decrypted JSON content: ${e.message}", e)
-                            promise.reject("E_STORAGE_ERROR", "Failed to parse decrypted token data: ${e.message}", e)
+                            Log.e(
+                                NAME,
+                                "Failed to parse/migrate decrypted token content for type $tokenType — returning null",
+                                e,
+                            )
+                            promise.resolve(null)
                         }
                     } else {
-                        Log.e(NAME, "Decrypted content is not valid JSON")
-                        promise.reject("E_STORAGE_ERROR", "Decrypted token content is not valid JSON")
+                        Log.w(
+                            NAME,
+                            "Decrypted token content is empty or not valid JSON at $tokenFilePath — " +
+                                "returning null for type $tokenType",
+                        )
+                        promise.resolve(null)
                     }
                 } else {
                     Log.w(
@@ -478,8 +486,13 @@ class BcscCoreModule(
                     promise.resolve(null)
                 }
             } catch (e: DecryptionException) {
-                Log.e(NAME, "Failed to decrypt token file from path: $tokenFilePath - ${e.message}", e)
-                promise.reject("E_STORAGE_ERROR", "Failed to decrypt token file: ${e.message}", e)
+                Log.e(
+                    NAME,
+                    "Failed to decrypt token file from path: $tokenFilePath - ${e.message} — " +
+                        "returning null for type $tokenType",
+                    e,
+                )
+                promise.resolve(null)
             }
         } catch (e: Exception) {
             Log.e(NAME, "Exception occurred while reading/decrypting token file using bcsc-file-port: ${e.message}", e)

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/storage/NativeCompatibleStorage.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/storage/NativeCompatibleStorage.kt
@@ -10,6 +10,7 @@ import com.google.gson.GsonBuilder
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
+import java.io.IOException
 import java.lang.reflect.Type
 import java.util.TimeZone
 
@@ -238,21 +239,54 @@ class NativeCompatibleStorage(
     internal fun writeEncryptedFile(
         file: File,
         content: String,
-    ): Boolean =
-        try {
-            // Ensure parent directory exists
-            file.parentFile?.mkdirs()
+    ): Boolean {
+        // Ensure parent directory exists
+        val parent = file.parentFile
+        parent?.mkdirs()
 
-            // Encrypt and write
-            val encryptedBytes = encryption.encrypt(content)
-            FileOutputStream(file).use { fos ->
+        val encryptedBytes =
+            try {
+                encryption.encrypt(content)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to encrypt file: ${file.absolutePath}", e)
+                return false
+            }
+
+        // Write to a temp file and atomically rename it into place rather than writing
+        // the destination directly. FileOutputStream(file) truncates the destination to
+        // zero bytes before writing, so a crash/kill/full-disk between truncate and write
+        // leaves a 0-byte file that later fails to decrypt ("Decrypted token content is
+        // not valid JSON") and bricks unlock. A temp-write + fsync + rename guarantees a
+        // reader always sees either the previous complete file or the new complete file.
+        // Nullable handle used only for finally cleanup; the file operations below use the
+        // non-null `tmp` val so there is no smart-cast on a nullable var.
+        var tempFile: File? = null
+        return try {
+            val tmp = File.createTempFile("${file.name}_", ".tmp", parent)
+            tempFile = tmp
+            FileOutputStream(tmp).use { fos ->
                 fos.write(encryptedBytes)
+                fos.flush()
+                fos.fd.sync() // flush to disk so the rename can't expose an empty file
+            }
+
+            if (!tmp.renameTo(file)) {
+                // renameTo can fail if the destination already exists on some platforms;
+                // fall back to delete-then-rename.
+                file.delete()
+                if (!tmp.renameTo(file)) {
+                    throw IOException("Failed to rename temp file to ${file.absolutePath}")
+                }
             }
             true
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to encrypt/write file: ${file.absolutePath}", e)
+            Log.e(TAG, "Failed to write file: ${file.absolutePath}", e)
             false
+        } finally {
+            // Clean up the temp file if the rename did not consume it.
+            tempFile?.takeIf { it.exists() }?.delete()
         }
+    }
 
     // MARK: - Account Storage (Native Compatible)
 


### PR DESCRIPTION
# Summary of Changes

This PR address the three different facets of the corrupted token file issue:
- prevents future corrupted tokens by making writes atomic
- returns null rather than throwing if a token is 0 bytes
- recovers when in the corrupted token situation

# Testing Instructions

Convert, make sure happy paths still work, then once you're verified, run the following commands:

```sh
adb shell run-as ca.bc.gov.id.servicescard.dev ls files/sit (get your account ID)
adb shell run-as ca.bc.gov.id.servicescard.dev cp /dev/null files/sit/<account ID>/tokens (corrupt your token file)
```
 
Relaunch app, ensure you are directed through the recovery flow and end up back on step 2 of the setup steps.

# Acceptance Criteria

Happy paths still work and recovery works too

# Screenshots, videos, or gifs

https://github.com/user-attachments/assets/e96133a0-c911-4f89-9730-a3430d3b2b66

# Related Issues

#3992