### PR TITLE
feat: restart verification

### DIFF
--- a/app/src/bcsc-theme/components/FloatingHelpMenuHeaderButton.tsx
+++ b/app/src/bcsc-theme/components/FloatingHelpMenuHeaderButton.tsx
@@ -2,14 +2,16 @@ import { HelpCentreUrl } from '@/constants'
 import { ButtonLocation, IconButton, testIdWithKey } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React, { ReactElement, useCallback, useRef, useState } from 'react'
+import React, { ReactNode, useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useRestartVerification } from '../hooks/useRestartVerification'
 import { BCSCScreens } from '../types/navigators'
 import FloatingHelpMenu, { FloatingHelpMenuRef } from './FloatingHelpMenu'
 import { ListButton, ListButtonGroup, ListButtonProps } from './ListButton'
 
 type FloatingHelpMenuButtonProps = {
-  children: ReactElement<ListButtonProps> | ReactElement<ListButtonProps>[]
+  // ListButton rows; falsy children are filtered out by ListButtonGroup so rows can be conditional
+  children: ReactNode
   ref?: React.Ref<FloatingHelpMenuRef>
 }
 
@@ -56,6 +58,28 @@ type FloatingHelpMenuButtonOptions = {
   webViewScreen: keyof WebViewParamList
   /** Help centre article opened by "Learn More". Defaults to the help centre home page. */
   learnMoreUrl?: HelpCentreUrl
+  /** Show the "Restart verification process" option. Only valid within the verification flow. */
+  showRestartVerification?: boolean
+}
+
+type RestartVerificationListButtonProps = {
+  /** Called when the user confirms the restart, so the owning menu can close itself. */
+  onConfirm: () => void
+} & Pick<ListButtonProps, 'position'>
+
+/**
+ * "Restart verification process" menu row. Kept as its own component so the verification-reset
+ * hooks only run in menus that opt in via `showRestartVerification` (i.e. the verify flow).
+ */
+const RestartVerificationListButton = ({ onConfirm, position }: RestartVerificationListButtonProps) => {
+  const { t } = useTranslation()
+  const promptRestartVerification = useRestartVerification()
+
+  return (
+    <ListButton position={position} onPress={() => promptRestartVerification(onConfirm)}>
+      {t('BCSC.HelpMenu.RestartVerification')}
+    </ListButton>
+  )
 }
 
 /**
@@ -70,6 +94,7 @@ type FloatingHelpMenuButtonOptions = {
 export const createFloatingHelpMenuButton = ({
   webViewScreen,
   learnMoreUrl = HelpCentreUrl.HOME,
+  showRestartVerification = false,
 }: FloatingHelpMenuButtonOptions) => {
   const FloatingHelpMenuHeaderRight = () => {
     const { t } = useTranslation()
@@ -100,6 +125,9 @@ export const createFloatingHelpMenuButton = ({
         >
           {t('BCSC.HelpMenu.ReportProblem')}
         </ListButton>
+        {showRestartVerification && (
+          <RestartVerificationListButton onConfirm={() => floatingHelpMenuRef.current?.close()} />
+        )}
       </FloatingHelpMenuButton>
     )
   }

--- a/app/src/bcsc-theme/components/FloatingHelpMenuHeaderButton.tsx
+++ b/app/src/bcsc-theme/components/FloatingHelpMenuHeaderButton.tsx
@@ -48,6 +48,7 @@ type WebViewParamList = {
   [BCSCScreens.AuthWebView]: { url: string; title: string }
   [BCSCScreens.OnboardingWebView]: { url: string; title: string }
   [BCSCScreens.VerifyWebView]: { url: string; title: string }
+  [BCSCScreens.PromptWebView]: { url: string; title: string }
 }
 
 type FloatingHelpMenuButtonOptions = {

--- a/app/src/bcsc-theme/features/verify/ScanSerialScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/ScanSerialScreen.tsx
@@ -144,9 +144,9 @@ const IdCardMaskOverlay: React.FC<IdCardMaskOverlayProps> = ({
           strokeWidth={3}
         />
 
-        {/* Magstripe — solid bar along the right edge (the card's top edge, held upright) */}
+        {/* Magstripe — solid bar along the left edge (the card's top edge, held upright) */}
         <Rect
-          x={x + cardWidth * 0.68}
+          x={x + cardWidth * 0.09}
           y={y}
           width={cardWidth * 0.23}
           height={cardHeight}
@@ -154,20 +154,20 @@ const IdCardMaskOverlay: React.FC<IdCardMaskOverlayProps> = ({
           fillOpacity={0.5}
         />
 
-        {/* 2D (PDF417) barcode — tall band along the left edge */}
+        {/* 2D (PDF417) barcode — tall band along the right edge, lower half */}
         <BarcodeGuide
-          x={x + cardWidth * 0.04}
-          y={y + cardHeight * 0.04}
+          x={x + cardWidth * 0.76}
+          y={y + cardHeight * 0.36}
           width={cardWidth * 0.2}
           height={cardHeight * 0.6}
           bars="horizontal"
           pattern={BARCODE_PATTERN_2D}
         />
 
-        {/* 1D barcode — horizontal band near the bottom */}
+        {/* 1D barcode — horizontal band near the top, right of the magstripe */}
         <BarcodeGuide
-          x={x + cardWidth * 0.05}
-          y={y + cardHeight * 0.89}
+          x={x + cardWidth * 0.4}
+          y={y + cardHeight * 0.04}
           width={cardWidth * 0.55}
           height={cardHeight * 0.07}
           bars="vertical"

--- a/app/src/bcsc-theme/hooks/useRestartVerification.test.tsx
+++ b/app/src/bcsc-theme/hooks/useRestartVerification.test.tsx
@@ -1,0 +1,103 @@
+import * as BCSCLoadingContextModule from '@/bcsc-theme/contexts/BCSCLoadingContext'
+import * as ErrorAlertContextModule from '@/contexts/ErrorAlertContext'
+import { AppEventCode } from '@/events/appEventCode'
+import { act, renderHook } from '@testing-library/react-native'
+import { useRestartVerification } from './useRestartVerification'
+import * as useSecureActionsModule from './useSecureActions'
+import * as useVerificationResetModule from './useVerificationReset'
+
+jest.mock('@/bcsc-theme/contexts/BCSCLoadingContext', () => ({
+  useLoadingScreen: jest.fn(),
+}))
+jest.mock('@/contexts/ErrorAlertContext', () => ({
+  useErrorAlert: jest.fn(),
+}))
+jest.mock('./useSecureActions', () => ({
+  useSecureActions: jest.fn(),
+}))
+jest.mock('./useVerificationReset', () => ({
+  useVerificationReset: jest.fn(),
+}))
+
+const mockEmitAlert = jest.fn()
+const mockStopLoading = jest.fn()
+const mockStartLoading = jest.fn().mockReturnValue(mockStopLoading)
+const mockVerificationReset = jest.fn()
+const mockContinueVerificationProcess = jest.fn()
+
+/** Renders the hook, invokes the prompt and returns the alert actions it was shown with */
+const promptAndGetAlertActions = async (onConfirm?: () => void) => {
+  const { result } = renderHook(() => useRestartVerification())
+
+  await act(async () => {
+    result.current(onConfirm)
+  })
+
+  expect(mockEmitAlert).toHaveBeenCalledWith(
+    'Alerts.RestartVerification.Title',
+    'Alerts.RestartVerification.Description',
+    {
+      event: AppEventCode.RESTART_VERIFICATION,
+      actions: [
+        expect.objectContaining({ text: 'Global.Cancel', style: 'cancel' }),
+        expect.objectContaining({ text: 'Alerts.RestartVerification.Action1', style: 'destructive' }),
+      ],
+    }
+  )
+
+  return mockEmitAlert.mock.calls[0][2].actions
+}
+
+describe('useRestartVerification', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    jest.mocked(BCSCLoadingContextModule.useLoadingScreen).mockReturnValue({
+      startLoading: mockStartLoading,
+    } as any)
+    jest.mocked(ErrorAlertContextModule.useErrorAlert).mockReturnValue({
+      emitAlert: mockEmitAlert,
+    } as any)
+    jest.mocked(useSecureActionsModule.useSecureActions).mockReturnValue({
+      continueVerificationProcess: mockContinueVerificationProcess,
+    } as any)
+    jest.mocked(useVerificationResetModule.useVerificationReset).mockReturnValue(mockVerificationReset)
+    mockVerificationReset.mockResolvedValue(true)
+  })
+
+  it('shows a confirmation alert without resetting anything', async () => {
+    await promptAndGetAlertActions()
+
+    expect(mockVerificationReset).not.toHaveBeenCalled()
+    expect(mockContinueVerificationProcess).not.toHaveBeenCalled()
+    expect(mockStartLoading).not.toHaveBeenCalled()
+  })
+
+  it('resets verification and re-enters the verify flow when confirmed', async () => {
+    const onConfirm = jest.fn()
+    const actions = await promptAndGetAlertActions(onConfirm)
+
+    await act(async () => {
+      await actions[1].onPress()
+    })
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    expect(mockStartLoading).toHaveBeenCalledWith('Alerts.RestartVerification.Loading')
+    expect(mockVerificationReset).toHaveBeenCalledTimes(1)
+    expect(mockContinueVerificationProcess).toHaveBeenCalledTimes(1)
+    expect(mockStopLoading).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not re-enter the verify flow when the reset fails', async () => {
+    mockVerificationReset.mockResolvedValue(false)
+    const actions = await promptAndGetAlertActions()
+
+    await act(async () => {
+      await actions[1].onPress()
+    })
+
+    expect(mockVerificationReset).toHaveBeenCalledTimes(1)
+    expect(mockContinueVerificationProcess).not.toHaveBeenCalled()
+    expect(mockStopLoading).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/src/bcsc-theme/hooks/useRestartVerification.tsx
+++ b/app/src/bcsc-theme/hooks/useRestartVerification.tsx
@@ -1,0 +1,66 @@
+import { useLoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
+import { useErrorAlert } from '@/contexts/ErrorAlertContext'
+import { AppEventCode } from '@/events/appEventCode'
+import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSecureActions } from './useSecureActions'
+import { useVerificationReset } from './useVerificationReset'
+
+/**
+ * Returns a callback that asks the user to confirm restarting the identity verification process.
+ *
+ * On confirmation, all verification progress is reset (see {@link useVerificationReset}) behind
+ * a loading screen, then the verification status is set back to in-progress so the RootStack
+ * remounts the VerifyStack at the first verification step.
+ *
+ * @returns {(onConfirm?: () => void) => void} Callback that shows the confirmation alert. The
+ * optional `onConfirm` is invoked when the user confirms, before the reset starts (e.g. to
+ * close the menu the restart was triggered from).
+ */
+export const useRestartVerification = () => {
+  const { t } = useTranslation()
+  const { emitAlert } = useErrorAlert()
+  const loadingScreen = useLoadingScreen()
+  const verificationReset = useVerificationReset()
+  const { continueVerificationProcess } = useSecureActions()
+
+  const restartVerification = useCallback(async () => {
+    const stopLoading = loadingScreen.startLoading(t('Alerts.RestartVerification.Loading'))
+
+    try {
+      const success = await verificationReset()
+
+      // On failure the reset already shows a factory reset alert, so only re-enter the verify flow on success
+      if (success) {
+        continueVerificationProcess()
+      }
+    } finally {
+      stopLoading()
+    }
+  }, [loadingScreen, t, verificationReset, continueVerificationProcess])
+
+  const promptRestartVerification = useCallback(
+    (onConfirm?: () => void) => {
+      emitAlert(t('Alerts.RestartVerification.Title'), t('Alerts.RestartVerification.Description'), {
+        event: AppEventCode.RESTART_VERIFICATION,
+        actions: [
+          {
+            text: t('Global.Cancel'),
+            style: 'cancel',
+          },
+          {
+            text: t('Alerts.RestartVerification.Action1'),
+            style: 'destructive',
+            onPress: async () => {
+              onConfirm?.()
+              await restartVerification()
+            },
+          },
+        ],
+      })
+    },
+    [emitAlert, t, restartVerification]
+  )
+
+  return promptRestartVerification
+}

--- a/app/src/bcsc-theme/hooks/useVerificationReset.tsx
+++ b/app/src/bcsc-theme/hooks/useVerificationReset.tsx
@@ -23,7 +23,8 @@ import { useSecureActions } from './useSecureActions'
  *
  * A factory reset alert is shown if any error occurs so the user isn't stuck with a broken app
  *
- * @returns {() => Promise<void>} Callback that performs the verification reset
+ * @returns {() => Promise<boolean>} Callback that performs the verification reset and resolves
+ * with whether the reset completed successfully
  */
 export const useVerificationReset = () => {
   const [store] = useStore<BCState>()
@@ -67,7 +68,7 @@ export const useVerificationReset = () => {
     [logger, registrationService, store.bcscSecure.registrationAccessToken]
   )
 
-  const verificationReset = useCallback(async () => {
+  const verificationReset = useCallback(async (): Promise<boolean> => {
     try {
       await withAccount(async (account) => {
         if (!store.bcscSecure.registrationAccessToken) {
@@ -112,9 +113,12 @@ export const useVerificationReset = () => {
           logger.info(`[useVerificationReset] New registration created with client_id: ${temp.client_id}`)
         logger.info('[useVerificationReset] New IAS registration created. Renewal reset complete.')
       })
+
+      return true
     } catch (error) {
       logger.error('[useVerificationReset] Error during account renewal reset', error as Error)
       factoryResetAlert(error)
+      return false
     }
   }, [
     store.bcscSecure.registrationAccessToken,

--- a/app/src/bcsc-theme/navigators/PromptStack.tsx
+++ b/app/src/bcsc-theme/navigators/PromptStack.tsx
@@ -1,12 +1,14 @@
+import { createFloatingHelpMenuButton } from '@/bcsc-theme/components/FloatingHelpMenuHeaderButton'
 import { createHeaderWithoutBanner } from '@/bcsc-theme/components/HeaderWithBanner'
-import { DEFAULT_HEADER_TITLE_CONTAINER_STYLE } from '@/constants'
+import { BCSCPromptStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
+import { DEFAULT_HEADER_TITLE_CONTAINER_STYLE, HelpCentreUrl } from '@/constants'
 import { useDefaultStackOptions, useTheme } from '@bifold/core'
 import { createStackNavigator } from '@react-navigation/stack'
 import React from 'react'
 
-import { createHeaderRightMoreButton } from '@/bcsc-theme/components/HeaderRightMoreButton'
-import { BCSCScreens } from '@/bcsc-theme/types/navigators'
+import { createHeaderBackButton } from '../components/HeaderBackButton'
 import { VerifyPromptScreen } from '../features/onboarding/VerifyPromptScreen'
+import { WebViewScreen } from '../features/webview/WebViewScreen'
 
 /**
  * Wraps the verify prompt in a single-screen stack so it gets the same themed header
@@ -17,7 +19,7 @@ import { VerifyPromptScreen } from '../features/onboarding/VerifyPromptScreen'
 const PromptStack: React.FC = () => {
   const theme = useTheme()
   const defaultStackOptions = useDefaultStackOptions(theme)
-  const Stack = createStackNavigator()
+  const Stack = createStackNavigator<BCSCPromptStackParams>()
 
   return (
     <Stack.Navigator
@@ -28,11 +30,24 @@ const PromptStack: React.FC = () => {
         headerBackTitleVisible: false,
         headerTitleContainerStyle: DEFAULT_HEADER_TITLE_CONTAINER_STYLE,
         header: createHeaderWithoutBanner,
-        headerRight: createHeaderRightMoreButton,
+        headerRight: createFloatingHelpMenuButton({
+          webViewScreen: BCSCScreens.PromptWebView,
+          learnMoreUrl: HelpCentreUrl.HOW_TO_SETUP,
+        }),
         title: '',
       }}
     >
       <Stack.Screen name={BCSCScreens.VerifyPrompt} component={VerifyPromptScreen} />
+      <Stack.Screen
+        name={BCSCScreens.PromptWebView}
+        component={WebViewScreen}
+        // This stack hides the back button by default (the prompt is a root screen), so the
+        // WebView opened from the help menu needs its own back button to return to the prompt.
+        options={({ route }) => ({
+          title: route.params.title,
+          headerLeft: createHeaderBackButton,
+        })}
+      />
     </Stack.Navigator>
   )
 }

--- a/app/src/bcsc-theme/navigators/VerifyStack.tsx
+++ b/app/src/bcsc-theme/navigators/VerifyStack.tsx
@@ -89,7 +89,10 @@ const VerifyStack = () => {
         headerBackTestID: testIdWithKey('Back'),
         headerBackTitleVisible: false,
         header: createHeaderWithoutBanner,
-        headerRight: createFloatingHelpMenuButton({ webViewScreen: BCSCScreens.VerifyWebView }),
+        headerRight: createFloatingHelpMenuButton({
+          webViewScreen: BCSCScreens.VerifyWebView,
+          showRestartVerification: true,
+        }),
       }}
     >
       <Stack.Screen
@@ -101,6 +104,7 @@ const VerifyStack = () => {
           headerRight: createFloatingHelpMenuButton({
             webViewScreen: BCSCScreens.VerifyWebView,
             learnMoreUrl: HelpCentreUrl.HOW_TO_SETUP,
+            showRestartVerification: true,
           }),
         }}
       />
@@ -169,6 +173,7 @@ const VerifyStack = () => {
           headerRight: createFloatingHelpMenuButton({
             webViewScreen: BCSCScreens.VerifyWebView,
             learnMoreUrl: HelpCentreUrl.VERIFICATION_METHODS,
+            showRestartVerification: true,
           }),
         }}
       />
@@ -180,6 +185,7 @@ const VerifyStack = () => {
           headerRight: createFloatingHelpMenuButton({
             webViewScreen: BCSCScreens.VerifyWebView,
             learnMoreUrl: HelpCentreUrl.VERIFY_IN_PERSON,
+            showRestartVerification: true,
           }),
         }}
       />
@@ -235,6 +241,7 @@ const VerifyStack = () => {
           headerRight: createFloatingHelpMenuButton({
             webViewScreen: BCSCScreens.VerifyWebView,
             learnMoreUrl: HelpCentreUrl.ACCEPTED_IDENTITY_DOCUMENTS,
+            showRestartVerification: true,
           }),
         }}
       />
@@ -246,6 +253,7 @@ const VerifyStack = () => {
           headerRight: createFloatingHelpMenuButton({
             webViewScreen: BCSCScreens.VerifyWebView,
             learnMoreUrl: HelpCentreUrl.ACCEPTED_IDENTITY_DOCUMENTS,
+            showRestartVerification: true,
           }),
         }}
       />

--- a/app/src/bcsc-theme/types/navigators.ts
+++ b/app/src/bcsc-theme/types/navigators.ts
@@ -112,6 +112,7 @@ export enum BCSCScreens {
   OnboardingWebView = `${BCSCStacks.Onboarding} Web view`,
   OnboardingDeveloper = `${BCSCStacks.Onboarding} Developer`,
   VerifyPrompt = `${BCSCStacks.Prompt} Verify Prompt`,
+  PromptWebView = `${BCSCStacks.Prompt} Web view`,
   MainLoading = `${BCSCStacks.Main} Loading`,
   MainSettings = `${BCSCStacks.Main} In App Settings`,
   MainWebView = `${BCSCStacks.Main} Web view`,
@@ -183,6 +184,7 @@ export type BCSCOnboardingStackParams = {
 
 export type BCSCPromptStackParams = {
   [BCSCScreens.VerifyPrompt]: undefined
+  [BCSCScreens.PromptWebView]: { url: string; title: string }
 }
 
 export type BCSCVerifyStackParams = {

--- a/app/src/events/appEventCode.ts
+++ b/app/src/events/appEventCode.ts
@@ -53,6 +53,7 @@ export enum AppEventCode {
   NO_TOKENS_RETURNED = 'no_tokens_returned',
   PHYSICAL_CARD_WILL_EXPIRE = 'physical_card_will_expire',
   PROBLEM_WITH_CONNECTION = 'problem_with_connection',
+  RESTART_VERIFICATION = 'restart_verification',
   SERVER_ERROR = 'server_error',
   UNKNOWN_SERVER_ERROR = 'unknown_server_error', // Non-IAS error code
   SERVER_TIMEOUT = 'server_timeout',

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -231,6 +231,7 @@ const translation = {
       "LearnMore": "Learn more",
       "GiveFeedback": "Give feedback",
       "ReportProblem": "Report a problem",
+      "RestartVerification": "Restart verification process",
     },
     "Contacts": {
       "Title": "Contacts",
@@ -1331,6 +1332,12 @@ const translation = {
       "Title": "Are you sure?",
       "Description": "Your verification request sent to Service BC will be deleted. Then you can choose another way to verify.",
       "Action1": "Delete Verify Request",
+    },
+    "RestartVerification": {
+      "Title": "Are you sure?",
+      "Description": "Your verification progress will be deleted and you will start the verification process from the beginning.",
+      "Action1": "Restart Verification",
+      "Loading": "Restarting verification...",
     },
     "DataUseWarning": {
       "Title": "Data Use",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -225,6 +225,7 @@ const translation = {
       "LearnMore": "Learn about BCSC app (FR)",
       "GiveFeedback": "Give feedback (FR)",
       "ReportProblem": "Report a problem (FR)",
+      "RestartVerification": "Restart verification process (FR)",
     },
     "Contacts": {
       "Title": "Contacts (FR)",
@@ -1336,6 +1337,12 @@ const translation = {
       "Title": "Are you sure? (FR)",
       "Description": "Your verification request sent to Service BC will be deleted. Then you can choose another way to verify. (FR)",
       "Action1": "Delete Verify Request (FR)",
+    },
+    "RestartVerification": {
+      "Title": "Are you sure? (FR)",
+      "Description": "Your verification progress will be deleted and you will start the verification process from the beginning. (FR)",
+      "Action1": "Restart Verification (FR)",
+      "Loading": "Restarting verification... (FR)",
     },
     "DataUseWarning": {
       "Title": "Data Use (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -225,6 +225,7 @@ const translation = {
       "LearnMore": "Learn about BCSC app (PT-BR)",
       "GiveFeedback": "Give feedback (PT-BR)",
       "ReportProblem": "Report a problem (PT-BR)",
+      "RestartVerification": "Restart verification process (PT-BR)",
     },
     "Contacts": {
       "Title": "Contacts (PT-BR)",
@@ -1336,6 +1337,12 @@ const translation = {
       "Title": "Are you sure? (PT-BR)",
       "Description": "Your verification request sent to Service BC will be deleted. Then you can choose another way to verify. (PT-BR)",
       "Action1": "Delete Verify Request (PT-BR)",
+    },
+    "RestartVerification": {
+      "Title": "Are you sure? (PT-BR)",
+      "Description": "Your verification progress will be deleted and you will start the verification process from the beginning. (PT-BR)",
+      "Action1": "Restart Verification (PT-BR)",
+      "Loading": "Restarting verification... (PT-BR)",
     },
     "DataUseWarning": {
       "Title": "Data Use (PT-BR)",


### PR DESCRIPTION
# Summary of Changes

Adds a "Restart verification process" option to the verify flow's help menu, plus two related verification UX changes:

- **Restart verification** — new `useRestartVerification` hook wired into the floating help menu on all VerifyStack screens (opt-in via `showRestartVerification`). Tapping it shows a confirmation alert, then resets verification state behind a loading screen (existing `useVerificationReset`) and re-enters the verify flow at step 1. `useVerificationReset` now returns a success boolean so the flow only re-enters on success. Includes a new `restart_verification` analytics event and en/fr/pt-br strings.
- **Help menu on the verify prompt** — PromptStack now uses the floating help menu and gets its own WebView screen (`PromptWebView`) with a back button so "Learn more" works from the prompt.
- **Card scan overlay** — rotated the ID-card mask guides 180° so the magstripe is on the left and the barcodes are top-right/bottom-right, matching how the card should be held.

# Testing Instructions

1. Start verification (Identity Selection or any later step, e.g. Choose How to Verify).
2. Open the help menu (top-right `?`) → "Restart verification process" → confirm the alert.
3. Verify the loading screen shows, then you land back at the first verification step with progress cleared. Cancelling the alert should change nothing.
4. On the verify prompt screen (after onboarding), open the help menu → "Learn more" and confirm the help centre opens in a WebView with a working back button.
5. On Scan Serial, confirm the card guide shows the magstripe band on the left and barcode guides top-right and lower-right.

Unit tests: `yarn test useRestartVerification useVerificationReset`

# Acceptance Criteria

- [ ] "Restart verification process" appears in the help menu on VerifyStack screens only, and requires confirmation before resetting.
- [ ] After restart, the user is returned to the first verification step with prior progress (ID, address, email, evidence) cleared and the device re-registered with IAS.
- [ ] A failed reset shows the factory reset alert and does not re-enter the verify flow.
- [ ] Help menu "Learn more" works from the verify prompt screen.
- [ ] Scan card overlay matches design (magstripe on the left).

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A
