### PR TITLE
feat(errors): add native error registry definitions and unified mapper

### DIFF
--- a/app/__mocks__/react-native-bcsc-core.ts
+++ b/app/__mocks__/react-native-bcsc-core.ts
@@ -43,26 +43,38 @@ export enum BCSCAccountType {
   NoBcscCard = 'Other - no BC Services Card',
 }
 
+// Kept in sync with the real `BcscNativeErrorCodes` in packages/bcsc-core/src/index.ts.
+// Jest cannot currently re-export the real enum (see TODO above), so it is duplicated here.
 export const BcscNativeErrorCodes = {
-  /** toJSON method failed while serializing dynamic client registration body (error 120-1) */
+  // DCR / keychain (E_120_* series)
   TOJSON_METHOD_FAILURE: 'E_120_TOJSON_METHOD_FAILURE',
-  /** toJSONString method failed while serializing device info JWT (error 120-2) */
   TOJSONSTRING_METHOD_FAILURE: 'E_120_TOJSONSTRING_METHOD_FAILURE',
-  /** Keychain key already exists during key pair generation (error 120-3) */
   KEYCHAIN_KEY_EXISTS: 'E_120_KEYCHAIN_KEY_EXISTS_ERROR',
-  /** Keychain key does not exist when retrieving key pair (error 120-4) */
   KEYCHAIN_KEY_DOESNT_EXIST: 'E_120_KEYCHAIN_KEY_DOESNT_EXIST_ERROR',
-  /** Keychain key generation error during key pair generation (error 120-5) */
   KEYCHAIN_KEY_GENERATION_ERROR: 'E_120_KEYCHAIN_KEY_GENERATION_ERROR',
-  /** Error creating device info JWT during client registration (error 120-6) */
   JWT_DEVICE_INFO_ERROR: 'E_120_JWT_DEVICE_INFO_ERROR',
-  /** JSON serialization failed for a native request or payload */
-  JSON_SERIALIZATION_FAILED: 'E_120_JSON_SERIALIZATION_FAILED',
-  /** Secure hardware / keystore could not generate a new keypair */
-  KEYPAIR_GENERATION_FAILED: 'E_KEYPAIR_GENERATION_FAILED',
-  /** Keypair exists but could not be retrieved from secure storage */
+  KEYCHAIN_UNAVAILABLE: 'E_120_KEYCHAIN_UNAVAILABLE_ERROR',
+  // Account / Token
+  ACCOUNT_NOT_FOUND: 'E_ACCOUNT_NOT_FOUND',
+  INVALID_TOKEN_TYPE: 'E_INVALID_TOKEN_TYPE',
+  TOKEN_DELETE_ERROR: 'E_TOKEN_DELETE_ERROR',
+  // Key operations
+  KEY_NOT_FOUND: 'E_KEY_NOT_FOUND',
+  KEY_EXPORT_FAILED: 'E_KEY_EXPORT_FAILED',
+  KEY_ERROR: 'E_KEY_ERROR',
+  KEYSTORE_UNAVAILABLE: 'E_KEYSTORE_UNAVAILABLE',
+  KEYSTORE_ERROR: 'E_KEYSTORE_ERROR',
+  // JWT / Signing
+  UUID_NOT_FOUND: 'E_UUID_NOT_FOUND',
+  NO_KEYS_FOUND: 'E_NO_KEYS_FOUND',
   KEYPAIR_RETRIEVAL_FAILED: 'E_KEYPAIR_RETRIEVAL_FAILED',
-  /** JWS token could not be parsed (malformed or invalid format) */
+  JWT_SIGN_FAILED: 'E_JWT_SIGN_FAILED',
+  // PIN
+  INVALID_PARAMETERS: 'E_INVALID_PARAMETERS',
+  SET_PIN_FAILED: 'E_SET_PIN_FAILED',
+  DELETE_PIN_FAILED: 'E_DELETE_PIN_FAILED',
+  // Parsing
+  JSON_SERIALIZATION_FAILED: 'E_JSON_SERIALIZATION_FAILED',
   FAILED_TO_PARSE_JWS: 'E_FAILED_TO_PARSE_JWS',
 } as const
 

--- a/app/src/bcsc-theme/utils/native-error-map.test.ts
+++ b/app/src/bcsc-theme/utils/native-error-map.test.ts
@@ -1,7 +1,19 @@
 import { AppError } from '@/errors/appError'
 import { ErrorRegistry } from '@/errors/errorRegistry'
+import { BcscNativeErrorCodes } from 'react-native-bcsc-core'
 
-import { throwAppError, toAppError } from './native-error-map'
+import {
+  mapNativeBcscError,
+  nativeBcscErrorMap,
+  throwAppError,
+  throwNativeBcscError,
+  toAppError,
+} from './native-error-map'
+
+jest.mock('react-native-bcsc-core')
+
+/** Build a fake native module rejection: an Error carrying a string `code` (and optional userInfo). */
+const nativeError = (code: string, message = 'native failure'): Error => Object.assign(new Error(message), { code })
 
 jest.mock('@/contexts/NavigationContainerContext', () => ({
   navigationRef: { isReady: () => false, getCurrentRoute: () => undefined },
@@ -71,6 +83,84 @@ describe('native-error-map', () => {
 
     it('throws an AppError for a non-Error value', () => {
       expect(() => throwAppError(42, ErrorRegistry.STORAGE_READ_ERROR)).toThrow(AppError)
+    })
+  })
+
+  describe('nativeBcscErrorMap', () => {
+    it('maps every BcscNativeErrorCodes value to a definition (shared contract is fully covered)', () => {
+      for (const code of Object.values(BcscNativeErrorCodes)) {
+        expect(nativeBcscErrorMap.get(code)).toBeDefined()
+      }
+    })
+
+    it('maps a raw-string-only native code (not in the enum) to its definition', () => {
+      expect(nativeBcscErrorMap.get('E_JWE_DECRYPT_ERROR')).toBe(ErrorRegistry.DECRYPT_JWE_ERROR)
+    })
+
+    it('maps both platforms’ divergent strings for the same condition to one definition', () => {
+      // iOS variant + Android variant of the same JWT encryption failure
+      expect(nativeBcscErrorMap.get('E_JWT_ENCRYPTION_ERROR')).toBe(ErrorRegistry.JWT_ENCRYPTION_FAILED)
+      expect(nativeBcscErrorMap.get('E_JWT_ENCRYPTION_FAILED')).toBe(ErrorRegistry.JWT_ENCRYPTION_FAILED)
+      // iOS keychain-unavailable + Android keystore-unavailable → one retryable definition
+      expect(nativeBcscErrorMap.get('E_120_KEYCHAIN_UNAVAILABLE_ERROR')).toBe(ErrorRegistry.KEYCHAIN_UNAVAILABLE)
+      expect(nativeBcscErrorMap.get('E_KEYSTORE_UNAVAILABLE')).toBe(ErrorRegistry.KEYCHAIN_UNAVAILABLE)
+    })
+
+    it('does not map E_DEVICE_AUTH_CANCELLED (user cancel is control flow, not an error)', () => {
+      expect(nativeBcscErrorMap.get('E_DEVICE_AUTH_CANCELLED')).toBeUndefined()
+    })
+  })
+
+  describe('mapNativeBcscError', () => {
+    it('maps a known native code to its AppError, preserving the cause', () => {
+      const error = nativeError('E_JWT_SIGN_FAILED')
+      const result = mapNativeBcscError(error)
+
+      expect(result).toBeInstanceOf(AppError)
+      expect(result.appEvent).toBe(ErrorRegistry.SIGN_CLAIMS_ERROR.appEvent)
+      expect(result.cause).toBe(error)
+    })
+
+    it('groups Android storage-domain codes by operation', () => {
+      expect(mapNativeBcscError(nativeError('E_GET_EVIDENCE_ERROR')).appEvent).toBe(
+        ErrorRegistry.NATIVE_STORAGE_READ_FAILED.appEvent
+      )
+      expect(mapNativeBcscError(nativeError('E_SET_CREDENTIAL_ERROR')).appEvent).toBe(
+        ErrorRegistry.NATIVE_STORAGE_WRITE_FAILED.appEvent
+      )
+      expect(mapNativeBcscError(nativeError('E_DELETE_AUTH_REQUEST_ERROR')).appEvent).toBe(
+        ErrorRegistry.NATIVE_STORAGE_DELETE_FAILED.appEvent
+      )
+    })
+
+    it('falls back to UNMAPPED_NATIVE_ERROR for an unknown native code, preserving the raw code', () => {
+      const error = nativeError('E_TOTALLY_UNKNOWN_CODE', 'device gone')
+      const result = mapNativeBcscError(error)
+
+      expect(result.appEvent).toBe(ErrorRegistry.UNMAPPED_NATIVE_ERROR.appEvent)
+      expect(result.statusCode).toBe(9900)
+      expect(result.cause).toBe(error)
+      // Raw native code is never lost — it surfaces via technicalMessage (and the error report).
+      expect(result.technicalMessage).toContain('E_TOTALLY_UNKNOWN_CODE')
+    })
+
+    it('falls back to UNMAPPED_NATIVE_ERROR for a non-native error', () => {
+      expect(mapNativeBcscError(new Error('plain')).appEvent).toBe(ErrorRegistry.UNMAPPED_NATIVE_ERROR.appEvent)
+      expect(mapNativeBcscError('a string').appEvent).toBe(ErrorRegistry.UNMAPPED_NATIVE_ERROR.appEvent)
+    })
+  })
+
+  describe('throwNativeBcscError', () => {
+    it('throws the mapped AppError', () => {
+      const error = nativeError('E_KEY_NOT_FOUND')
+
+      expect(() => throwNativeBcscError(error)).toThrow(AppError)
+      try {
+        throwNativeBcscError(error)
+      } catch (thrown) {
+        expect((thrown as AppError).appEvent).toBe(ErrorRegistry.KEYCHAIN_KEY_NOT_FOUND.appEvent)
+        expect((thrown as AppError).cause).toBe(error)
+      }
     })
   })
 })

--- a/app/src/bcsc-theme/utils/native-error-map.ts
+++ b/app/src/bcsc-theme/utils/native-error-map.ts
@@ -1,5 +1,6 @@
-import { AppError } from '@/errors'
+import { AppError, ErrorRegistry } from '@/errors'
 import { ErrorDefinition } from '@/errors/errorRegistry'
+import { isBcscNativeError } from 'react-native-bcsc-core'
 
 // TODO (MD): Move to `errorHandler.ts`
 
@@ -15,4 +16,165 @@ export const toAppError = (error: unknown, definition: ErrorDefinition): AppErro
  */
 export const throwAppError = (error: unknown, definition: ErrorDefinition): never => {
   throw toAppError(error, definition)
+}
+
+/**
+ * Single source of truth mapping raw native bcsc-core rejection codes (`error.code`, e.g.
+ * `E_KEY_NOT_FOUND`) to their app-level {@link ErrorDefinition}.
+ *
+ * Keyed by the RAW native string because the native layer rejects with codes beyond the
+ * `BcscNativeErrorCodes` enum, and the same condition can carry different strings per platform
+ * (iOS vs Android) — both are mapped to one definition here rather than renamed natively.
+ *
+ * Codes not present here fall through to {@link ErrorRegistry.UNMAPPED_NATIVE_ERROR}, which still
+ * preserves the raw native code via the error `cause` (surfaced by `AppError.technicalMessage`).
+ */
+export const nativeBcscErrorMap: ReadonlyMap<string, ErrorDefinition> = new Map<string, ErrorDefinition>([
+  // --- DCR / keychain (E_120_* series) — reuse existing definitions ---
+  ['E_120_TOJSON_METHOD_FAILURE', ErrorRegistry.TOJSON_METHOD_FAILURE],
+  ['E_120_TOJSONSTRING_METHOD_FAILURE', ErrorRegistry.TOJSONSTRING_METHOD_FAILURE],
+  ['E_120_KEYCHAIN_KEY_EXISTS_ERROR', ErrorRegistry.KEYCHAIN_KEY_EXISTS],
+  ['E_120_KEYCHAIN_KEY_DOESNT_EXIST_ERROR', ErrorRegistry.KEYCHAIN_KEY_NOT_FOUND],
+  ['E_120_KEYCHAIN_KEY_GENERATION_ERROR', ErrorRegistry.KEYCHAIN_KEY_GENERATION_ERROR],
+  ['E_120_JWT_DEVICE_INFO_ERROR', ErrorRegistry.JWT_DEVICE_INFO_ERROR],
+  // Keychain/keystore temporarily unavailable — retryable. iOS + Android strings → one definition.
+  ['E_120_KEYCHAIN_UNAVAILABLE_ERROR', ErrorRegistry.KEYCHAIN_UNAVAILABLE],
+  ['E_KEYSTORE_UNAVAILABLE', ErrorRegistry.KEYCHAIN_UNAVAILABLE],
+
+  // --- Serialization ---
+  ['E_JSON_SERIALIZATION_FAILED', ErrorRegistry.SERIALIZE_JSON_ERROR],
+
+  // --- Keys / keystore ---
+  ['E_KEY_NOT_FOUND', ErrorRegistry.KEYCHAIN_KEY_NOT_FOUND],
+  ['E_KEY_EXPORT_FAILED', ErrorRegistry.KEY_EXPORT_FAILED],
+  ['E_KEY_DATA_EXTRACTION_FAILED', ErrorRegistry.KEY_EXPORT_FAILED],
+  ['E_KEY_COMPONENT_PARSING_FAILED', ErrorRegistry.KEY_EXPORT_FAILED],
+  ['E_KEY_ERROR', ErrorRegistry.KEY_OPERATION_ERROR],
+  ['E_KEYSTORE_ERROR', ErrorRegistry.KEY_OPERATION_ERROR],
+  ['E_NO_KEYS_FOUND', ErrorRegistry.NO_SIGNING_KEYS],
+  ['E_KEYPAIR_RETRIEVAL_FAILED', ErrorRegistry.NO_SIGNING_KEYS],
+
+  // --- Signing / JWT / JWE / JWS ---
+  ['E_JWT_SIGN_FAILED', ErrorRegistry.SIGN_CLAIMS_ERROR],
+  ['E_FAILED_TO_PARSE_JWS', ErrorRegistry.PARSE_JWS_ERROR],
+  ['E_INVALID_JWT', ErrorRegistry.PARSE_JWT_ERROR],
+  ['E_DECODE_LOGIN_CHALLENGE_ERROR', ErrorRegistry.PARSE_JWT_ERROR],
+  ['E_INVALID_JWK', ErrorRegistry.MISSING_JWK_ERROR],
+  ['E_PAYLOAD_DECODE_ERROR', ErrorRegistry.DECRYPT_JWE_ERROR],
+  ['E_JWE_DECRYPT_ERROR', ErrorRegistry.DECRYPT_JWE_ERROR],
+  ['E_JWE_PARSE_ERROR', ErrorRegistry.DECRYPT_JWE_ERROR],
+  ['E_BCSC_DECODE_ERROR', ErrorRegistry.DECRYPT_JWE_ERROR],
+  ['E_JWT_ENCRYPTION_FAILED', ErrorRegistry.JWT_ENCRYPTION_FAILED],
+  ['E_JWT_ENCRYPTION_ERROR', ErrorRegistry.JWT_ENCRYPTION_FAILED],
+  ['E_JWT_CREATION_FAILED', ErrorRegistry.JWT_CREATION_FAILED],
+  ['E_JWT_PAYLOAD_CREATION_FAILED', ErrorRegistry.JWT_CREATION_FAILED],
+
+  // --- Tokens ---
+  ['E_TOKEN_SAVE_FAILED', ErrorRegistry.TOKEN_SAVE_FAILED],
+  ['E_TOKEN_SAVE_ERROR', ErrorRegistry.TOKEN_SAVE_FAILED],
+  ['E_TOKEN_DELETE_ERROR', ErrorRegistry.TOKEN_DELETE_FAILED],
+
+  // --- Accounts ---
+  ['E_ACCOUNT_NOT_FOUND', ErrorRegistry.ACCOUNT_NOT_FOUND],
+  ['E_NO_ACCOUNT', ErrorRegistry.NATIVE_ACCOUNT_ID_NOT_FOUND],
+  ['E_ACCOUNT_ID_NOT_FOUND', ErrorRegistry.NATIVE_ACCOUNT_ID_NOT_FOUND],
+
+  // --- Native storage: grouped by operation (read / write / delete). The Android E_GET_*/E_SET_*/
+  // E_DELETE_* domain families collapse here; the raw code stays in AppError.technicalMessage. ---
+  // read
+  ['E_READ_FAILED', ErrorRegistry.NATIVE_STORAGE_READ_FAILED],
+  ['E_STORAGE_ERROR', ErrorRegistry.NATIVE_STORAGE_READ_FAILED],
+  ['E_GET_ACCOUNT_ERROR', ErrorRegistry.NATIVE_STORAGE_READ_FAILED],
+  ['E_GET_ACCOUNT_FLAGS_ERROR', ErrorRegistry.NATIVE_STORAGE_READ_FAILED],
+  ['E_GET_GLOBAL_FLAGS_ERROR', ErrorRegistry.NATIVE_STORAGE_READ_FAILED],
+  ['E_GET_EVIDENCE_ERROR', ErrorRegistry.NATIVE_STORAGE_READ_FAILED],
+  ['E_GET_CREDENTIAL_ERROR', ErrorRegistry.NATIVE_STORAGE_READ_FAILED],
+  ['E_HAS_CREDENTIAL_ERROR', ErrorRegistry.NATIVE_STORAGE_READ_FAILED],
+  ['E_GET_AUTH_REQUEST_ERROR', ErrorRegistry.NATIVE_STORAGE_READ_FAILED],
+  ['E_GET_SAVED_SERVICES_ERROR', ErrorRegistry.NATIVE_STORAGE_READ_FAILED],
+  // write
+  ['E_SAVE_FAILED', ErrorRegistry.NATIVE_STORAGE_WRITE_FAILED],
+  ['E_ENCODE_FAILED', ErrorRegistry.NATIVE_STORAGE_WRITE_FAILED],
+  ['E_FILE_ACCESS_ERROR', ErrorRegistry.NATIVE_STORAGE_WRITE_FAILED],
+  ['E_SAVE_PHOTO_ERROR', ErrorRegistry.NATIVE_STORAGE_WRITE_FAILED],
+  ['E_SAVE_ACCOUNT_FAILED', ErrorRegistry.NATIVE_STORAGE_WRITE_FAILED],
+  ['E_ACCOUNT_STORAGE_FAILED', ErrorRegistry.NATIVE_STORAGE_WRITE_FAILED],
+  ['E_ACCOUNT_ID_NOT_SET', ErrorRegistry.NATIVE_STORAGE_WRITE_FAILED],
+  ['E_UPDATE_ACCOUNT_LIST_ENTRY_FAILED', ErrorRegistry.NATIVE_STORAGE_WRITE_FAILED],
+  ['E_SET_ACCOUNT_FLAGS_ERROR', ErrorRegistry.NATIVE_STORAGE_WRITE_FAILED],
+  ['E_SET_GLOBAL_FLAGS_ERROR', ErrorRegistry.NATIVE_STORAGE_WRITE_FAILED],
+  ['E_SET_EVIDENCE_ERROR', ErrorRegistry.NATIVE_STORAGE_WRITE_FAILED],
+  ['E_SET_CREDENTIAL_ERROR', ErrorRegistry.NATIVE_STORAGE_WRITE_FAILED],
+  ['E_SET_AUTH_REQUEST_ERROR', ErrorRegistry.NATIVE_STORAGE_WRITE_FAILED],
+  ['E_SET_SAVED_SERVICES_ERROR', ErrorRegistry.NATIVE_STORAGE_WRITE_FAILED],
+  // delete
+  ['E_DELETE_FAILED', ErrorRegistry.NATIVE_STORAGE_DELETE_FAILED],
+  ['E_REMOVE_ACCOUNT_ERROR', ErrorRegistry.NATIVE_STORAGE_DELETE_FAILED],
+  ['E_FAILED_TO_DELETE_ACCOUNT', ErrorRegistry.NATIVE_STORAGE_DELETE_FAILED],
+  ['E_DELETE_ACCOUNT_FLAGS_ERROR', ErrorRegistry.NATIVE_STORAGE_DELETE_FAILED],
+  ['E_DELETE_EVIDENCE_ERROR', ErrorRegistry.NATIVE_STORAGE_DELETE_FAILED],
+  ['E_DELETE_CREDENTIAL_ERROR', ErrorRegistry.NATIVE_STORAGE_DELETE_FAILED],
+  ['E_DELETE_AUTH_REQUEST_ERROR', ErrorRegistry.NATIVE_STORAGE_DELETE_FAILED],
+  ['E_DELETE_SAVED_SERVICES_ERROR', ErrorRegistry.NATIVE_STORAGE_DELETE_FAILED],
+
+  // --- Device auth / security. NOTE: E_DEVICE_AUTH_CANCELLED is intentionally NOT mapped — a user
+  // cancel is control flow, handled at the call site, never surfaced as an error. ---
+  ['E_CAN_DEVICE_AUTH_ERROR', ErrorRegistry.DEVICE_AUTH_UNAVAILABLE],
+  ['E_NO_ACTIVITY', ErrorRegistry.DEVICE_AUTH_UNAVAILABLE],
+  ['E_DEVICE_AUTH_ERROR', ErrorRegistry.DEVICE_SECURITY_SETUP_FAILED],
+  ['E_SETUP_DEVICE_SECURITY_ERROR', ErrorRegistry.DEVICE_SECURITY_SETUP_FAILED],
+  ['E_SETUP_DEVICE_SECURITY_FAILED', ErrorRegistry.DEVICE_SECURITY_SETUP_FAILED],
+  ['E_UNLOCK_DEVICE_SECURITY_ERROR', ErrorRegistry.DEVICE_SECURITY_SETUP_FAILED],
+
+  // --- Device identity ---
+  ['E_UUID_NOT_FOUND', ErrorRegistry.UUID_NOT_FOUND],
+
+  // --- Invalid parameters / security method / token type ---
+  ['E_INVALID_PARAMETERS', ErrorRegistry.NATIVE_INVALID_PARAMETERS],
+  ['E_INVALID_SECURITY_METHOD', ErrorRegistry.NATIVE_INVALID_PARAMETERS],
+  ['E_INVALID_TOKEN_TYPE', ErrorRegistry.NATIVE_INVALID_PARAMETERS],
+  ['E_ACCOUNT_INVALID', ErrorRegistry.NATIVE_INVALID_PARAMETERS],
+  ['E_MISSING_INVALID_ACCOUNT_ID', ErrorRegistry.NATIVE_INVALID_PARAMETERS],
+  ['E_INVALID_BASE64', ErrorRegistry.NATIVE_INVALID_PARAMETERS],
+
+  // --- OAuth request bodies ---
+  ['E_DCR_ERROR', ErrorRegistry.DCR_BODY_BUILD_FAILED],
+  ['E_BCSC_DCR_ERROR', ErrorRegistry.DCR_BODY_BUILD_FAILED],
+  ['E_DEVICE_CODE_ERROR', ErrorRegistry.DEVICE_CODE_REQUEST_FAILED],
+  ['E_BCSC_DEVICE_CODE_ERROR', ErrorRegistry.DEVICE_CODE_REQUEST_FAILED],
+
+  // --- PIN / security method ---
+  ['E_SET_PIN_FAILED', ErrorRegistry.PIN_SET_FAILED],
+  ['E_DELETE_PIN_FAILED', ErrorRegistry.PIN_DELETE_FAILED],
+  ['E_VERIFY_PIN_ERROR', ErrorRegistry.PIN_OPERATION_ERROR],
+  ['E_HAS_PIN_SET_ERROR', ErrorRegistry.PIN_OPERATION_ERROR],
+  ['E_IS_PIN_AUTO_GENERATED_ERROR', ErrorRegistry.PIN_OPERATION_ERROR],
+  ['E_IS_ACCOUNT_LOCKED_ERROR', ErrorRegistry.PIN_OPERATION_ERROR],
+  ['E_GET_SECURITY_METHOD_ERROR', ErrorRegistry.PIN_OPERATION_ERROR],
+  ['E_SET_SECURITY_METHOD_ERROR', ErrorRegistry.PIN_OPERATION_ERROR],
+])
+
+/**
+ * Maps a caught native bcsc-core rejection to an {@link AppError} via {@link nativeBcscErrorMap}.
+ *
+ * Mapped native codes become their specific AppError. Unmapped native codes — and non-native errors
+ * — fall back to {@link ErrorRegistry.UNMAPPED_NATIVE_ERROR}; the raw native code is never lost
+ * because it is preserved on the error `cause` and surfaced by `AppError.technicalMessage`.
+ */
+export const mapNativeBcscError = (error: unknown): AppError => {
+  if (isBcscNativeError(error)) {
+    const definition = nativeBcscErrorMap.get(error.code)
+    if (definition) {
+      return AppError.fromErrorDefinition(definition, { cause: error })
+    }
+  }
+
+  return AppError.fromErrorDefinition(ErrorRegistry.UNMAPPED_NATIVE_ERROR, { cause: error })
+}
+
+/**
+ * Throwing variant of {@link mapNativeBcscError}.
+ */
+export const throwNativeBcscError = (error: unknown): never => {
+  throw mapNativeBcscError(error)
 }

--- a/app/src/errors/errorRegistry.ts
+++ b/app/src/errors/errorRegistry.ts
@@ -87,6 +87,16 @@ export const ErrorRegistry = {
     category: ErrorCategory.UNKNOWN,
     message: 'A fatal error occurred — app functionality may be compromised',
   },
+  // Fallback for native bcsc-core rejections whose code is not explicitly mapped. The raw native
+  // code is preserved via the error `cause` (surfaced by AppError.technicalMessage), so the failure
+  // is never hidden — distinct from a true UNKNOWN_ERROR.
+  UNMAPPED_NATIVE_ERROR: {
+    statusCode: 9900, // dedicated 9900-9989 band for unmapped native codes
+    appEvent: AppEventCode.UNMAPPED_NATIVE_ERROR,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.UNKNOWN,
+    message: 'An unmapped native module error occurred — see technical details for the raw native error code',
+  },
 
   // ============================================
   // Camera/Scanning Errors (2000-2099)
@@ -529,6 +539,35 @@ export const ErrorRegistry = {
     category: ErrorCategory.TOKEN,
     message: 'Failed to embed or extract device info from JWT payload',
   },
+  // --- Native bcsc-core token/crypto errors (#3419) ---
+  TOKEN_SAVE_FAILED: {
+    statusCode: 2515,
+    appEvent: AppEventCode.TOKEN_SAVE_FAILED,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.TOKEN,
+    message: 'Failed to save token to native secure storage — retryable',
+  },
+  TOKEN_DELETE_FAILED: {
+    statusCode: 2516,
+    appEvent: AppEventCode.TOKEN_DELETE_FAILED,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.TOKEN,
+    message: 'Failed to delete token from native secure storage',
+  },
+  JWT_ENCRYPTION_FAILED: {
+    statusCode: 2517,
+    appEvent: AppEventCode.JWT_ENCRYPTION_FAILED,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.TOKEN,
+    message: 'Native JWT/JWE encryption failed — recipient key invalid or cipher error',
+  },
+  JWT_CREATION_FAILED: {
+    statusCode: 2518,
+    appEvent: AppEventCode.JWT_CREATION_FAILED,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.TOKEN,
+    message: 'Native JWT construction or payload creation failed',
+  },
 
   // ============================================
   // Storage Errors (2600-2699)
@@ -611,6 +650,50 @@ export const ErrorRegistry = {
     category: ErrorCategory.STORAGE,
     message: 'Storage write failed because the device is out of disk space',
   },
+  // --- Native bcsc-core storage/key errors (#3419). Android E_GET_*/E_SET_*/E_DELETE_* domain
+  // families collapse by operation; the raw native code is preserved in AppError.technicalMessage. ---
+  NATIVE_STORAGE_READ_FAILED: {
+    statusCode: 2611,
+    appEvent: AppEventCode.NATIVE_STORAGE_READ_FAILED,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.STORAGE,
+    message: 'Native secure storage read failed — retryable (raw native code in technical details)',
+  },
+  NATIVE_STORAGE_WRITE_FAILED: {
+    statusCode: 2612,
+    appEvent: AppEventCode.NATIVE_STORAGE_WRITE_FAILED,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.STORAGE,
+    message: 'Native secure storage write failed — retryable (raw native code in technical details)',
+  },
+  NATIVE_STORAGE_DELETE_FAILED: {
+    statusCode: 2613,
+    appEvent: AppEventCode.NATIVE_STORAGE_DELETE_FAILED,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.STORAGE,
+    message: 'Native secure storage delete failed — retryable (raw native code in technical details)',
+  },
+  KEY_EXPORT_FAILED: {
+    statusCode: 2614,
+    appEvent: AppEventCode.KEY_EXPORT_FAILED,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.STORAGE,
+    message: 'Failed to export or extract key material from the keystore',
+  },
+  KEY_OPERATION_ERROR: {
+    statusCode: 2615,
+    appEvent: AppEventCode.KEY_OPERATION_ERROR,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.STORAGE,
+    message: 'Unexpected error during a native key/keystore operation',
+  },
+  NO_SIGNING_KEYS: {
+    statusCode: 2616,
+    appEvent: AppEventCode.NO_SIGNING_KEYS,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.STORAGE,
+    message: 'No signing keys available in the keystore — re-registration may be required',
+  },
 
   // ============================================
   // Device Errors (2700-2799)
@@ -670,6 +753,28 @@ export const ErrorRegistry = {
     severity: ErrorSeverity.ERROR,
     category: ErrorCategory.DEVICE,
     message: 'Device authentication failed — biometric or passcode verification did not succeed',
+  },
+  // --- Native bcsc-core device errors (#3419) ---
+  DEVICE_AUTH_UNAVAILABLE: {
+    statusCode: 2708,
+    appEvent: AppEventCode.DEVICE_AUTH_UNAVAILABLE,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.DEVICE,
+    message: 'Device authentication is not available — no enrolled biometric/passcode or no host activity',
+  },
+  DEVICE_SECURITY_SETUP_FAILED: {
+    statusCode: 2709,
+    appEvent: AppEventCode.DEVICE_SECURITY_SETUP_FAILED,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.DEVICE,
+    message: 'Failed to set up or unlock device security',
+  },
+  UUID_NOT_FOUND: {
+    statusCode: 2710,
+    appEvent: AppEventCode.UUID_NOT_FOUND,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.DEVICE,
+    message: 'Device UUID is not available',
   },
 
   // ============================================
@@ -842,6 +947,56 @@ export const ErrorRegistry = {
     severity: ErrorSeverity.ERROR,
     category: ErrorCategory.GENERAL,
     message: 'Client metadata is invalid — missing required fields or contains invalid values',
+  },
+  // --- Native bcsc-core general/PIN/account errors (#3419) ---
+  NATIVE_INVALID_PARAMETERS: {
+    statusCode: 2825,
+    appEvent: AppEventCode.NATIVE_INVALID_PARAMETERS,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.GENERAL,
+    message: 'Invalid parameters passed to a native operation',
+  },
+  NATIVE_ACCOUNT_ID_NOT_FOUND: {
+    statusCode: 2826,
+    appEvent: AppEventCode.NATIVE_ACCOUNT_ID_NOT_FOUND,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.GENERAL,
+    message: 'Current account ID not found in native storage',
+  },
+  DCR_BODY_BUILD_FAILED: {
+    statusCode: 2827,
+    appEvent: AppEventCode.DCR_BODY_BUILD_FAILED,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.GENERAL,
+    message: 'Failed to build the dynamic client registration request body (native)',
+  },
+  DEVICE_CODE_REQUEST_FAILED: {
+    statusCode: 2828,
+    appEvent: AppEventCode.DEVICE_CODE_REQUEST_FAILED,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.GENERAL,
+    message: 'Failed to build the device code request body (native)',
+  },
+  PIN_SET_FAILED: {
+    statusCode: 2829,
+    appEvent: AppEventCode.PIN_SET_FAILED,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.GENERAL,
+    message: 'Failed to set PIN (native)',
+  },
+  PIN_DELETE_FAILED: {
+    statusCode: 2830,
+    appEvent: AppEventCode.PIN_DELETE_FAILED,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.GENERAL,
+    message: 'Failed to delete PIN (native)',
+  },
+  PIN_OPERATION_ERROR: {
+    statusCode: 2831,
+    appEvent: AppEventCode.PIN_OPERATION_ERROR,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.GENERAL,
+    message: 'A native PIN or security-method operation failed',
   },
 
   // ============================================

--- a/app/src/events/appEventCode.ts
+++ b/app/src/events/appEventCode.ts
@@ -179,6 +179,28 @@ export enum AppEventCode {
   ATTESTATION_UNSUPPORTED_PLATFORM = 'attestation_unsupported_platform', // Non-IAS error code
   // Account Errors
   ACCOUNT_NOT_FOUND = 'account_not_found', // Non-IAS error code
+  // Native module errors (#3419) — distinct codes for bcsc-core native rejections
+  TOKEN_SAVE_FAILED = 'token_save_failed', // Non-IAS error code
+  TOKEN_DELETE_FAILED = 'token_delete_failed', // Non-IAS error code
+  JWT_ENCRYPTION_FAILED = 'jwt_encryption_failed', // Non-IAS error code
+  JWT_CREATION_FAILED = 'jwt_creation_failed', // Non-IAS error code
+  NATIVE_STORAGE_READ_FAILED = 'native_storage_read_failed', // Non-IAS error code
+  NATIVE_STORAGE_WRITE_FAILED = 'native_storage_write_failed', // Non-IAS error code
+  NATIVE_STORAGE_DELETE_FAILED = 'native_storage_delete_failed', // Non-IAS error code
+  KEY_EXPORT_FAILED = 'key_export_failed', // Non-IAS error code
+  KEY_OPERATION_ERROR = 'key_operation_error', // Non-IAS error code
+  NO_SIGNING_KEYS = 'no_signing_keys', // Non-IAS error code
+  DEVICE_AUTH_UNAVAILABLE = 'device_auth_unavailable', // Non-IAS error code
+  DEVICE_SECURITY_SETUP_FAILED = 'device_security_setup_failed', // Non-IAS error code
+  UUID_NOT_FOUND = 'uuid_not_found', // Non-IAS error code
+  NATIVE_INVALID_PARAMETERS = 'native_invalid_parameters', // Non-IAS error code
+  NATIVE_ACCOUNT_ID_NOT_FOUND = 'native_account_id_not_found', // Non-IAS error code
+  DCR_BODY_BUILD_FAILED = 'dcr_body_build_failed', // Non-IAS error code
+  DEVICE_CODE_REQUEST_FAILED = 'device_code_request_failed', // Non-IAS error code
+  PIN_SET_FAILED = 'pin_set_failed', // Non-IAS error code
+  PIN_DELETE_FAILED = 'pin_delete_failed', // Non-IAS error code
+  PIN_OPERATION_ERROR = 'pin_operation_error', // Non-IAS error code
+  UNMAPPED_NATIVE_ERROR = 'unmapped_native_error', // Non-IAS error code
 }
 
 const AppEventCodeSet = new Set<string>(Object.values(AppEventCode))


### PR DESCRIPTION
## What

Adds a single, shared way to turn native (iOS/Android) `bcsc-core` errors into app errors with their own distinct codes, plus the error definitions to back them. This is **PR 1 of 2** — it only adds the new pieces and doesn't change any behaviour yet.

## Why

The native module reports lots of specific failures, but on the JavaScript side almost all of them were collapsed into a few generic "something went wrong" buckets. That threw away the real cause, so when something broke we couldn't tell *what* actually failed. This PR lays the groundwork to fix that.

## Key Changes & Decisions

- **New error definitions** for native token, storage, key, device, and PIN failures — each with its own code and message.
- **One shared mapper** that translates a native error into the right app error. The iOS and Android names for the same problem map to a single definition.
- **Nothing gets lost:** any native error we haven't explicitly mapped still surfaces with its original native code attached, instead of disappearing into a generic error.
- **Grouped sensibly:** the many Android storage errors are grouped by operation (read / write / delete) to keep the list manageable — the exact native code is still kept for debugging.
- **No wiring yet:** call sites are switched over in PR 2, so this PR is safe and behaviour-neutral on its own.
- Fixed an out-of-date test mock so it matches the real native error list.

## Testing

- New unit tests for the mapper and the fallback (the raw native code is preserved).
- Type-check, full test suite (238 suites / 2221 tests), lint, and formatting all pass.
- Confirmed the existing "Report a problem" flow and analytics reporting keep working unchanged.

Part of #3419.