### PR TITLE
fix: open help menu on BCSC scan and pairing screens (#3982)

### DIFF
--- a/app/src/bcsc-theme/navigators/QRCoreStack.tsx
+++ b/app/src/bcsc-theme/navigators/QRCoreStack.tsx
@@ -4,7 +4,7 @@ import ManualPairing from '@/bcsc-theme/features/pairing/ManualPairing'
 import QRDisplay from '@/bcsc-theme/features/qr-core/QRDisplay'
 import QRScanner from '@/bcsc-theme/features/qr-core/QRScanner'
 import { useVerificationStatus } from '@/bcsc-theme/hooks/useVerificationStatus'
-import { BCSCQRCoreScreens, BCSCQRCoreTabParams } from '@/bcsc-theme/types/navigators'
+import { BCSCQRCoreScreens, BCSCQRCoreTabParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { HelpCentreUrl } from '@/constants'
 import { ButtonLocation, IconButton, testIdWithKey, useTheme } from '@bifold/core'
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
@@ -14,7 +14,7 @@ import { useTranslation } from 'react-i18next'
 import { Platform, StyleSheet, Text, useWindowDimensions, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
-import { createAuthHelpHeaderButton } from '../components/HelpHeaderButton'
+import { createFloatingHelpMenuButton } from '../components/FloatingHelpMenuHeaderButton'
 
 type TabBarIconProps = {
   focused: boolean
@@ -115,7 +115,10 @@ const QRCoreStack: React.FC = () => {
             tabBarShowLabel: false,
             tabBarAccessibilityLabel: t('Scan.ScanQRCode'),
             tabBarTestID: testIdWithKey('ScanQRCode'),
-            headerRight: createAuthHelpHeaderButton({ helpCentreUrl: HelpCentreUrl.COMPUTER_LOGIN }),
+            headerRight: createFloatingHelpMenuButton({
+              webViewScreen: BCSCScreens.MainWebView,
+              learnMoreUrl: HelpCentreUrl.COMPUTER_LOGIN,
+            }),
           }}
         />
         <Tab.Screen
@@ -140,7 +143,10 @@ const QRCoreStack: React.FC = () => {
             tabBarShowLabel: false,
             tabBarAccessibilityLabel: t('BCSC.ManualPairing.TabTitle'),
             tabBarTestID: testIdWithKey('PairingCode'),
-            headerRight: createAuthHelpHeaderButton({ helpCentreUrl: HelpCentreUrl.COMPUTER_LOGIN }),
+            headerRight: createFloatingHelpMenuButton({
+              webViewScreen: BCSCScreens.MainWebView,
+              learnMoreUrl: HelpCentreUrl.COMPUTER_LOGIN,
+            }),
           }}
         />
       </Tab.Navigator>


### PR DESCRIPTION
## What
The `?` help icon on the BCSC **camera scan** screen and the **Pairing code** screen did nothing when tapped. Both now open the help context menu (Learn more / Give feedback / Report a problem + BCSC version), matching every other screen.

Closes #3982

## Why
Those two QRCore tabs wired their header `?` via `createAuthHelpHeaderButton`, which calls `navigate(AuthWebView)`. `AuthWebView` is registered only in `AuthStack` — a sibling of `MainStack` that is never mounted alongside it — so from `MainStack → QRCore` the route is unreachable. React Navigation dropped the action and logged `The action 'NAVIGATE' … was not handled by any navigator`, leaving the icon dead.

## Decisions
- **Reused `createFloatingHelpMenuButton`** (the existing context-menu pattern used by every other primary screen) rather than just fixing the navigation target — the ticket asks for a context menu, not a direct link.
- **Targeted `MainWebView`** (registered in the parent `MainStack`, reachable via navigation bubbling, same as `TabStack`'s menu). Opening the menu needs no navigation, so the icon responds immediately; "Learn more" still opens the `COMPUTER_LOGIN` article these screens intended.
- **Scope:** fixed both affected tabs (Scanner + Pairing code). Left the "My QR code" tab as-is (no help button today) and left the pre-existing `TODO (V4.1.x)` "Give feedback" / "Report a problem" stubs untouched — out of scope for this bug.

## Test plan
- `yarn typecheck` + `eslint` pass.
- Manual (BUILD_TARGET=bcsc): Home → FAB → scanner → tap `?` → menu opens, no nav warning; repeat on the Pairing code tab.
