### PR TITLE
fix: prevent audio desync in recorded video

### DIFF
--- a/.yarn/patches/react-native-vision-camera-npm-4.7.3-dc361fe55c.patch
+++ b/.yarn/patches/react-native-vision-camera-npm-4.7.3-dc361fe55c.patch
@@ -134,3 +134,27 @@ index 8e57710f2444ac76f1f790ef98db1b6e2987a3e7..95fa82270d42eef48488e9afda7a7be3
  
          // Create RecordingSession for the temp file
          let recordingSession = try RecordingSession(url: options.path,
+diff --git a/ios/Core/CameraSession+Audio.swift b/ios/Core/CameraSession+Audio.swift
+index 3d67c8c6bccf49bef9783b058fb55da7b807c879..4115681ad3702834ef647f29f26ca6b4f8871662 100644
+--- a/ios/Core/CameraSession+Audio.swift
++++ b/ios/Core/CameraSession+Audio.swift
+@@ -22,12 +22,15 @@ extension CameraSession {
+     do {
+       let audioSession = AVAudioSession.sharedInstance()
+ 
++      // PATCH: Keep recording audio I/O on the built-in low-latency route. Bluetooth A2DP
++      // (and AirPlay) output is heavily buffered, which inflates the session I/O latency and
++      // bakes an audio/video sync offset into the recorded file when a BT device (headphones,
++      // car) is connected. Dropping these routes keeps capture on the built-in path; .mixWithOthers
++      // is also dropped so background audio pauses during recording. Mirrors ias-ios behaviour.
++      // Remove if VisionCamera compensates input latency in its AVAssetWriter timestamps.
+       try audioSession.updateCategory(AVAudioSession.Category.playAndRecord,
+                                       mode: .videoRecording,
+-                                      options: [.mixWithOthers,
+-                                                .allowBluetoothA2DP,
+-                                                .defaultToSpeaker,
+-                                                .allowAirPlay])
++                                      options: [.defaultToSpeaker])
+ 
+       if #available(iOS 14.5, *) {
+         // prevents the audio session from being interrupted by a phone call

--- a/yarn.lock
+++ b/yarn.lock
@@ -17285,7 +17285,7 @@ __metadata:
 
 "react-native-vision-camera@patch:react-native-vision-camera@npm%3A4.7.3#~/.yarn/patches/react-native-vision-camera-npm-4.7.3-dc361fe55c.patch":
   version: 4.7.3
-  resolution: "react-native-vision-camera@patch:react-native-vision-camera@npm%3A4.7.3#~/.yarn/patches/react-native-vision-camera-npm-4.7.3-dc361fe55c.patch::version=4.7.3&hash=9cec31"
+  resolution: "react-native-vision-camera@patch:react-native-vision-camera@npm%3A4.7.3#~/.yarn/patches/react-native-vision-camera-npm-4.7.3-dc361fe55c.patch::version=4.7.3&hash=0907f2"
   peerDependencies:
     "@shopify/react-native-skia": "*"
     react: "*"
@@ -17299,7 +17299,7 @@ __metadata:
       optional: true
     react-native-worklets-core:
       optional: true
-  checksum: 10c0/76cd9bf254051198448f4dd9cad4bcd833479736f07e2cb758741f7f4bbccfe42e3d9f67e1b24fe740adfa3ad87fcb256c13e4e3a791150f44731b728e426225
+  checksum: 10c0/2341dfb7181a7ff28534aceb0dce25b292923ec48795c6c01642627da42485d15f5f8d2ae4ca63dbb54137a017ec66a0e5fba15f646315160e1f8ea0ba3c76f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary of Changes

There were some reports of users using bluetooth devices having out of sync audio, this patch update prevents bluetooth usage in send video

I decided not to remove bluetooth support from live call since there have been zero reports of audio desync there and it's a different mechanism
 
# Testing Instructions

Use bluetooth headset, put your bluetooth headset in a drawer or another room (still connected) and then do a send-video request

# Acceptance Criteria

It doesn't record from the mic in your bluetooth headset

# Screenshots, videos, or gifs

N/A

# Related Issues

#4069 