### PR TITLE
fix: add diagnostic logging to jwe decrypt functions

### DIFF
--- a/app/src/bcsc-theme/services/hooks/useUserService.test.tsx
+++ b/app/src/bcsc-theme/services/hooks/useUserService.test.tsx
@@ -38,7 +38,7 @@ describe('useUserService', () => {
 
       await expect(result.current.getUserInfo()).rejects.toThrow(mockError)
       expect(userApi.getUserInfo).toHaveBeenCalled()
-      expect(mockAlerts.failedToDeserializeJsonAlert).toHaveBeenCalled()
+      expect(mockAlerts.failedToDeserializeJsonAlert).toHaveBeenCalledWith(mockError)
     })
 
     it('should show alert on JWE decryption error and rethrow error', async () => {
@@ -55,7 +55,10 @@ describe('useUserService', () => {
 
       await expect(result.current.getUserInfo()).rejects.toThrow(mockError)
       expect(userApi.getUserInfo).toHaveBeenCalled()
-      expect(mockAlerts.unableToDecryptJweAlert).toHaveBeenCalled()
+      // Regression: the alert must receive the ORIGINAL AppError. Calling it bare makes
+      // ensureAppError(undefined, …) rebuild a cause-less error, dropping the native decode
+      // diagnostics (E_…_ERROR + [keys=…]) from the problem report.
+      expect(mockAlerts.unableToDecryptJweAlert).toHaveBeenCalledWith(mockError)
     })
 
     it('should show alert on claims set error and rethrow error', async () => {
@@ -72,7 +75,7 @@ describe('useUserService', () => {
 
       await expect(result.current.getUserInfo()).rejects.toThrow(mockError)
       expect(userApi.getUserInfo).toHaveBeenCalled()
-      expect(mockAlerts.failedToGetClaimsSetAlert).toHaveBeenCalled()
+      expect(mockAlerts.failedToGetClaimsSetAlert).toHaveBeenCalledWith(mockError)
     })
 
     it('should show alert on JWS parse error and rethrow error', async () => {
@@ -89,7 +92,7 @@ describe('useUserService', () => {
 
       await expect(result.current.getUserInfo()).rejects.toThrow(mockError)
       expect(userApi.getUserInfo).toHaveBeenCalled()
-      expect(mockAlerts.failedToParseJwsAlert).toHaveBeenCalled()
+      expect(mockAlerts.failedToParseJwsAlert).toHaveBeenCalledWith(mockError)
     })
 
     it('should show alert on token unexpectedly null error and rethrow error', async () => {
@@ -106,7 +109,7 @@ describe('useUserService', () => {
 
       await expect(result.current.getUserInfo()).rejects.toThrow(mockError)
       expect(userApi.getUserInfo).toHaveBeenCalled()
-      expect(mockAlerts.tokenUnexpectedlyNullAlert).toHaveBeenCalled()
+      expect(mockAlerts.tokenUnexpectedlyNullAlert).toHaveBeenCalledWith(mockError)
     })
   })
 
@@ -162,7 +165,7 @@ describe('useUserService', () => {
 
       await expect(result.current.getUserMetadata()).rejects.toThrow(mockError)
       expect(userApi.getUserInfo).toHaveBeenCalled()
-      expect(mockAlerts.failedToDeserializeJsonAlert).toHaveBeenCalled()
+      expect(mockAlerts.failedToDeserializeJsonAlert).toHaveBeenCalledWith(mockError)
     })
 
     it('should show alert on JWE decryption error and rethrow error', async () => {
@@ -179,7 +182,7 @@ describe('useUserService', () => {
 
       await expect(result.current.getUserMetadata()).rejects.toThrow(mockError)
       expect(userApi.getUserInfo).toHaveBeenCalled()
-      expect(mockAlerts.unableToDecryptJweAlert).toHaveBeenCalled()
+      expect(mockAlerts.unableToDecryptJweAlert).toHaveBeenCalledWith(mockError)
     })
 
     it('should show alert on claims set error and rethrow error', async () => {
@@ -196,7 +199,7 @@ describe('useUserService', () => {
 
       await expect(result.current.getUserMetadata()).rejects.toThrow(mockError)
       expect(userApi.getUserInfo).toHaveBeenCalled()
-      expect(mockAlerts.failedToGetClaimsSetAlert).toHaveBeenCalled()
+      expect(mockAlerts.failedToGetClaimsSetAlert).toHaveBeenCalledWith(mockError)
     })
 
     it('should show alert on JWS parse error and rethrow error', async () => {
@@ -213,7 +216,7 @@ describe('useUserService', () => {
 
       await expect(result.current.getUserMetadata()).rejects.toThrow(mockError)
       expect(userApi.getUserInfo).toHaveBeenCalled()
-      expect(mockAlerts.failedToParseJwsAlert).toHaveBeenCalled()
+      expect(mockAlerts.failedToParseJwsAlert).toHaveBeenCalledWith(mockError)
     })
 
     it('should show alert on token unexpectedly null error and rethrow error', async () => {
@@ -230,7 +233,7 @@ describe('useUserService', () => {
 
       await expect(result.current.getUserMetadata()).rejects.toThrow(mockError)
       expect(userApi.getUserInfo).toHaveBeenCalled()
-      expect(mockAlerts.tokenUnexpectedlyNullAlert).toHaveBeenCalled()
+      expect(mockAlerts.tokenUnexpectedlyNullAlert).toHaveBeenCalledWith(mockError)
     })
   })
 

--- a/app/src/bcsc-theme/services/hooks/useUserService.tsx
+++ b/app/src/bcsc-theme/services/hooks/useUserService.tsx
@@ -21,24 +21,27 @@ export const useUserService = () => {
 
   const handleUserApiError = useCallback(
     (error: unknown): never => {
+      // Forward the caught AppError so its native diagnostics (cause → technicalMessage) survive
+      // into the modal and the problem report. Calling these with no argument builds a fresh,
+      // cause-less AppError via ensureAppError(undefined, …) and drops the diagnostics.
       if (isAppError(error, AppEventCode.ERR_109_FAILED_TO_DESERIALIZE_JSON)) {
-        alerts.failedToDeserializeJsonAlert()
+        alerts.failedToDeserializeJsonAlert(error)
       }
 
       if (isAppError(error, AppEventCode.ERR_110_UNABLE_TO_DECRYPT_JWE)) {
-        alerts.unableToDecryptJweAlert()
+        alerts.unableToDecryptJweAlert(error)
       }
 
       if (isAppError(error, AppEventCode.ERR_114_FAILED_TO_GET_CLAIMS_SET_AFTER_DECRYPT_AND_VERIFY)) {
-        alerts.failedToGetClaimsSetAlert()
+        alerts.failedToGetClaimsSetAlert(error)
       }
 
       if (isAppError(error, AppEventCode.ERR_117_FAILED_TO_PARSE_JWS)) {
-        alerts.failedToParseJwsAlert()
+        alerts.failedToParseJwsAlert(error)
       }
 
       if (isAppError(error, AppEventCode.ERR_119_TOKEN_UNEXPECTEDLY_NULL)) {
-        alerts.tokenUnexpectedlyNullAlert()
+        alerts.tokenUnexpectedlyNullAlert(error)
       }
 
       throw error

--- a/app/src/errors/appError.test.ts
+++ b/app/src/errors/appError.test.ts
@@ -145,36 +145,10 @@ describe('AppError', () => {
       expect(error.fullMessage).toContain('jweEnc=A256CBC-HS512')
     })
 
-    it('should append URL if set', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Something went wrong', identity)
-      error.url = 'https://example.com/device/token'
-
-      expect(error.fullMessage).toBe(
-        'Something went wrong\nDebug: [general.unknown_server_error.1234]\nRequest: https://example.com/device/token'
-      )
-    })
-
-    it('should include HTTP method with URL when both are set', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Something went wrong', identity)
-      error.url = 'https://example.com/device/token'
-      error.method = 'POST'
-
-      expect(error.fullMessage).toBe(
-        'Something went wrong\nDebug: [general.unknown_server_error.1234]\nRequest: POST https://example.com/device/token'
-      )
-    })
-
-    it('should append screen name when screen is set', () => {
+    it('omits screen and request context — that is report-only, not shown in the user-facing message', () => {
+      // Screen/Request are intentionally kept out of fullMessage (the "Show details" string)
+      // so infra context never alarms the user. They are appended only to the "Report this
+      // problem" payload in ErrorModal.handleReport.
       const identity = {
         category: ErrorCategory.GENERAL,
         appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
@@ -182,10 +156,12 @@ describe('AppError', () => {
       }
       const error = new AppError('Something went wrong', identity)
       error.screen = 'HomeScreen'
+      error.url = 'https://example.com/device/token'
+      error.method = 'POST'
 
-      expect(error.fullMessage).toBe(
-        'Something went wrong\nDebug: [general.unknown_server_error.1234]\nScreen: HomeScreen'
-      )
+      expect(error.fullMessage).toBe('Something went wrong\nDebug: [general.unknown_server_error.1234]')
+      expect(error.fullMessage).not.toContain('Screen:')
+      expect(error.fullMessage).not.toContain('Request:')
     })
   })
 

--- a/app/src/errors/appError.test.ts
+++ b/app/src/errors/appError.test.ts
@@ -94,6 +94,27 @@ describe('AppError', () => {
       )
     })
 
+    it('carries native decode diagnostics (code + JWE/key summary) into fullMessage for 2507 reports', () => {
+      // Mirrors useUserApi.getUserInfo: a react-native-bcsc-core rejection (an Error with a
+      // `code` prefix and the enriched diagnostics message) is wrapped as DECRYPT_JWE_ERROR.
+      // The native detail must survive into fullMessage — that is the string the problem
+      // report surfaces, and what lets us tell the 2507 root causes apart in the field.
+      const nativeError: Error & { code?: string } = new Error(
+        'Unable to decode payload: Decryption failed [keys=2, newest=https://idsit.gov.bc.ca/device/abc/2, ' +
+          'jweParts=5, jweAlg=RSA1_5, jweEnc=A256CBC-HS512, jweKid=https://idsit.gov.bc.ca/device/abc/1, ' +
+          'kidMatchesLocal=false]'
+      )
+      nativeError.code = 'E_PAYLOAD_DECODE_ERROR'
+
+      const error = AppError.fromErrorDefinition(ErrorRegistry.DECRYPT_JWE_ERROR, { cause: nativeError })
+
+      expect(error.statusCode).toBe(2507)
+      expect(error.fullMessage).toContain('[token.err_110_unable_to_decrypt_jwe.2507]')
+      expect(error.fullMessage).toContain('E_PAYLOAD_DECODE_ERROR')
+      expect(error.fullMessage).toContain('kidMatchesLocal=false')
+      expect(error.fullMessage).toContain('jweEnc=A256CBC-HS512')
+    })
+
     it('should append URL if set', () => {
       const identity = {
         category: ErrorCategory.GENERAL,

--- a/app/src/errors/appError.ts
+++ b/app/src/errors/appError.ts
@@ -133,6 +133,15 @@ export class AppError extends Error {
       formattedMessage += ` ${this.technicalMessage}`
     }
 
+    if (this.screen) {
+      formattedMessage += `\nScreen: ${this.screen}`
+    }
+
+    if (this.url) {
+      const request = this.method ? `${this.method} ${this.url}` : this.url
+      formattedMessage += `\nRequest: ${request}`
+    }
+
     return formattedMessage
   }
 

--- a/app/src/errors/appError.ts
+++ b/app/src/errors/appError.ts
@@ -118,6 +118,11 @@ export class AppError extends Error {
   /**
    * Get the full error message, including technical details if available.
    *
+   * This is the user-facing details string (shown behind "Show details" in the error
+   * modal), so it deliberately excludes the active screen and request URL — that infra
+   * context could alarm users. Screen/Request are appended only to the "Report this
+   * problem" payload sent to Loki, never shown to the user. See ErrorModal.handleReport.
+   *
    * @example
    * `No internet connection
    * Debug: [network.err_no_internet.2100] Failed to fetch resource`
@@ -131,15 +136,6 @@ export class AppError extends Error {
 
     if (this.technicalMessage) {
       formattedMessage += ` ${this.technicalMessage}`
-    }
-
-    if (this.screen) {
-      formattedMessage += `\nScreen: ${this.screen}`
-    }
-
-    if (this.url) {
-      const request = this.method ? `${this.method} ${this.url}` : this.url
-      formattedMessage += `\nRequest: ${request}`
     }
 
     return formattedMessage

--- a/app/src/errors/components/ErrorModal.test.tsx
+++ b/app/src/errors/components/ErrorModal.test.tsx
@@ -185,13 +185,13 @@ describe('BCSCErrorModal', () => {
       )
     })
 
-    it('does not re-append Screen/Request to the report — fullMessage already carries them', () => {
-      // error.message IS AppError.fullMessage, which now includes the Screen/Request lines.
-      // handleReport must not append them again, or each appears twice in the report.
+    it('appends Screen/Request to the report — fullMessage keeps them out of the user-facing message', () => {
+      // error.message IS AppError.fullMessage, which deliberately omits Screen/Request so the
+      // user-facing "Show details" stays clean. handleReport re-adds them — exactly once — so
+      // the Loki problem report still carries the infra context.
       const payload: ErrorModalPayload = {
         ...validPayload,
-        message:
-          'JWE decryption failed\nDebug: [token.err_110_unable_to_decrypt_jwe.2507]\nScreen: Home\nRequest: GET https://example.com/userinfo',
+        message: 'JWE decryption failed\nDebug: [token.err_110_unable_to_decrypt_jwe.2507]',
         screen: 'Home',
         url: 'https://example.com/userinfo',
         method: 'GET',
@@ -203,7 +203,7 @@ describe('BCSCErrorModal', () => {
 
       const reported = (appLogger.report as jest.Mock).mock.calls[0][0] as BifoldError
       expect(reported.message.match(/Screen: Home/g)).toHaveLength(1)
-      expect(reported.message.match(/Request: /g)).toHaveLength(1)
+      expect(reported.message).toContain('Request: GET https://example.com/userinfo')
       expect(reported.message).toContain('Report ID: report-uuid-123')
     })
 

--- a/app/src/errors/components/ErrorModal.test.tsx
+++ b/app/src/errors/components/ErrorModal.test.tsx
@@ -185,6 +185,28 @@ describe('BCSCErrorModal', () => {
       )
     })
 
+    it('does not re-append Screen/Request to the report — fullMessage already carries them', () => {
+      // error.message IS AppError.fullMessage, which now includes the Screen/Request lines.
+      // handleReport must not append them again, or each appears twice in the report.
+      const payload: ErrorModalPayload = {
+        ...validPayload,
+        message:
+          'JWE decryption failed\nDebug: [token.err_110_unable_to_decrypt_jwe.2507]\nScreen: Home\nRequest: GET https://example.com/userinfo',
+        screen: 'Home',
+        url: 'https://example.com/userinfo',
+        method: 'GET',
+        reportUUID: 'report-uuid-123',
+      }
+      const { getByTestId } = renderModal({ error: payload, enableReport: true })
+
+      fireEvent.press(getByTestId('com.aries.bifold:id/ReportThisProblem'))
+
+      const reported = (appLogger.report as jest.Mock).mock.calls[0][0] as BifoldError
+      expect(reported.message.match(/Screen: Home/g)).toHaveLength(1)
+      expect(reported.message.match(/Request: /g)).toHaveLength(1)
+      expect(reported.message).toContain('Report ID: report-uuid-123')
+    })
+
     it('should disable the Report button after being pressed', async () => {
       const { getByTestId } = renderModal({ error: validPayload, enableReport: true })
 

--- a/app/src/errors/components/ErrorModal.tsx
+++ b/app/src/errors/components/ErrorModal.tsx
@@ -65,14 +65,9 @@ export const BCSCErrorModal: React.FC<BCSCErrorModalProps> = ({
 
     Analytics.trackAlertActionEvent(error.appEvent as AppEventCode, ANALYTICS_REPORT_THIS_PROBLEM_LABEL)
 
+    // error.message is already AppError.fullMessage, which now includes the Screen/Request lines —
+    // don't re-append them here or they show up twice in the report.
     let reportMessage = error.message
-    if (error.screen) {
-      reportMessage += `\nScreen: ${error.screen}`
-    }
-    if (error.url) {
-      const request = error.method ? `${error.method} ${error.url}` : error.url
-      reportMessage += `\nRequest: ${request}`
-    }
     if (error.reportUUID) {
       reportMessage += `\nReport ID: ${error.reportUUID}`
     }

--- a/app/src/errors/components/ErrorModal.tsx
+++ b/app/src/errors/components/ErrorModal.tsx
@@ -65,9 +65,17 @@ export const BCSCErrorModal: React.FC<BCSCErrorModalProps> = ({
 
     Analytics.trackAlertActionEvent(error.appEvent as AppEventCode, ANALYTICS_REPORT_THIS_PROBLEM_LABEL)
 
-    // error.message is already AppError.fullMessage, which now includes the Screen/Request lines —
-    // don't re-append them here or they show up twice in the report.
+    // error.message is AppError.fullMessage — the user-facing details string, which
+    // deliberately omits the screen name and request URL so we don't surface infra
+    // details to the user. Append them here so they still ride along in the Loki report.
     let reportMessage = error.message
+    if (error.screen) {
+      reportMessage += `\nScreen: ${error.screen}`
+    }
+    if (error.url) {
+      const request = error.method ? `${error.method} ${error.url}` : error.url
+      reportMessage += `\nRequest: ${request}`
+    }
     if (error.reportUUID) {
       reportMessage += `\nReport ID: ${error.reportUUID}`
     }

--- a/app/src/screens/ErrorAlertTest.tsx
+++ b/app/src/screens/ErrorAlertTest.tsx
@@ -259,12 +259,15 @@ const ErrorAlertTest: React.FC<ErrorAlertTestProps> = ({ onBack }) => {
     // A syntactically valid 5-part JWE: a real (base64url) protected header plus dummy
     // key/iv/ciphertext/tag. Native decrypt fails and rejects with the full diagnostics —
     // the same shape as a real "server encrypted to a key this device no longer holds" error.
+    // base64url-encode the header. Padding is dropped with split('=') rather than an anchored
+    // /=+$/ regex (which static analysis flags for super-linear backtracking) — mirrors the
+    // native Base64URL.encode convention (`components(separatedBy: "=")[0]`).
     const header = btoa(
       JSON.stringify({ alg: 'RSA1_5', enc: 'A256CBC-HS512', kid: 'https://idsit.gov.bc.ca/device/dev-trigger/1' })
     )
       .replace(/\+/g, '-')
       .replace(/\//g, '_')
-      .replace(/=+$/, '')
+      .split('=')[0]
     const fakeJwe = `${header}.ZW5jcnlwdGVkS2V5.aXY.Y2lwaGVydGV4dA.dGFn`
 
     try {

--- a/app/src/screens/ErrorAlertTest.tsx
+++ b/app/src/screens/ErrorAlertTest.tsx
@@ -259,14 +259,14 @@ const ErrorAlertTest: React.FC<ErrorAlertTestProps> = ({ onBack }) => {
     // A syntactically valid 5-part JWE: a real (base64url) protected header plus dummy
     // key/iv/ciphertext/tag. Native decrypt fails and rejects with the full diagnostics —
     // the same shape as a real "server encrypted to a key this device no longer holds" error.
-    // base64url-encode the header. Padding is dropped with split('=') rather than an anchored
-    // /=+$/ regex (which static analysis flags for super-linear backtracking) — mirrors the
+    // base64url-encode the header with literal string ops (no regex — nothing for static
+    // analysis to flag): '+'→'-', '/'→'_', and drop '=' padding via split, mirroring the
     // native Base64URL.encode convention (`components(separatedBy: "=")[0]`).
     const header = btoa(
       JSON.stringify({ alg: 'RSA1_5', enc: 'A256CBC-HS512', kid: 'https://idsit.gov.bc.ca/device/dev-trigger/1' })
     )
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
+      .replaceAll('+', '-')
+      .replaceAll('/', '_')
       .split('=')[0]
     const fakeJwe = `${header}.ZW5jcnlwdGVkS2V5.aXY.Y2lwaGVydGV4dA.dGFn`
 

--- a/app/src/screens/ErrorAlertTest.tsx
+++ b/app/src/screens/ErrorAlertTest.tsx
@@ -1,5 +1,6 @@
 import BCSCApiClient from '@/bcsc-theme/api/client'
 import { useBCSCApiClient } from '@/bcsc-theme/hooks/useBCSCApiClient'
+import { toAppError } from '@/bcsc-theme/utils/native-error-map'
 import { VERIFY_DEVICE_ASSERTION_PATH } from '@/constants'
 import { useErrorAlert } from '@/contexts/ErrorAlertContext'
 import { AppError } from '@/errors'
@@ -11,6 +12,7 @@ import { AxiosError } from 'axios'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, View } from 'react-native'
+import { decodePayload } from 'react-native-bcsc-core'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
 interface ErrorAlertTestProps {
@@ -248,6 +250,35 @@ const ErrorAlertTest: React.FC<ErrorAlertTestProps> = ({ onBack }) => {
     emitErrorModal('Error Modal Triggered', description, AppError.fromErrorDefinition(ErrorRegistry[key]))
   }
 
+  // Calls the REAL native decodePayload with a deliberately bad JWE so we exercise the same
+  // 2507 path as useUserApi.getUserInfo and surface the native diagnostics (jweParts/jweAlg/
+  // jweEnc/jweKid/kidMatchesLocal). The modal's "Report this problem" action then uploads them to Grafana.
+  const triggerJweDecryptError = async () => {
+    onBack() // close the dev modal so the resulting error modal is visible
+
+    // A syntactically valid 5-part JWE: a real (base64url) protected header plus dummy
+    // key/iv/ciphertext/tag. Native decrypt fails and rejects with the full diagnostics —
+    // the same shape as a real "server encrypted to a key this device no longer holds" error.
+    const header = btoa(
+      JSON.stringify({ alg: 'RSA1_5', enc: 'A256CBC-HS512', kid: 'https://idsit.gov.bc.ca/device/dev-trigger/1' })
+    )
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')
+    const fakeJwe = `${header}.ZW5jcnlwdGVkS2V5.aXY.Y2lwaGVydGV4dA.dGFn`
+
+    try {
+      await decodePayload(fakeJwe)
+    } catch (error) {
+      // Wrap as DECRYPT_JWE_ERROR (2507) with the native error as cause, exactly like getUserInfo.
+      emitErrorModal(
+        'JWE Decrypt Error (test)',
+        'Forced a native decodePayload failure to exercise the 2507 diagnostics path.',
+        toAppError(error, ErrorRegistry.DECRYPT_JWE_ERROR)
+      )
+    }
+  }
+
   const triggerErrorAsAlert = (description: string) => {
     emitAlert('Native alert triggered', description, {
       actions: [
@@ -327,6 +358,25 @@ const ErrorAlertTest: React.FC<ErrorAlertTestProps> = ({ onBack }) => {
               </View>
             )
           })}
+        </View>
+
+        {/* Native decode diagnostics — real decodePayload failure (2507) */}
+        <View style={styles.section}>
+          <Text style={styles.sectionHeader}>{'Native decode diagnostics'}</Text>
+          <Text style={styles.description}>
+            {'Calls the real native decodePayload with a crafted bad JWE to trigger a genuine ' +
+              'DECRYPT_JWE_ERROR (2507) carrying native diagnostics (jweParts/jweAlg/jweEnc/jweKid/' +
+              'kidMatchesLocal). On the modal, tap "Report this problem" to send it to Grafana.'}
+          </Text>
+          <View style={styles.buttonRow}>
+            <Button
+              title={'Trigger JWE Decrypt Error (2507)'}
+              accessibilityLabel={'Trigger JWE decrypt error'}
+              testID={'error-jwe-decrypt'}
+              buttonType={ButtonType.Secondary}
+              onPress={triggerJweDecryptError}
+            />
+          </View>
         </View>
 
         <View style={styles.section}>

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -1644,24 +1644,32 @@ class BcscCoreModule(
      * header and whether its kid matches a local key — enough to tell "no key" / "wrong
      * key" / "unsupported alg" / "corrupt" apart from a field report alone. The alias is
      * the same identifier the recovery flow matches against the server's jwks kids.
+     *
+     * Never throws. decodePayload builds this up front on every call (success path
+     * included), so a failure while gathering diagnostics must never break decoding —
+     * the whole body is guarded and degrades to a fallback string.
      */
-    private fun decodeDiagnosticsSummary(jweString: String): String {
-        val header = incomingJWEHeader(jweString)
-        val aliases: List<String> =
-            try {
-                keyPairSource
-                    .getAllBcscKeyPairInfos()
-                    .sortedByDescending { it.getCreatedAt() }
-                    .map { it.getAlias() }
-            } catch (e: Exception) {
-                emptyList()
-            }
-        val newest = aliases.firstOrNull() ?: "none"
-        val kidMatchesLocal = header.kid.isNotEmpty() && aliases.contains(header.kid)
-        val jweKid = if (header.kid.isEmpty()) "none" else header.kid
-        return "[keys=${aliases.size}, newest=$newest, jweParts=${header.parts}, " +
-            "jweAlg=${header.alg}, jweEnc=${header.enc}, jweKid=$jweKid, kidMatchesLocal=$kidMatchesLocal]"
-    }
+    private fun decodeDiagnosticsSummary(jweString: String): String =
+        try {
+            val header = incomingJWEHeader(jweString)
+            val aliases: List<String> =
+                try {
+                    keyPairSource
+                        .getAllBcscKeyPairInfos()
+                        .sortedByDescending { it.getCreatedAt() }
+                        .map { it.getAlias() }
+                } catch (e: Exception) {
+                    emptyList()
+                }
+            val newest = aliases.firstOrNull() ?: "none"
+            val kidMatchesLocal = header.kid.isNotEmpty() && aliases.contains(header.kid)
+            val jweKid = if (header.kid.isEmpty()) "none" else header.kid
+            "[keys=${aliases.size}, newest=$newest, jweParts=${header.parts}, " +
+                "jweAlg=${header.alg}, jweEnc=${header.enc}, jweKid=$jweKid, kidMatchesLocal=$kidMatchesLocal]"
+        } catch (e: Exception) {
+            Log.w(NAME, "decodeDiagnosticsSummary: failed to build diagnostics", e)
+            "[diagnostics unavailable]"
+        }
 
     @ReactMethod
     override fun decodePayload(

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -1622,7 +1622,7 @@ class BcscCoreModule(
     private fun incomingJWEHeader(jweString: String): JweHeaderInfo {
         val parts = jweString.split(".")
         if (parts.size != 5) {
-            return JweHeaderInfo("?", "?", "", parts.size)
+            return JweHeaderInfo("?", "?", "?", parts.size)
         }
         return try {
             var seg = parts[0].replace("-", "+").replace("_", "/")
@@ -1634,7 +1634,7 @@ class BcscCoreModule(
             val obj = org.json.JSONObject(headerJson)
             JweHeaderInfo(obj.optString("alg", "?"), obj.optString("enc", "?"), obj.optString("kid", ""), parts.size)
         } catch (e: Exception) {
-            JweHeaderInfo("?", "?", "", parts.size)
+            JweHeaderInfo("?", "?", "?", parts.size)
         }
     }
 

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -1607,17 +1607,76 @@ class BcscCoreModule(
         }
     }
 
+    private data class JweHeaderInfo(
+        val alg: String,
+        val enc: String,
+        val kid: String,
+        val parts: Int,
+    )
+
+    /**
+     * Best-effort read of the *incoming* JWE protected header for diagnostics. Reads the
+     * real `kid` straight off the wire so we can tell whether the server encrypted to a key
+     * this device actually holds. Never throws — unreadable fields come back as "?".
+     */
+    private fun incomingJWEHeader(jweString: String): JweHeaderInfo {
+        val parts = jweString.split(".")
+        if (parts.size != 5) {
+            return JweHeaderInfo("?", "?", "", parts.size)
+        }
+        return try {
+            var seg = parts[0].replace("-", "+").replace("_", "/")
+            val mod = seg.length % 4
+            if (mod > 0) {
+                seg += "=".repeat(4 - mod)
+            }
+            val headerJson = String(android.util.Base64.decode(seg, android.util.Base64.DEFAULT), Charsets.UTF_8)
+            val obj = org.json.JSONObject(headerJson)
+            JweHeaderInfo(obj.optString("alg", "?"), obj.optString("enc", "?"), obj.optString("kid", ""), parts.size)
+        } catch (e: Exception) {
+            JweHeaderInfo("?", "?", "", parts.size)
+        }
+    }
+
+    /**
+     * Compact decrypt diagnostics for reject MESSAGE strings (the problem-report view
+     * surfaces only the message text). Carries the alias inventory plus the incoming JWE
+     * header and whether its kid matches a local key — enough to tell "no key" / "wrong
+     * key" / "unsupported alg" / "corrupt" apart from a field report alone. The alias is
+     * the same identifier the recovery flow matches against the server's jwks kids.
+     */
+    private fun decodeDiagnosticsSummary(jweString: String): String {
+        val header = incomingJWEHeader(jweString)
+        val aliases: List<String> =
+            try {
+                keyPairSource
+                    .getAllBcscKeyPairInfos()
+                    .sortedByDescending { it.getCreatedAt() }
+                    .map { it.getAlias() }
+            } catch (e: Exception) {
+                emptyList()
+            }
+        val newest = aliases.firstOrNull() ?: "none"
+        val kidMatchesLocal = header.kid.isNotEmpty() && aliases.contains(header.kid)
+        val jweKid = if (header.kid.isEmpty()) "none" else header.kid
+        return "[keys=${aliases.size}, newest=$newest, jweParts=${header.parts}, " +
+            "jweAlg=${header.alg}, jweEnc=${header.enc}, jweKid=$jweKid, kidMatchesLocal=$kidMatchesLocal]"
+    }
+
     @ReactMethod
     override fun decodePayload(
         jweString: String,
         promise: Promise,
     ) {
+        // Built once up front so every failure path reports the same picture, which is what
+        // makes 2507 reports self-classifying in the field.
+        val diagnostics = decodeDiagnosticsSummary(jweString)
         try {
             // Get the current (latest) key pair for decryption
             val currentKeyPair = keyPairSource.getCurrentBcscKeyPair()
 
             if (currentKeyPair.getKeyPair()?.private == null) {
-                promise.reject("E_NO_KEYS_FOUND", "No private key available for decryption")
+                promise.reject("E_NO_KEYS_FOUND", "No private key available for decryption $diagnostics")
                 return
             }
 
@@ -1634,7 +1693,7 @@ class BcscCoreModule(
             // Parse the JWT to extract and decode the payload (claims)
             val jwtSegments = jwtPayload.split(".")
             if (jwtSegments.size != JWS_COMPACT_SEGMENT_COUNT) {
-                promise.reject("E_FAILED_TO_PARSE_JWS", "Invalid JWS format in decrypted payload")
+                promise.reject("E_FAILED_TO_PARSE_JWS", "Invalid JWS format in decrypted payload $diagnostics")
                 return
             }
 
@@ -1658,20 +1717,31 @@ class BcscCoreModule(
             Log.d(NAME, "decodePayload: Successfully decoded JWE payload")
             promise.resolve(decodedPayload)
         } catch (e: BcscException) {
-            Log.e(NAME, "decodePayload: BCSC key error: ${e.devMessage}", e)
-            promise.reject("E_BCSC_DECODE_ERROR", "Error accessing key for JWE decryption: ${e.devMessage}", e)
+            // Key retrieval / keystore problem (key unavailable, OEM keystore error, invalidation).
+            Log.e(NAME, "decodePayload: BCSC key error: ${e.devMessage} $diagnostics", e)
+            promise.reject(
+                "E_BCSC_DECODE_ERROR",
+                "Error accessing key for JWE decryption: ${e.devMessage} $diagnostics",
+                e,
+            )
         } catch (e: java.text.ParseException) {
-            Log.e(NAME, "decodePayload: JWE parse error: ${e.message}", e)
-            promise.reject("E_JWE_PARSE_ERROR", "Invalid JWE format", e)
+            // Malformed / truncated / replaced JWE on the wire (transport corruption).
+            Log.e(NAME, "decodePayload: JWE parse error: ${e.message} $diagnostics", e)
+            promise.reject("E_JWE_PARSE_ERROR", "Invalid JWE format: ${e.message} $diagnostics", e)
         } catch (e: com.nimbusds.jose.JOSEException) {
-            Log.e(NAME, "decodePayload: JWE decryption error: ${e.message}", e)
-            promise.reject("E_JWE_DECRYPT_ERROR", "Failed to decrypt JWE", e)
+            // Wrong key (kidMatchesLocal=false) or unsupported alg/enc — read the diagnostics.
+            Log.e(NAME, "decodePayload: JWE decryption error: ${e.message} $diagnostics", e)
+            promise.reject("E_JWE_DECRYPT_ERROR", "Failed to decrypt JWE: ${e.message} $diagnostics", e)
         } catch (e: IllegalArgumentException) {
-            Log.e(NAME, "decodePayload: Base64 decode error: ${e.message}", e)
-            promise.reject("E_FAILED_TO_PARSE_JWS", "Failed to decode JWS payload segment", e)
+            Log.e(NAME, "decodePayload: Base64 decode error: ${e.message} $diagnostics", e)
+            promise.reject(
+                "E_FAILED_TO_PARSE_JWS",
+                "Failed to decode JWS payload segment: ${e.message} $diagnostics",
+                e,
+            )
         } catch (e: Exception) {
-            Log.e(NAME, "decodePayload: Unexpected error: ${e.message}", e)
-            promise.reject("E_PAYLOAD_DECODE_ERROR", "Unable to decode payload", e)
+            Log.e(NAME, "decodePayload: Unexpected error: ${e.message} $diagnostics", e)
+            promise.reject("E_PAYLOAD_DECODE_ERROR", "Unable to decode payload: ${e.message} $diagnostics", e)
         }
     }
 

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -232,6 +232,11 @@ class BcscCore: NSObject {
   /// inventory plus the incoming JWE header and whether its kid matches any local key —
   /// the essentials for telling "no key" / "wrong key" / "unsupported alg" / "corrupt"
   /// apart from a field report alone.
+  ///
+  /// Non-throwing by construction: `decodePayload` builds this up front on every call
+  /// (success path included), so it must never break decoding. It leans only on crash-safe
+  /// helpers (`incomingJWEHeader`, `base64URLDecodeSafely`) and never force-unwraps — keep
+  /// it that way. (The Android twin can throw, so there the whole body is guarded.)
   private func decodeDiagnosticsSummary(keys: [PrivateKeyInfo], jweString: String) -> String {
     let header = incomingJWEHeader(jweString)
     let newest = keys.sorted(by: { $0.created > $1.created }).first?.tag ?? "none"

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -183,6 +183,49 @@ class BcscCore: NSObject {
     return "[keys=\(keys.count), newest=\(newest.tag)]"
   }
 
+  /// Human-readable message for a thrown error. `JOSEException` is a bare `struct`
+  /// (not `LocalizedError`), so `localizedDescription` would hide its real text
+  /// ("Decryption failed", "Unsupported JWE algorithm […]", "Expected … 5 parts […]").
+  /// Reach into it explicitly; fall back to `localizedDescription` for everything else
+  /// (e.g. `KeychainError`, which IS `LocalizedError`).
+  private func errorMessage(_ error: Error) -> String {
+    if let jose = error as? JOSEException {
+      return jose.description
+    }
+    return error.localizedDescription
+  }
+
+  /// Best-effort read of the *incoming* JWE protected header for diagnostics. Reads the
+  /// real `kid` straight off the wire — NOT `JWEHeader.kid`, which the parser overwrites
+  /// with the server's own public-key id. Unreadable fields come back as "?".
+  private func incomingJWEHeader(_ jweString: String) -> (alg: String, enc: String, kid: String, parts: Int) {
+    let parts = jweString.components(separatedBy: ".")
+    guard parts.count == 5, let headerSegment = parts.first,
+          let obj = (try? JSONSerialization.jsonObject(with: Base64URL.decode(headerSegment))) as? [String: Any]
+    else {
+      return ("?", "?", "?", parts.count)
+    }
+    return (
+      (obj["alg"] as? String) ?? "?",
+      (obj["enc"] as? String) ?? "?",
+      (obj["kid"] as? String) ?? "",
+      parts.count
+    )
+  }
+
+  /// Compact decrypt diagnostics for reject MESSAGE strings (the problem-report view
+  /// surfaces only the message text, not the structured userInfo). Carries the key
+  /// inventory plus the incoming JWE header and whether its kid matches any local key —
+  /// the essentials for telling "no key" / "wrong key" / "unsupported alg" / "corrupt"
+  /// apart from a field report alone.
+  private func decodeDiagnosticsSummary(keys: [PrivateKeyInfo], jweString: String) -> String {
+    let header = incomingJWEHeader(jweString)
+    let newest = keys.sorted(by: { $0.created > $1.created }).first?.tag ?? "none"
+    let kidMatchesLocal = !header.kid.isEmpty && keys.contains { $0.tag == header.kid }
+    let jweKid = header.kid.isEmpty ? "none" : header.kid
+    return "[keys=\(keys.count), newest=\(newest), jweParts=\(header.parts), jweAlg=\(header.alg), jweEnc=\(header.enc), jweKid=\(jweKid), kidMatchesLocal=\(kidMatchesLocal)]"
+  }
+
   private func signJWT(payload: JWTClaimsSet, reject: @escaping RCTPromiseRejectBlock) -> String? {
     let keyPairManager = KeyPairManager()
     let keys = keyPairManager.findAllPrivateKeys()
@@ -1252,23 +1295,54 @@ class BcscCore: NSObject {
   ) {
     let keyPairManager = KeyPairManager()
     let keys = keyPairManager.findAllPrivateKeys()
+    // Built once up front so every failure path reports the same picture: key
+    // inventory + the incoming JWE's alg/enc/kid + whether that kid matches a local
+    // key. This is what makes 2507 reports self-classifying in the field.
+    let diagnostics = decodeDiagnosticsSummary(keys: keys, jweString: jweString)
 
     guard let latestKeyInfo = keys.sorted(by: { $0.created > $1.created }).first else {
-      reject("E_NO_KEYS_FOUND", "No keys available to sign the JWT.", nil)
+      reject(
+        "E_NO_KEYS_FOUND",
+        "No keys available to decrypt JWE \(diagnostics)",
+        keychainDiagnosticsError(site: "decode_payload_no_keys", underlying: KeychainError.keyNotExists, keys: keys)
+      )
+      return
+    }
+
+    let keyPair: (public: SecKey, private: SecKey)
+    do {
+      keyPair = try keyPairManager.getKeyPair(with: latestKeyInfo.tag)
+    } catch let KeychainError.keychainUnavailable(status) {
+      // The key likely exists but can't be read right now (device locked, auth
+      // failure, or launched in the background before first unlock). Distinct,
+      // retryable signal — do not conflate with a genuine decryption failure.
+      reject(
+        "E_KEYCHAIN_UNAVAILABLE",
+        "Keychain temporarily unavailable while retrieving decrypt key (OSStatus \(status)) \(diagnostics)",
+        keychainDiagnosticsError(
+          site: "decode_payload_retrieve_key", underlying: KeychainError.keychainUnavailable(status), keys: keys
+        )
+      )
+      return
+    } catch {
+      reject(
+        "E_KEYPAIR_RETRIEVAL_FAILED",
+        "Failed to retrieve decrypt key: \(errorMessage(error)) \(diagnostics)",
+        keychainDiagnosticsError(site: "decode_payload_retrieve_key", underlying: error, keys: keys)
+      )
       return
     }
 
     do {
-      let keyPair = try keyPairManager.getKeyPair(with: latestKeyInfo.tag)
       let jwe = try JWE.parse(s: jweString)
       let decrypter = RSADecrypter(privateKey: keyPair.private)
-      // Decrpyt payload into JWT
+      // Decrypt payload into JWT
       let payload = try jwe.decrypt(withDecrypter: decrypter)
 
       // Break down and decode JWT
       let segments = payload.components(separatedBy: ".")
       guard segments.count == BcscCore.jwsCompactSegmentCount else {
-        reject("E_FAILED_TO_PARSE_JWS", "Invalid JWS format in decrypted payload", nil)
+        reject("E_FAILED_TO_PARSE_JWS", "Invalid JWS format in decrypted payload \(diagnostics)", nil)
         return
       }
       var base64String = segments[1]
@@ -1283,12 +1357,22 @@ class BcscCore: NSObject {
       guard let decodedData = Data(base64Encoded: base64String),
             let base64Decoded = String(data: decodedData, encoding: .utf8)
       else {
-        reject("E_FAILED_TO_PARSE_JWS", "Failed to decode JWS payload segment", nil)
+        reject("E_FAILED_TO_PARSE_JWS", "Failed to decode JWS payload segment \(diagnostics)", nil)
         return
       }
       resolve(base64Decoded)
     } catch {
-      reject("E_PAYLOAD_DECODE_ERROR", "Unable to decode payload", nil)
+      // Wrong key, unsupported alg, corrupted/garbled ciphertext, or a malformed JWE all
+      // land here. The diagnostics string is what tells them apart downstream:
+      //   [keys=0]              → no usable key
+      //   kidMatchesLocal=false → server encrypted to a key this device doesn't hold
+      //   jweAlg/jweEnc unsupported → algorithm mismatch (iOS supports RSA1_5 + CBC-HMAC)
+      //   jweParts!=5 / jweAlg=? → corrupted or replaced ciphertext in transit
+      reject(
+        "E_PAYLOAD_DECODE_ERROR",
+        "Unable to decode payload: \(errorMessage(error)) \(diagnostics)",
+        keychainDiagnosticsError(site: "decode_payload_decrypt", underlying: error, keys: keys)
+      )
     }
   }
 

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -195,13 +195,27 @@ class BcscCore: NSObject {
     return error.localizedDescription
   }
 
+  /// Safe base64url→`Data` for diagnostics: returns `nil` on malformed input instead of
+  /// force-unwrapping like `Base64URL.decode` (`Data(base64Encoded:)!`), which would crash
+  /// on a corrupt header — the exact case this diagnostic exists to report.
+  private func base64URLDecodeSafely(_ segment: String) -> Data? {
+    var base64 = segment.replacingOccurrences(of: "-", with: "+")
+      .replacingOccurrences(of: "_", with: "/")
+    let remainder = base64.count % 4
+    if remainder > 0 {
+      base64 += String(repeating: "=", count: 4 - remainder)
+    }
+    return Data(base64Encoded: base64)
+  }
+
   /// Best-effort read of the *incoming* JWE protected header for diagnostics. Reads the
   /// real `kid` straight off the wire — NOT `JWEHeader.kid`, which the parser overwrites
   /// with the server's own public-key id. Unreadable fields come back as "?".
   private func incomingJWEHeader(_ jweString: String) -> (alg: String, enc: String, kid: String, parts: Int) {
     let parts = jweString.components(separatedBy: ".")
     guard parts.count == 5, let headerSegment = parts.first,
-          let obj = (try? JSONSerialization.jsonObject(with: Base64URL.decode(headerSegment))) as? [String: Any]
+          let headerData = base64URLDecodeSafely(headerSegment),
+          let obj = (try? JSONSerialization.jsonObject(with: headerData)) as? [String: Any]
     else {
       return ("?", "?", "?", parts.count)
     }


### PR DESCRIPTION
# Summary of Changes

**This is diagnostics, not a fix.** It does not change decryption behaviour — a user hitting **error 2507 (unable to decrypt JWE)** will still hit it. What it changes is our ability to tell _why_ from a field report alone.

## What we're trying to diagnose

2507 is thrown whenever the app fails to decrypt the `/userinfo` JWE the server returns (seen on the Home and Login Request screens). It has been trickling in during the staged production rollout (~10 reports / 7 days) and is expected to scale with the rollout percentage. The problem is that today **every distinct failure collapses into the same opaque 2507** — "no key", "wrong key", "unsupported algorithm", and "corrupt/truncated ciphertext" are indistinguishable in the report, so we cannot tell which real fix to build. The native path also surfaced a bare `Unable to decode payload` with no key inventory, and on iOS the unhelpful `localizedDescription` instead of the real `JOSEException` text.

This PR makes 2507 reports **self-classifying**. Every decode reject now appends a compact, bridge-safe summary `[keys, newest, jweParts, jweAlg, jweEnc, jweKid, kidMatchesLocal]` plus the underlying error message. Read straight off a report, those fields separate the root causes:

| Signature in the report                                                 | Cause it points to                                                                            |
| ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| `kidMatchesLocal=false`, `jweKid` is a real key id                      | Server encrypted to a key this device doesn't hold/select (rotation, migration, multi-device) |
| `[keys=0]` (persists)                                                   | No usable private key (restore to a new device, keystore wiped)                               |
| iOS `E_KEYCHAIN_UNAVAILABLE`, or transient `[keys=0]` that recovers     | Keychain locked / pre-first-unlock — retryable, not a real decrypt failure                    |
| `jweEnc`/`jweAlg` not in the supported set (e.g. `A256GCM`, `RSA-OAEP`) | Server changed the algorithm (iOS supports only RSA1_5 + CBC-HMAC)                            |
| `jweParts!=5` or `jweAlg=?`                                             | Corrupted / replaced JWE in transit (proxy, captive portal, truncation)                       |

## What changed

- **Android `BcscCoreModule.decodePayload`** and **iOS `BcscCore.decodePayload`**: build the diagnostics summary up front and append it (plus the underlying reason) to every reject path. The decryption attempt itself is untouched.
- **iOS** additionally distinguishes a temporarily-unavailable keychain (`E_KEYCHAIN_UNAVAILABLE`, retryable) from a genuine decryption failure, and reads the real `JOSEException` text instead of `localizedDescription`.
- The diagnostics already reach problem reports via `AppError.fullMessage` (`technicalMessage` = native code + message); no JS change was needed beyond a regression test that locks that contract.

# Testing Instructions

- Run the `appError` unit suite (`app/src/errors/appError.test.ts`). The new test confirms the native diagnostics + error code survive into `AppError.fullMessage` for 2507 (asserts `statusCode 2507`, the `token.err_110_unable_to_decrypt_jwe.2507` tag, `E_PAYLOAD_DECODE_ERROR`, and fields like `kidMatchesLocal=false`, `jweEnc=A256CBC-HS512`).
- Native (manual, Android + iOS): trigger a decode failure during get-user-info (e.g. force a key/`kid` mismatch) and confirm the problem-report message contains the `[keys=…, jweKid=…, kidMatchesLocal=…]` summary and the underlying reason.
- iOS: confirm a locked-device / keychain-unavailable failure surfaces as `E_KEYCHAIN_UNAVAILABLE` rather than a generic `E_PAYLOAD_DECODE_ERROR`.

# Acceptance Criteria

- 2507 problem reports include the decode diagnostics summary and the underlying error message.
- "No key" / "wrong key" / "unsupported alg" / "corrupt JWE" are distinguishable from a report alone.
- iOS keychain-unavailable failures report distinctly (`E_KEYCHAIN_UNAVAILABLE`) and are not conflated with decryption failures.
- Success path and existing decode behaviour are unchanged; the diagnostics builder never throws (unreadable fields → `?`).

# Next Steps

This is the first half of a deliberate **diagnostics-first** approach — ship observability, then fix the cause the data actually shows. After this has been in the field for ~1–2 weeks:

1. **Read the 2507 distribution** using the table above to find the dominant cause.
2. **Build the targeted fix** (none ships in this PR):
   - _Right key held but not selected_ (`kidMatchesLocal=false` with the kid present locally) → kid-aware + try-all-local-keys decryption in `decodePayload`, and enforce the iOS HMAC tag (currently computed but not checked). Self-contained, no server coordination.
   - _Key / server desync_ → wire the server-JWKS reconcile-and-retry (today it only runs on a token-endpoint 401) into the 2507 path.
   - _No key present_ (`[keys=0]`) → route to a clean re-registration flow instead of "Something went wrong", and stop Android silently seeding a fresh `rsa1` (which turns a recoverable no-key into a permanent mismatch).
   - _Unsupported alg/enc_ → coordinate with the backend before any `alg`/`enc` change (iOS supports only RSA1_5 + CBC-HMAC).
3. Full investigation and the complete ~25-scenario hypothesis catalog live in `tmp/err_2507_investigation.md`.

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A
