### PR TITLE
feat: settings header chevron dropdowns

### DIFF
--- a/app/__mocks__/react-native-reanimated.ts
+++ b/app/__mocks__/react-native-reanimated.ts
@@ -1,4 +1,5 @@
 import { View } from 'react-native'
+import * as Reanimated from 'react-native-reanimated'
 
 const Easing = {
   linear: (t: number) => t,
@@ -7,6 +8,7 @@ const Easing = {
 
 module.exports = {
   __esModule: true,
+  ...Reanimated,
   default: {
     addWhitelistedNativeProps: jest.fn(),
     createAnimatedComponent: (component: any) => component,

--- a/app/src/bcsc-theme/features/settings/SettingsContent.test.tsx
+++ b/app/src/bcsc-theme/features/settings/SettingsContent.test.tsx
@@ -133,4 +133,31 @@ describe('SettingsContent', () => {
     fireEvent.press(row)
     expect(row).toBeTruthy()
   })
+
+  it('hides the section content when its chevron is pressed, and shows it again on a second press', () => {
+    renderWithState()
+
+    // Unauthenticated view renders exactly two collapsible sections: Help, then More Info.
+    // Index 0 is the Help section's chevron.
+    const [helpChevron] = screen.getAllByTestId(tid('SectionHeaderChevron'))
+
+    expect(screen.getByTestId(tid('Help'))).toBeTruthy()
+    expect(screen.getByTestId(tid('ContactUs'))).toBeTruthy()
+    expect(screen.getByTestId(tid('Feedback'))).toBeTruthy()
+
+    fireEvent.press(helpChevron)
+
+    expect(screen.queryByTestId(tid('Help'))).toBeNull()
+    expect(screen.queryByTestId(tid('ContactUs'))).toBeNull()
+    expect(screen.queryByTestId(tid('Feedback'))).toBeNull()
+    // The other section's content is untouched.
+    expect(screen.getByTestId(tid('Accessibility'))).toBeTruthy()
+    expect(screen.getByTestId(tid('TermsOfUse'))).toBeTruthy()
+
+    fireEvent.press(helpChevron)
+
+    expect(screen.getByTestId(tid('Help'))).toBeTruthy()
+    expect(screen.getByTestId(tid('ContactUs'))).toBeTruthy()
+    expect(screen.getByTestId(tid('Feedback'))).toBeTruthy()
+  })
 })

--- a/app/src/bcsc-theme/features/settings/SettingsContent.tsx
+++ b/app/src/bcsc-theme/features/settings/SettingsContent.tsx
@@ -78,10 +78,13 @@ const SectionHeader: React.FC<
   }))
 
   const toggleSection = () => {
-    chevronRotation.value = withTiming(showSection ? HALF_ROTATION : DEFAULT_ROTATION, {
-      duration: TRANSITION_IN_DURATION,
+    setShowSection((prev) => {
+      const next = !prev
+      chevronRotation.value = withTiming(next ? DEFAULT_ROTATION : HALF_ROTATION, {
+        duration: TRANSITION_IN_DURATION,
+      })
+      return next
     })
-    setShowSection((show) => !show)
   }
 
   return (
@@ -94,8 +97,8 @@ const SectionHeader: React.FC<
         <PressableOpacity
           onPress={toggleSection}
           hitSlop={hitSlop}
-          testID={testIdWithKey(showSection ? 'CloseSection' : 'OpenSection')}
-          accessibilityLabel={t(showSection ? 'Global.Close' : 'Global.Open')}
+          testID={testIdWithKey('SectionHeaderChevron')}
+          accessibilityLabel={t(showSection ? 'Global.HideDetails' : 'Global.ShowDetails')}
           accessibilityRole="button"
           style={styles.sectionHeaderChevron}
         >

--- a/app/src/bcsc-theme/features/settings/SettingsContent.tsx
+++ b/app/src/bcsc-theme/features/settings/SettingsContent.tsx
@@ -34,6 +34,8 @@ import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
 const TRANSITION_IN_DURATION = 200
 const TRANSITION_OUT_DURATION = 150
+const DEFAULT_ROTATION = 0
+const HALF_ROTATION = 180
 
 interface SettingsContentProps {
   onContactUs: () => void
@@ -69,15 +71,17 @@ const SectionHeader: React.FC<
   const { t } = useTranslation()
   const { TextTheme } = useTheme()
   const [showSection, setShowSection] = useState(true)
-  const chevronRotation = useSharedValue(0)
+  const chevronRotation = useSharedValue(DEFAULT_ROTATION)
 
   const chevronStyle = useAnimatedStyle(() => ({
     transform: [{ rotate: `${chevronRotation.value}deg` }],
   }))
 
   const toggleSection = () => {
+    chevronRotation.value = withTiming(showSection ? HALF_ROTATION : DEFAULT_ROTATION, {
+      duration: TRANSITION_IN_DURATION,
+    })
     setShowSection((show) => !show)
-    chevronRotation.value = withTiming(showSection ? 180 : 0, { duration: TRANSITION_IN_DURATION })
   }
 
   return (

--- a/app/src/bcsc-theme/features/settings/SettingsContent.tsx
+++ b/app/src/bcsc-theme/features/settings/SettingsContent.tsx
@@ -17,12 +17,23 @@ import {
   useTheme,
 } from '@bifold/core'
 import { useFocusEffect } from '@react-navigation/native'
-import React, { ReactNode, useCallback, useContext, useState } from 'react'
+import React, { PropsWithChildren, ReactNode, useCallback, useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Linking, StyleSheet, TouchableWithoutFeedback, Vibration, View } from 'react-native'
 import { AccountSecurityMethod, getAccountSecurityMethod } from 'react-native-bcsc-core'
 import { getBuildNumber, getVersion } from 'react-native-device-info'
+import Animated, {
+  FadeIn,
+  FadeOut,
+  LinearTransition,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
+
+const TRANSITION_IN_DURATION = 200
+const TRANSITION_OUT_DURATION = 150
 
 interface SettingsContentProps {
   onContactUs: () => void
@@ -48,19 +59,56 @@ interface SettingsContentProps {
 
 type SectionStyles = ReturnType<typeof makeStyles>
 
-const SectionHeader: React.FC<{
-  title: string
-  iconName: string
-  styles: SectionStyles
-}> = ({ title, iconName, styles }) => {
+const SectionHeader: React.FC<
+  PropsWithChildren<{
+    title: string
+    iconName: string
+    styles: SectionStyles
+  }>
+> = ({ title, iconName, styles, children }) => {
+  const { t } = useTranslation()
   const { TextTheme } = useTheme()
+  const [showSection, setShowSection] = useState(true)
+  const chevronRotation = useSharedValue(0)
+
+  const chevronStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${chevronRotation.value}deg` }],
+  }))
+
+  const toggleSection = () => {
+    setShowSection((show) => !show)
+    chevronRotation.value = withTiming(showSection ? 180 : 0, { duration: TRANSITION_IN_DURATION })
+  }
+
   return (
-    <View style={styles.sectionHeader}>
-      <Icon name={iconName} size={22} color={TextTheme.bold.color} />
-      <ThemedText variant="bold" style={styles.sectionHeaderText}>
-        {title}
-      </ThemedText>
-    </View>
+    <Animated.View layout={LinearTransition.duration(TRANSITION_IN_DURATION)}>
+      <View style={styles.sectionHeader}>
+        <Icon name={iconName} size={22} color={TextTheme.bold.color} />
+        <ThemedText variant="bold" style={styles.sectionHeaderText}>
+          {title}
+        </ThemedText>
+        <PressableOpacity
+          onPress={toggleSection}
+          hitSlop={hitSlop}
+          testID={testIdWithKey(showSection ? 'CloseSection' : 'OpenSection')}
+          accessibilityLabel={t(showSection ? 'Global.Close' : 'Global.Open')}
+          accessibilityRole="button"
+          style={styles.sectionHeaderChevron}
+        >
+          <Animated.View style={chevronStyle}>
+            <Icon name="chevron-down" size={22} color={TextTheme.bold.color} />
+          </Animated.View>
+        </PressableOpacity>
+      </View>
+      {showSection ? (
+        <Animated.View
+          entering={FadeIn.duration(TRANSITION_IN_DURATION)}
+          exiting={FadeOut.duration(TRANSITION_OUT_DURATION)}
+        >
+          {children}
+        </Animated.View>
+      ) : null}
+    </Animated.View>
   )
 }
 
@@ -184,81 +232,83 @@ const AuthenticatedSection: React.FC<AuthenticatedSectionProps> = ({
         </View>
       ) : null}
 
-      <SectionHeader title={t('BCSC.Settings.Features.Header')} iconName="bullhorn-outline" styles={styles} />
-      <View style={styles.sectionContainer}>
-        <ListButtonGroup>
-          {[
-            onContacts ? (
-              <ListButton key="contacts" onPress={onContacts} testID={testIdWithKey('Contacts')}>
-                {t('BCSC.Settings.Features.Contacts')}
-              </ListButton>
-            ) : null,
-            <ListButton key="scanqr" onPress={onScanMyQR ?? noop} testID={testIdWithKey('ScanQR')}>
-              {t('BCSC.Settings.Features.ScanQR')}
-            </ListButton>,
-            <ListButton key="proof" onPress={onSendProofRequest ?? noop} testID={testIdWithKey('SendProofRequest')}>
-              {t('BCSC.Settings.Features.SendProofRequest')}
-            </ListButton>,
-          ]}
-        </ListButtonGroup>
-      </View>
+      <SectionHeader title={t('BCSC.Settings.Features.Header')} iconName="bullhorn-outline" styles={styles}>
+        <View style={styles.sectionContainer}>
+          <ListButtonGroup>
+            {[
+              onContacts ? (
+                <ListButton key="contacts" onPress={onContacts} testID={testIdWithKey('Contacts')}>
+                  {t('BCSC.Settings.Features.Contacts')}
+                </ListButton>
+              ) : null,
+              <ListButton key="scanqr" onPress={onScanMyQR ?? noop} testID={testIdWithKey('ScanQR')}>
+                {t('BCSC.Settings.Features.ScanQR')}
+              </ListButton>,
+              <ListButton key="proof" onPress={onSendProofRequest ?? noop} testID={testIdWithKey('SendProofRequest')}>
+                {t('BCSC.Settings.Features.SendProofRequest')}
+              </ListButton>,
+            ]}
+          </ListButtonGroup>
+        </View>
+      </SectionHeader>
 
-      <SectionHeader title={t('BCSC.Settings.HeaderA')} iconName="cog-outline" styles={styles} />
-      <View style={styles.sectionContainer}>
-        <ListButtonGroup>
-          {[
-            onAppSecurity ? (
-              <ListButton key="security" onPress={onAppSecurity} testID={testIdWithKey('AppSecurity')}>
-                {t('BCSC.Settings.AppSecurity.ChangeAppSecurity')}
-              </ListButton>
-            ) : null,
-            showChangePIN ? (
-              <ListButton key="pin" onPress={onChangePIN!} testID={testIdWithKey('ChangePIN')}>
-                {t('BCSC.Settings.ChangePIN.ButtonTitle')}
-              </ListButton>
-            ) : null,
-            onAutoLock ? (
-              <ListButton key="lock" onPress={onAutoLock} testID={testIdWithKey('AutoLock')}>
-                <Row title={t('BCSC.Settings.AutoLockTime')} endAdornment={autoLockTimeText} />
-              </ListButton>
-            ) : null,
-            <ListButton key="notifications" onPress={onNotifications ?? noop} testID={testIdWithKey('Notifications')}>
-              {t('BCSC.Settings.Notifications')}
-            </ListButton>,
-            <ListButton key="analytics" onPress={onPressOptInAnalytics} testID={testIdWithKey('AnalyticsOptIn')}>
-              <Row title={t('BCSC.Settings.AnalyticsOptIn')} endAdornment={analyticsOptInText} />
-            </ListButton>,
-            isVerified ? (
-              <ListButton key="adddevice" onPress={onAddDevice ?? noop} testID={testIdWithKey('AddDevice')}>
-                {t('BCSC.Settings.AddDevice')}
-              </ListButton>
-            ) : null,
-            isVerified ? (
-              <ListButton key="mydevices" onPress={onMyDevices ?? noop} testID={testIdWithKey('MyDevices')}>
-                <Row
-                  title={t('BCSC.Settings.MyDevices')}
-                  endAdornment={deviceCount ? t('BCSC.Settings.MyDevicesCount', { count: deviceCount }) : undefined}
-                />
-              </ListButton>
-            ) : null,
-            isVerified && onForgetAllPairings ? (
-              <ListButton key="forget" onPress={onForgetAllPairings} testID={testIdWithKey('ForgetPairings')}>
-                {t('BCSC.Settings.ForgetPairings')}
-              </ListButton>
-            ) : null,
-            onResetWallet ? (
-              <ListButton key="reset" onPress={onResetWallet} testID={testIdWithKey('ResetWallet')}>
-                <Row title={t('BCSC.Settings.ResetWallet')} />
-              </ListButton>
-            ) : null,
-            onPressRemoveAccount ? (
-              <ListButton key="remove" onPress={onPressRemoveAccount} testID={testIdWithKey('RemoveAccount')}>
-                <Row title={t('BCSC.Settings.RemoveAccount')} />
-              </ListButton>
-            ) : null,
-          ]}
-        </ListButtonGroup>
-      </View>
+      <SectionHeader title={t('BCSC.Settings.HeaderA')} iconName="cog-outline" styles={styles}>
+        <View style={styles.sectionContainer}>
+          <ListButtonGroup>
+            {[
+              onAppSecurity ? (
+                <ListButton key="security" onPress={onAppSecurity} testID={testIdWithKey('AppSecurity')}>
+                  {t('BCSC.Settings.AppSecurity.ChangeAppSecurity')}
+                </ListButton>
+              ) : null,
+              showChangePIN ? (
+                <ListButton key="pin" onPress={onChangePIN!} testID={testIdWithKey('ChangePIN')}>
+                  {t('BCSC.Settings.ChangePIN.ButtonTitle')}
+                </ListButton>
+              ) : null,
+              onAutoLock ? (
+                <ListButton key="lock" onPress={onAutoLock} testID={testIdWithKey('AutoLock')}>
+                  <Row title={t('BCSC.Settings.AutoLockTime')} endAdornment={autoLockTimeText} />
+                </ListButton>
+              ) : null,
+              <ListButton key="notifications" onPress={onNotifications ?? noop} testID={testIdWithKey('Notifications')}>
+                {t('BCSC.Settings.Notifications')}
+              </ListButton>,
+              <ListButton key="analytics" onPress={onPressOptInAnalytics} testID={testIdWithKey('AnalyticsOptIn')}>
+                <Row title={t('BCSC.Settings.AnalyticsOptIn')} endAdornment={analyticsOptInText} />
+              </ListButton>,
+              isVerified ? (
+                <ListButton key="adddevice" onPress={onAddDevice ?? noop} testID={testIdWithKey('AddDevice')}>
+                  {t('BCSC.Settings.AddDevice')}
+                </ListButton>
+              ) : null,
+              isVerified ? (
+                <ListButton key="mydevices" onPress={onMyDevices ?? noop} testID={testIdWithKey('MyDevices')}>
+                  <Row
+                    title={t('BCSC.Settings.MyDevices')}
+                    endAdornment={deviceCount ? t('BCSC.Settings.MyDevicesCount', { count: deviceCount }) : undefined}
+                  />
+                </ListButton>
+              ) : null,
+              isVerified && onForgetAllPairings ? (
+                <ListButton key="forget" onPress={onForgetAllPairings} testID={testIdWithKey('ForgetPairings')}>
+                  {t('BCSC.Settings.ForgetPairings')}
+                </ListButton>
+              ) : null,
+              onResetWallet ? (
+                <ListButton key="reset" onPress={onResetWallet} testID={testIdWithKey('ResetWallet')}>
+                  <Row title={t('BCSC.Settings.ResetWallet')} />
+                </ListButton>
+              ) : null,
+              onPressRemoveAccount ? (
+                <ListButton key="remove" onPress={onPressRemoveAccount} testID={testIdWithKey('RemoveAccount')}>
+                  <Row title={t('BCSC.Settings.RemoveAccount')} />
+                </ListButton>
+              ) : null,
+            ]}
+          </ListButtonGroup>
+        </View>
+      </SectionHeader>
     </>
   )
 }
@@ -284,6 +334,9 @@ const makeStyles = (
       gap: Spacing.xs / 2,
       borderRadius: Spacing.sm,
       overflow: 'hidden',
+    },
+    sectionHeaderChevron: {
+      marginLeft: 'auto',
     },
     profileCard: {
       flexDirection: 'row',
@@ -432,52 +485,54 @@ export const SettingsContent: React.FC<SettingsContentProps> = ({
         />
       ) : null}
 
-      <SectionHeader title={t('BCSC.Settings.HelpHeader')} iconName="help-circle-outline" styles={styles} />
-      <View style={styles.sectionContainer}>
-        <ListButtonGroup>
-          <ListButton onPress={onHelp} testID={testIdWithKey('Help')}>
-            {t('BCSC.Settings.HelpUsingApp')}
-          </ListButton>
-          <ListButton onPress={onContactUs} testID={testIdWithKey('ContactUs')}>
-            {t('BCSC.Settings.ContactUs')}
-          </ListButton>
-          <ListButton
-            onPress={onPressFeedback}
-            testID={testIdWithKey('Feedback')}
-            accessibilityHint={t('Global.A11y.OpensInBrowser')}
-          >
-            {t('BCSC.Settings.GiveFeedback')}
-          </ListButton>
-        </ListButtonGroup>
-      </View>
-
-      <SectionHeader title={t('BCSC.Settings.MoreInfoHeader')} iconName="information-outline" styles={styles} />
-      <View style={styles.sectionContainer}>
-        <ListButtonGroup>
-          <ListButton
-            onPress={onPressAccessibility}
-            testID={testIdWithKey('Accessibility')}
-            accessibilityHint={t('Global.A11y.OpensInBrowser')}
-          >
-            {t('BCSC.Settings.Accessibility')}
-          </ListButton>
-          <ListButton
-            onPress={onPressTermsOfUse}
-            testID={testIdWithKey('TermsOfUse')}
-            accessibilityHint={t('Global.A11y.OpensInBrowser')}
-          >
-            {t('BCSC.Settings.TermsOfUse')}
-          </ListButton>
-          <ListButton onPress={onPrivacy} testID={testIdWithKey('Privacy')}>
-            {t('BCSC.Settings.Privacy')}
-          </ListButton>
-          {store.preferences.developerModeEnabled ? (
-            <ListButton key="dev" onPress={onPressDeveloperMode} testID={testIdWithKey('DeveloperMode')}>
-              {t('BCSC.Settings.DeveloperOptions')}
+      <SectionHeader title={t('BCSC.Settings.HelpHeader')} iconName="help-circle-outline" styles={styles}>
+        <View style={styles.sectionContainer}>
+          <ListButtonGroup>
+            <ListButton onPress={onHelp} testID={testIdWithKey('Help')}>
+              {t('BCSC.Settings.HelpUsingApp')}
             </ListButton>
-          ) : null}
-        </ListButtonGroup>
-      </View>
+            <ListButton onPress={onContactUs} testID={testIdWithKey('ContactUs')}>
+              {t('BCSC.Settings.ContactUs')}
+            </ListButton>
+            <ListButton
+              onPress={onPressFeedback}
+              testID={testIdWithKey('Feedback')}
+              accessibilityHint={t('Global.A11y.OpensInBrowser')}
+            >
+              {t('BCSC.Settings.GiveFeedback')}
+            </ListButton>
+          </ListButtonGroup>
+        </View>
+      </SectionHeader>
+
+      <SectionHeader title={t('BCSC.Settings.MoreInfoHeader')} iconName="information-outline" styles={styles}>
+        <View style={styles.sectionContainer}>
+          <ListButtonGroup>
+            <ListButton
+              onPress={onPressAccessibility}
+              testID={testIdWithKey('Accessibility')}
+              accessibilityHint={t('Global.A11y.OpensInBrowser')}
+            >
+              {t('BCSC.Settings.Accessibility')}
+            </ListButton>
+            <ListButton
+              onPress={onPressTermsOfUse}
+              testID={testIdWithKey('TermsOfUse')}
+              accessibilityHint={t('Global.A11y.OpensInBrowser')}
+            >
+              {t('BCSC.Settings.TermsOfUse')}
+            </ListButton>
+            <ListButton onPress={onPrivacy} testID={testIdWithKey('Privacy')}>
+              {t('BCSC.Settings.Privacy')}
+            </ListButton>
+            {store.preferences.developerModeEnabled ? (
+              <ListButton key="dev" onPress={onPressDeveloperMode} testID={testIdWithKey('DeveloperMode')}>
+                {t('BCSC.Settings.DeveloperOptions')}
+              </ListButton>
+            ) : null}
+          </ListButtonGroup>
+        </View>
+      </SectionHeader>
 
       <View style={styles.versionContainer}>
         <TouchableWithoutFeedback

--- a/app/src/bcsc-theme/features/settings/__snapshots__/AuthSettingsScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/settings/__snapshots__/AuthSettingsScreen.test.tsx.snap
@@ -44,590 +44,812 @@ exports[`AuthSettings renders correctly 1`] = `
       >
         <View>
           <View
-            style={
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "gap": 8,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <Text
-              allowFontScaling={false}
-              selectable={false}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontSize": 22,
-                  },
-                  undefined,
-                  {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  {},
-                ]
-              }
-            >
-              󰘥
-            </Text>
-            <Text
-              maxFontSizeMultiplier={2}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontFamily": "BCSans-Regular",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                  {
-                    "flexShrink": 1,
-                  },
-                ]
-              }
-            >
-              BCSC.Settings.HelpHeader
-            </Text>
-          </View>
-          <View
-            style={
-              {
-                "borderRadius": 8,
-                "gap": 2,
-                "overflow": "hidden",
+            layout={
+              LinearTransition {
+                "build": [Function],
+                "durationV": 200,
+                "randomizeDelay": false,
+                "reduceMotionV": "system",
               }
             }
           >
             <View
               style={
                 {
-                  "flexDirection": "column",
-                  "gap": 2,
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 8,
+                  "paddingVertical": 16,
+                }
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontSize": 22,
+                    },
+                    undefined,
+                    {
+                      "fontFamily": "Material Design Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                󰘥
+              </Text>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                    },
+                    {
+                      "flexShrink": 1,
+                    },
+                  ]
+                }
+              >
+                BCSC.Settings.HelpHeader
+              </Text>
+              <View
+                accessibilityLabel="Global.HideDetails"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                hitSlop={
+                  {
+                    "bottom": 44,
+                    "left": 44,
+                    "right": 44,
+                    "top": 44,
+                  }
+                }
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "marginLeft": "auto",
+                  }
+                }
+                testID="com.ariesbifold:id/SectionHeaderChevron"
+              >
+                <View
+                  style={
+                    {
+                      "transform": [
+                        {
+                          "rotate": "0deg",
+                        },
+                      ],
+                    }
+                  }
+                >
+                  <Text
+                    allowFontScaling={false}
+                    selectable={false}
+                    style={
+                      [
+                        {
+                          "color": "#313132",
+                          "fontSize": 22,
+                        },
+                        undefined,
+                        {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        {},
+                      ]
+                    }
+                  >
+                    󰅀
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              entering={
+                FadeIn {
+                  "build": [Function],
+                  "durationV": 200,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
+                }
+              }
+              exiting={
+                FadeOut {
+                  "build": [Function],
+                  "durationV": 150,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
                 }
               }
             >
               <View
-                accessibilityLabel="BCSC.Settings.HelpUsingApp"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderTopLeftRadius": 8,
-                      "borderTopRightRadius": 8,
-                    },
-                  ]
+                  {
+                    "borderRadius": 8,
+                    "gap": 2,
+                    "overflow": "hidden",
+                  }
                 }
-                testID="com.ariesbifold:id/Help"
               >
                 <View
                   style={
                     {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                      "flexDirection": "column",
+                      "gap": 2,
                     }
                   }
                 >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                  <View
+                    accessibilityLabel="BCSC.Settings.HelpUsingApp"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderTopLeftRadius": 8,
+                          "borderTopRightRadius": 8,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/Help"
                   >
-                    BCSC.Settings.HelpUsingApp
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityLabel="BCSC.Settings.ContactUs"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderRadius": 0,
-                    },
-                  ]
-                }
-                testID="com.ariesbifold:id/ContactUs"
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.HelpUsingApp
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    accessibilityLabel="BCSC.Settings.ContactUs"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
                     }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderRadius": 0,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/ContactUs"
                   >
-                    BCSC.Settings.ContactUs
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.GiveFeedback"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderBottomLeftRadius": 8,
-                      "borderBottomRightRadius": 8,
-                    },
-                  ]
-                }
-                testID="com.ariesbifold:id/Feedback"
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.ContactUs
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    accessibilityHint="Global.A11y.OpensInBrowser"
+                    accessibilityLabel="BCSC.Settings.GiveFeedback"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
                     }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderBottomLeftRadius": 8,
+                          "borderBottomRightRadius": 8,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/Feedback"
                   >
-                    BCSC.Settings.GiveFeedback
-                  </Text>
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.GiveFeedback
+                      </Text>
+                    </View>
+                  </View>
                 </View>
               </View>
             </View>
           </View>
           <View
-            style={
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "gap": 8,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <Text
-              allowFontScaling={false}
-              selectable={false}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontSize": 22,
-                  },
-                  undefined,
-                  {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  {},
-                ]
-              }
-            >
-              󰋽
-            </Text>
-            <Text
-              maxFontSizeMultiplier={2}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontFamily": "BCSans-Regular",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                  {
-                    "flexShrink": 1,
-                  },
-                ]
-              }
-            >
-              BCSC.Settings.MoreInfoHeader
-            </Text>
-          </View>
-          <View
-            style={
-              {
-                "borderRadius": 8,
-                "gap": 2,
-                "overflow": "hidden",
+            layout={
+              LinearTransition {
+                "build": [Function],
+                "durationV": 200,
+                "randomizeDelay": false,
+                "reduceMotionV": "system",
               }
             }
           >
             <View
               style={
                 {
-                  "flexDirection": "column",
-                  "gap": 2,
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 8,
+                  "paddingVertical": 16,
+                }
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontSize": 22,
+                    },
+                    undefined,
+                    {
+                      "fontFamily": "Material Design Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                󰋽
+              </Text>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                    },
+                    {
+                      "flexShrink": 1,
+                    },
+                  ]
+                }
+              >
+                BCSC.Settings.MoreInfoHeader
+              </Text>
+              <View
+                accessibilityLabel="Global.HideDetails"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                hitSlop={
+                  {
+                    "bottom": 44,
+                    "left": 44,
+                    "right": 44,
+                    "top": 44,
+                  }
+                }
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "marginLeft": "auto",
+                  }
+                }
+                testID="com.ariesbifold:id/SectionHeaderChevron"
+              >
+                <View
+                  style={
+                    {
+                      "transform": [
+                        {
+                          "rotate": "0deg",
+                        },
+                      ],
+                    }
+                  }
+                >
+                  <Text
+                    allowFontScaling={false}
+                    selectable={false}
+                    style={
+                      [
+                        {
+                          "color": "#313132",
+                          "fontSize": 22,
+                        },
+                        undefined,
+                        {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        {},
+                      ]
+                    }
+                  >
+                    󰅀
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              entering={
+                FadeIn {
+                  "build": [Function],
+                  "durationV": 200,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
+                }
+              }
+              exiting={
+                FadeOut {
+                  "build": [Function],
+                  "durationV": 150,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
                 }
               }
             >
               <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.Accessibility"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderTopLeftRadius": 8,
-                      "borderTopRightRadius": 8,
-                    },
-                  ]
+                  {
+                    "borderRadius": 8,
+                    "gap": 2,
+                    "overflow": "hidden",
+                  }
                 }
-                testID="com.ariesbifold:id/Accessibility"
               >
                 <View
                   style={
                     {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                      "flexDirection": "column",
+                      "gap": 2,
                     }
                   }
                 >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                  <View
+                    accessibilityHint="Global.A11y.OpensInBrowser"
+                    accessibilityLabel="BCSC.Settings.Accessibility"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderTopLeftRadius": 8,
+                          "borderTopRightRadius": 8,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/Accessibility"
                   >
-                    BCSC.Settings.Accessibility
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.TermsOfUse"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderRadius": 0,
-                    },
-                  ]
-                }
-                testID="com.ariesbifold:id/TermsOfUse"
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.Accessibility
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    accessibilityHint="Global.A11y.OpensInBrowser"
+                    accessibilityLabel="BCSC.Settings.TermsOfUse"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
                     }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderRadius": 0,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/TermsOfUse"
                   >
-                    BCSC.Settings.TermsOfUse
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityLabel="BCSC.Settings.Privacy"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderBottomLeftRadius": 8,
-                      "borderBottomRightRadius": 8,
-                    },
-                  ]
-                }
-                testID="com.ariesbifold:id/Privacy"
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.TermsOfUse
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    accessibilityLabel="BCSC.Settings.Privacy"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
                     }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderBottomLeftRadius": 8,
+                          "borderBottomRightRadius": 8,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/Privacy"
                   >
-                    BCSC.Settings.Privacy
-                  </Text>
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.Privacy
+                      </Text>
+                    </View>
+                  </View>
                 </View>
               </View>
             </View>

--- a/app/src/bcsc-theme/features/settings/__snapshots__/MainSettingsScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/settings/__snapshots__/MainSettingsScreen.test.tsx.snap
@@ -44,590 +44,812 @@ exports[`MainSettings renders correctly 1`] = `
       >
         <View>
           <View
-            style={
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "gap": 8,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <Text
-              allowFontScaling={false}
-              selectable={false}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontSize": 22,
-                  },
-                  undefined,
-                  {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  {},
-                ]
-              }
-            >
-              󰘥
-            </Text>
-            <Text
-              maxFontSizeMultiplier={2}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontFamily": "BCSans-Regular",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                  {
-                    "flexShrink": 1,
-                  },
-                ]
-              }
-            >
-              BCSC.Settings.HelpHeader
-            </Text>
-          </View>
-          <View
-            style={
-              {
-                "borderRadius": 8,
-                "gap": 2,
-                "overflow": "hidden",
+            layout={
+              LinearTransition {
+                "build": [Function],
+                "durationV": 200,
+                "randomizeDelay": false,
+                "reduceMotionV": "system",
               }
             }
           >
             <View
               style={
                 {
-                  "flexDirection": "column",
-                  "gap": 2,
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 8,
+                  "paddingVertical": 16,
+                }
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontSize": 22,
+                    },
+                    undefined,
+                    {
+                      "fontFamily": "Material Design Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                󰘥
+              </Text>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                    },
+                    {
+                      "flexShrink": 1,
+                    },
+                  ]
+                }
+              >
+                BCSC.Settings.HelpHeader
+              </Text>
+              <View
+                accessibilityLabel="Global.HideDetails"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                hitSlop={
+                  {
+                    "bottom": 44,
+                    "left": 44,
+                    "right": 44,
+                    "top": 44,
+                  }
+                }
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "marginLeft": "auto",
+                  }
+                }
+                testID="com.ariesbifold:id/SectionHeaderChevron"
+              >
+                <View
+                  style={
+                    {
+                      "transform": [
+                        {
+                          "rotate": "0deg",
+                        },
+                      ],
+                    }
+                  }
+                >
+                  <Text
+                    allowFontScaling={false}
+                    selectable={false}
+                    style={
+                      [
+                        {
+                          "color": "#313132",
+                          "fontSize": 22,
+                        },
+                        undefined,
+                        {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        {},
+                      ]
+                    }
+                  >
+                    󰅀
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              entering={
+                FadeIn {
+                  "build": [Function],
+                  "durationV": 200,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
+                }
+              }
+              exiting={
+                FadeOut {
+                  "build": [Function],
+                  "durationV": 150,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
                 }
               }
             >
               <View
-                accessibilityLabel="BCSC.Settings.HelpUsingApp"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderTopLeftRadius": 8,
-                      "borderTopRightRadius": 8,
-                    },
-                  ]
+                  {
+                    "borderRadius": 8,
+                    "gap": 2,
+                    "overflow": "hidden",
+                  }
                 }
-                testID="com.ariesbifold:id/Help"
               >
                 <View
                   style={
                     {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                      "flexDirection": "column",
+                      "gap": 2,
                     }
                   }
                 >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                  <View
+                    accessibilityLabel="BCSC.Settings.HelpUsingApp"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderTopLeftRadius": 8,
+                          "borderTopRightRadius": 8,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/Help"
                   >
-                    BCSC.Settings.HelpUsingApp
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityLabel="BCSC.Settings.ContactUs"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderRadius": 0,
-                    },
-                  ]
-                }
-                testID="com.ariesbifold:id/ContactUs"
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.HelpUsingApp
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    accessibilityLabel="BCSC.Settings.ContactUs"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
                     }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderRadius": 0,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/ContactUs"
                   >
-                    BCSC.Settings.ContactUs
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.GiveFeedback"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderBottomLeftRadius": 8,
-                      "borderBottomRightRadius": 8,
-                    },
-                  ]
-                }
-                testID="com.ariesbifold:id/Feedback"
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.ContactUs
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    accessibilityHint="Global.A11y.OpensInBrowser"
+                    accessibilityLabel="BCSC.Settings.GiveFeedback"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
                     }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderBottomLeftRadius": 8,
+                          "borderBottomRightRadius": 8,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/Feedback"
                   >
-                    BCSC.Settings.GiveFeedback
-                  </Text>
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.GiveFeedback
+                      </Text>
+                    </View>
+                  </View>
                 </View>
               </View>
             </View>
           </View>
           <View
-            style={
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "gap": 8,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <Text
-              allowFontScaling={false}
-              selectable={false}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontSize": 22,
-                  },
-                  undefined,
-                  {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  {},
-                ]
-              }
-            >
-              󰋽
-            </Text>
-            <Text
-              maxFontSizeMultiplier={2}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontFamily": "BCSans-Regular",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                  {
-                    "flexShrink": 1,
-                  },
-                ]
-              }
-            >
-              BCSC.Settings.MoreInfoHeader
-            </Text>
-          </View>
-          <View
-            style={
-              {
-                "borderRadius": 8,
-                "gap": 2,
-                "overflow": "hidden",
+            layout={
+              LinearTransition {
+                "build": [Function],
+                "durationV": 200,
+                "randomizeDelay": false,
+                "reduceMotionV": "system",
               }
             }
           >
             <View
               style={
                 {
-                  "flexDirection": "column",
-                  "gap": 2,
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 8,
+                  "paddingVertical": 16,
+                }
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontSize": 22,
+                    },
+                    undefined,
+                    {
+                      "fontFamily": "Material Design Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                󰋽
+              </Text>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                    },
+                    {
+                      "flexShrink": 1,
+                    },
+                  ]
+                }
+              >
+                BCSC.Settings.MoreInfoHeader
+              </Text>
+              <View
+                accessibilityLabel="Global.HideDetails"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                hitSlop={
+                  {
+                    "bottom": 44,
+                    "left": 44,
+                    "right": 44,
+                    "top": 44,
+                  }
+                }
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "marginLeft": "auto",
+                  }
+                }
+                testID="com.ariesbifold:id/SectionHeaderChevron"
+              >
+                <View
+                  style={
+                    {
+                      "transform": [
+                        {
+                          "rotate": "0deg",
+                        },
+                      ],
+                    }
+                  }
+                >
+                  <Text
+                    allowFontScaling={false}
+                    selectable={false}
+                    style={
+                      [
+                        {
+                          "color": "#313132",
+                          "fontSize": 22,
+                        },
+                        undefined,
+                        {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        {},
+                      ]
+                    }
+                  >
+                    󰅀
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              entering={
+                FadeIn {
+                  "build": [Function],
+                  "durationV": 200,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
+                }
+              }
+              exiting={
+                FadeOut {
+                  "build": [Function],
+                  "durationV": 150,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
                 }
               }
             >
               <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.Accessibility"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderTopLeftRadius": 8,
-                      "borderTopRightRadius": 8,
-                    },
-                  ]
+                  {
+                    "borderRadius": 8,
+                    "gap": 2,
+                    "overflow": "hidden",
+                  }
                 }
-                testID="com.ariesbifold:id/Accessibility"
               >
                 <View
                   style={
                     {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                      "flexDirection": "column",
+                      "gap": 2,
                     }
                   }
                 >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                  <View
+                    accessibilityHint="Global.A11y.OpensInBrowser"
+                    accessibilityLabel="BCSC.Settings.Accessibility"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderTopLeftRadius": 8,
+                          "borderTopRightRadius": 8,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/Accessibility"
                   >
-                    BCSC.Settings.Accessibility
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.TermsOfUse"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderRadius": 0,
-                    },
-                  ]
-                }
-                testID="com.ariesbifold:id/TermsOfUse"
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.Accessibility
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    accessibilityHint="Global.A11y.OpensInBrowser"
+                    accessibilityLabel="BCSC.Settings.TermsOfUse"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
                     }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderRadius": 0,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/TermsOfUse"
                   >
-                    BCSC.Settings.TermsOfUse
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityLabel="BCSC.Settings.Privacy"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderBottomLeftRadius": 8,
-                      "borderBottomRightRadius": 8,
-                    },
-                  ]
-                }
-                testID="com.ariesbifold:id/Privacy"
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.TermsOfUse
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    accessibilityLabel="BCSC.Settings.Privacy"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
                     }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderBottomLeftRadius": 8,
+                          "borderBottomRightRadius": 8,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/Privacy"
                   >
-                    BCSC.Settings.Privacy
-                  </Text>
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.Privacy
+                      </Text>
+                    </View>
+                  </View>
                 </View>
               </View>
             </View>

--- a/app/src/bcsc-theme/features/settings/__snapshots__/VerifySettingsScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/settings/__snapshots__/VerifySettingsScreen.test.tsx.snap
@@ -44,590 +44,812 @@ exports[`VerifySettings renders correctly 1`] = `
       >
         <View>
           <View
-            style={
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "gap": 8,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <Text
-              allowFontScaling={false}
-              selectable={false}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontSize": 22,
-                  },
-                  undefined,
-                  {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  {},
-                ]
-              }
-            >
-              󰘥
-            </Text>
-            <Text
-              maxFontSizeMultiplier={2}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontFamily": "BCSans-Regular",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                  {
-                    "flexShrink": 1,
-                  },
-                ]
-              }
-            >
-              BCSC.Settings.HelpHeader
-            </Text>
-          </View>
-          <View
-            style={
-              {
-                "borderRadius": 8,
-                "gap": 2,
-                "overflow": "hidden",
+            layout={
+              LinearTransition {
+                "build": [Function],
+                "durationV": 200,
+                "randomizeDelay": false,
+                "reduceMotionV": "system",
               }
             }
           >
             <View
               style={
                 {
-                  "flexDirection": "column",
-                  "gap": 2,
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 8,
+                  "paddingVertical": 16,
+                }
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontSize": 22,
+                    },
+                    undefined,
+                    {
+                      "fontFamily": "Material Design Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                󰘥
+              </Text>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                    },
+                    {
+                      "flexShrink": 1,
+                    },
+                  ]
+                }
+              >
+                BCSC.Settings.HelpHeader
+              </Text>
+              <View
+                accessibilityLabel="Global.HideDetails"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                hitSlop={
+                  {
+                    "bottom": 44,
+                    "left": 44,
+                    "right": 44,
+                    "top": 44,
+                  }
+                }
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "marginLeft": "auto",
+                  }
+                }
+                testID="com.ariesbifold:id/SectionHeaderChevron"
+              >
+                <View
+                  style={
+                    {
+                      "transform": [
+                        {
+                          "rotate": "0deg",
+                        },
+                      ],
+                    }
+                  }
+                >
+                  <Text
+                    allowFontScaling={false}
+                    selectable={false}
+                    style={
+                      [
+                        {
+                          "color": "#313132",
+                          "fontSize": 22,
+                        },
+                        undefined,
+                        {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        {},
+                      ]
+                    }
+                  >
+                    󰅀
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              entering={
+                FadeIn {
+                  "build": [Function],
+                  "durationV": 200,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
+                }
+              }
+              exiting={
+                FadeOut {
+                  "build": [Function],
+                  "durationV": 150,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
                 }
               }
             >
               <View
-                accessibilityLabel="BCSC.Settings.HelpUsingApp"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderTopLeftRadius": 8,
-                      "borderTopRightRadius": 8,
-                    },
-                  ]
+                  {
+                    "borderRadius": 8,
+                    "gap": 2,
+                    "overflow": "hidden",
+                  }
                 }
-                testID="com.ariesbifold:id/Help"
               >
                 <View
                   style={
                     {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                      "flexDirection": "column",
+                      "gap": 2,
                     }
                   }
                 >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                  <View
+                    accessibilityLabel="BCSC.Settings.HelpUsingApp"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderTopLeftRadius": 8,
+                          "borderTopRightRadius": 8,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/Help"
                   >
-                    BCSC.Settings.HelpUsingApp
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityLabel="BCSC.Settings.ContactUs"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderRadius": 0,
-                    },
-                  ]
-                }
-                testID="com.ariesbifold:id/ContactUs"
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.HelpUsingApp
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    accessibilityLabel="BCSC.Settings.ContactUs"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
                     }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderRadius": 0,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/ContactUs"
                   >
-                    BCSC.Settings.ContactUs
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.GiveFeedback"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderBottomLeftRadius": 8,
-                      "borderBottomRightRadius": 8,
-                    },
-                  ]
-                }
-                testID="com.ariesbifold:id/Feedback"
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.ContactUs
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    accessibilityHint="Global.A11y.OpensInBrowser"
+                    accessibilityLabel="BCSC.Settings.GiveFeedback"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
                     }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderBottomLeftRadius": 8,
+                          "borderBottomRightRadius": 8,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/Feedback"
                   >
-                    BCSC.Settings.GiveFeedback
-                  </Text>
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.GiveFeedback
+                      </Text>
+                    </View>
+                  </View>
                 </View>
               </View>
             </View>
           </View>
           <View
-            style={
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "gap": 8,
-                "paddingVertical": 16,
-              }
-            }
-          >
-            <Text
-              allowFontScaling={false}
-              selectable={false}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontSize": 22,
-                  },
-                  undefined,
-                  {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  {},
-                ]
-              }
-            >
-              󰋽
-            </Text>
-            <Text
-              maxFontSizeMultiplier={2}
-              style={
-                [
-                  {
-                    "color": "#313132",
-                    "fontFamily": "BCSans-Regular",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                  {
-                    "flexShrink": 1,
-                  },
-                ]
-              }
-            >
-              BCSC.Settings.MoreInfoHeader
-            </Text>
-          </View>
-          <View
-            style={
-              {
-                "borderRadius": 8,
-                "gap": 2,
-                "overflow": "hidden",
+            layout={
+              LinearTransition {
+                "build": [Function],
+                "durationV": 200,
+                "randomizeDelay": false,
+                "reduceMotionV": "system",
               }
             }
           >
             <View
               style={
                 {
-                  "flexDirection": "column",
-                  "gap": 2,
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 8,
+                  "paddingVertical": 16,
+                }
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontSize": 22,
+                    },
+                    undefined,
+                    {
+                      "fontFamily": "Material Design Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                󰋽
+              </Text>
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                    },
+                    {
+                      "flexShrink": 1,
+                    },
+                  ]
+                }
+              >
+                BCSC.Settings.MoreInfoHeader
+              </Text>
+              <View
+                accessibilityLabel="Global.HideDetails"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                hitSlop={
+                  {
+                    "bottom": 44,
+                    "left": 44,
+                    "right": 44,
+                    "top": 44,
+                  }
+                }
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "marginLeft": "auto",
+                  }
+                }
+                testID="com.ariesbifold:id/SectionHeaderChevron"
+              >
+                <View
+                  style={
+                    {
+                      "transform": [
+                        {
+                          "rotate": "0deg",
+                        },
+                      ],
+                    }
+                  }
+                >
+                  <Text
+                    allowFontScaling={false}
+                    selectable={false}
+                    style={
+                      [
+                        {
+                          "color": "#313132",
+                          "fontSize": 22,
+                        },
+                        undefined,
+                        {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        {},
+                      ]
+                    }
+                  >
+                    󰅀
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              entering={
+                FadeIn {
+                  "build": [Function],
+                  "durationV": 200,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
+                }
+              }
+              exiting={
+                FadeOut {
+                  "build": [Function],
+                  "durationV": 150,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
                 }
               }
             >
               <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.Accessibility"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderTopLeftRadius": 8,
-                      "borderTopRightRadius": 8,
-                    },
-                  ]
+                  {
+                    "borderRadius": 8,
+                    "gap": 2,
+                    "overflow": "hidden",
+                  }
                 }
-                testID="com.ariesbifold:id/Accessibility"
               >
                 <View
                   style={
                     {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                      "flexDirection": "column",
+                      "gap": 2,
                     }
                   }
                 >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                  <View
+                    accessibilityHint="Global.A11y.OpensInBrowser"
+                    accessibilityLabel="BCSC.Settings.Accessibility"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderTopLeftRadius": 8,
+                          "borderTopRightRadius": 8,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/Accessibility"
                   >
-                    BCSC.Settings.Accessibility
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityHint="Global.A11y.OpensInBrowser"
-                accessibilityLabel="BCSC.Settings.TermsOfUse"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderRadius": 0,
-                    },
-                  ]
-                }
-                testID="com.ariesbifold:id/TermsOfUse"
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.Accessibility
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    accessibilityHint="Global.A11y.OpensInBrowser"
+                    accessibilityLabel="BCSC.Settings.TermsOfUse"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
                     }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderRadius": 0,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/TermsOfUse"
                   >
-                    BCSC.Settings.TermsOfUse
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityLabel="BCSC.Settings.Privacy"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    {
-                      "backgroundColor": "#003366",
-                      "padding": 16,
-                    },
-                    {
-                      "borderBottomLeftRadius": 8,
-                      "borderBottomRightRadius": 8,
-                    },
-                  ]
-                }
-                testID="com.ariesbifold:id/Privacy"
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 8,
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.TermsOfUse
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    accessibilityLabel="BCSC.Settings.Privacy"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
                     }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
                     style={
                       [
                         {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 18,
-                          "fontWeight": "normal",
+                          "backgroundColor": "#003366",
+                          "padding": 16,
                         },
                         {
-                          "color": "#FFFFFF",
+                          "borderBottomLeftRadius": 8,
+                          "borderBottomRightRadius": 8,
                         },
                       ]
                     }
+                    testID="com.ariesbifold:id/Privacy"
                   >
-                    BCSC.Settings.Privacy
-                  </Text>
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                        }
+                      }
+                    >
+                      <Text
+                        maxFontSizeMultiplier={2}
+                        style={
+                          [
+                            {
+                              "color": "#313132",
+                              "fontFamily": "BCSans-Regular",
+                              "fontSize": 18,
+                              "fontWeight": "normal",
+                            },
+                            {
+                              "color": "#FFFFFF",
+                            },
+                          ]
+                        }
+                      >
+                        BCSC.Settings.Privacy
+                      </Text>
+                    </View>
+                  </View>
                 </View>
               </View>
             </View>


### PR DESCRIPTION
# Summary of Changes

This PR adds "chevrons" to the Settings headers to collapse and expand the sections.

Protip: Files changed -> Settings icon -> hide whitespace changes

# Testing Instructions

1. Go to settings
2. Click the chevron

# Acceptance Criteria

Settings section collapses and expands

# Screenshots, videos, or gifs


https://github.com/user-attachments/assets/471293d3-6ad3-4d95-9568-f709bcba1c92



# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
