### PR TITLE
fix: show basic alert for unsupported-OS rejections (#4091)

### DIFF
--- a/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
@@ -21,6 +21,7 @@ import {
   noTokensReturnedErrorPolicy,
   pairingCodeErrorPolicy,
   unexpectedServerErrorPolicy,
+  unsupportedOsOnAssertionErrorPolicy,
   updateRequiredErrorPolicy,
   verificationSessionExpiredErrorPolicy,
   verifyDeviceAssertionErrorPolicy,
@@ -132,22 +133,91 @@ describe('clientErrorPolicies', () => {
         expect(mockAlert).toHaveBeenCalledWith(error)
       })
 
-      it('should show dynamic registration alert when technicalMessage indicates unsupported os', () => {
+      it('should show the unsupported OS alert (basic, no report) when technicalMessage indicates unsupported os', () => {
         const error = newError('invalid_client_metadata')
         error.cause = new Error('unsupported os version') as AxiosError
         const mockAlert = jest.fn()
-        const context = { alerts: { dynamicRegistrationErrorAlert: mockAlert } }
+        const context = { alerts: { unsupportedOsAlert: mockAlert } }
         invalidClientMetadataErrorPolicy.handle(error, context as any)
-        expect(mockAlert).toHaveBeenCalledWith(error)
+        expect(mockAlert).toHaveBeenCalled()
       })
 
-      it('should match unsupported os check case-insensitively', () => {
+      it('should match the unsupported os check case-insensitively', () => {
         const error = newError('invalid_client_metadata')
         error.cause = new Error('Client registration failed: Unsupported OS Version detected') as AxiosError
         const mockAlert = jest.fn()
-        const context = { alerts: { dynamicRegistrationErrorAlert: mockAlert } }
+        const context = { alerts: { unsupportedOsAlert: mockAlert } }
         invalidClientMetadataErrorPolicy.handle(error, context as any)
-        expect(mockAlert).toHaveBeenCalledWith(error)
+        expect(mockAlert).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('unsupportedOsOnAssertionErrorPolicy', () => {
+    const assertionContext = {
+      endpoint: '/api/cardTap/v3/mobile/assertion',
+      statusCode: 401,
+      apiEndpoints: { cardTap: '/api/cardTap' },
+    }
+
+    // Build an ERR_210_UNAUTHORIZED error whose raw response body carries (or omits) the errorMessage marker.
+    const unauthorizedWithErrorMessage = (errorMessage?: unknown): AxiosAppError => {
+      const error = newError('err_210_unauthorized')
+      error.cause = { response: { data: errorMessage === undefined ? {} : { errorMessage } } } as AxiosError
+      return error
+    }
+
+    describe('matches', () => {
+      it('should match a 401 on the assertion endpoint whose errorMessage indicates unsupported OS', () => {
+        const error = unauthorizedWithErrorMessage('unsupported OS')
+        expect(unsupportedOsOnAssertionErrorPolicy.matches(error, assertionContext as any)).toBeTruthy()
+      })
+
+      it('should match case-insensitively', () => {
+        const error = unauthorizedWithErrorMessage('Unsupported OS version detected')
+        expect(unsupportedOsOnAssertionErrorPolicy.matches(error, assertionContext as any)).toBeTruthy()
+      })
+
+      it('should NOT match a genuine 401 with no errorMessage marker', () => {
+        const error = unauthorizedWithErrorMessage()
+        expect(unsupportedOsOnAssertionErrorPolicy.matches(error, assertionContext as any)).toBeFalsy()
+      })
+
+      it('should NOT match the marker on a different endpoint', () => {
+        const error = unauthorizedWithErrorMessage('unsupported OS')
+        const context = { endpoint: '/api/other-endpoint', statusCode: 401, apiEndpoints: { cardTap: '/api/cardTap' } }
+        expect(unsupportedOsOnAssertionErrorPolicy.matches(error, context as any)).toBeFalsy()
+      })
+
+      it('should NOT match a non-401 error even with the marker present', () => {
+        const error = newError('invalid_pairing_code')
+        error.cause = { response: { data: { errorMessage: 'unsupported OS' } } } as AxiosError
+        expect(unsupportedOsOnAssertionErrorPolicy.matches(error, assertionContext as any)).toBeFalsy()
+      })
+    })
+
+    describe('handle', () => {
+      it('should show the unsupported OS alert and mark the error handled', () => {
+        const error = unauthorizedWithErrorMessage('unsupported OS')
+        const mockAlert = jest.fn()
+        const context = { alerts: { unsupportedOsAlert: mockAlert }, logger: { info: jest.fn() } }
+        unsupportedOsOnAssertionErrorPolicy.handle(error, context as any)
+        expect(mockAlert).toHaveBeenCalled()
+        expect(error.handled).toBe(true)
+      })
+    })
+
+    describe('ClientErrorHandlingPolicies find', () => {
+      it('should resolve to unsupportedOsOnAssertionErrorPolicy (before iasErrorPolicy) for an unsupported-OS 401', () => {
+        const error = unauthorizedWithErrorMessage('unsupported OS')
+        const policy = ClientErrorHandlingPolicies.find((p) => p.matches(error, assertionContext as any))
+        expect(policy).toBe(unsupportedOsOnAssertionErrorPolicy)
+      })
+
+      it('should resolve to iasErrorPolicy for a genuine 401 with no marker (Report path preserved)', () => {
+        const error = unauthorizedWithErrorMessage()
+        const policy = ClientErrorHandlingPolicies.find((p) => p.matches(error, assertionContext as any))
+        expect(policy).toBe(iasErrorPolicy)
       })
     })
   })

--- a/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
@@ -197,13 +197,12 @@ describe('clientErrorPolicies', () => {
     })
 
     describe('handle', () => {
-      it('should show the unsupported OS alert and mark the error handled', () => {
+      it('should show the unsupported OS alert', () => {
         const error = unauthorizedWithErrorMessage('unsupported OS')
         const mockAlert = jest.fn()
         const context = { alerts: { unsupportedOsAlert: mockAlert }, logger: { info: jest.fn() } }
         unsupportedOsOnAssertionErrorPolicy.handle(error, context as any)
         expect(mockAlert).toHaveBeenCalled()
-        expect(error.handled).toBe(true)
       })
     })
 
@@ -892,13 +891,12 @@ describe('clientErrorPolicies', () => {
     })
 
     describe('handle', () => {
-      it('should call failedToRetrieveStringResourceAlert and mark error as handled', () => {
+      it('should call failedToRetrieveStringResourceAlert', () => {
         const error = newError('err_400_failed_to_retrieve_string_resource')
         const mockAlert = jest.fn()
         const context = { alerts: { failedToRetrieveStringResourceAlert: mockAlert } }
         failedToRetrieveStringResourceErrorPolicy.handle(error, context as any)
         expect(mockAlert).toHaveBeenCalled()
-        expect(error.handled).toBe(true)
       })
     })
   })
@@ -917,13 +915,12 @@ describe('clientErrorPolicies', () => {
     })
 
     describe('handle', () => {
-      it('should call invalidUrlAlert and mark error as handled', () => {
+      it('should call invalidUrlAlert', () => {
         const error = newError('err_500_invalid_url')
         const mockAlert = jest.fn()
         const context = { alerts: { invalidUrlAlert: mockAlert } }
         invalidUrlErrorPolicy.handle(error, context as any)
         expect(mockAlert).toHaveBeenCalled()
-        expect(error.handled).toBe(true)
       })
     })
   })
@@ -942,13 +939,12 @@ describe('clientErrorPolicies', () => {
     })
 
     describe('handle', () => {
-      it('should call invalidRegistrationRequestAlert and mark error as handled', () => {
+      it('should call invalidRegistrationRequestAlert', () => {
         const error = newError('err_501_invalid_registration_request')
         const mockAlert = jest.fn()
         const context = { alerts: { invalidRegistrationRequestAlert: mockAlert } }
         invalidRegistrationRequestErrorPolicy.handle(error, context as any)
         expect(mockAlert).toHaveBeenCalled()
-        expect(error.handled).toBe(true)
       })
     })
   })
@@ -1166,7 +1162,6 @@ describe('clientErrorPolicies', () => {
           }
           verifyDeviceAssertionErrorPolicy.handle(error, context as any)
           expect(mockAlert).toHaveBeenCalled()
-          expect(error.handled).toBe(true)
         })
 
         it('should emit the problem with account alert', () => {
@@ -1177,7 +1172,6 @@ describe('clientErrorPolicies', () => {
           }
           verifyDeviceAssertionErrorPolicy.handle(error, context as any)
           expect(mockAlert).toHaveBeenCalled()
-          expect(error.handled).toBe(true)
         })
 
         it('should emit the invalid pairing code alert', () => {
@@ -1188,7 +1182,6 @@ describe('clientErrorPolicies', () => {
           }
           verifyDeviceAssertionErrorPolicy.handle(error, context as any)
           expect(mockAlert).toHaveBeenCalled()
-          expect(error.handled).toBe(true)
         })
 
         it('should emit the login remembered pairing code code alert', () => {
@@ -1199,7 +1192,6 @@ describe('clientErrorPolicies', () => {
           }
           verifyDeviceAssertionErrorPolicy.handle(error, context as any)
           expect(mockAlert).toHaveBeenCalled()
-          expect(error.handled).toBe(true)
         })
 
         it('should emit the login remembered device invalid pairing code alert', () => {
@@ -1210,7 +1202,6 @@ describe('clientErrorPolicies', () => {
           }
           verifyDeviceAssertionErrorPolicy.handle(error, context as any)
           expect(mockAlert).toHaveBeenCalled()
-          expect(error.handled).toBe(true)
         })
       })
     })

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -368,10 +368,9 @@ export const unsupportedOsOnAssertionErrorPolicy: ErrorHandlingPolicy = {
       errorMessage.toLowerCase().includes(ASSERTION_UNSUPPORTED_OS_MARKER)
     )
   },
-  handle: (error, context) => {
+  handle: (_error, context) => {
     context.logger.info('[UnsupportedOsOnAssertionErrorPolicy] OS-unsupported 401 on assertion — showing basic alert')
     context.alerts.unsupportedOsAlert()
-    error.handled = true
   },
 }
 
@@ -392,7 +391,6 @@ export const verifyDeviceAssertionErrorPolicy: ErrorHandlingPolicy = {
     }
 
     alert(error)
-    error.handled = true
   },
 }
 
@@ -476,9 +474,8 @@ export const failedToRetrieveStringResourceErrorPolicy: ErrorHandlingPolicy = {
   matches: (error) => {
     return error.appEvent === AppEventCode.ERR_400_FAILED_TO_RETRIEVE_STRING_RESOURCE
   },
-  handle: (error, context) => {
+  handle: (_error, context) => {
     context.alerts.failedToRetrieveStringResourceAlert()
-    error.handled = true
   },
 }
 
@@ -489,7 +486,6 @@ export const invalidUrlErrorPolicy: ErrorHandlingPolicy = {
   },
   handle: (error, context) => {
     context.alerts.invalidUrlAlert(error)
-    error.handled = true
   },
 }
 
@@ -500,7 +496,6 @@ export const invalidRegistrationRequestErrorPolicy: ErrorHandlingPolicy = {
   },
   handle: (error, context) => {
     context.alerts.invalidRegistrationRequestAlert(error)
-    error.handled = true
   },
 }
 

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -12,6 +12,9 @@ import { BCSCModals, BCSCScreens } from '../types/navigators'
 import { BCSCEndpoints } from './client'
 
 const UNSUPPORTED_OS_TECHNICAL_MESSAGE = 'unsupported os version'
+// Assertion-401 unsupported-OS marker lives in the response body's `errorMessage` field (V3 parity);
+// V3 matched the looser "unsupported os" substring (the server sends e.g. "unsupported OS").
+const ASSERTION_UNSUPPORTED_OS_MARKER = 'unsupported os'
 
 export type ErrorMatcherContext = {
   endpoint: string // current route name for context
@@ -122,8 +125,9 @@ export const invalidClientMetadataErrorPolicy: ErrorHandlingPolicy = {
     return error.appEvent === AppEventCode.INVALID_CLIENT_METADATA
   },
   handle: (error, context) => {
+    // Unsupported-OS rejection (issue #4091): show the basic alert (no "Report a Problem"), matching V3.
     if (error.technicalMessage?.toLowerCase().includes(UNSUPPORTED_OS_TECHNICAL_MESSAGE)) {
-      return context.alerts.dynamicRegistrationErrorAlert(error)
+      return context.alerts.unsupportedOsAlert()
     }
 
     context.alerts.invalidClientMetadataAlert(error)
@@ -348,6 +352,29 @@ export const birthdateLockoutErrorPolicy: ErrorHandlingPolicy = {
   },
 }
 
+// Error policy for unsupported-OS rejection on the pairing-code login (assertion) endpoint (issue #4091).
+// Mirrors V3: the assertion 401 carries the marker in the response body's `errorMessage` field, which the
+// V4 error pipeline does not surface into `technicalMessage` — so match it from the raw body. Show the basic
+// unsupported-OS alert (no "Report a Problem") instead of the generic "Something went wrong" modal. Genuine
+// auth failures carry no such marker and fall through to the normal unauthorized path.
+export const unsupportedOsOnAssertionErrorPolicy: ErrorHandlingPolicy = {
+  matches: (error, context) => {
+    const responseData = error.cause.response?.data as { errorMessage?: unknown } | undefined
+    const errorMessage = responseData?.errorMessage
+    return (
+      error.appEvent === AppEventCode.ERR_210_UNAUTHORIZED &&
+      context.endpoint === `${context.apiEndpoints.cardTap}/${VERIFY_DEVICE_ASSERTION_PATH}` &&
+      typeof errorMessage === 'string' &&
+      errorMessage.toLowerCase().includes(ASSERTION_UNSUPPORTED_OS_MARKER)
+    )
+  },
+  handle: (error, context) => {
+    context.logger.info('[UnsupportedOsOnAssertionErrorPolicy] OS-unsupported 401 on assertion — showing basic alert')
+    context.alerts.unsupportedOsAlert()
+    error.handled = true
+  },
+}
+
 // Error policy for verify device assertion endpoint errors
 export const verifyDeviceAssertionErrorPolicy: ErrorHandlingPolicy = {
   matches: (error, context) => {
@@ -490,6 +517,7 @@ export const ClientErrorHandlingPolicies: ErrorHandlingPolicy[] = [
   noTokensReturnedErrorPolicy,
   updateRequiredErrorPolicy,
   verifyNotCompletedErrorPolicy,
+  unsupportedOsOnAssertionErrorPolicy,
   verifyDeviceAssertionErrorPolicy,
   expiredAppSetupErrorPolicy,
   loginRejectedOnClientMetadataErrorPolicy,

--- a/app/src/hooks/useAlerts.test.tsx
+++ b/app/src/hooks/useAlerts.test.tsx
@@ -1414,6 +1414,28 @@ describe('useAlerts', () => {
       })
     })
 
+    describe('unsupportedOsAlert', () => {
+      it('should show a basic alert (no error modal) with the unsupported OS copy', () => {
+        const mockNavigation = { navigate: jest.fn(), dispatch: jest.fn() }
+        const mockEmitAlert = jest.fn()
+        const mockEmitErrorModal = jest.fn()
+        jest
+          .spyOn(ErrorAlertContext, 'useErrorAlert')
+          .mockReturnValue({ emitAlert: mockEmitAlert, emitErrorModal: mockEmitErrorModal } as any)
+
+        const { result } = renderHook(() => useAlerts(mockNavigation as any))
+
+        result.current.unsupportedOsAlert()
+
+        expect(mockEmitAlert).toHaveBeenCalledWith(
+          'Alerts.DynamicRegistrationError.Title',
+          'Alerts.DynamicRegistrationError.Description',
+          expect.objectContaining({ event: AppEventCode.ADD_CARD_DYNAMIC_REGISTRATION })
+        )
+        expect(mockEmitErrorModal).not.toHaveBeenCalled()
+      })
+    })
+
     describe('termsOfUseErrorAlert', () => {
       it('should show an alert with the correct title and message', () => {
         const mockNavigation = { navigate: jest.fn(), dispatch: jest.fn() }

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -337,6 +337,10 @@ export const useAlerts = (navigation: NavigationProp<any>) => {
       invalidClientMetadataAlert: _createBasicErrorModal(AppEventCode.INVALID_CLIENT_METADATA, 'SomethingWentWrong'),
       serverConfigurationAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_SERVER_CONFIGURATION, 'ProblemWithService', { errorCode: '201' }),
       dynamicRegistrationErrorAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_DYNAMIC_REGISTRATION, 'DynamicRegistrationError', { errorCode: '202' }),
+      // Unsupported-OS rejection (issue #4091): basic alert (OK only, no "Report a Problem"),
+      // matching V3. Reuses the DynamicRegistrationError "(error 202)" copy. Shared by the
+      // registration (2824) and pairing-login (2208) unsupported-OS paths — see clientErrorPolicies.ts.
+      unsupportedOsAlert: _createBasicAlert(AppEventCode.ADD_CARD_DYNAMIC_REGISTRATION, 'DynamicRegistrationError', { errorCode: '202' }),
       termsOfUseErrorAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_TERMS_OF_USE, 'ProblemWithService', { errorCode: '203' }),
       incorrectOsAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_INCORRECT_OS, 'DynamicRegistrationError', { errorCode: '204' }),
       addCardNotAvailableAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_PROVIDER, 'AddCardNotAvailable'),


### PR DESCRIPTION
## What

Unsupported-OS API rejections now show a plain native alert (**OK only, no "Report a Problem"**), matching V3 — instead of the error modal. Covers both endpoints that reject an unsupported/beta OS:

| Flow | Endpoint | HTTP | Code → AppEvent |
|---|---|---|---|
| Registration | `POST /device/register/` | 400 | 2824 → `INVALID_CLIENT_METADATA` |
| Pairing-code login | `POST …/v3/mobile/assertion/` | 401 | 2208 → `ERR_210_UNAUTHORIZED` |

Both surface the existing "Problem with Service / The OS on this device is not supported… (error 202)" copy as a basic alert.


<img width="256" alt="Screenshot_20260624-012612" src="https://github.com/user-attachments/assets/685d0ae7-da78-445d-917b-dfad79866213" />


## Why

These are **expected device/OS-incompatibility conditions** (e.g. an unsupported or beta OS), not app defects. Today they surface the error modal with a "Report a Problem" button, so users file them as bugs. V3 showed a basic OK-only alert for exactly these cases; this restores that behaviour and stops the false defect reports.

Closes #4091.

## Decisions

- **Surgical scope.** Added one dedicated basic `unsupportedOsAlert` reusing the existing `DynamicRegistrationError` "(error 202)" copy. Left `dynamicRegistrationErrorAlert` / `incorrectOsAlert` and the legacy IAS 202/204 modal paths untouched. No change to the shared `_createBasicAlert` factory.
- **Registration (Trigger 2).** Detection already existed — `invalidClientMetadataErrorPolicy` checks `technicalMessage` for `"unsupported os version"`. Just repointed that branch from the modal to the new basic alert. Generic (non-OS) client-metadata failures stay a reportable modal.
- **Pairing login (Trigger 1).** Added `unsupportedOsOnAssertionErrorPolicy`. The two endpoints use **different** markers: V3 matched the assertion 401's `errorMessage` **body field** (`"unsupported OS"`), not `error_description`. The V4 error pipeline only surfaces `error`/`error_description` into `technicalMessage`, so the `errorMessage` object field never reached it — that's why the marker looked absent. The policy reads the raw `error.cause.response.data.errorMessage` directly (V3 parity), registered before `verifyDeviceAssertionErrorPolicy`/`iasErrorPolicy`. **Marker-gated**, so genuine 401s fall through to the normal "Something went wrong" modal (Report preserved).
- **Same copy for both** triggers — matches V3, which routed both to `add_card_dynamic_registration` (error 202). No new i18n keys.
- **Telemetry unchanged.** The `AppError` is constructed in the interceptor before any policy runs, so Snowplow `mobile_error` still fires (analytics-gated), and the basic-alert path still fires `ALERT_DISPLAY`. Switching modal → basic alert drops only the user-tapped "Report this problem" → Loki — i.e. the false reports we want to stop.

## Testing

- `yarn typecheck`, ESLint, and Prettier clean; `yarn test` for the two affected suites — **238 passed**.
- New/updated unit tests, including policy-ordering coverage proving an unsupported-OS 401 resolves to the new policy while a marker-less 401 resolves to `iasErrorPolicy` (Report path preserved).
- **Manual E2E (Android):** forced an unsupported OS version natively (overrode the `system_version` device claim) and **confirmed the pairing-code (cardtap) 401 path** shows the basic alert with no Report. This also validated that the backend does return the `errorMessage: "unsupported OS"` marker the new policy matches. _(The temporary native override is not part of this PR.)_
- Registration path: detection is unchanged from the existing shipped policy (only the alert target changed) and is unit-tested; no separate native repro needed.
