### PR TITLE
feat: ToU version system check

### DIFF
--- a/app/src/bcsc-theme/features/modal/TermsOfUseUpdated.test.tsx
+++ b/app/src/bcsc-theme/features/modal/TermsOfUseUpdated.test.tsx
@@ -1,36 +1,27 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
-import { BCSCScreens } from '@/bcsc-theme/types/navigators'
+import { BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
 import { BCLocalStorageKeys } from '@/store'
 import { PersistentStorage } from '@bifold/core'
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
-import * as PushNotifications from '../../../utils/PushNotificationsHelper'
-import { TermsOfUseScreen } from './TermsOfUseScreen'
+import { TermsOfUseUpdated } from './TermsOfUseUpdated'
 
 jest.mock('@/bcsc-theme/api/hooks/useApi')
-jest.mock('../../../utils/PushNotificationsHelper', () => ({
-  status: jest.fn(),
-  NotificationPermissionStatus: {
-    DENIED: 'denied',
-    GRANTED: 'granted',
-    UNKNOWN: 'unknown',
-    BLOCKED: 'blocked',
-  },
-}))
 
 const mockTermsOfUseResponse = {
-  version: '1.0',
-  date: '2024-01-01',
-  html: '<p>Terms of Use content</p>',
+  version: '9',
+  date: '2025-06-06',
+  html: '<p>Updated Terms of Use content</p>',
 }
 
-describe('TermsOfUseScreen', () => {
+describe('TermsOfUseUpdated', () => {
   let mockNavigation: any
 
   beforeEach(() => {
     mockNavigation = useNavigation()
+    mockNavigation.canGoBack = jest.fn().mockReturnValue(true)
     jest.clearAllMocks()
     jest.useFakeTimers()
 
@@ -50,7 +41,7 @@ describe('TermsOfUseScreen', () => {
   const renderAndAccept = async () => {
     const tree = render(
       <BasicAppContext>
-        <TermsOfUseScreen navigation={mockNavigation as never} />
+        <TermsOfUseUpdated navigation={mockNavigation as never} route={{} as never} />
       </BasicAppContext>
     )
 
@@ -65,33 +56,31 @@ describe('TermsOfUseScreen', () => {
     return tree
   }
 
-  it('persists the accepted terms version and navigates to notifications when permission not granted', async () => {
+  it('persists the accepted terms version and goes back when accept is pressed', async () => {
     const storageSpy = jest.spyOn(PersistentStorage, 'storeValueForKey').mockResolvedValue()
-    jest
-      .mocked(PushNotifications.status)
-      .mockResolvedValue(PushNotifications.NotificationPermissionStatus.DENIED as never)
+    mockNavigation.canGoBack.mockReturnValue(true)
 
     await renderAndAccept()
 
     await waitFor(() => {
-      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.OnboardingNotifications)
+      expect(mockNavigation.goBack).toHaveBeenCalled()
     })
 
     expect(storageSpy).toHaveBeenCalledWith(
       BCLocalStorageKeys.BCSC,
-      expect.objectContaining({ acceptedTermsOfUseVersion: '1.0' })
+      expect.objectContaining({ acceptedTermsOfUseVersion: '9' })
     )
   })
 
-  it('navigates to secure app screen when notification permission already granted', async () => {
-    jest
-      .mocked(PushNotifications.status)
-      .mockResolvedValue(PushNotifications.NotificationPermissionStatus.GRANTED as never)
+  it('falls back to the tab stack when there is no screen to go back to', async () => {
+    mockNavigation.canGoBack.mockReturnValue(false)
 
     await renderAndAccept()
 
     await waitFor(() => {
-      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.OnboardingSecureApp)
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCStacks.Tab, { screen: BCSCScreens.Home })
     })
+
+    expect(mockNavigation.goBack).not.toHaveBeenCalled()
   })
 })

--- a/app/src/bcsc-theme/features/modal/TermsOfUseUpdated.tsx
+++ b/app/src/bcsc-theme/features/modal/TermsOfUseUpdated.tsx
@@ -1,0 +1,44 @@
+import { TermsOfUseResponseData } from '@/bcsc-theme/api/hooks/useConfigApi'
+import { BCSCMainStackParams, BCSCModals, BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
+import { BCDispatchAction, BCState } from '@/store'
+import { useStore } from '@bifold/core'
+import { StackScreenProps } from '@react-navigation/stack'
+import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { TermsOfUseContent } from '../onboarding/TermsOfUseContent'
+
+type TermsOfUseUpdatedProps = StackScreenProps<BCSCMainStackParams, BCSCModals.TermsOfUseUpdated>
+
+/**
+ * Blocking modal displayed when the server's Terms of Use version differs from the
+ * version the user last accepted. The user must accept the updated terms to continue.
+ *
+ * @see {TermsOfUseSystemCheck.ts} for the system check that presents this modal.
+ *
+ * @returns {*} {React.ReactElement} The TermsOfUseUpdated component.
+ */
+export const TermsOfUseUpdated = ({ navigation }: TermsOfUseUpdatedProps): React.ReactElement => {
+  const { t } = useTranslation()
+  const [, dispatch] = useStore<BCState>()
+
+  const handleAccept = useCallback(
+    (termsOfUse: TermsOfUseResponseData) => {
+      dispatch({
+        type: BCDispatchAction.UPDATE_ACCEPTED_TERMS_OF_USE_VERSION,
+        payload: [String(termsOfUse.version)],
+      })
+
+      // Dismiss deterministically: return to the previous route if there is one,
+      // otherwise fall back to the tab stack so the user is never stranded.
+      if (navigation.canGoBack()) {
+        navigation.goBack()
+        return
+      }
+
+      navigation.navigate(BCSCStacks.Tab, { screen: BCSCScreens.Home })
+    },
+    [dispatch, navigation]
+  )
+
+  return <TermsOfUseContent onAccept={handleAccept} headerText={t('BCSC.Modals.TermsOfUseUpdated.Header')} />
+}

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.test.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.test.tsx
@@ -1,0 +1,106 @@
+import useApi from '@/bcsc-theme/api/hooks/useApi'
+import { BasicAppContext } from '@mocks/helpers/app'
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
+import React from 'react'
+import { TermsOfUseContent } from './TermsOfUseContent'
+
+jest.mock('@/bcsc-theme/api/hooks/useApi')
+
+const mockTermsOfUseResponse = {
+  version: '1.0',
+  date: '2024-01-01',
+  html: '<p>Terms of Use content</p>',
+}
+
+describe('TermsOfUseContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+
+    const useApiMock = jest.mocked(useApi)
+    useApiMock.mockReturnValue({
+      config: {
+        getTermsOfUse: jest.fn().mockResolvedValue(mockTermsOfUseResponse),
+        getServerStatus: jest.fn(),
+      },
+    } as any)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('renders correctly after loading terms', async () => {
+    const tree = render(
+      <BasicAppContext>
+        <TermsOfUseContent onAccept={jest.fn()} />
+      </BasicAppContext>
+    )
+
+    await waitFor(() => {
+      expect(tree.queryByTestId('mocked-webview')).toBeTruthy()
+    })
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('shows loading indicator while fetching terms', () => {
+    const useApiMock = jest.mocked(useApi)
+    useApiMock.mockReturnValue({
+      config: {
+        getTermsOfUse: jest.fn().mockReturnValue(new Promise(() => {})), // never resolves
+        getServerStatus: jest.fn(),
+      },
+    } as any)
+
+    const tree = render(
+      <BasicAppContext>
+        <TermsOfUseContent onAccept={jest.fn()} />
+      </BasicAppContext>
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('shows retry button on error', async () => {
+    const useApiMock = jest.mocked(useApi)
+    useApiMock.mockReturnValue({
+      config: {
+        getTermsOfUse: jest.fn().mockRejectedValue(new Error('Network error')),
+        getServerStatus: jest.fn(),
+      },
+    } as any)
+
+    const tree = render(
+      <BasicAppContext>
+        <TermsOfUseContent onAccept={jest.fn()} />
+      </BasicAppContext>
+    )
+
+    await waitFor(() => {
+      expect(tree.getByTestId('com.ariesbifold:id/RetryTermsOfUse')).toBeTruthy()
+    })
+  })
+
+  it('calls onAccept with the loaded terms when accept is pressed', async () => {
+    const onAccept = jest.fn()
+
+    const tree = render(
+      <BasicAppContext>
+        <TermsOfUseContent onAccept={onAccept} />
+      </BasicAppContext>
+    )
+
+    await waitFor(() => {
+      expect(tree.queryByTestId('mocked-webview')).toBeTruthy()
+    })
+
+    // Simulate the webview finishing loading to enable the accept button
+    fireEvent(tree.getByTestId('mocked-webview'), 'load')
+    fireEvent.press(tree.getByTestId('com.ariesbifold:id/AcceptAndContinue'))
+
+    await waitFor(() => {
+      expect(onAccept).toHaveBeenCalledWith(mockTermsOfUseResponse)
+    })
+  })
+})

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.tsx
@@ -1,0 +1,145 @@
+import useApi from '@/bcsc-theme/api/hooks/useApi'
+import { TermsOfUseResponseData } from '@/bcsc-theme/api/hooks/useConfigApi'
+import { createTermsOfUseHtml } from '@/bcsc-theme/utils/webview-utils'
+import {
+  Button,
+  ButtonType,
+  ContentGradient,
+  ScreenWrapper,
+  testIdWithKey,
+  ThemedText,
+  TOKENS,
+  useServices,
+  useTheme,
+} from '@bifold/core'
+import { a11yLabel } from '@utils/accessibility'
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ActivityIndicator, StyleSheet, useWindowDimensions, View } from 'react-native'
+import { WebViewContent } from '../webview/WebViewContent'
+
+interface TermsOfUseContentProps {
+  /**
+   * Called when the user presses the accept button, with the terms that were displayed.
+   */
+  onAccept: (termsOfUse: TermsOfUseResponseData) => void | Promise<void>
+  /**
+   * Header text rendered above the terms. Defaults to the onboarding header.
+   */
+  headerText?: string
+}
+
+/**
+ * Reusable Terms of Use content component that fetches and presents the terms of use to the user.
+ *
+ * Used by the onboarding Terms of Use screen and the updated terms re-acceptance modal.
+ *
+ * @returns {*} {React.ReactElement} The TermsOfUseContent component.
+ */
+export const TermsOfUseContent = ({ onAccept, headerText }: TermsOfUseContentProps): React.ReactElement => {
+  const { t } = useTranslation()
+  const { Spacing, ColorPalette, TextTheme } = useTheme()
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const { config } = useApi()
+  const [termsOfUse, setTermsOfUse] = useState<TermsOfUseResponseData | null>(null)
+  const [webViewIsLoaded, setWebViewIsLoaded] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState(false)
+  const { fontScale } = useWindowDimensions()
+
+  const fetchTermsOfUse = useCallback(async () => {
+    try {
+      setIsLoading(true)
+      const data = await config.getTermsOfUse()
+      setError(false)
+      setTermsOfUse(data)
+    } catch (err) {
+      logger.error('Failed to fetch Terms of Use', err as Error)
+      setError(true)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [config, logger])
+
+  useEffect(() => {
+    fetchTermsOfUse()
+  }, [fetchTermsOfUse])
+
+  const styles = StyleSheet.create({
+    scrollContainer: {
+      paddingHorizontal: Spacing.sm,
+      flex: 1,
+    },
+    loadingContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+  })
+
+  const controls = (
+    <View style={{ width: '100%' }}>
+      <ContentGradient backgroundColor={ColorPalette.brand.primaryBackground} />
+      {error ? (
+        <Button
+          title={t('Init.Retry')}
+          buttonType={ButtonType.Primary}
+          onPress={fetchTermsOfUse}
+          testID={testIdWithKey('RetryTermsOfUse')}
+          accessibilityLabel={a11yLabel(t('Init.Retry'))}
+          disabled={isLoading}
+        />
+      ) : (
+        <Button
+          title={t('BCSC.Onboarding.AcceptAndContinueButton')}
+          buttonType={ButtonType.Primary}
+          onPress={async () => {
+            if (termsOfUse) {
+              await onAccept(termsOfUse)
+            }
+          }}
+          testID={testIdWithKey('AcceptAndContinue')}
+          accessibilityLabel={a11yLabel(t('BCSC.Onboarding.AcceptAndContinueButton'))}
+          disabled={!webViewIsLoaded || isLoading}
+        />
+      )}
+    </View>
+  )
+
+  if (!termsOfUse) {
+    return (
+      <ScreenWrapper controls={controls} scrollViewContainerStyle={styles.scrollContainer}>
+        <View style={styles.loadingContainer}>
+          {error && !isLoading ? (
+            <View style={{ flexDirection: 'row' }}>
+              <ThemedText style={{ flexWrap: 'wrap', flexShrink: 1, textAlign: 'center' }}>
+                {t('BCSC.Onboarding.TermsOfUseLoadError')}
+              </ThemedText>
+            </View>
+          ) : (
+            <ActivityIndicator size="large" />
+          )}
+        </View>
+      </ScreenWrapper>
+    )
+  }
+
+  return (
+    <ScreenWrapper scrollable={false} controls={controls} scrollViewContainerStyle={styles.scrollContainer}>
+      <WebViewContent
+        html={createTermsOfUseHtml(
+          {
+            termsOfUse,
+            colorPalette: ColorPalette,
+            textColor: TextTheme.normal.color,
+            headerText: headerText ?? t('BCSC.Onboarding.TermsOfUseHeader'),
+            subtitlePrefix: t('BCSC.Onboarding.TermsOfUseSubtitle'),
+            versionLabel: t('BCSC.Onboarding.TermsOfUseVersion'),
+          },
+          fontScale
+        )}
+        onLoaded={() => setWebViewIsLoaded(true)}
+      />
+    </ScreenWrapper>
+  )
+}

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.tsx
@@ -54,7 +54,7 @@ export const TermsOfUseContent = ({ onAccept, headerText }: TermsOfUseContentPro
       setError(false)
       setTermsOfUse(data)
     } catch (err) {
-      logger.error('Failed to fetch Terms of Use', err as Error)
+      logger.error('Failed to fetch Terms of Use', err instanceof Error ? err : new Error(String(err)))
       setError(true)
     } finally {
       setIsLoading(false)

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.tsx
@@ -1,24 +1,11 @@
-import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { TermsOfUseResponseData } from '@/bcsc-theme/api/hooks/useConfigApi'
-import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import { BCSCOnboardingStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
-import { createTermsOfUseHtml } from '@/bcsc-theme/utils/webview-utils'
-import {
-  Button,
-  ButtonType,
-  ScreenWrapper,
-  testIdWithKey,
-  ThemedText,
-  TOKENS,
-  useServices,
-  useTheme,
-} from '@bifold/core'
+import { BCDispatchAction, BCState } from '@/store'
+import { useStore } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
-import { a11yLabel } from '@utils/accessibility'
-import { useCallback, useEffect, useState } from 'react'
-import { useTranslation } from 'react-i18next'
-import { ActivityIndicator, StyleSheet, useWindowDimensions, View } from 'react-native'
-import { WebViewContent } from '../webview/WebViewContent'
+import { useCallback } from 'react'
+import * as PushNotifications from '../../../utils/PushNotificationsHelper'
+import { TermsOfUseContent } from './TermsOfUseContent'
 
 interface TermsOfUseScreenProps {
   navigation: StackNavigationProp<BCSCOnboardingStackParams, BCSCScreens.OnboardingTermsOfUse>
@@ -30,119 +17,26 @@ interface TermsOfUseScreenProps {
  * @returns {*} {React.ReactElement} The TermsOfUseScreen component.
  */
 export const TermsOfUseScreen = ({ navigation }: TermsOfUseScreenProps): React.ReactElement => {
-  const { t } = useTranslation()
-  const { Spacing, ColorPalette, TextTheme } = useTheme()
-  const [logger] = useServices([TOKENS.UTIL_LOGGER])
-  const { config } = useApi()
-  const [termsOfUse, setTermsOfUse] = useState<TermsOfUseResponseData | null>(null)
-  const [webViewIsLoaded, setWebViewIsLoaded] = useState(false)
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState(false)
-  const { fontScale } = useWindowDimensions()
+  const [, dispatch] = useStore<BCState>()
 
-  const fetchTermsOfUse = useCallback(async () => {
-    try {
-      setIsLoading(true)
-      const data = await config.getTermsOfUse()
-      setError(false)
-      setTermsOfUse(data)
-    } catch (err) {
-      logger.error('Failed to fetch Terms of Use', err as Error)
-      setError(true)
-    } finally {
-      setIsLoading(false)
-    }
-  }, [config, logger])
+  const handleAccept = useCallback(
+    async (termsOfUse: TermsOfUseResponseData) => {
+      dispatch({
+        type: BCDispatchAction.UPDATE_ACCEPTED_TERMS_OF_USE_VERSION,
+        payload: [String(termsOfUse.version)],
+      })
 
-  useEffect(() => {
-    fetchTermsOfUse()
-  }, [fetchTermsOfUse])
+      const status = await PushNotifications.status()
 
-  const styles = StyleSheet.create({
-    scrollContainer: {
-      padding: Spacing.lg,
-      flex: 1,
+      // if permission is granted, skip notification screen
+      if (status === PushNotifications.NotificationPermissionStatus.GRANTED) {
+        return navigation.navigate(BCSCScreens.OnboardingSecureApp)
+      }
+
+      navigation.navigate(BCSCScreens.OnboardingNotifications)
     },
-    loadingContainer: {
-      flex: 1,
-      justifyContent: 'center',
-      alignItems: 'center',
-    },
-    // Reserve a thin gap below the WebView so the ControlContainer's
-    // upward DropShadow has non-webview pixels to render on top of
-    webViewContainer: {
-      flex: 1,
-      marginBottom: Spacing.md,
-    },
-  })
-
-  const controls = (
-    <ControlContainer>
-      {error ? (
-        <Button
-          title={t('Init.Retry')}
-          buttonType={ButtonType.Primary}
-          onPress={fetchTermsOfUse}
-          testID={testIdWithKey('RetryTermsOfUse')}
-          accessibilityLabel={a11yLabel(t('Init.Retry'))}
-          disabled={isLoading}
-        />
-      ) : (
-        <Button
-          title={t('BCSC.Onboarding.AcceptAndContinueButton')}
-          buttonType={ButtonType.Primary}
-          onPress={() => {
-            navigation.navigate(BCSCScreens.OnboardingOptInAnalytics)
-          }}
-          testID={testIdWithKey('AcceptAndContinue')}
-          accessibilityLabel={a11yLabel(t('BCSC.Onboarding.AcceptAndContinueButton'))}
-          disabled={!webViewIsLoaded || isLoading}
-        />
-      )}
-    </ControlContainer>
+    [dispatch, navigation]
   )
 
-  if (!termsOfUse) {
-    return (
-      <ScreenWrapper padded={false} controls={controls} scrollViewContainerStyle={styles.scrollContainer}>
-        <View style={styles.loadingContainer}>
-          {error && !isLoading ? (
-            <View style={{ flexDirection: 'row' }}>
-              <ThemedText style={{ flexWrap: 'wrap', flexShrink: 1, textAlign: 'center' }}>
-                {t('BCSC.Onboarding.TermsOfUseLoadError')}
-              </ThemedText>
-            </View>
-          ) : (
-            <ActivityIndicator size="large" />
-          )}
-        </View>
-      </ScreenWrapper>
-    )
-  }
-
-  return (
-    <ScreenWrapper
-      padded={false}
-      scrollable={false}
-      controls={controls}
-      scrollViewContainerStyle={styles.scrollContainer}
-    >
-      <View style={styles.webViewContainer}>
-        <WebViewContent
-          html={createTermsOfUseHtml(
-            {
-              termsOfUse,
-              colorPalette: ColorPalette,
-              textColor: TextTheme.normal.color,
-              headerText: t('BCSC.Onboarding.TermsOfUseHeader'),
-              subtitlePrefix: t('BCSC.Onboarding.TermsOfUseSubtitle'),
-              versionLabel: t('BCSC.Onboarding.TermsOfUseVersion'),
-            },
-            fontScale
-          )}
-          onLoaded={() => setWebViewIsLoaded(true)}
-        />
-      </View>
-    </ScreenWrapper>
-  )
+  return <TermsOfUseContent onAccept={handleAccept} />
 }

--- a/app/src/bcsc-theme/features/onboarding/__snapshots__/TermsOfUseContent.test.tsx.snap
+++ b/app/src/bcsc-theme/features/onboarding/__snapshots__/TermsOfUseContent.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TermsOfUse renders correctly after loading terms 1`] = `
+exports[`TermsOfUseContent renders correctly after loading terms 1`] = `
 <RNCSafeAreaView
   edges={
     {
@@ -240,7 +240,7 @@ exports[`TermsOfUse renders correctly after loading terms 1`] = `
 </RNCSafeAreaView>
 `;
 
-exports[`TermsOfUse shows loading indicator while fetching terms 1`] = `
+exports[`TermsOfUseContent shows loading indicator while fetching terms 1`] = `
 <RNCSafeAreaView
   edges={
     {

--- a/app/src/bcsc-theme/features/onboarding/__snapshots__/TermsOfUseContent.test.tsx.snap
+++ b/app/src/bcsc-theme/features/onboarding/__snapshots__/TermsOfUseContent.test.tsx.snap
@@ -21,33 +21,25 @@ exports[`TermsOfUseContent renders correctly after loading terms 1`] = `
   }
 >
   <View
-    style={
-      {
-        "flex": 1,
-        "marginBottom": 16,
-      }
+    allowsBackForwardNavigationGestures={true}
+    bounces={false}
+    domStorageEnabled={true}
+    javaScriptEnabled={true}
+    mixedContentMode="compatibility"
+    onError={[Function]}
+    onHttpError={[Function]}
+    onLoad={[Function]}
+    originWhitelist={
+      [
+        "*",
+      ]
     }
-  >
-    <View
-      allowsBackForwardNavigationGestures={true}
-      bounces={false}
-      domStorageEnabled={true}
-      javaScriptEnabled={true}
-      mixedContentMode="compatibility"
-      onError={[Function]}
-      onHttpError={[Function]}
-      onLoad={[Function]}
-      originWhitelist={
-        [
-          "*",
-        ]
-      }
-      renderLoading={[Function]}
-      sharedCookiesEnabled={true}
-      source={
-        {
-          "baseUrl": "",
-          "html": "<!DOCTYPE html>
+    renderLoading={[Function]}
+    sharedCookiesEnabled={true}
+    source={
+      {
+        "baseUrl": "",
+        "html": "<!DOCTYPE html>
 <html>
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -81,27 +73,29 @@ exports[`TermsOfUseContent renders correctly after loading terms 1`] = `
 <p>Terms of Use content</p>
 </body>
 </html>",
-        }
       }
-      startInLoadingState={true}
-      style={
-        {
-          "backgroundColor": "#F2F2F2",
-        }
+    }
+    startInLoadingState={true}
+    style={
+      {
+        "backgroundColor": "#F2F2F2",
       }
-      testID="mocked-webview"
-      textZoom={200}
-      thirdPartyCookiesEnabled={true}
-      userAgent="BCServicesCard/4.0.0 (iOS 17.4; Build 142)"
-    />
-  </View>
+    }
+    testID="mocked-webview"
+    textZoom={200}
+    thirdPartyCookiesEnabled={true}
+    userAgent="BCServicesCard/4.0.0 (iOS 17.4; Build 142)"
+  />
   <View
     style={
       [
         {
           "gap": 16,
         },
-        false,
+        {
+          "paddingBottom": 16,
+          "paddingHorizontal": 16,
+        },
         undefined,
       ]
     }
@@ -109,7 +103,6 @@ exports[`TermsOfUseContent renders correctly after loading terms 1`] = `
     <View
       style={
         {
-          "flexGrow": 1,
           "width": "100%",
         }
       }
@@ -117,122 +110,168 @@ exports[`TermsOfUseContent renders correctly after loading terms 1`] = `
       <View
         style={
           {
-            "left": 0,
+            "height": 30,
             "position": "absolute",
-            "right": 0,
-            "shadowColor": "#000",
-            "shadowOffset": {
-              "height": -3,
-              "width": 0,
-            },
-            "shadowOpacity": 0.9,
-            "shadowRadius": 3,
-            "top": 0,
-            "zIndex": -1,
+            "top": -30,
+            "width": "100%",
           }
         }
       >
-        <View
-          style={
-            {
-              "backgroundColor": "#F2F2F2",
-              "height": 1,
-            }
-          }
-        />
-      </View>
-      <View
-        style={
-          {
-            "backgroundColor": "#F2F2F2",
-            "flexGrow": 1,
-            "gap": 8,
-            "padding": 24,
-          }
-        }
-      >
-        <View
-          accessibilityLabel="BCSC.Onboarding.AcceptAndContinueButton"
-          accessibilityRole="button"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": true,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
+        <RNSVGSvgView
+          bbHeight="30"
+          bbWidth="100%"
           focusable={false}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
+          height="30"
           style={
-            {
-              "backgroundColor": "#757575",
-              "borderRadius": 4,
-              "opacity": 1,
-              "padding": 16,
-            }
-          }
-          testID="com.ariesbifold:id/AcceptAndContinue"
-        >
-          <View
-            style={
+            [
               {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
+                "backgroundColor": "transparent",
+                "borderWidth": 0,
+              },
+              {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "flex": 0,
+                "height": 30,
+                "width": "100%",
+              },
+            ]
+          }
+          width="100%"
+        >
+          <RNSVGGroup
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
               }
             }
           >
-            <Text
-              maxFontSizeMultiplier={2}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontFamily": "BCSans-Regular",
-                    "fontSize": 18,
-                    "fontWeight": "normal",
-                  },
+            <RNSVGDefs>
+              <RNSVGLinearGradient
+                gradient={
                   [
-                    {
-                      "color": "#FFFFFF",
-                      "fontFamily": "BCSans-Regular",
-                      "fontSize": 18,
-                      "fontWeight": "bold",
-                      "textAlign": "center",
-                    },
-                    {
-                      "color": "#FFFFFF",
-                      "fontFamily": "BCSans-Regular",
-                      "fontSize": 18,
-                      "fontWeight": "bold",
-                      "textAlign": "center",
-                    },
-                    false,
-                  ],
+                    0,
+                    15921906,
+                    1,
+                    -855310,
+                  ]
+                }
+                gradientTransform={null}
+                gradientUnits={0}
+                name="gradient"
+                x1="0%"
+                x2="0%"
+                y1="0%"
+                y2="100%"
+              />
+            </RNSVGDefs>
+            <RNSVGRect
+              fill={
+                {
+                  "brushRef": "gradient",
+                  "type": 1,
+                }
+              }
+              height="30"
+              propList={
+                [
+                  "fill",
                 ]
               }
-            >
-              BCSC.Onboarding.AcceptAndContinueButton
-            </Text>
-          </View>
+              width="100%"
+              x={0}
+              y={0}
+            />
+          </RNSVGGroup>
+        </RNSVGSvgView>
+      </View>
+      <View
+        accessibilityLabel="BCSC.Onboarding.AcceptAndContinueButton"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": true,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={false}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "backgroundColor": "#757575",
+            "borderRadius": 4,
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/AcceptAndContinue"
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            maxFontSizeMultiplier={2}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                },
+                [
+                  {
+                    "color": "#FFFFFF",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "#FFFFFF",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                    "textAlign": "center",
+                  },
+                  false,
+                ],
+              ]
+            }
+          >
+            BCSC.Onboarding.AcceptAndContinueButton
+          </Text>
         </View>
       </View>
     </View>
@@ -263,10 +302,12 @@ exports[`TermsOfUseContent shows loading indicator while fetching terms 1`] = `
   <RCTScrollView
     contentContainerStyle={
       [
-        false,
+        {
+          "padding": 16,
+        },
         {
           "flex": 1,
-          "padding": 24,
+          "paddingHorizontal": 8,
         },
       ]
     }
@@ -294,7 +335,10 @@ exports[`TermsOfUseContent shows loading indicator while fetching terms 1`] = `
         {
           "gap": 16,
         },
-        false,
+        {
+          "paddingBottom": 16,
+          "paddingHorizontal": 16,
+        },
         undefined,
       ]
     }
@@ -302,7 +346,6 @@ exports[`TermsOfUseContent shows loading indicator while fetching terms 1`] = `
     <View
       style={
         {
-          "flexGrow": 1,
           "width": "100%",
         }
       }
@@ -310,122 +353,168 @@ exports[`TermsOfUseContent shows loading indicator while fetching terms 1`] = `
       <View
         style={
           {
-            "left": 0,
+            "height": 30,
             "position": "absolute",
-            "right": 0,
-            "shadowColor": "#000",
-            "shadowOffset": {
-              "height": -3,
-              "width": 0,
-            },
-            "shadowOpacity": 0.9,
-            "shadowRadius": 3,
-            "top": 0,
-            "zIndex": -1,
+            "top": -30,
+            "width": "100%",
           }
         }
       >
-        <View
-          style={
-            {
-              "backgroundColor": "#F2F2F2",
-              "height": 1,
-            }
-          }
-        />
-      </View>
-      <View
-        style={
-          {
-            "backgroundColor": "#F2F2F2",
-            "flexGrow": 1,
-            "gap": 8,
-            "padding": 24,
-          }
-        }
-      >
-        <View
-          accessibilityLabel="BCSC.Onboarding.AcceptAndContinueButton"
-          accessibilityRole="button"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": true,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
+        <RNSVGSvgView
+          bbHeight="30"
+          bbWidth="100%"
           focusable={false}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
+          height="30"
           style={
-            {
-              "backgroundColor": "#757575",
-              "borderRadius": 4,
-              "opacity": 1,
-              "padding": 16,
-            }
-          }
-          testID="com.ariesbifold:id/AcceptAndContinue"
-        >
-          <View
-            style={
+            [
               {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
+                "backgroundColor": "transparent",
+                "borderWidth": 0,
+              },
+              {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "flex": 0,
+                "height": 30,
+                "width": "100%",
+              },
+            ]
+          }
+          width="100%"
+        >
+          <RNSVGGroup
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
               }
             }
           >
-            <Text
-              maxFontSizeMultiplier={2}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontFamily": "BCSans-Regular",
-                    "fontSize": 18,
-                    "fontWeight": "normal",
-                  },
+            <RNSVGDefs>
+              <RNSVGLinearGradient
+                gradient={
                   [
-                    {
-                      "color": "#FFFFFF",
-                      "fontFamily": "BCSans-Regular",
-                      "fontSize": 18,
-                      "fontWeight": "bold",
-                      "textAlign": "center",
-                    },
-                    {
-                      "color": "#FFFFFF",
-                      "fontFamily": "BCSans-Regular",
-                      "fontSize": 18,
-                      "fontWeight": "bold",
-                      "textAlign": "center",
-                    },
-                    false,
-                  ],
+                    0,
+                    15921906,
+                    1,
+                    -855310,
+                  ]
+                }
+                gradientTransform={null}
+                gradientUnits={0}
+                name="gradient"
+                x1="0%"
+                x2="0%"
+                y1="0%"
+                y2="100%"
+              />
+            </RNSVGDefs>
+            <RNSVGRect
+              fill={
+                {
+                  "brushRef": "gradient",
+                  "type": 1,
+                }
+              }
+              height="30"
+              propList={
+                [
+                  "fill",
                 ]
               }
-            >
-              BCSC.Onboarding.AcceptAndContinueButton
-            </Text>
-          </View>
+              width="100%"
+              x={0}
+              y={0}
+            />
+          </RNSVGGroup>
+        </RNSVGSvgView>
+      </View>
+      <View
+        accessibilityLabel="BCSC.Onboarding.AcceptAndContinueButton"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": true,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={false}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "backgroundColor": "#757575",
+            "borderRadius": 4,
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/AcceptAndContinue"
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            maxFontSizeMultiplier={2}
+            style={
+              [
+                {
+                  "color": "#313132",
+                  "fontFamily": "BCSans-Regular",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                },
+                [
+                  {
+                    "color": "#FFFFFF",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "#FFFFFF",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                    "textAlign": "center",
+                  },
+                  false,
+                ],
+              ]
+            }
+          >
+            BCSC.Onboarding.AcceptAndContinueButton
+          </Text>
         </View>
       </View>
     </View>

--- a/app/src/bcsc-theme/hooks/useCreateSystemChecks.test.tsx
+++ b/app/src/bcsc-theme/hooks/useCreateSystemChecks.test.tsx
@@ -81,6 +81,10 @@ jest.mock('@/services/system-checks/ServerClockSkewSystemCheck', () => ({
   ServerClockSkewSystemCheck: class ServerClockSkewSystemCheck {},
 }))
 
+jest.mock('@/services/system-checks/TermsOfUseSystemCheck', () => ({
+  TermsOfUseSystemCheck: class TermsOfUseSystemCheck {},
+}))
+
 jest.mock('@/bcsc-theme/components/AppBanner', () => ({
   BCSCBanner: {
     IAS_SERVER_UNAVAILABLE: 'IASServerUnavailableBanner',
@@ -300,16 +304,18 @@ describe('useGetSystemChecks', () => {
 
         mockUseTokenApi.mockReturnValue({ getCachedIdTokenMetadata: jest.fn() })
         mockUseRegistrationApi.mockReturnValue({})
+        mockUseConfigApi.mockReturnValue({ getTermsOfUse: jest.fn() })
 
         const { result } = renderHook(() => useCreateSystemChecks())
 
         const systemChecks = await result.current[SystemCheckScope.MAIN_STACK].getSystemChecks()
 
-        expect(systemChecks).toHaveLength(4) // DeviceCountSystemCheck, AccountExpiryWarningBannerSystemCheck, UpdateDeviceRegistrationSystemCheck
+        expect(systemChecks).toHaveLength(5) // DeviceCountSystemCheck, AccountExpiryWarningBannerSystemCheck, EventReasonAlertsSystemCheck, TermsOfUseSystemCheck, UpdateDeviceRegistrationSystemCheck
         expect(systemChecks[0].constructor.name).toBe('DeviceCountSystemCheck')
         expect(systemChecks[1].constructor.name).toBe('AccountExpiryWarningBannerSystemCheck')
         expect(systemChecks[2].constructor.name).toBe('EventReasonAlertsSystemCheck')
-        expect(systemChecks[3].constructor.name).toBe('UpdateDeviceRegistrationSystemCheck')
+        expect(systemChecks[3].constructor.name).toBe('TermsOfUseSystemCheck')
+        expect(systemChecks[4].constructor.name).toBe('UpdateDeviceRegistrationSystemCheck')
       })
     })
   })

--- a/app/src/bcsc-theme/hooks/useCreateSystemChecks.test.tsx
+++ b/app/src/bcsc-theme/hooks/useCreateSystemChecks.test.tsx
@@ -287,6 +287,7 @@ describe('useGetSystemChecks', () => {
             },
             bcscSecure: {
               isHydrated: true,
+              verified: true,
             },
           },
           jest.fn(),
@@ -316,6 +317,51 @@ describe('useGetSystemChecks', () => {
         expect(systemChecks[2].constructor.name).toBe('EventReasonAlertsSystemCheck')
         expect(systemChecks[3].constructor.name).toBe('TermsOfUseSystemCheck')
         expect(systemChecks[4].constructor.name).toBe('UpdateDeviceRegistrationSystemCheck')
+      })
+
+      it('skips the id-token / account checks for an unverified user but still runs Terms of Use', async () => {
+        jest.spyOn(DeviceInfo, 'getBundleId').mockReturnValue('ca.bc.gov.id.servicescard')
+        mockUseStore.mockReturnValue([
+          {
+            stateLoaded: true,
+            developer: {
+              environment: {
+                analyticsAppId: 'test-app-id',
+              },
+            },
+            bcsc: {
+              analyticsOptIn: true,
+            },
+            bcscSecure: {
+              isHydrated: true,
+              verified: false,
+            },
+          },
+          jest.fn(),
+        ])
+
+        mockUseServices.mockReturnValue([{ info: jest.fn(), error: jest.fn() }])
+        mockUseBCSCApiClientState.mockReturnValue({ client: {}, isClientReady: true })
+        mockUseNavigationContainer.mockReturnValue({ isNavigationReady: true })
+        mockGetBundleId.mockReturnValue('ca.bc.gov.id.servicescard')
+        // Unverified users have no loaded account
+        jest.spyOn(React, 'useContext').mockReturnValue({ account: null })
+        mockUseTokenApi.mockReturnValue({ getCachedIdTokenMetadata: jest.fn() })
+        mockUseRegistrationApi.mockReturnValue({})
+        mockUseConfigApi.mockReturnValue({ getTermsOfUse: jest.fn() })
+
+        const { result } = renderHook(() => useCreateSystemChecks())
+
+        const systemChecks = await result.current[SystemCheckScope.MAIN_STACK].getSystemChecks()
+        const names = systemChecks.map((check) => check.constructor.name)
+
+        // Token-dependent checks would call getIdToken (which surfaces a user-facing
+        // "token null" error for unverified users), so they are skipped — but the
+        // account-independent Terms of Use check still runs.
+        expect(names).toContain('TermsOfUseSystemCheck')
+        expect(names).not.toContain('DeviceCountSystemCheck')
+        expect(names).not.toContain('EventReasonAlertsSystemCheck')
+        expect(names).not.toContain('AccountExpiryWarningBannerSystemCheck')
       })
     })
   })

--- a/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
+++ b/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
@@ -68,6 +68,7 @@ export const useCreateSystemChecks = (): UseGetSystemChecksReturn => {
 
   const defaultReadiness = isNavigationReady && client && isClientReady
   const accountExpirationDate = accountContext?.account?.account_expiration_date
+  const isVerified = Boolean(store.bcscSecure.verified)
   const isBCServicesCardBundle = getBundleId().includes(BCSC_BUILD_SUFFIX)
 
   // update credential metadata ref on store change
@@ -120,29 +121,53 @@ export const useCreateSystemChecks = (): UseGetSystemChecksReturn => {
    * @returns Array of system check strategies
    */
   const getMainSystemChecks = useCallback(async (): Promise<SystemCheckStrategy[]> => {
-    if (!accountExpirationDate) {
-      throw new Error('Account expiration date undefined. Did you forget to check isReady?')
+    // Guard the native call so a failure here cannot throw away the whole batch
+    let dismissedAt: number | undefined
+    try {
+      dismissedAt = await getMaxDevicesBannerLastDisplayedDate()
+    } catch {
+      dismissedAt = undefined
     }
-
-    const dismissedAt = await getMaxDevicesBannerLastDisplayedDate()
     const getIdToken = () => tokenService.getCachedIdTokenMetadata({ refreshCache: false })
     const updateRegistration = () =>
       registrationService.updateRegistration(store.bcscSecure.registrationAccessToken, store.bcsc.selectedNickname)
 
-    const systemChecks: SystemCheckStrategy[] = [
-      new DeviceCountSystemCheck(getIdToken, utils, dismissedAt),
-      new AccountExpiryWarningBannerSystemCheck(accountExpirationDate, utils),
-      new EventReasonAlertsSystemCheck(getIdToken, emitAlert, credentialMetadataRef.current, utils, navigation),
+    const systemChecks: SystemCheckStrategy[] = []
+
+    // DeviceCount and EventReasonAlerts read the cached id token, which only exists
+    // for verified users; calling getIdToken without one surfaces a user-facing
+    // "token null" error (err 119). Gate them on verification so unverified users
+    // still get the account-independent checks (Terms of Use) below.
+    if (isVerified) {
+      systemChecks.push(new DeviceCountSystemCheck(getIdToken, utils, dismissedAt))
+    }
+
+    // Account expiry is only meaningful once the account metadata has loaded, which
+    // happens only for verified users. Include it conditionally so unverified users
+    // still get the account-independent checks rather than the whole batch being
+    // gated off when accountExpirationDate is undefined.
+    if (accountExpirationDate) {
+      systemChecks.push(new AccountExpiryWarningBannerSystemCheck(accountExpirationDate, utils))
+    }
+
+    if (isVerified) {
+      systemChecks.push(
+        new EventReasonAlertsSystemCheck(getIdToken, emitAlert, credentialMetadataRef.current, utils, navigation)
+      )
+    }
+
+    // Terms of Use applies to every user (the endpoint is public, no token needed)
+    systemChecks.push(
       new TermsOfUseSystemCheck(
         () => configApi.getTermsOfUse(),
         store.bcsc.acceptedTermsOfUseVersion,
         navigation,
         utils
-      ),
+      )
       // TODO (ar/bm): v3 doesn't include the checks below; re-add if needed in future
       // AccountExpiryWarningAlertSystemCheck
       // AccountExpiryAlertSystemCheck
-    ]
+    )
 
     // Only run device registration update check for BCSC builds (ie: bundleId ca.bc.gov.id.servicescard)
     if (isBCServicesCardBundle) {
@@ -158,6 +183,7 @@ export const useCreateSystemChecks = (): UseGetSystemChecksReturn => {
     return systemChecks
   }, [
     accountExpirationDate,
+    isVerified,
     utils,
     emitAlert,
     navigation,
@@ -180,15 +206,10 @@ export const useCreateSystemChecks = (): UseGetSystemChecksReturn => {
       },
       [SystemCheckScope.MAIN_STACK]: {
         getSystemChecks: getMainSystemChecks,
-        isReady: Boolean(defaultReadiness && store.bcscSecure.isHydrated && accountExpirationDate),
+        // Not gated on accountExpirationDate: the batch runs for unverified users too,
+        // and account-dependent checks are included conditionally in the builder.
+        isReady: Boolean(defaultReadiness && store.bcscSecure.isHydrated),
       },
     }
-  }, [
-    accountExpirationDate,
-    defaultReadiness,
-    getMainSystemChecks,
-    getStartupSystemChecks,
-    store.bcscSecure.isHydrated,
-    store.stateLoaded,
-  ])
+  }, [defaultReadiness, getMainSystemChecks, getStartupSystemChecks, store.bcscSecure.isHydrated, store.stateLoaded])
 }

--- a/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
+++ b/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
@@ -9,6 +9,7 @@ import { DeviceCountSystemCheck } from '@/services/system-checks/DeviceCountSyst
 import { EventReasonAlertsSystemCheck } from '@/services/system-checks/EventReasonAlertsSystemCheck'
 import { ServerClockSkewSystemCheck } from '@/services/system-checks/ServerClockSkewSystemCheck'
 import { ServerStatusSystemCheck } from '@/services/system-checks/ServerStatusSystemCheck'
+import { TermsOfUseSystemCheck } from '@/services/system-checks/TermsOfUseSystemCheck'
 import { UpdateAppSystemCheck } from '@/services/system-checks/UpdateAppSystemCheck'
 import { UpdateDeviceRegistrationSystemCheck } from '@/services/system-checks/UpdateDeviceRegistrationSystemCheck'
 import { BCState } from '@/store'
@@ -132,6 +133,12 @@ export const useCreateSystemChecks = (): UseGetSystemChecksReturn => {
       new DeviceCountSystemCheck(getIdToken, utils, dismissedAt),
       new AccountExpiryWarningBannerSystemCheck(accountExpirationDate, utils),
       new EventReasonAlertsSystemCheck(getIdToken, emitAlert, credentialMetadataRef.current, utils, navigation),
+      new TermsOfUseSystemCheck(
+        () => configApi.getTermsOfUse(),
+        store.bcsc.acceptedTermsOfUseVersion,
+        navigation,
+        utils
+      ),
       // TODO (ar/bm): v3 doesn't include the checks below; re-add if needed in future
       // AccountExpiryWarningAlertSystemCheck
       // AccountExpiryAlertSystemCheck
@@ -157,10 +164,12 @@ export const useCreateSystemChecks = (): UseGetSystemChecksReturn => {
     isBCServicesCardBundle,
     tokenService,
     registrationService,
+    configApi,
     store.bcscSecure.registrationAccessToken,
     store.bcsc.selectedNickname,
     store.bcsc.appVersion,
     store.bcsc.appBuildNumber,
+    store.bcsc.acceptedTermsOfUseVersion,
   ])
 
   return useMemo(() => {

--- a/app/src/bcsc-theme/hooks/useSystemChecks.tsx
+++ b/app/src/bcsc-theme/hooks/useSystemChecks.tsx
@@ -141,9 +141,10 @@ export const useSystemChecks = (scope: SystemCheckScope) => {
       try {
         const getIdToken = () => tokenService.getCachedIdTokenMetadata({ refreshCache: false })
 
-        await runSystemChecks([
-          new EventReasonAlertsSystemCheck(getIdToken, emitAlert, credentialMetadataRef.current, utils, navigation),
-        ])
+        await runSystemChecks(
+          [new EventReasonAlertsSystemCheck(getIdToken, emitAlert, credentialMetadataRef.current, utils, navigation)],
+          logger
+        )
       } catch (error) {
         logger.error(`Device invalidation check failed after token refresh: ${(error as Error).message}`)
       }
@@ -164,7 +165,7 @@ export const useSystemChecks = (scope: SystemCheckScope) => {
       try {
         const systemCheckStrategies = await scopeSystemCheck.getSystemChecks()
 
-        const results = await runSystemChecks(systemCheckStrategies)
+        const results = await runSystemChecks(systemCheckStrategies, logger)
 
         const systemCheckResults = systemCheckStrategies.reduce<Record<string, boolean>>((acc, check, index) => {
           // Collect results for logging ie: { DeviceCountSystemCheck: true, AccountExpiryWarningBannerSystemCheck: false }

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -47,6 +47,7 @@ import { DeviceInvalidated } from '../features/modal/DeviceInvalidated'
 import { InternetDisconnected } from '../features/modal/InternetDisconnected'
 import { MandatoryUpdate } from '../features/modal/MandatoryUpdate'
 import { ServiceOutage } from '../features/modal/ServiceOutage'
+import { TermsOfUseUpdated } from '../features/modal/TermsOfUseUpdated'
 import { usePairingService } from '../features/pairing'
 import ManualPairingCode from '../features/pairing/ManualPairing'
 import PairingConfirmation from '../features/pairing/PairingConfirmation'
@@ -483,6 +484,15 @@ const MainStack: React.FC = () => {
           <Stack.Screen
             name={BCSCModals.ServiceOutage}
             component={ServiceOutage}
+            options={{
+              ...getDefaultModalOptions(t('BCSC.Title')),
+              gestureEnabled: false,
+            }}
+          />
+
+          <Stack.Screen
+            name={BCSCModals.TermsOfUseUpdated}
+            component={TermsOfUseUpdated}
             options={{
               ...getDefaultModalOptions(t('BCSC.Title')),
               gestureEnabled: false,

--- a/app/src/bcsc-theme/types/navigators.ts
+++ b/app/src/bcsc-theme/types/navigators.ts
@@ -19,6 +19,7 @@ export enum BCSCModals {
   MandatoryUpdate = 'BCSCMandatoryUpdate',
   DeviceInvalidated = 'BCSCDeviceInvalidated',
   ServiceOutage = 'BCSCServiceOutage',
+  TermsOfUseUpdated = 'BCSCTermsOfUseUpdated',
 }
 
 /**
@@ -297,6 +298,7 @@ export type BCSCMainStackParams = {
   [BCSCModals.MandatoryUpdate]: undefined
   [BCSCModals.ServiceOutage]: { statusMessage?: string; contactLink?: string }
   [BCSCModals.DeviceInvalidated]: { invalidationReason: BCSCReason }
+  [BCSCModals.TermsOfUseUpdated]: undefined
 }
 
 export type BCSCAuthStackParams = {

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -175,6 +175,8 @@ const translation = {
     "SwitchTheme": "Switch theme",
     "Testing": "Testing",
     "ErrorAlertTest": "Error & Alert Testing",
+    "StaleTermsOfUse": "Stale Terms of Use Acceptance",
+    "AcceptedTermsVersion": "Accepted version",
     "ErrorModals": "Error Modals",
     "ErrorModalsDescription": "Trigger errors that display as modal dialogs with title, description, and technical details.",
     "ErrorAsNativeAlert": "Errors as Native Alerts",

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -487,6 +487,9 @@ const translation = {
         "CheckAgainButton": "Check again",
         "LearnMore": "Learn more",
       },
+      "TermsOfUseUpdated": {
+        "Header": "The Terms of Use have been updated. Before you continue to use the Service, you must read and accept the updated terms.",
+      },
     },
     "Home": {
       "WhereToUseTitle": "Where to use",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -478,6 +478,9 @@ const translation = {
         "CheckAgainButton": "Check again (FR)",
         "LearnMore": "Learn more (FR)",
       },
+      "TermsOfUseUpdated": {
+        "Header": "The Terms of Use have been updated. Before you continue to use the Service, you must read and accept the updated terms. (FR)",
+      },
     },
     "Home": {
       "WhereToUseTitle": "Where to use (FR)",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -169,6 +169,8 @@ const translation = {
     "SwitchTheme": "Switch theme (FR)",
     "Testing": "Testing (FR)",
     "ErrorAlertTest": "Error & Alert Testing (FR)",
+    "StaleTermsOfUse": "Stale Terms of Use Acceptance (FR)",
+    "AcceptedTermsVersion": "Accepted version (FR)",
     "ErrorModals": "Error Modals (FR)",
     "ErrorModalsDescription": "Trigger errors that display as modal dialogs with title, description, and technical details. (FR)",
     "ErrorAsNativeAlert": "Errors as Native Alerts (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -478,6 +478,9 @@ const translation = {
         "CheckAgainButton": "Check again (PT-BR)",
         "LearnMore": "Learn more (PT-BR)",
       },
+      "TermsOfUseUpdated": {
+        "Header": "The Terms of Use have been updated. Before you continue to use the Service, you must read and accept the updated terms. (PT-BR)",
+      },
     },
     "Home": {
       "WhereToUseTitle": "Where to use (PT-BR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -169,6 +169,8 @@ const translation = {
     "SwitchTheme": "Switch theme (PT-BR)",
     "Testing": "Testing (PT-BR)",
     "ErrorAlertTest": "Error & Alert Testing (PT-BR)",
+    "StaleTermsOfUse": "Stale Terms of Use Acceptance (PT-BR)",
+    "AcceptedTermsVersion": "Accepted version (PT-BR)",
     "ErrorModals": "Error Modals (PT-BR)",
     "ErrorModalsDescription": "Trigger errors that display as modal dialogs with title, description, and technical details. (PT-BR)",
     "ErrorAsNativeAlert": "Errors as Native Alerts (PT-BR)",

--- a/app/src/screens/Developer.tsx
+++ b/app/src/screens/Developer.tsx
@@ -296,6 +296,15 @@ const Developer: React.FC = () => {
     }
   }
 
+  const staleTermsOfUseAcceptance = () => {
+    // Set a version that will never match the server's, so the Terms of Use
+    // re-acceptance modal is presented on the next unlock (MainStack mount)
+    dispatch({
+      type: BCDispatchAction.UPDATE_ACCEPTED_TERMS_OF_USE_VERSION,
+      payload: ['-1'],
+    })
+  }
+
   const toggleMode = () => {
     lockOutUser(LockoutReason.Logout)
 
@@ -580,8 +589,25 @@ const Developer: React.FC = () => {
               accessibilityLabel={t('Developer.ErrorAlertTest')}
               testID={testIdWithKey('ErrorAlertTest')}
               onPress={() => setErrorAlertTestModalVisible(true)}
+              showRowSeparator
             >
               <Icon name="chevron-right" size={24} color={ColorPalette.brand.link} />
+            </SectionRow>
+            <SectionRow
+              title={t('Developer.StaleTermsOfUse')}
+              accessibilityLabel={t('Developer.StaleTermsOfUse')}
+              testID={testIdWithKey('StaleTermsOfUse')}
+              onPress={staleTermsOfUseAcceptance}
+              subContent={
+                <Text style={[styles.rowTitle, { marginTop: 10 }]}>
+                  {`${t('Developer.AcceptedTermsVersion')}: `}
+                  <Text style={[styles.rowTitle, { fontWeight: 'bold' }]}>
+                    {store.bcsc.acceptedTermsOfUseVersion ?? '—'}
+                  </Text>
+                </Text>
+              }
+            >
+              <Icon name="restore" size={24} color={ColorPalette.brand.link} />
             </SectionRow>
           </>
         ) : null}

--- a/app/src/services/system-checks/TermsOfUseSystemCheck.test.ts
+++ b/app/src/services/system-checks/TermsOfUseSystemCheck.test.ts
@@ -1,0 +1,137 @@
+import { TermsOfUseResponseData } from '@/bcsc-theme/api/hooks/useConfigApi'
+import { BCSCModals } from '@/bcsc-theme/types/navigators'
+import { TermsOfUseSystemCheck } from '@/services/system-checks/TermsOfUseSystemCheck'
+import { BCDispatchAction } from '@/store'
+import { MockLogger } from '@bifold/core'
+
+const mockTermsOfUse = (version: unknown): TermsOfUseResponseData =>
+  ({
+    version,
+    date: '2025-06-06',
+    html: '<p>Terms of Use content</p>',
+  }) as TermsOfUseResponseData
+
+const createMockUtils = () => ({
+  dispatch: jest.fn(),
+  translation: jest.fn() as any,
+  logger: new MockLogger(),
+})
+
+describe('TermsOfUseSystemCheck', () => {
+  describe('runCheck', () => {
+    it('should return true when accepted version matches the server version', async () => {
+      const mockGetTermsOfUse = jest.fn().mockResolvedValue(mockTermsOfUse('8'))
+      const mockNavigation = { navigate: jest.fn() } as any
+
+      const termsOfUseCheck = new TermsOfUseSystemCheck(mockGetTermsOfUse, '8', mockNavigation, createMockUtils())
+
+      const result = await termsOfUseCheck.runCheck()
+
+      expect(mockGetTermsOfUse).toHaveBeenCalled()
+      expect(result).toBe(true)
+    })
+
+    it('should return false when accepted version differs from the server version', async () => {
+      const mockGetTermsOfUse = jest.fn().mockResolvedValue(mockTermsOfUse('9'))
+      const mockNavigation = { navigate: jest.fn() } as any
+
+      const termsOfUseCheck = new TermsOfUseSystemCheck(mockGetTermsOfUse, '8', mockNavigation, createMockUtils())
+
+      const result = await termsOfUseCheck.runCheck()
+
+      expect(result).toBe(false)
+    })
+
+    it('should return true when no accepted version is recorded (grandfathering)', async () => {
+      const mockGetTermsOfUse = jest.fn().mockResolvedValue(mockTermsOfUse('8'))
+      const mockNavigation = { navigate: jest.fn() } as any
+
+      const termsOfUseCheck = new TermsOfUseSystemCheck(mockGetTermsOfUse, undefined, mockNavigation, createMockUtils())
+
+      const result = await termsOfUseCheck.runCheck()
+
+      expect(result).toBe(true)
+    })
+
+    it('should return true when the terms of use fetch fails (fail open)', async () => {
+      const mockGetTermsOfUse = jest.fn().mockRejectedValue(new Error('Network error'))
+      const mockNavigation = { navigate: jest.fn() } as any
+
+      const termsOfUseCheck = new TermsOfUseSystemCheck(mockGetTermsOfUse, '8', mockNavigation, createMockUtils())
+
+      const result = await termsOfUseCheck.runCheck()
+
+      expect(result).toBe(true)
+    })
+
+    it('should compare versions as strings when the server returns a number', async () => {
+      const mockGetTermsOfUse = jest.fn().mockResolvedValue(mockTermsOfUse(8))
+      const mockNavigation = { navigate: jest.fn() } as any
+
+      const termsOfUseCheck = new TermsOfUseSystemCheck(mockGetTermsOfUse, '8', mockNavigation, createMockUtils())
+
+      const result = await termsOfUseCheck.runCheck()
+
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('onFail', () => {
+    it('should navigate to the blocking terms of use modal', () => {
+      const mockGetTermsOfUse = jest.fn()
+      const mockNavigation = { navigate: jest.fn() } as any
+      const mockUtils = createMockUtils()
+
+      const termsOfUseCheck = new TermsOfUseSystemCheck(mockGetTermsOfUse, '8', mockNavigation, mockUtils)
+
+      termsOfUseCheck.onFail()
+
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCModals.TermsOfUseUpdated)
+      expect(mockUtils.dispatch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('onSuccess', () => {
+    it('should seed the accepted version when none was recorded', async () => {
+      const mockGetTermsOfUse = jest.fn().mockResolvedValue(mockTermsOfUse(8))
+      const mockNavigation = { navigate: jest.fn() } as any
+      const mockUtils = createMockUtils()
+
+      const termsOfUseCheck = new TermsOfUseSystemCheck(mockGetTermsOfUse, undefined, mockNavigation, mockUtils)
+
+      await termsOfUseCheck.runCheck()
+      termsOfUseCheck.onSuccess()
+
+      expect(mockUtils.dispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_ACCEPTED_TERMS_OF_USE_VERSION,
+        payload: ['8'],
+      })
+    })
+
+    it('should not dispatch when an accepted version was already recorded', async () => {
+      const mockGetTermsOfUse = jest.fn().mockResolvedValue(mockTermsOfUse('8'))
+      const mockNavigation = { navigate: jest.fn() } as any
+      const mockUtils = createMockUtils()
+
+      const termsOfUseCheck = new TermsOfUseSystemCheck(mockGetTermsOfUse, '8', mockNavigation, mockUtils)
+
+      await termsOfUseCheck.runCheck()
+      termsOfUseCheck.onSuccess()
+
+      expect(mockUtils.dispatch).not.toHaveBeenCalled()
+    })
+
+    it('should not dispatch when the terms of use fetch failed', async () => {
+      const mockGetTermsOfUse = jest.fn().mockRejectedValue(new Error('Network error'))
+      const mockNavigation = { navigate: jest.fn() } as any
+      const mockUtils = createMockUtils()
+
+      const termsOfUseCheck = new TermsOfUseSystemCheck(mockGetTermsOfUse, undefined, mockNavigation, mockUtils)
+
+      await termsOfUseCheck.runCheck()
+      termsOfUseCheck.onSuccess()
+
+      expect(mockUtils.dispatch).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/app/src/services/system-checks/TermsOfUseSystemCheck.ts
+++ b/app/src/services/system-checks/TermsOfUseSystemCheck.ts
@@ -51,7 +51,10 @@ export class TermsOfUseSystemCheck implements SystemCheckStrategy {
       const termsOfUse = await this.getTermsOfUse()
       this.fetchedVersion = String(termsOfUse.version)
     } catch (error) {
-      this.utils.logger.error('TermsOfUseSystemCheck: Terms of Use request failed', error as Error)
+      this.utils.logger.error(
+        'TermsOfUseSystemCheck: Terms of Use request failed',
+        error instanceof Error ? error : new Error(String(error))
+      )
       // Fail open: do not block or re-prompt the user when the terms cannot be fetched
       return true
     }

--- a/app/src/services/system-checks/TermsOfUseSystemCheck.ts
+++ b/app/src/services/system-checks/TermsOfUseSystemCheck.ts
@@ -1,0 +1,98 @@
+import { TermsOfUseResponseData } from '@/bcsc-theme/api/hooks/useConfigApi'
+import { BCSCModals } from '@/bcsc-theme/types/navigators'
+import { BCDispatchAction } from '@/store'
+import { SystemCheckNavigation, SystemCheckStrategy, SystemCheckUtils } from './system-checks'
+
+/**
+ * Checks if the user has accepted the latest Terms of Use version from the server.
+ *
+ * Rules (in logical order):
+ *
+ *   Pass:
+ *    A. Terms of Use fetch fails (fail open, do not block the user on a server issue)
+ *    B. No accepted version is recorded (existing user from before tracking was added);
+ *       the current server version is seeded as accepted via onSuccess (grandfathering)
+ *    C. Accepted version matches the server version
+ *
+ *   Fail:
+ *    A. Accepted version differs from the server version => user must re-accept
+ *
+ * @see {TermsOfUseUpdated.tsx} for the blocking modal displayed on failure.
+ *
+ * @class TermsOfUseSystemCheck
+ * @implements {SystemCheckStrategy}
+ */
+export class TermsOfUseSystemCheck implements SystemCheckStrategy {
+  private readonly getTermsOfUse: () => Promise<TermsOfUseResponseData>
+  private readonly acceptedVersion: string | undefined
+  private readonly navigation: SystemCheckNavigation
+  private readonly utils: SystemCheckUtils
+  private fetchedVersion: string | undefined
+
+  constructor(
+    getTermsOfUse: () => Promise<TermsOfUseResponseData>,
+    acceptedVersion: string | undefined,
+    navigation: SystemCheckNavigation,
+    utils: SystemCheckUtils
+  ) {
+    this.getTermsOfUse = getTermsOfUse
+    this.acceptedVersion = acceptedVersion
+    this.navigation = navigation
+    this.utils = utils
+  }
+
+  /**
+   * Runs the terms of use check to verify the user has accepted the latest server version.
+   *
+   * @returns {Promise<boolean>} - A promise that resolves to true if no re-acceptance is needed, false otherwise.
+   */
+  async runCheck() {
+    try {
+      const termsOfUse = await this.getTermsOfUse()
+      this.fetchedVersion = String(termsOfUse.version)
+    } catch (error) {
+      this.utils.logger.error('TermsOfUseSystemCheck: Terms of Use request failed', error as Error)
+      // Fail open: do not block or re-prompt the user when the terms cannot be fetched
+      return true
+    }
+
+    this.utils.logger.info('TermsOfUseSystemCheck', {
+      acceptedVersion: this.acceptedVersion,
+      serverVersion: this.fetchedVersion,
+    })
+
+    // No recorded acceptance (user onboarded before tracking existed): pass and
+    // seed the current server version in onSuccess instead of re-prompting
+    if (this.acceptedVersion === undefined) {
+      return true
+    }
+
+    return String(this.acceptedVersion) === this.fetchedVersion
+  }
+
+  /**
+   * Handles the failure of the terms of use check by displaying the blocking re-acceptance modal.
+   *
+   * @returns {*} {void}
+   */
+  onFail() {
+    this.navigation.navigate(BCSCModals.TermsOfUseUpdated)
+  }
+
+  /**
+   * Handles the success of the terms of use check by seeding the accepted version
+   * for users who onboarded before acceptance tracking existed (grandfathering).
+   *
+   * @returns {*} {void}
+   */
+  onSuccess() {
+    // Only seed when nothing was recorded and the fetch succeeded, to avoid
+    // a redundant storage write on every check
+    if (this.acceptedVersion === undefined && this.fetchedVersion !== undefined) {
+      this.utils.dispatch({
+        type: BCDispatchAction.UPDATE_ACCEPTED_TERMS_OF_USE_VERSION,
+        payload: [this.fetchedVersion],
+      })
+    }
+  }
+}

--- a/app/src/services/system-checks/system-checks.test.ts
+++ b/app/src/services/system-checks/system-checks.test.ts
@@ -98,6 +98,50 @@ describe('System Checks', () => {
       expect(results).toEqual([true, true])
       expect(mockOnSuccess).toHaveBeenCalledTimes(2)
     })
+
+    it('isolates a check that throws in runCheck so the rest of the batch still runs', async () => {
+      const throwingOnFail = jest.fn()
+      const survivorOnFail = jest.fn()
+
+      const throwingCheck: SystemCheckStrategy = {
+        runCheck: jest.fn().mockRejectedValue(new Error('no id token')),
+        onFail: throwingOnFail,
+      }
+
+      const survivorCheck: SystemCheckStrategy = {
+        runCheck: jest.fn().mockResolvedValue(false),
+        onFail: survivorOnFail,
+      }
+
+      const results = await runSystemChecks([throwingCheck, survivorCheck])
+
+      // The thrown check is recorded as false and its handler is skipped...
+      expect(results).toEqual([false, false])
+      expect(throwingOnFail).not.toHaveBeenCalled()
+      // ...but the surviving check is still handled
+      expect(survivorOnFail).toHaveBeenCalledTimes(1)
+    })
+
+    it('isolates a check whose handler throws so later checks are still handled', async () => {
+      const laterOnFail = jest.fn()
+
+      const checkWithThrowingHandler: SystemCheckStrategy = {
+        runCheck: jest.fn().mockResolvedValue(false),
+        onFail: jest.fn().mockImplementation(() => {
+          throw new Error('handler boom')
+        }),
+      }
+
+      const laterCheck: SystemCheckStrategy = {
+        runCheck: jest.fn().mockResolvedValue(false),
+        onFail: laterOnFail,
+      }
+
+      const results = await runSystemChecks([checkWithThrowingHandler, laterCheck])
+
+      expect(results).toEqual([false, false])
+      expect(laterOnFail).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('DeviceCountSystemCheck', () => {

--- a/app/src/services/system-checks/system-checks.ts
+++ b/app/src/services/system-checks/system-checks.ts
@@ -73,27 +73,45 @@ export type SystemCheckNavigation = {
  * @param {SystemCheckStrategy[]} checks - An array of startup checks to run.
  * @returns {*} {Promise<boolean[]>} - An array of boolean results indicating the success of each check.
  */
-export async function runSystemChecks(checks: SystemCheckStrategy[]) {
-  const runCheckPromises: Promise<boolean>[] = []
+export async function runSystemChecks(checks: SystemCheckStrategy[], logger?: BifoldLogger) {
+  // Run every check concurrently but isolate failures: a single check that throws
+  // (e.g. EventReasonAlertsSystemCheck when an unverified user has no cached id token)
+  // must not abort the whole batch and prevent the others (e.g. TermsOfUseSystemCheck)
+  // from running. Promise.allSettled keeps one rejection from sinking the rest.
+  const settled = await Promise.allSettled(checks.map((check) => Promise.resolve(check.runCheck())))
 
-  // Add all startup check promises to array
-  for (const check of checks) {
-    const ensurePromise = Promise.resolve(check.runCheck()) // SonarQube compliance
-    runCheckPromises.push(ensurePromise)
-  }
+  const results: boolean[] = []
 
-  // Wait for all startup checks to complete in parallel
-  const results = await Promise.all(runCheckPromises)
+  // Handle outcomes in order
+  for (let index = 0; index < settled.length; index++) {
+    const outcome = settled[index]
+    const name = checks[index].constructor.name
 
-  // Handle failures in order
-  // To be determined if we want automatic failure handling or not (pass param if not)
-  for (let index = 0; index < results.length; index++) {
-    if (!results[index]) {
-      await checks[index].onFail()
+    if (outcome.status === 'rejected') {
+      // An errored check is inconclusive: record false and skip its handlers
+      logger?.error(
+        `runSystemChecks: ${name} threw during runCheck`,
+        outcome.reason instanceof Error ? outcome.reason : new Error(String(outcome.reason))
+      )
+      results.push(false)
       continue
     }
 
-    await checks[index].onSuccess?.()
+    results.push(outcome.value)
+
+    try {
+      if (!outcome.value) {
+        await checks[index].onFail()
+      } else {
+        await checks[index].onSuccess?.()
+      }
+    } catch (error) {
+      // A failing handler must not prevent the remaining checks from being handled
+      logger?.error(
+        `runSystemChecks: ${name} threw during ${outcome.value ? 'onSuccess' : 'onFail'}`,
+        error instanceof Error ? error : new Error(String(error))
+      )
+    }
   }
 
   return results

--- a/app/src/services/system-checks/system-checks.ts
+++ b/app/src/services/system-checks/system-checks.ts
@@ -67,10 +67,48 @@ export type SystemCheckNavigation = {
   getState: () => NavigationState | undefined
 }
 
+/** Coerce an unknown thrown value into an Error for logging. */
+function toError(reason: unknown): Error {
+  return reason instanceof Error ? reason : new Error(String(reason))
+}
+
+/**
+ * Handles a single settled check outcome, isolated from the rest of the batch:
+ * logs a thrown runCheck, otherwise runs the matching onSuccess/onFail handler
+ * (catching any handler failure). Returns the check's boolean result — false when
+ * the check threw, since the outcome is then inconclusive.
+ */
+async function handleCheckOutcome(
+  check: SystemCheckStrategy,
+  outcome: PromiseSettledResult<boolean>,
+  logger?: BifoldLogger
+): Promise<boolean> {
+  const name = check.constructor.name
+
+  if (outcome.status === 'rejected') {
+    logger?.error(`runSystemChecks: ${name} threw during runCheck`, toError(outcome.reason))
+    return false
+  }
+
+  const passed = outcome.value
+  try {
+    if (passed) {
+      await check.onSuccess?.()
+    } else {
+      await check.onFail()
+    }
+  } catch (error) {
+    logger?.error(`runSystemChecks: ${name} threw during ${passed ? 'onSuccess' : 'onFail'}`, toError(error))
+  }
+
+  return passed
+}
+
 /**
  * Runs a series of startup checks and handles failures and successes accordingly.
  *
  * @param {SystemCheckStrategy[]} checks - An array of startup checks to run.
+ * @param {BifoldLogger} [logger] - Optional logger used to report isolated check failures.
  * @returns {*} {Promise<boolean[]>} - An array of boolean results indicating the success of each check.
  */
 export async function runSystemChecks(checks: SystemCheckStrategy[], logger?: BifoldLogger) {
@@ -80,38 +118,10 @@ export async function runSystemChecks(checks: SystemCheckStrategy[], logger?: Bi
   // from running. Promise.allSettled keeps one rejection from sinking the rest.
   const settled = await Promise.allSettled(checks.map((check) => Promise.resolve(check.runCheck())))
 
+  // Handle outcomes in order so each check's onFail/onSuccess runs sequentially
   const results: boolean[] = []
-
-  // Handle outcomes in order
   for (let index = 0; index < settled.length; index++) {
-    const outcome = settled[index]
-    const name = checks[index].constructor.name
-
-    if (outcome.status === 'rejected') {
-      // An errored check is inconclusive: record false and skip its handlers
-      logger?.error(
-        `runSystemChecks: ${name} threw during runCheck`,
-        outcome.reason instanceof Error ? outcome.reason : new Error(String(outcome.reason))
-      )
-      results.push(false)
-      continue
-    }
-
-    results.push(outcome.value)
-
-    try {
-      if (!outcome.value) {
-        await checks[index].onFail()
-      } else {
-        await checks[index].onSuccess?.()
-      }
-    } catch (error) {
-      // A failing handler must not prevent the remaining checks from being handled
-      logger?.error(
-        `runSystemChecks: ${name} threw during ${outcome.value ? 'onSuccess' : 'onFail'}`,
-        error instanceof Error ? error : new Error(String(error))
-      )
-    }
+    results.push(await handleCheckOutcome(checks[index], settled[index], logger))
   }
 
   return results

--- a/app/src/store.tsx
+++ b/app/src/store.tsx
@@ -97,6 +97,7 @@ export interface BCSCState {
   deviceLimitBannerDismissedAt?: string
   credentialMetadata?: CredentialMetadata
   hasSeenVerifyPrompt?: boolean
+  acceptedTermsOfUseVersion?: string
 }
 
 export enum VerificationStatus {
@@ -239,6 +240,7 @@ enum BCSCDispatchAction {
   RESET_SEND_VIDEO = 'bcsc/clearPhotoAndVideo',
   UPDATE_ANALYTICS_OPT_IN = 'bcsc/updateAnalyticsOptIn',
   UPDATE_CREDENTIAL_METADATA = 'bcsc/updateCredentialMetadata',
+  UPDATE_ACCEPTED_TERMS_OF_USE_VERSION = 'bcsc/updateAcceptedTermsOfUseVersion',
   // Secure state actions
   HYDRATE_SECURE_STATE = 'bcsc/hydrateSecureState',
   CLEAR_SECURE_STATE = 'bcsc/clearSecureState',
@@ -793,6 +795,14 @@ const bcReducer = (state: BCState, action: ReducerAction<BCDispatchAction>): BCS
     case BCDispatchAction.UPDATE_CREDENTIAL_METADATA: {
       const credentialMetadata = (action?.payload || []).pop() ?? undefined
       const bcsc = { ...state.bcsc, credentialMetadata }
+      const newState = { ...state, bcsc }
+      PersistentStorage.storeValueForKey<BCSCState>(BCLocalStorageKeys.BCSC, bcsc)
+      return newState
+    }
+
+    case BCSCDispatchAction.UPDATE_ACCEPTED_TERMS_OF_USE_VERSION: {
+      const acceptedTermsOfUseVersion = (action?.payload || []).pop() ?? undefined
+      const bcsc = { ...state.bcsc, acceptedTermsOfUseVersion }
       const newState = { ...state, bcsc }
       PersistentStorage.storeValueForKey<BCSCState>(BCLocalStorageKeys.BCSC, bcsc)
       return newState


### PR DESCRIPTION
# Summary of Changes

The app never persisted which Terms of Use version the user accepted, so server-side ToU updates went unnoticed and users were never re-prompted.

- Persist the accepted ToU version (`acceptedTermsOfUseVersion`) in `BCSCState` when the user accepts during onboarding
- New `TermsOfUseSystemCheck` (MAIN_STACK scope) compares the stored version against `GET /v3/terms` on each unlock and presents a blocking `TermsOfUseUpdated` modal on mismatch; accepting persists the new version and dismisses
- Existing users are grandfathered: with no recorded acceptance, the current server version is seeded silently (no re-prompt blast on update)
- Fail open: if the terms fetch fails, the check passes (no false re-prompts)
- Extracted shared `TermsOfUseContent` component, reused by the onboarding screen and the new modal
- Dev utility: "Stale Terms of Use Acceptance" row on the Developer screen (BCSC Testing section) sets the stored version to `-1` to trigger the re-prompt

# Testing Instructions

1. Fresh install → onboard → accept ToU → version is persisted (visible on the Developer screen)
2. Lock and unlock → no re-prompt (versions match)
3. Developer screen → tap "Stale Terms of Use Acceptance" (accepted version shows `-1`) → lock/relaunch and unlock → blocking ToU modal appears (swipe-dismiss disabled)
4. Accept → modal dismisses, accepted version updates to the server's; subsequent unlocks show no prompt

Unit tests: `yarn test src/services/system-checks/TermsOfUseSystemCheck.test.ts src/bcsc-theme/hooks/useCreateSystemChecks.test.tsx src/bcsc-theme/features/onboarding src/bcsc-theme/features/modal/TermsOfUseUpdated.test.tsx`

# Acceptance Criteria

- [ ] Accepting the ToU (onboarding or re-prompt) persists the accepted version
- [ ] A server-side ToU version change triggers a blocking re-acceptance modal on next unlock
- [ ] Users with no recorded acceptance are seeded silently and not re-prompted
- [ ] ToU fetch failures do not block the user or trigger a re-prompt
- [ ] All tests, typecheck, and lint pass

# Screenshots, videos, or gifs

<img width="349" height="758" alt="image" src="https://github.com/user-attachments/assets/01d9622d-8f1f-422a-98fa-da3ee284adeb" />


# Related Issues

N/A
