### PR TITLE
fix: missing sha and graceful error handling

### DIFF
--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -1917,7 +1917,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-attestation (2.12.12):
+  - react-native-attestation (2.12.13):
     - boost
     - DoubleConversion
     - fast_float
@@ -3684,7 +3684,7 @@ SPEC CHECKSUMS:
   React-logger: a913317214a26565cd4c045347edf1bcacb80a3f
   React-Mapbuffer: 94f4264de2cb156960cd82b338a403f4653f2fd9
   React-microtasksnativemodule: 6c4ee39a36958c39c97b074d28f360246a335e84
-  react-native-attestation: ab2e1bf0514f33642464301c8c1b81d5f87b3006
+  react-native-attestation: 4295cea60021942378109d803b4910070e9a00b9
   react-native-config: eae2b928a919c9743d710bbff3b7592882268fe8
   react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
   react-native-keyboard-controller: 7e305e26078360602b5d523ff84250b5a054a6ff

--- a/app/package.json
+++ b/app/package.json
@@ -52,12 +52,12 @@
     "snowplow:stop": "docker ps -a -q --filter ancestor=snowplow/snowplow-micro:3.0.1 | xargs -r docker rm -f && echo 'Snowplow Micro analytics container stopped and removed'"
   },
   "dependencies": {
-    "@bifold/core": "2.12.12",
-    "@bifold/oca": "2.12.12",
-    "@bifold/react-hooks": "2.12.12",
-    "@bifold/react-native-attestation": "2.12.12",
-    "@bifold/remote-logs": "2.12.12",
-    "@bifold/verifier": "2.12.12",
+    "@bifold/core": "2.12.13",
+    "@bifold/oca": "2.12.13",
+    "@bifold/react-hooks": "2.12.13",
+    "@bifold/react-native-attestation": "2.12.13",
+    "@bifold/remote-logs": "2.12.13",
+    "@bifold/verifier": "2.12.13",
     "@credo-ts/anoncreds": "0.5.19",
     "@credo-ts/askar": "0.5.19",
     "@credo-ts/core": "0.5.19",

--- a/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.test.ts
@@ -253,6 +253,95 @@ describe('useVerificationMethodModel', () => {
       expect(mockVideoPromptsMissingAlert).not.toHaveBeenCalled()
     })
 
+    it('refetches prompts when the request id is persisted but sha is missing (post app-cycle)', async () => {
+      const storeWithoutSha = {
+        ...mockStore,
+        bcsc: { ...mockStore.bcsc, prompts: [{ id: 1, prompt: 'Stale prompt' }] },
+        bcscSecure: {
+          ...mockStore.bcscSecure,
+          verificationRequestId: 'existing-id',
+          verificationRequestSha: undefined,
+        },
+      }
+      jest.mocked(Bifold).useStore.mockReturnValue([storeWithoutSha, mockDispatch])
+
+      const fetched = { id: 'existing-id', sha256: 'fresh-sha', prompts: [{ id: 1, prompt: 'Say your name' }] }
+      mockEvidenceApi.getVerificationRequestPrompts.mockResolvedValue(fetched)
+      jest.mocked(removeFileSafely).mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => useVerificationMethodModel({ navigation: mockNavigation }))
+
+      await act(async () => {
+        await result.current.handlePressSendVideo()
+      })
+
+      expect(mockEvidenceApi.getVerificationRequestPrompts).toHaveBeenCalledWith('existing-id')
+      expect(mockEvidenceApi.createVerificationRequest).not.toHaveBeenCalled()
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_REQUEST_SHA,
+        payload: ['fresh-sha'],
+      })
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.InformationRequired)
+    })
+
+    it('recovers from a stale id by creating a fresh verification request when prompts fetch fails', async () => {
+      const storeWithStaleId = {
+        ...mockStore,
+        bcsc: { ...mockStore.bcsc, prompts: [] },
+        bcscSecure: { ...mockStore.bcscSecure, verificationRequestId: 'stale-id', verificationRequestSha: undefined },
+      }
+      jest.mocked(Bifold).useStore.mockReturnValue([storeWithStaleId, mockDispatch])
+
+      const serverError = new Error('Request failed with status code 500')
+      mockEvidenceApi.getVerificationRequestPrompts.mockRejectedValue(serverError)
+      const fresh = { id: 'fresh-id', sha256: 'fresh-sha', prompts: [{ id: 1, prompt: 'Say your name' }] }
+      mockEvidenceApi.createVerificationRequest.mockResolvedValue(fresh)
+      jest.mocked(removeFileSafely).mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => useVerificationMethodModel({ navigation: mockNavigation }))
+
+      await act(async () => {
+        await result.current.handlePressSendVideo()
+      })
+
+      expect(mockEvidenceApi.getVerificationRequestPrompts).toHaveBeenCalledWith('stale-id')
+      expect(mockEvidenceApi.createVerificationRequest).toHaveBeenCalledTimes(1)
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_REQUEST_ID,
+        payload: ['fresh-id'],
+      })
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_REQUEST_SHA,
+        payload: ['fresh-sha'],
+      })
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.InformationRequired)
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('creating a fresh request'))
+    })
+
+    it('skips the refetch when both id, sha, and prompts are already in state', async () => {
+      const fullyHydrated = {
+        ...mockStore,
+        bcsc: { ...mockStore.bcsc, prompts: [{ id: 1, prompt: 'Say your name' }] },
+        bcscSecure: {
+          ...mockStore.bcscSecure,
+          verificationRequestId: 'existing-id',
+          verificationRequestSha: 'cached-sha',
+        },
+      }
+      jest.mocked(Bifold).useStore.mockReturnValue([fullyHydrated, mockDispatch])
+      jest.mocked(removeFileSafely).mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => useVerificationMethodModel({ navigation: mockNavigation }))
+
+      await act(async () => {
+        await result.current.handlePressSendVideo()
+      })
+
+      expect(mockEvidenceApi.createVerificationRequest).not.toHaveBeenCalled()
+      expect(mockEvidenceApi.getVerificationRequestPrompts).not.toHaveBeenCalled()
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.InformationRequired)
+    })
+
     it('aborts with a retryable alert and no navigation when no prompts are returned', async () => {
       // Regression for #4018: the server can return an empty prompt set; never walk the user into
       // TakeVideoScreen (which hard-stops) — show a retryable alert and stay put instead.

--- a/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.tsx
@@ -34,11 +34,21 @@ const useVerificationMethodModel = ({ navigation }: useVerificationMethodModelPr
         verificationRequest = await evidence.createVerificationRequest()
       }
 
-      // Use `?.length` (not just `!prompts`): an empty array is truthy, so a leftover/empty `[]` would
-      // otherwise skip this refetch and strand the user with no prompts on TakeVideoScreen.
-      if (store.bcscSecure.verificationRequestId && !store.bcsc.prompts?.length) {
-        // NOTE: Making this request too many times will be rate limited by the server.
-        verificationRequest = await evidence.getVerificationRequestPrompts(store.bcscSecure.verificationRequestId)
+      if (
+        store.bcscSecure.verificationRequestId &&
+        (!store.bcscSecure.verificationRequestSha || !store.bcsc.prompts?.length)
+      ) {
+        try {
+          verificationRequest = await evidence.getVerificationRequestPrompts(store.bcscSecure.verificationRequestId)
+        } catch (error) {
+          // IAS returns 500 for any call against a verification id that has been deleted
+          // server-side (TTL expired, agent cancelled, etc.). The local id is now useless —
+          // start a fresh request so the user isn't stuck on a stale id across cycles.
+          logger.warn(
+            `[useVerificationMethodModel] Failed to fetch prompts for stored verification id; creating a fresh request: ${error instanceof Error ? error.message : String(error)}`
+          )
+          verificationRequest = await evidence.createVerificationRequest()
+        }
       }
 
       if (verificationRequest) {
@@ -74,6 +84,7 @@ const useVerificationMethodModel = ({ navigation }: useVerificationMethodModelPr
     }
   }, [
     store.bcscSecure.verificationRequestId,
+    store.bcscSecure.verificationRequestSha,
     store.bcsc.prompts,
     store.bcsc.videoPath,
     store.bcsc.photoPath,

--- a/app/src/bcsc-theme/features/verify/send-video/useEvidenceUploadModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/useEvidenceUploadModel.test.ts
@@ -40,10 +40,12 @@ jest.mock('@bifold/core', () => {
 })
 
 const mockUpdateAccountFlags = jest.fn().mockResolvedValue(undefined)
+const mockUpdateVerificationRequest = jest.fn().mockResolvedValue(undefined)
 jest.mock('@/bcsc-theme/hooks/useSecureActions', () => ({
   __esModule: true,
   default: jest.fn(() => ({
     updateAccountFlags: mockUpdateAccountFlags,
+    updateVerificationRequest: mockUpdateVerificationRequest,
   })),
 }))
 
@@ -81,6 +83,8 @@ describe('useEvidenceUploadModel', () => {
     uploadVideoEvidenceBinary: jest.fn(),
     sendEvidenceMetadata: jest.fn(),
     sendVerificationRequest: jest.fn(),
+    createVerificationRequest: jest.fn(),
+    getVerificationRequestPrompts: jest.fn(),
   }
 
   const baseStore: any = {
@@ -189,7 +193,13 @@ describe('useEvidenceUploadModel', () => {
       expect(mockFileUploadErrorAlert).toHaveBeenCalled()
     })
 
-    it('should emit fileUploadErrorAlert when verification request data is missing', async () => {
+    it('routes back to Verification Method Selection without hitting the evidence API when sha is missing', async () => {
+      // IAS rotates prompts on every GET /prompts, so refetching here would
+      // invalidate the user's recorded video (different sha → "invalid sha256"
+      // on finalize). Instead, clear the broken local state and bounce back to
+      // Verification Method Selection where handlePressSendVideo will refetch
+      // once and force a re-record.
+      const mockDispatch = jest.fn()
       const bifoldMock = jest.mocked(Bifold)
       bifoldMock.useStore.mockReturnValue([
         {
@@ -200,9 +210,16 @@ describe('useEvidenceUploadModel', () => {
             videoPath: '/video.mp4',
             videoDuration: 10,
             prompts: [{ text: 'smile' }],
+            photoMetadata: { some: 'metadata' },
+          },
+          bcscSecure: {
+            ...baseStore.bcscSecure,
+            verificationRequestId: 'persisted-id',
+            verificationRequestSha: undefined,
+            additionalEvidenceData: [],
           },
         } as BCState,
-        jest.fn(),
+        mockDispatch,
       ])
 
       const { result } = renderHook(() => useEvidenceUploadModel(mockNavigation))
@@ -211,7 +228,59 @@ describe('useEvidenceUploadModel', () => {
         await result.current.handleSend()
       })
 
-      expect(mockFileUploadErrorAlert).toHaveBeenCalled()
+      // No evidence API calls at all — recovery must not refetch prompts.
+      expect(mockEvidenceApi.getVerificationRequestPrompts).not.toHaveBeenCalled()
+      expect(mockEvidenceApi.createVerificationRequest).not.toHaveBeenCalled()
+      expect(mockEvidenceApi.uploadPhotoEvidenceMetadata).not.toHaveBeenCalled()
+      expect(mockEvidenceApi.sendVerificationRequest).not.toHaveBeenCalled()
+      // Local state cleared: id + sha both nulled so the next handlePressSendVideo
+      // calls createVerificationRequest and gets a fresh, valid request to record
+      // against. The orphaned server-side id is TTL'd by IAS.
+      expect(mockUpdateVerificationRequest).toHaveBeenCalledWith(null, null)
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: expect.stringContaining('updateVideoPrompts') })
+      )
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: expect.stringContaining('clearPhotoAndVideo') })
+      )
+      // Navigation reset to Verification Method Selection.
+      expect(mockNavigation.dispatch).toHaveBeenCalled()
+      // Silent: no FILE_UPLOAD_ERROR alert.
+      expect(mockFileUploadErrorAlert).not.toHaveBeenCalled()
+    })
+
+    it('routes back to Verification Method Selection without hitting the evidence API when both id and sha are missing', async () => {
+      // Same path applies for the missing-id case (e.g. a force-kill that lost
+      // the id and sha together, or a Bogus dev button). We can't reuse the
+      // recorded video either way, so just clear and bounce.
+      const mockDispatch = jest.fn()
+      const bifoldMock = jest.mocked(Bifold)
+      bifoldMock.useStore.mockReturnValue([
+        {
+          ...baseStore,
+          bcsc: {
+            ...baseStore.bcsc,
+            photoPath: '/photo.jpg',
+            videoPath: '/video.mp4',
+            videoDuration: 10,
+            prompts: [{ text: 'smile' }],
+            photoMetadata: { some: 'metadata' },
+          },
+        } as BCState,
+        mockDispatch,
+      ])
+
+      const { result } = renderHook(() => useEvidenceUploadModel(mockNavigation))
+
+      await act(async () => {
+        await result.current.handleSend()
+      })
+
+      expect(mockEvidenceApi.getVerificationRequestPrompts).not.toHaveBeenCalled()
+      expect(mockEvidenceApi.createVerificationRequest).not.toHaveBeenCalled()
+      expect(mockUpdateVerificationRequest).toHaveBeenCalledWith(null, null)
+      expect(mockNavigation.dispatch).toHaveBeenCalled()
+      expect(mockFileUploadErrorAlert).not.toHaveBeenCalled()
     })
 
     it('should complete the full upload flow and navigate on success', async () => {

--- a/app/src/bcsc-theme/features/verify/send-video/useEvidenceUploadModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/useEvidenceUploadModel.test.ts
@@ -193,12 +193,12 @@ describe('useEvidenceUploadModel', () => {
       expect(mockFileUploadErrorAlert).toHaveBeenCalled()
     })
 
-    it('routes back to Verification Method Selection without hitting the evidence API when sha is missing', async () => {
+    it('routes back to Verification Method Selection and surfaces the error alert when sha is missing', async () => {
       // IAS rotates prompts on every GET /prompts, so refetching here would
       // invalidate the user's recorded video (different sha → "invalid sha256"
-      // on finalize). Instead, clear the broken local state and bounce back to
-      // Verification Method Selection where handlePressSendVideo will refetch
-      // once and force a re-record.
+      // on finalize). Instead, clear the broken local state, bounce back to
+      // Verification Method Selection, and let the existing FILE_UPLOAD_ERROR
+      // alert pop on top of that screen so the user knows why they were moved.
       const mockDispatch = jest.fn()
       const bifoldMock = jest.mocked(Bifold)
       bifoldMock.useStore.mockReturnValue([
@@ -245,14 +245,14 @@ describe('useEvidenceUploadModel', () => {
       )
       // Navigation reset to Verification Method Selection.
       expect(mockNavigation.dispatch).toHaveBeenCalled()
-      // Silent: no FILE_UPLOAD_ERROR alert.
-      expect(mockFileUploadErrorAlert).not.toHaveBeenCalled()
+      // Error alert pops on top of the destination screen.
+      expect(mockFileUploadErrorAlert).toHaveBeenCalled()
     })
 
-    it('routes back to Verification Method Selection without hitting the evidence API when both id and sha are missing', async () => {
+    it('routes back to Verification Method Selection and surfaces the error alert when both id and sha are missing', async () => {
       // Same path applies for the missing-id case (e.g. a force-kill that lost
       // the id and sha together, or a Bogus dev button). We can't reuse the
-      // recorded video either way, so just clear and bounce.
+      // recorded video either way, so just clear, bounce, and alert.
       const mockDispatch = jest.fn()
       const bifoldMock = jest.mocked(Bifold)
       bifoldMock.useStore.mockReturnValue([
@@ -280,7 +280,7 @@ describe('useEvidenceUploadModel', () => {
       expect(mockEvidenceApi.createVerificationRequest).not.toHaveBeenCalled()
       expect(mockUpdateVerificationRequest).toHaveBeenCalledWith(null, null)
       expect(mockNavigation.dispatch).toHaveBeenCalled()
-      expect(mockFileUploadErrorAlert).not.toHaveBeenCalled()
+      expect(mockFileUploadErrorAlert).toHaveBeenCalled()
     })
 
     it('should complete the full upload flow and navigate on success', async () => {

--- a/app/src/bcsc-theme/features/verify/send-video/useEvidenceUploadModel.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/useEvidenceUploadModel.tsx
@@ -139,7 +139,7 @@ const useEvidenceUploadModel = (
             routes: [{ name: BCSCScreens.SetupSteps }, { name: BCSCScreens.VerificationMethodSelection }],
           })
         )
-        return
+        throw new Error('Missing verification request data, resetting so you can try again.')
       }
 
       if (!photoMetadata) {

--- a/app/src/bcsc-theme/features/verify/send-video/useEvidenceUploadModel.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/useEvidenceUploadModel.tsx
@@ -11,7 +11,7 @@ import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigator
 import { getVideoMetadata } from '@/bcsc-theme/utils/file-info'
 import { AppError, ErrorRegistry } from '@/errors'
 import { useAlerts } from '@/hooks/useAlerts'
-import { BCState } from '@/store'
+import { BCDispatchAction, BCState } from '@/store'
 import readFileInChunks from '@/utils/read-file'
 import { TOKENS, useServices, useStore } from '@bifold/core'
 import { CommonActions } from '@react-navigation/native'
@@ -25,9 +25,9 @@ const useEvidenceUploadModel = (
   navigation: StackNavigationProp<BCSCVerifyStackParams, BCSCScreens.InformationRequired>
 ) => {
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
-  const [store] = useStore<BCState>()
+  const [store, dispatch] = useStore<BCState>()
   const { evidence } = useApi()
-  const { updateAccountFlags } = useSecureActions()
+  const { updateAccountFlags, updateVerificationRequest } = useSecureActions()
   const { processAdditionalEvidence } = useEvidenceUpload()
   const { t } = useTranslation()
   const loadingScreen = useLoadingScreen()
@@ -127,7 +127,19 @@ const useEvidenceUploadModel = (
       }
 
       if (!verificationRequestId || !verificationRequestSha) {
-        throw new Error('Missing verification request data')
+        logger.warn(
+          '[useEvidenceUploadModel] Missing verification request data at submit; routing back to Verification Method Selection so prompts can be refreshed and video re-recorded'
+        )
+        await updateVerificationRequest(null, null)
+        dispatch({ type: BCDispatchAction.UPDATE_VIDEO_PROMPTS, payload: [undefined] })
+        dispatch({ type: BCDispatchAction.RESET_SEND_VIDEO })
+        navigation.dispatch(
+          CommonActions.reset({
+            index: 1,
+            routes: [{ name: BCSCScreens.SetupSteps }, { name: BCSCScreens.VerificationMethodSelection }],
+          })
+        )
+        return
       }
 
       if (!photoMetadata) {
@@ -182,6 +194,7 @@ const useEvidenceUploadModel = (
       stopLoading()
     }
   }, [
+    dispatch,
     fileUploadErrorAlert,
     finalizeVerification,
     loadingScreen,
@@ -194,6 +207,7 @@ const useEvidenceUploadModel = (
     prompts,
     t,
     updateAccountFlags,
+    updateVerificationRequest,
     uploadEvidenceFiles,
     uploadEvidenceMetadata,
     verificationRequestId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1747,13 +1747,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bifold/core@npm:2.12.12":
-  version: 2.12.12
-  resolution: "@bifold/core@npm:2.12.12"
+"@bifold/core@npm:2.12.13":
+  version: 2.12.13
+  resolution: "@bifold/core@npm:2.12.13"
   dependencies:
     "@types/base-64": "npm:^1.0.2"
   peerDependencies:
-    "@bifold/react-hooks": 2.12.12
+    "@bifold/react-hooks": 2.12.13
     "@credo-ts/anoncreds": 0.5.19
     "@credo-ts/askar": 0.5.19
     "@credo-ts/core": 0.5.19
@@ -1822,26 +1822,26 @@ __metadata:
     uuid: ~9.0.1
   bin:
     bifold: bin/bifold
-  checksum: 10c0/39857c82313a2ff7a107ef0a8c7320634190c66f677cc627a125e1eacf7e5493a02d24def2c19cc474fe3f77cc08fb8e962934171ef85c0b6583d9990a9f0a70
+  checksum: 10c0/a4441d8df9828f8b937c852537e1a5e18aa80a12045ea3b1025b635ba45d00938805404ad5aa4563f221bcd0ee4fc66ed986c9e4496e734bdef1ff9895372116
   languageName: node
   linkType: hard
 
-"@bifold/oca@npm:2.12.12":
-  version: 2.12.12
-  resolution: "@bifold/oca@npm:2.12.12"
+"@bifold/oca@npm:2.12.13":
+  version: 2.12.13
+  resolution: "@bifold/oca@npm:2.12.13"
   dependencies:
     "@credo-ts/anoncreds": "npm:0.5.19"
     "@credo-ts/core": "npm:0.5.19"
     axios: "npm:~1.13.2"
     lodash.startcase: "npm:~4.4.0"
     react-native-fs: "npm:~2.20.0"
-  checksum: 10c0/e4f268ee2bd9c6f61ab075dcfdb179b98acc034ac670f8cbe093e1ee6f1e21b55c92d1ad4715ee39ef1aa81a6f8c9129bc47e1285c6eefba16291c7aebcf854f
+  checksum: 10c0/221e51ef86ef43fa9b54fac467f61999be252a173fddf611322c93ee5b6a99bebad41d8c4f09e5acf27a5223c9dacc35555252417118460708141660bd69151d
   languageName: node
   linkType: hard
 
-"@bifold/react-hooks@npm:2.12.12":
-  version: 2.12.12
-  resolution: "@bifold/react-hooks@npm:2.12.12"
+"@bifold/react-hooks@npm:2.12.13":
+  version: 2.12.13
+  resolution: "@bifold/react-hooks@npm:2.12.13"
   dependencies:
     rxjs: "npm:^7.2.0"
   peerDependencies:
@@ -1850,25 +1850,25 @@ __metadata:
     react: ">=17.0.0 <19.0.0"
   bin:
     bifold: bin/bifold
-  checksum: 10c0/5b1f26bb9a30beda960fca4cb9aa2546ec44323eca34d52ea1fe1059ce19b26b7b61fe63dc1fae69047719929baffd92950bf0b4bdda099b3cddc2739418f8cc
+  checksum: 10c0/2986554896bec9f4f1e46604188b664f5ae97a0b13bb826103d456b1bf72b487e12909cc45c9dc7fd194d225ae07fe897afe77b5e844f9ead7ae3cd28a9a4d3b
   languageName: node
   linkType: hard
 
-"@bifold/react-native-attestation@npm:2.12.12":
-  version: 2.12.12
-  resolution: "@bifold/react-native-attestation@npm:2.12.12"
+"@bifold/react-native-attestation@npm:2.12.13":
+  version: 2.12.13
+  resolution: "@bifold/react-native-attestation@npm:2.12.13"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/d66db3d7f6b53209c8c39fb4f8ff863308f1b312cb4d4f4a82b39d88c852764f5623d3ae7e2ea99047f13c2bd5bc484f045382af9390d1faa1144ad2e5d14adc
+  checksum: 10c0/da35d459581420a5ba5fa0fa4b4a287d896efbb7a8c17036fcc8ddd4d6749ca76f7547611944170ac19406a943a125bbb7ef3a8b2cd3d231ecc965f6356701de
   languageName: node
   linkType: hard
 
-"@bifold/remote-logs@npm:2.12.12":
-  version: 2.12.12
-  resolution: "@bifold/remote-logs@npm:2.12.12"
+"@bifold/remote-logs@npm:2.12.13":
+  version: 2.12.13
+  resolution: "@bifold/remote-logs@npm:2.12.13"
   dependencies:
-    "@bifold/core": "npm:2.12.12"
+    "@bifold/core": "npm:2.12.13"
     "@credo-ts/core": "npm:0.5.19"
     axios: "npm:~1.13.2"
     buffer: "npm:~6.0.3"
@@ -1882,20 +1882,20 @@ __metadata:
     react: ~19.1.4
     react-native: 0.81.5
     react-native-logs: ~5.1.0
-  checksum: 10c0/84b910ca2c8c8452dea40c436b409ee59a71efd04b326bd1436a95a528c056a49795395231e14a316d7b9990d5101c2fd4dceec9b42257155335440a5613b08e
+  checksum: 10c0/38434840cbfd077cd15db48c5443e97141d530ca8103037ce532f30f14fc742d43055b0d9bd8052f565b9c044e4cf223a2326b4cc9a11145418acb594d06427b
   languageName: node
   linkType: hard
 
-"@bifold/verifier@npm:2.12.12":
-  version: 2.12.12
-  resolution: "@bifold/verifier@npm:2.12.12"
+"@bifold/verifier@npm:2.12.13":
+  version: 2.12.13
+  resolution: "@bifold/verifier@npm:2.12.13"
   peerDependencies:
-    "@bifold/react-hooks": 2.12.12
+    "@bifold/react-hooks": 2.12.13
     "@credo-ts/anoncreds": 0.5.19
     "@credo-ts/core": 0.5.19
     "@hyperledger/anoncreds-shared": 0.3.4
     react: ~19.1.4
-  checksum: 10c0/b60345a1774879a27bbeee39681eabe865fddccfd4adc5aeb8382e373262a61417c3f5e7708de6ec6abe9f16fa1a4cb06948397dad8175dff2bd67939222ba5c
+  checksum: 10c0/55e3fc3ae3483a58b9a0ee49ac3e062f8c7e63513e1e8f6a258a3da7f8fb82abb330ab96c5bdf3bed630566cc418e97c0c3aa253663d1cc9da1b66732990b593
   languageName: node
   linkType: hard
 
@@ -8068,12 +8068,12 @@ __metadata:
     "@babel/core": "npm:~7.28.6"
     "@babel/preset-env": "npm:~7.28.6"
     "@babel/runtime": "npm:~7.28.6"
-    "@bifold/core": "npm:2.12.12"
-    "@bifold/oca": "npm:2.12.12"
-    "@bifold/react-hooks": "npm:2.12.12"
-    "@bifold/react-native-attestation": "npm:2.12.12"
-    "@bifold/remote-logs": "npm:2.12.12"
-    "@bifold/verifier": "npm:2.12.12"
+    "@bifold/core": "npm:2.12.13"
+    "@bifold/oca": "npm:2.12.13"
+    "@bifold/react-hooks": "npm:2.12.13"
+    "@bifold/react-native-attestation": "npm:2.12.13"
+    "@bifold/remote-logs": "npm:2.12.13"
+    "@bifold/verifier": "npm:2.12.13"
     "@credo-ts/anoncreds": "npm:0.5.19"
     "@credo-ts/askar": "npm:0.5.19"
     "@credo-ts/core": "npm:0.5.19"


### PR DESCRIPTION
# Summary of Changes

This PR fixes and prevents a problem reports we've been getting:
- if a sha is missing, we refetch a new one
- if an id is missing or failing, we refetch a new one and reroute the user back to the verification method selection screen so they can rerecord selfie and video with updated prompts
 
# Testing Instructions

Put this button in both the VerificationMethodSelection screen and the InformationRequiredScreen:
```tsx
<Button
    buttonType={ButtonType.Secondary}
    title={'Corrupt'}
    onPress={async () => {
      console.log('store.bcscSecure.verificationRequestId:', store.bcscSecure.verificationRequestId)
      console.log('store.bcscSecure.verificationRequestSha:', store.bcscSecure.verificationRequestSha)
      // try uncommenting one of the two lines below at a time to check the various handlings
      // await updateVerificationRequest(store.bcscSecure.verificationRequestId ?? null, null)
      // await updateVerificationRequest(null, store.bcscSecure.verificationRequestSha ?? null)
    }}
/>
```
Press it with one line uncommented in one of the screens, continue the send video flow.
Repeat until all combinations of lines and screens are tested.

# Acceptance Criteria

Send video is more resilient

# Screenshots, videos, or gifs

N/A

# Related Issues

#4048 
#4049 