### PR TITLE
feat: report receipt

### DIFF
--- a/app/src/errors/components/ErrorInfoCard.test.tsx
+++ b/app/src/errors/components/ErrorInfoCard.test.tsx
@@ -1,3 +1,4 @@
+import Clipboard from '@react-native-clipboard/clipboard'
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import { ErrorInfoCard, ErrorInfoCardProps, colors as errorInfoCardColors } from './ErrorInfoCard'
@@ -192,6 +193,48 @@ describe('ErrorInfoCard', () => {
       fireEvent.press(getByTestId('com.aries.bifold:id/ReportThisProblem'))
 
       expect(getByText('Error.Reported')).toBeTruthy()
+    })
+  })
+
+  describe('reference code', () => {
+    const referenceCode = '7K2P-9XQF'
+
+    it('should display the reference code after reporting when onReport returns one', () => {
+      const onReport = jest.fn(() => referenceCode)
+      const { getByTestId, getByText } = render(<ErrorInfoCard {...defaultProps} enableReport onReport={onReport} />)
+
+      fireEvent.press(getByTestId('com.aries.bifold:id/ReportThisProblem'))
+
+      expect(getByTestId('com.aries.bifold:id/ReferenceCode')).toBeTruthy()
+      expect(getByText(referenceCode)).toBeTruthy()
+      expect(getByText('Error.ShareCodeWithSupport')).toBeTruthy()
+    })
+
+    it('should not display a reference code before reporting', () => {
+      const onReport = jest.fn(() => referenceCode)
+      const { queryByTestId } = render(<ErrorInfoCard {...defaultProps} enableReport onReport={onReport} />)
+
+      expect(queryByTestId('com.aries.bifold:id/ReferenceCode')).toBeNull()
+    })
+
+    it('should not display a reference code when onReport returns nothing', () => {
+      const { getByTestId, queryByTestId } = render(
+        <ErrorInfoCard {...defaultProps} enableReport onReport={mockOnReport} />
+      )
+
+      fireEvent.press(getByTestId('com.aries.bifold:id/ReportThisProblem'))
+
+      expect(queryByTestId('com.aries.bifold:id/ReferenceCode')).toBeNull()
+    })
+
+    it('should copy the reference code to the clipboard when copy is pressed', () => {
+      const onReport = jest.fn(() => referenceCode)
+      const { getByTestId } = render(<ErrorInfoCard {...defaultProps} enableReport onReport={onReport} />)
+
+      fireEvent.press(getByTestId('com.aries.bifold:id/ReportThisProblem'))
+      fireEvent.press(getByTestId('com.aries.bifold:id/CopyReferenceCode'))
+
+      expect(Clipboard.setString).toHaveBeenCalledWith(referenceCode)
     })
   })
 

--- a/app/src/errors/components/ErrorInfoCard.tsx
+++ b/app/src/errors/components/ErrorInfoCard.tsx
@@ -77,9 +77,9 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
 
   const handleReport = () => {
     setReported(true)
-    const code = onReport?.()
-    if (code) {
-      setReferenceCode(code)
+    const reportedCode = onReport?.()
+    if (reportedCode) {
+      setReferenceCode(reportedCode)
     }
   }
 

--- a/app/src/errors/components/ErrorInfoCard.tsx
+++ b/app/src/errors/components/ErrorInfoCard.tsx
@@ -1,7 +1,8 @@
 import { PressableOpacity } from '@/components/PressableOpacity'
 import { hitSlop } from '@/constants'
 import { testIdWithKey } from '@bifold/core'
-import React, { useMemo, useState } from 'react'
+import Clipboard from '@react-native-clipboard/clipboard'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native'
 import { getBuildNumber, getVersion } from 'react-native-device-info'
@@ -37,7 +38,11 @@ export interface ErrorInfoCardProps {
   message?: string
   code?: number
   onDismiss: () => void
-  onReport?: () => void
+  /**
+   * Invoked when the user reports the problem. May return a reference code that
+   * the card then surfaces for the user to share with support.
+   */
+  onReport?: () => string | void
   enableReport?: boolean
   action?: ErrorModalAction
 }
@@ -56,12 +61,38 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
   const { width } = useWindowDimensions()
   const [showDetails, setShowDetails] = useState(false)
   const [reported, setReported] = useState(false)
+  const [referenceCode, setReferenceCode] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const copyResetTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (copyResetTimeout.current) {
+        clearTimeout(copyResetTimeout.current)
+      }
+    }
+  }, [])
 
   const formattedDetails = message ? `${t('Error.ErrorCode')} ${code ?? 0} - ${message}` : ''
 
   const handleReport = () => {
     setReported(true)
-    onReport?.()
+    const code = onReport?.()
+    if (code) {
+      setReferenceCode(code)
+    }
+  }
+
+  const handleCopy = () => {
+    if (!referenceCode) {
+      return
+    }
+    Clipboard.setString(referenceCode)
+    setCopied(true)
+    if (copyResetTimeout.current) {
+      clearTimeout(copyResetTimeout.current)
+    }
+    copyResetTimeout.current = setTimeout(() => setCopied(false), 2000)
   }
 
   const containerStyle = useMemo(
@@ -165,6 +196,38 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
               </TouchableOpacity>
             )}
           </View>
+
+          {reported && referenceCode && (
+            <View style={styles.referenceContainer} testID={testIdWithKey('ReferenceCode')}>
+              <Text style={styles.referenceLabel}>{t('Error.ReferenceCode')}</Text>
+              <View style={styles.referenceRow}>
+                <Text
+                  style={styles.referenceCode}
+                  selectable
+                  accessibilityLabel={`${t('Error.ReferenceCode')}: ${referenceCode}`}
+                  testID={testIdWithKey('ReferenceCodeValue')}
+                >
+                  {referenceCode}
+                </Text>
+                <TouchableOpacity
+                  accessibilityLabel={copied ? t('Error.CodeCopied') : t('Error.CopyCode')}
+                  accessibilityRole="button"
+                  testID={testIdWithKey('CopyReferenceCode')}
+                  style={styles.copyButton}
+                  onPress={handleCopy}
+                  activeOpacity={0.7}
+                >
+                  <CommunityIcon
+                    name={copied ? 'check' : 'content-copy'}
+                    size={18}
+                    color={copied ? colors.successIcon : colors.link}
+                  />
+                  <Text style={styles.copyButtonText}>{copied ? t('Error.CodeCopied') : t('Error.CopyCode')}</Text>
+                </TouchableOpacity>
+              </View>
+              <Text style={styles.referenceHint}>{t('Error.ShareCodeWithSupport')}</Text>
+            </View>
+          )}
 
           <Text style={styles.footer} testID={testIdWithKey('VersionNumber')}>
             {t('Settings.Version')} {getVersion()} ({getBuildNumber()})
@@ -296,6 +359,51 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     color: colors.destructiveButtonText,
+  },
+  referenceContainer: {
+    marginTop: 16,
+    marginHorizontal: 4,
+    padding: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.cardBorder,
+    backgroundColor: '#F2F2F2',
+  },
+  referenceLabel: {
+    fontSize: 13,
+    color: colors.textSecondary,
+    marginBottom: 4,
+  },
+  referenceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  referenceCode: {
+    fontSize: 20,
+    fontWeight: '700',
+    letterSpacing: 2,
+    color: colors.text,
+    flexShrink: 1,
+  },
+  copyButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    marginLeft: 8,
+  },
+  copyButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.link,
+    marginLeft: 4,
+  },
+  referenceHint: {
+    fontSize: 13,
+    color: colors.textSecondary,
+    marginTop: 8,
+    lineHeight: 18,
   },
   footer: {
     marginTop: 16,

--- a/app/src/errors/components/ErrorModal.test.tsx
+++ b/app/src/errors/components/ErrorModal.test.tsx
@@ -1,4 +1,4 @@
-import { appLogger } from '@/utils/logger'
+import { reportProblem } from '@/utils/logger'
 import { BifoldError } from '@bifold/core'
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
@@ -29,9 +29,7 @@ jest.mock('react-native-safe-area-context', () => {
 jest.mock('react-native-vector-icons/MaterialIcons', () => 'Icon')
 
 jest.mock('@/utils/logger', () => ({
-  appLogger: {
-    report: jest.fn(),
-  },
+  reportProblem: jest.fn(() => 'TEST-CODE'),
 }))
 
 jest.mock('@bifold/core', () => ({
@@ -180,9 +178,19 @@ describe('BCSCErrorModal', () => {
 
       fireEvent.press(getByTestId('com.aries.bifold:id/ReportThisProblem'))
 
-      expect(appLogger.report).toHaveBeenCalledWith(
+      expect(reportProblem).toHaveBeenCalledWith(
         new BifoldError(validPayload.title, validPayload.description, validPayload.message, validPayload.code)
       )
+    })
+
+    it('should surface the reference code returned by reportProblem after reporting', () => {
+      const { getByTestId, getByText } = renderModal({ error: validPayload, enableReport: true })
+
+      fireEvent.press(getByTestId('com.aries.bifold:id/ReportThisProblem'))
+
+      expect(getByTestId('com.aries.bifold:id/ReferenceCode')).toBeTruthy()
+      expect(getByText('TEST-CODE')).toBeTruthy()
+      expect(getByTestId('com.aries.bifold:id/CopyReferenceCode')).toBeTruthy()
     })
 
     it('should disable the Report button after being pressed', async () => {

--- a/app/src/errors/components/ErrorModal.tsx
+++ b/app/src/errors/components/ErrorModal.tsx
@@ -1,6 +1,6 @@
 import { AppEventCode } from '@/events/appEventCode'
 import { Analytics } from '@/utils/analytics/analytics-singleton'
-import { appLogger } from '@/utils/logger'
+import { reportProblem } from '@/utils/logger'
 import { BifoldError, useTheme } from '@bifold/core'
 import React, { useCallback, useMemo } from 'react'
 import { Modal, Pressable, StyleSheet } from 'react-native'
@@ -52,9 +52,9 @@ export const BCSCErrorModal: React.FC<BCSCErrorModalProps> = ({
    * Handler for "Report this problem" action in the error modal.
    * Tracks the event in analytics and sends a report to the logger (Loki Grafana) with error details.
    *
-   * @returns void
+   * @returns the reference code the user can share with support, or undefined if there is no error
    */
-  const handleReport = useCallback(() => {
+  const handleReport = useCallback((): string | undefined => {
     if (!error) {
       return
     }
@@ -65,7 +65,7 @@ export const BCSCErrorModal: React.FC<BCSCErrorModalProps> = ({
     reportError.cause = error.cause
     reportError.stack = error.stack
 
-    appLogger.report(reportError)
+    return reportProblem(reportError)
   }, [error])
 
   const overlayStyle = useMemo(

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -48,6 +48,10 @@ const translation = {
     "ErrorCode": "Error Code",
     "ReportThisProblem": "Report this problem",
     "Reported": "Reported",
+    "ReferenceCode": "Reference code",
+    "CopyCode": "Copy",
+    "CodeCopied": "Copied",
+    "ShareCodeWithSupport": "Share this code with support when you contact us.",
     "Unknown": "Unknown",
     "Problem": "Something went wrong",
     "ProblemDescription": "An unexpected error occurred. Please report this error and try again."

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -48,6 +48,10 @@ const translation = {
     "ErrorCode": "Code d'erreur",
     "ReportThisProblem": "Signaler ce problème",
     "Reported": "Signalé",
+    "ReferenceCode": "Code de référence",
+    "CopyCode": "Copier",
+    "CodeCopied": "Copié",
+    "ShareCodeWithSupport": "Communiquez ce code au soutien lorsque vous nous contactez.",
     "Unknown": "Inconnu",
     "Problem": "Un problème est survenu",
     "ProblemDescription": "An unexpected error occurred. Please report this error and try again. (FR)"

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -48,6 +48,10 @@ const translation = {
     "ErrorCode": "Código de erro",
     "ReportThisProblem": "Reportar este problema",
     "Reported": "Reportado",
+    "ReferenceCode": "Código de referência",
+    "CopyCode": "Copiar",
+    "CodeCopied": "Copiado",
+    "ShareCodeWithSupport": "Compartilhe este código com o suporte ao entrar em contato.",
     "Unknown": "Desconhecido",
     "Problem": "Algo deu errado",
     "ProblemDescription": "An unexpected error occurred. Please report this error and try again. (PT-BR)"

--- a/app/src/utils/logger.test.ts
+++ b/app/src/utils/logger.test.ts
@@ -1,8 +1,9 @@
-import { RemoteLogger } from '@bifold/remote-logs'
+import type { BifoldError } from '@bifold/core'
+import { RemoteLogger, lokiTransport } from '@bifold/remote-logs'
 import { LogLevel } from '@credo-ts/core'
 import Config from 'react-native-config'
 import { autoDisableRemoteLoggingIntervalInMinutes } from '../constants'
-import { appLogger, createAppLogger } from './logger'
+import { appLogger, createAppLogger, reportProblem } from './logger'
 
 type ConfigModule = {
   REMOTE_LOGGING_URL: string
@@ -25,11 +26,17 @@ jest.mock('react-native-config', () => ({
 jest.mock('@bifold/remote-logs', () => {
   return {
     RemoteLogger: jest.fn().mockImplementation((options) => ({ options })),
+    lokiTransport: jest.fn(),
   }
 })
 
 const mockedConfig = Config as ConfigModule
 const RemoteLoggerMock = RemoteLogger as unknown as jest.Mock
+const lokiTransportMock = lokiTransport as unknown as jest.Mock
+
+// Matches the ambiguity-free alphabet used by generateReferenceCode
+// (digits 2-9 and A-Z excluding I, L, O, U), grouped as XXXX-XXXX.
+const REFERENCE_CODE_PATTERN = /^[2-9A-HJKMNP-TV-Z]{4}-[2-9A-HJKMNP-TV-Z]{4}$/
 
 describe('createAppLogger', () => {
   beforeEach(() => {
@@ -103,5 +110,50 @@ describe('createAppLogger', () => {
     createAppLogger()
 
     expect(RemoteLoggerMock).toHaveBeenCalledWith(expect.objectContaining({ logLevel: expectedLevel }))
+  })
+})
+
+describe('reportProblem', () => {
+  const fakeError = {
+    title: 'Boom',
+    description: 'It exploded',
+    code: 2800,
+    message: 'stack trace details',
+  } as unknown as BifoldError
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns a reference code matching the expected format', () => {
+    expect(reportProblem(fakeError)).toMatch(REFERENCE_CODE_PATTERN)
+  })
+
+  it('sends an incident-report to Loki with the reference code as report_id', () => {
+    const refCode = reportProblem(fakeError)
+
+    expect(lokiTransportMock).toHaveBeenCalledTimes(1)
+    const payload = lokiTransportMock.mock.calls[0][0]
+    expect(payload.options.job).toBe('incident-report')
+    expect(payload.options.lokiUrl).toBe('https://logs.example')
+    expect(payload.rawMsg[0].message).toBe('Boom')
+    expect(payload.rawMsg[0].data).toMatchObject({
+      description: 'It exploded',
+      code: 2800,
+      message: 'stack trace details',
+      report_id: refCode,
+    })
+  })
+
+  it('never throws and still returns a code when the transport fails', () => {
+    lokiTransportMock.mockImplementationOnce(() => {
+      throw new Error('network down')
+    })
+
+    let refCode: string | undefined
+    expect(() => {
+      refCode = reportProblem(fakeError)
+    }).not.toThrow()
+    expect(refCode).toMatch(REFERENCE_CODE_PATTERN)
   })
 })

--- a/app/src/utils/logger.test.ts
+++ b/app/src/utils/logger.test.ts
@@ -119,6 +119,7 @@ describe('reportProblem', () => {
     description: 'It exploded',
     code: 2800,
     message: 'stack trace details',
+    stack: 'Error: Boom\n    at somewhere (file.ts:1:1)',
   } as unknown as BifoldError
 
   beforeEach(() => {
@@ -141,6 +142,7 @@ describe('reportProblem', () => {
       description: 'It exploded',
       code: 2800,
       message: 'stack trace details',
+      stack: 'Error: Boom\n    at somewhere (file.ts:1:1)',
       report_id: refCode,
     })
   })

--- a/app/src/utils/logger.ts
+++ b/app/src/utils/logger.ts
@@ -97,9 +97,9 @@ export const reportProblem = (error: BifoldError): string => {
         },
       })
     }
-  } catch (e) {
+  } catch (e: any) {
     // Never let a reporting failure prevent the user from getting their code.
-    appLogger.error?.('Failed to send problem report to Loki', e as Error)
+    appLogger.error?.('Failed to send problem report to Loki', e)
   }
 
   return referenceCode

--- a/app/src/utils/logger.ts
+++ b/app/src/utils/logger.ts
@@ -82,13 +82,13 @@ export const appLogger = createAppLogger()
  */
 export const reportProblem = (error: BifoldError): string => {
   const referenceCode = generateReferenceCode()
-  const { title, description, code, message } = error
+  const { title, description, code, message, stack } = error
 
   try {
     if (baseOptions.lokiUrl) {
       lokiTransport({
         msg: title,
-        rawMsg: [{ message: title, data: { description, code, message, report_id: referenceCode } }],
+        rawMsg: [{ message: title, data: { description, code, message, stack, report_id: referenceCode } }],
         level: { severity: 3, text: 'error' },
         options: {
           lokiUrl: baseOptions.lokiUrl,

--- a/app/src/utils/logger.ts
+++ b/app/src/utils/logger.ts
@@ -1,4 +1,5 @@
-import { RemoteLogger, RemoteLoggerOptions } from '@bifold/remote-logs'
+import type { BifoldError } from '@bifold/core'
+import { RemoteLogger, RemoteLoggerOptions, lokiTransport } from '@bifold/remote-logs'
 import { LogLevel } from '@credo-ts/core'
 import Config from 'react-native-config'
 import {
@@ -9,6 +10,7 @@ import {
   getVersion,
 } from 'react-native-device-info'
 import { autoDisableRemoteLoggingIntervalInMinutes } from '../constants'
+import { generateReferenceCode } from './reference-code'
 
 const baseOptions: RemoteLoggerOptions = {
   lokiUrl: Config.REMOTE_LOGGING_URL,
@@ -62,3 +64,43 @@ export const createAppLogger = (extraLabels: Record<string, string> = {}, logLev
 // (Optional) Named singleton for legacy code paths;
 // prefer injecting createAppLogger() instead.
 export const appLogger = createAppLogger()
+
+/**
+ * Sends a problem report to Loki and returns a user-facing reference code.
+ *
+ * The reference code is embedded in the report payload as `report_id`, so support
+ * can locate the incident later by searching the `incident-report` job for it
+ * (e.g. in Grafana: `{job="incident-report"} |= "<code>"`). It is intentionally
+ * placed in the log body rather than as a Loki label to avoid high label
+ * cardinality.
+ *
+ * Reporting is best-effort: any transport failure is swallowed so the user is
+ * always given a code to share, even when the network/Loki is unavailable.
+ *
+ * @param error - the error being reported
+ * @returns the reference code to surface to the user
+ */
+export const reportProblem = (error: BifoldError): string => {
+  const referenceCode = generateReferenceCode()
+  const { title, description, code, message } = error
+
+  try {
+    if (baseOptions.lokiUrl) {
+      lokiTransport({
+        msg: title,
+        rawMsg: [{ message: title, data: { description, code, message, report_id: referenceCode } }],
+        level: { severity: 3, text: 'error' },
+        options: {
+          lokiUrl: baseOptions.lokiUrl,
+          lokiLabels: baseOptions.lokiLabels,
+          job: 'incident-report',
+        },
+      })
+    }
+  } catch (e) {
+    // Never let a reporting failure prevent the user from getting their code.
+    appLogger.error?.('Failed to send problem report to Loki', e as Error)
+  }
+
+  return referenceCode
+}

--- a/app/src/utils/reference-code.test.ts
+++ b/app/src/utils/reference-code.test.ts
@@ -1,0 +1,21 @@
+import { generateReferenceCode } from './reference-code'
+
+// Matches the ambiguity-free alphabet used by generateReferenceCode
+// (digits 2-9 and A-Z excluding I, L, O, U), grouped as XXXX-XXXX.
+const REFERENCE_CODE_PATTERN = /^[2-9A-HJKMNP-TV-Z]{4}-[2-9A-HJKMNP-TV-Z]{4}$/
+
+describe('generateReferenceCode', () => {
+  it('produces a grouped, ambiguity-free code', () => {
+    for (let i = 0; i < 100; i++) {
+      const codeValue = generateReferenceCode()
+      expect(codeValue).toMatch(REFERENCE_CODE_PATTERN)
+      // No easily-confused glyphs (0/O, 1/I/L, U)
+      expect(codeValue).not.toMatch(/[01ILOU]/)
+    }
+  })
+
+  it('returns a fresh code on each call', () => {
+    const codes = new Set(Array.from({ length: 20 }, () => generateReferenceCode()))
+    expect(codes.size).toBe(20)
+  })
+})

--- a/app/src/utils/reference-code.ts
+++ b/app/src/utils/reference-code.ts
@@ -1,0 +1,25 @@
+/**
+ * Characters used to build a user-facing reference code. Visually ambiguous
+ * glyphs (0/O, 1/I/L, and U) are excluded so the code can be read aloud over the
+ * phone and typed back without confusion.
+ */
+const REFERENCE_CODE_ALPHABET = '23456789ABCDEFGHJKMNPQRSTVWXYZ'
+const REFERENCE_CODE_LENGTH = 8
+const REFERENCE_CODE_GROUP_SIZE = 4
+
+/**
+ * Generates a short, human-readable reference code, e.g. "7K2P-9XQF".
+ *
+ * It is grouped with a dash for readability and drawn from an ambiguity-free
+ * alphabet so a user can relay it to support without transcription errors.
+ */
+export const generateReferenceCode = (): string => {
+  let code = ''
+  for (let i = 0; i < REFERENCE_CODE_LENGTH; i++) {
+    if (i > 0 && i % REFERENCE_CODE_GROUP_SIZE === 0) {
+      code += '-'
+    }
+    code += REFERENCE_CODE_ALPHABET.charAt(Math.floor(Math.random() * REFERENCE_CODE_ALPHABET.length))
+  }
+  return code
+}


### PR DESCRIPTION
# Summary of Changes

Adds a "Report this problem" action to the error modal. When tapped, it sends an incident report to Loki (Grafana) and surfaces a short, human-readable reference code (e.g. `7K2P-9XQF`) that the user can copy and share with support. Support can then locate the incident by that code, giving a way to correlate a user-reported error with backend logs without collecting PII. Reporting is best-effort — transport failures are swallowed so the user always gets a code.

# Testing Instructions

1. Trigger an error that surfaces the BCSC error modal.
2. Tap **Report this problem** — the button should switch to **Reported** (with a check) and a reference code (`XXXX-XXXX`) should appear with a "Share this code with support" hint.
3. Tap **Copy** — it briefly shows **Copied** (~2s) and the code is on the clipboard.
4. (Optional) In Grafana/Loki, confirm an `incident-report` entry arrives with a matching `report_id`.

# Acceptance Criteria

- "Report this problem" appears on the error modal when reporting is enabled.
- Tapping it sends an `incident-report` to Loki with the reference code as `report_id` and displays that code.
- The code is copyable; the confirmation shows briefly, then reverts.
- A reporting/transport failure neither crashes nor blocks the code from being shown.
- New strings are localized in en, fr, and pt-br.

# Screenshots, videos, or gifs

<img width="350" height="757" alt="image" src="https://github.com/user-attachments/assets/cba9a746-298e-4d41-991d-ea52befe310e" />

# Related Issues

N/A
