### PR TITLE
feat: add device model to report logs

### DIFF
--- a/app/src/utils/logger.test.ts
+++ b/app/src/utils/logger.test.ts
@@ -15,6 +15,7 @@ jest.mock('react-native-device-info', () => ({
   getBuildNumber: jest.fn(() => '77'),
   getSystemName: jest.fn(() => 'iOS'),
   getSystemVersion: jest.fn(() => '17.0'),
+  getDeviceId: jest.fn(() => 'iPhone15,2'),
 }))
 
 jest.mock('react-native-config', () => ({
@@ -54,6 +55,7 @@ describe('createAppLogger', () => {
         application: 'testapp',
         version: '1.2.3-77',
         system: 'iOS v17.0',
+        model: 'iPhone15,2',
         subsystem: 'demo',
       },
       autoDisableRemoteLoggingIntervalInMinutes,

--- a/app/src/utils/logger.ts
+++ b/app/src/utils/logger.ts
@@ -4,6 +4,7 @@ import Config from 'react-native-config'
 import {
   getApplicationName,
   getBuildNumber,
+  getDeviceId,
   getSystemName,
   getSystemVersion,
   getVersion,
@@ -16,6 +17,7 @@ const baseOptions: RemoteLoggerOptions = {
     application: getApplicationName().toLowerCase(),
     version: `${getVersion()}-${getBuildNumber()}`,
     system: `${getSystemName()} v${getSystemVersion()}`,
+    model: getDeviceId(), // NOTE (bm): Not user-friendly model name, actual device model code, ie: iPhone 14 Pro shows up as iPhone 15,2
   },
   autoDisableRemoteLoggingIntervalInMinutes,
 }


### PR DESCRIPTION
# Summary of Changes

This PR adds the device model code to problem reports. Note that this is the model code, not the model itself, so it can be confusing. For example: the code for an iPhone 14 Plus is "iPhone 15,2"

# Testing Instructions

Report a problem, check the model field is present in Grafana

# Acceptance Criteria

Works

# Screenshots, videos, or gifs

N/A

# Related Issues

#4056 