### PR TITLE
fix: added source check for cold start login

### DIFF
--- a/app/src/bcsc-theme/features/pairing/PairingService.ts
+++ b/app/src/bcsc-theme/features/pairing/PairingService.ts
@@ -1,6 +1,12 @@
 import { AbstractBifoldLogger } from '@bifold/core'
 import { BCSCScreens } from '../../types/navigators'
-import { PairingNavigationEvent, PairingNavigationListener, PairingPayload, PendingPairingListener } from './types'
+import {
+  PairingNavigationEvent,
+  PairingNavigationListener,
+  PairingPayload,
+  PendingPairingListener,
+  pairingPayloadToServiceLoginParams,
+} from './types'
 
 /**
  * Central service for handling pairing requests from any source.
@@ -110,11 +116,7 @@ export class PairingService {
   private emitNavigation(payload: PairingPayload) {
     const event: PairingNavigationEvent = {
       screen: BCSCScreens.ServiceLogin,
-      params: {
-        serviceTitle: payload.serviceTitle,
-        pairingCode: payload.pairingCode,
-        fromAppSwitch: payload.source === 'deep-link',
-      },
+      params: pairingPayloadToServiceLoginParams(payload),
     }
     this.navigationListeners.forEach((listener) => listener(event))
   }

--- a/app/src/bcsc-theme/features/pairing/index.ts
+++ b/app/src/bcsc-theme/features/pairing/index.ts
@@ -1,4 +1,5 @@
 export { PairingService } from './PairingService'
 export { PairingServiceProvider, usePairingService } from './PairingServiceContext'
+export { pairingPayloadToServiceLoginParams } from './types'
 export type { PairingNavigationEvent, PairingNavigationListener, PairingPayload, PendingPairingListener } from './types'
 export { usePendingPairing } from './usePendingPairing'

--- a/app/src/bcsc-theme/features/pairing/types.ts
+++ b/app/src/bcsc-theme/features/pairing/types.ts
@@ -26,3 +26,14 @@ export type PairingNavigationEvent = {
 
 export type PairingNavigationListener = (event: PairingNavigationEvent) => void
 export type PendingPairingListener = (hasPending: boolean) => void
+
+/**
+ * Converts a PairingPayload to the parameters required for service login
+ * @param payload The pairing payload to convert
+ * @returns PairingNavigationEvent['params'] containing serviceTitle, pairingCode, and optional fromAppSwitch
+ */
+export const pairingPayloadToServiceLoginParams = (payload: PairingPayload): PairingNavigationEvent['params'] => ({
+  serviceTitle: payload.serviceTitle,
+  pairingCode: payload.pairingCode,
+  fromAppSwitch: payload.source === 'deep-link',
+})

--- a/app/src/bcsc-theme/navigators/MainStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.test.tsx
@@ -195,6 +195,15 @@ describe('MainStack', () => {
   })
 
   it('calls pairingPayloadToServiceLoginParams when there is a valid pending pairing', () => {
+    const payload: PairingPayload = { serviceTitle: 'My Service', pairingCode: 'abc123', source: 'manual' }
+    mockConsumePendingPairing.mockReturnValue(payload)
+
+    render(<MainStack />)
+
+    expect(PairingModule.pairingPayloadToServiceLoginParams).toHaveBeenCalledWith(payload)
+  })
+
+  it('calls pairingPayloadToServiceLoginParams for a deep-link pending pairing (cold start)', () => {
     const payload: PairingPayload = { serviceTitle: 'My Service', pairingCode: 'abc123', source: 'deep-link' }
     mockConsumePendingPairing.mockReturnValue(payload)
 

--- a/app/src/bcsc-theme/navigators/MainStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.test.tsx
@@ -1,0 +1,226 @@
+import { isAccountExpired } from '@/services/system-checks/AccountExpiryWarningBannerSystemCheck'
+import * as Bifold from '@bifold/core'
+import { useNavigation } from '@react-navigation/native'
+import { render } from '@testing-library/react-native'
+import React from 'react'
+import * as PairingModule from '../features/pairing'
+import { BCSCScreens } from '../types/navigators'
+import MainStack from './MainStack'
+
+jest.mock('@bifold/core')
+jest.mock('@react-navigation/stack', () => {
+  const Screen = ({ children }: any) => children
+  Screen.displayName = 'Screen'
+  const Navigator = ({ children }: any) => children
+  Navigator.displayName = 'Navigator'
+  return {
+    createStackNavigator: () => ({
+      Navigator,
+      Screen,
+    }),
+  }
+})
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+jest.mock('@/constants', () => ({
+  DEFAULT_HEADER_TITLE_CONTAINER_STYLE: {},
+  HelpCentreUrl: { COMPUTER_LOGIN: 'https://example.com' },
+}))
+jest.mock('@/services/system-checks/AccountExpiryWarningBannerSystemCheck', () => ({
+  isAccountExpired: jest.fn(),
+}))
+jest.mock('../contexts/BCSCStackContext', () => ({
+  useBCSCStack: jest.fn(),
+}))
+jest.mock('../contexts/BCSCAccountContext', () => ({
+  useAccount: jest.fn(),
+}))
+jest.mock('../hooks/useSystemChecks', () => ({
+  SystemCheckScope: { MAIN_STACK: 'MAIN_STACK' },
+  useSystemChecks: jest.fn(),
+}))
+jest.mock('../features/pairing', () => ({
+  usePairingService: jest.fn(),
+  pairingPayloadToServiceLoginParams: jest.fn(),
+}))
+jest.mock('../components/HeaderBackButton', () => ({
+  createHeaderBackButton: jest.fn(() => null),
+}))
+jest.mock('../components/HeaderWithBanner', () => ({
+  createHeaderWithoutBanner: jest.fn(() => null),
+}))
+jest.mock('../components/HelpHeaderButton', () => ({
+  createMainHelpHeaderButton: jest.fn(() => () => null),
+}))
+jest.mock('./stack-utils', () => ({
+  getDefaultModalOptions: jest.fn(() => ({})),
+}))
+jest.mock('./TabStack', () => 'BCSCTabStack')
+jest.mock('../../screens/Developer', () => 'Developer')
+jest.mock('../features/account-transfer/transferer/TransferQRDisplayScreen', () => 'TransferQRDisplayScreen')
+jest.mock('../features/account-transfer/transferer/TransferQRInformationScreen', () => 'TransferQRInformationScreen')
+jest.mock('../features/account-transfer/transferer/TransferSuccessScreen', () => 'TransferSuccessScreen')
+jest.mock('../features/account/AccountExpiredScreen', () => ({ AccountExpiredScreen: 'AccountExpiredScreen' }))
+jest.mock('../features/account/AccountRenewalFinalWarningScreen', () => ({
+  AccountRenewalFinalWarningScreen: 'AccountRenewalFinalWarningScreen',
+}))
+jest.mock('../features/account/AccountRenewalFirstWarningScreen', () => ({
+  AccountRenewalFirstWarningScreen: 'AccountRenewalFirstWarningScreen',
+}))
+jest.mock('../features/account/AccountRenewalInformationScreen', () => ({
+  AccountRenewalInformationScreen: 'AccountRenewalInformationScreen',
+}))
+jest.mock('../features/account/EditNicknameScreen', () => 'EditNicknameScreen')
+jest.mock('../features/account/RemoveAccountConfirmationScreen', () => ({
+  MainRemoveAccountConfirmationScreen: 'MainRemoveAccountConfirmationScreen',
+}))
+jest.mock('../features/account/TransferAgeRestrictionScreen', () => 'TransferAgeRestrictionScreen')
+jest.mock('../features/auth/MainChangePINScreen', () => ({ MainChangePINScreen: 'MainChangePINScreen' }))
+jest.mock('../features/auth/MainChangeSecurityScreen', () => ({
+  MainChangeSecurityScreen: 'MainChangeSecurityScreen',
+}))
+jest.mock('../features/modal/DeviceInvalidated', () => ({ DeviceInvalidated: 'DeviceInvalidated' }))
+jest.mock('../features/modal/InternetDisconnected', () => ({ InternetDisconnected: 'InternetDisconnected' }))
+jest.mock('../features/modal/MandatoryUpdate', () => ({ MandatoryUpdate: 'MandatoryUpdate' }))
+jest.mock('../features/modal/ServiceOutage', () => ({ ServiceOutage: 'ServiceOutage' }))
+jest.mock('../features/pairing/ManualPairing', () => 'ManualPairingCode')
+jest.mock('../features/pairing/PairingConfirmation', () => 'PairingConfirmation')
+jest.mock('../features/services/ServiceLoginScreen', () => ({ ServiceLoginScreen: 'ServiceLoginScreen' }))
+jest.mock('../features/settings/AutoLockScreen', () => ({ AutoLockScreen: 'AutoLockScreen' }))
+jest.mock('../features/settings/ContactUsScreen', () => ({ ContactUsScreen: 'ContactUsScreen' }))
+jest.mock('../features/settings/ForgetAllPairingsScreen', () => ({
+  ForgetAllPairingsScreen: 'ForgetAllPairingsScreen',
+}))
+jest.mock('../features/settings/MainPrivacyPolicyScreen', () => ({
+  MainPrivacyPolicyScreen: 'MainPrivacyPolicyScreen',
+}))
+jest.mock('../features/settings/MainSettingsScreen', () => ({ MainSettingsScreen: 'MainSettingsScreen' }))
+jest.mock('../features/webview/WebViewScreen', () => ({ WebViewScreen: 'WebViewScreen' }))
+
+const mockUnsubscribe = jest.fn()
+const mockOnNavigationRequest = jest.fn(() => mockUnsubscribe)
+const mockConsumePendingPairing = jest.fn(() => null)
+const mockLogger = { error: jest.fn() }
+
+const makePairingService = () => ({
+  consumePendingPairing: mockConsumePendingPairing,
+  onNavigationRequest: mockOnNavigationRequest,
+})
+
+describe('MainStack', () => {
+  let mockNavigation: ReturnType<typeof useNavigation>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockNavigation = useNavigation()
+    jest.mocked(Bifold.useDefaultStackOptions).mockReturnValue({} as any)
+    jest.mocked(Bifold.useTheme).mockReturnValue({} as any)
+    jest.mocked(Bifold.useTour).mockReturnValue({ currentStep: undefined } as any)
+    jest.mocked(Bifold.useServices).mockReturnValue([mockLogger] as any)
+    jest.mocked(Bifold.testIdWithKey).mockImplementation((key: string) => key)
+    jest.mocked(PairingModule.usePairingService).mockReturnValue(makePairingService() as any)
+    jest.mocked(PairingModule.pairingPayloadToServiceLoginParams).mockReturnValue({ pairingCode: 'code' } as any)
+    jest.requireMock('../contexts/BCSCAccountContext').useAccount.mockReturnValue({ account: null })
+    jest.mocked(isAccountExpired).mockReturnValue(false)
+  })
+
+  it('renders correctly', () => {
+    const { toJSON } = render(<MainStack />)
+    expect(toJSON()).toMatchSnapshot()
+  })
+
+  it('navigates to AccountExpired when account is expired', () => {
+    jest.requireMock('../contexts/BCSCAccountContext').useAccount.mockReturnValue({
+      account: { account_expiration_date: '2020-01-01' },
+    })
+    jest.mocked(isAccountExpired).mockReturnValue(true)
+
+    render(<MainStack />)
+
+    expect(mockNavigation.dispatch).toHaveBeenCalledWith({
+      type: 'RESET',
+      payload: { index: 0, routes: [{ name: BCSCScreens.AccountExpired }] },
+    })
+  })
+
+  it('does not navigate to AccountExpired when account is not expired', () => {
+    jest.requireMock('../contexts/BCSCAccountContext').useAccount.mockReturnValue({
+      account: { account_expiration_date: '2099-01-01' },
+    })
+    jest.mocked(isAccountExpired).mockReturnValue(false)
+
+    render(<MainStack />)
+
+    expect(mockNavigation.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('does not navigate to AccountExpired when there is no account', () => {
+    jest.requireMock('../contexts/BCSCAccountContext').useAccount.mockReturnValue({ account: null })
+
+    render(<MainStack />)
+
+    expect(mockNavigation.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('navigates to ServiceLogin when pairing service emits a navigation request', () => {
+    let capturedListener: ((args: any) => void) | undefined
+    mockOnNavigationRequest.mockImplementation((listener) => {
+      capturedListener = listener
+      return mockUnsubscribe
+    })
+
+    render(<MainStack />)
+
+    const params = { pairingCode: 'abc123' }
+    capturedListener!({ screen: BCSCScreens.ServiceLogin, params })
+
+    expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.ServiceLogin, params)
+  })
+
+  it('does not navigate when pairing service emits a non-ServiceLogin screen', () => {
+    let capturedListener: ((args: any) => void) | undefined
+    mockOnNavigationRequest.mockImplementation((listener) => {
+      capturedListener = listener
+      return mockUnsubscribe
+    })
+
+    render(<MainStack />)
+    capturedListener!({ screen: 'SomeOtherScreen', params: {} })
+
+    expect(mockNavigation.navigate).not.toHaveBeenCalled()
+  })
+
+  it('unsubscribes from pairing navigation requests on unmount', () => {
+    const { unmount } = render(<MainStack />)
+    unmount()
+
+    expect(mockUnsubscribe).toHaveBeenCalled()
+  })
+
+  it('calls pairingPayloadToServiceLoginParams when there is a valid pending pairing', () => {
+    const payload = { serviceTitle: 'My Service', pairingCode: 'abc123' }
+    mockConsumePendingPairing.mockReturnValue(payload)
+
+    render(<MainStack />)
+
+    expect(PairingModule.pairingPayloadToServiceLoginParams).toHaveBeenCalledWith(payload)
+  })
+
+  it('logs an error and skips pairingPayloadToServiceLoginParams when pending pairing is missing fields', () => {
+    mockConsumePendingPairing.mockReturnValue({ serviceTitle: null, pairingCode: null })
+
+    render(<MainStack />)
+
+    expect(mockLogger.error).toHaveBeenCalled()
+    expect(PairingModule.pairingPayloadToServiceLoginParams).not.toHaveBeenCalled()
+  })
+
+  it('does not call pairingPayloadToServiceLoginParams when there is no pending pairing', () => {
+    mockConsumePendingPairing.mockReturnValue(null)
+
+    render(<MainStack />)
+
+    expect(PairingModule.pairingPayloadToServiceLoginParams).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/bcsc-theme/navigators/MainStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.test.tsx
@@ -4,10 +4,27 @@ import { useNavigation } from '@react-navigation/native'
 import { render } from '@testing-library/react-native'
 import React from 'react'
 import * as PairingModule from '../features/pairing'
+import { PairingNavigationListener, PairingPayload } from '../features/pairing/types'
 import { BCSCScreens } from '../types/navigators'
 import MainStack from './MainStack'
 
+let capturedNavigationListener: PairingNavigationListener | undefined
+
+const mockUnsubscribe = jest.fn()
+const mockOnNavigationRequest = jest.fn((listener: PairingNavigationListener) => {
+  capturedNavigationListener = listener
+  return mockUnsubscribe
+})
+const mockConsumePendingPairing = jest.fn((): PairingPayload | null => null)
+const mockLogger = { error: jest.fn() }
+
+const makePairingService = () => ({
+  consumePendingPairing: mockConsumePendingPairing,
+  onNavigationRequest: mockOnNavigationRequest,
+})
+
 jest.mock('@bifold/core')
+jest.mock('@react-navigation/native')
 jest.mock('@react-navigation/stack', () => {
   const Screen = ({ children }: any) => children
   Screen.displayName = 'Screen'
@@ -98,22 +115,13 @@ jest.mock('../features/settings/MainPrivacyPolicyScreen', () => ({
 jest.mock('../features/settings/MainSettingsScreen', () => ({ MainSettingsScreen: 'MainSettingsScreen' }))
 jest.mock('../features/webview/WebViewScreen', () => ({ WebViewScreen: 'WebViewScreen' }))
 
-const mockUnsubscribe = jest.fn()
-const mockOnNavigationRequest = jest.fn(() => mockUnsubscribe)
-const mockConsumePendingPairing = jest.fn(() => null)
-const mockLogger = { error: jest.fn() }
-
-const makePairingService = () => ({
-  consumePendingPairing: mockConsumePendingPairing,
-  onNavigationRequest: mockOnNavigationRequest,
-})
-
 describe('MainStack', () => {
-  let mockNavigation: ReturnType<typeof useNavigation>
+  let mockNavigation: { dispatch: (...args: any[]) => void; navigate: (...args: any[]) => void }
 
   beforeEach(() => {
+    capturedNavigationListener = undefined
     jest.clearAllMocks()
-    mockNavigation = useNavigation()
+    mockNavigation = useNavigation() as typeof mockNavigation
     jest.mocked(Bifold.useDefaultStackOptions).mockReturnValue({} as any)
     jest.mocked(Bifold.useTheme).mockReturnValue({} as any)
     jest.mocked(Bifold.useTour).mockReturnValue({ currentStep: undefined } as any)
@@ -164,29 +172,17 @@ describe('MainStack', () => {
   })
 
   it('navigates to ServiceLogin when pairing service emits a navigation request', () => {
-    let capturedListener: ((args: any) => void) | undefined
-    mockOnNavigationRequest.mockImplementation((listener) => {
-      capturedListener = listener
-      return mockUnsubscribe
-    })
-
     render(<MainStack />)
 
-    const params = { pairingCode: 'abc123' }
-    capturedListener!({ screen: BCSCScreens.ServiceLogin, params })
+    const params = { serviceTitle: 'My Service', pairingCode: 'abc123' }
+    capturedNavigationListener!({ screen: BCSCScreens.ServiceLogin, params })
 
     expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.ServiceLogin, params)
   })
 
   it('does not navigate when pairing service emits a non-ServiceLogin screen', () => {
-    let capturedListener: ((args: any) => void) | undefined
-    mockOnNavigationRequest.mockImplementation((listener) => {
-      capturedListener = listener
-      return mockUnsubscribe
-    })
-
     render(<MainStack />)
-    capturedListener!({ screen: 'SomeOtherScreen', params: {} })
+    capturedNavigationListener!({ screen: 'SomeOtherScreen' as any, params: {} as any })
 
     expect(mockNavigation.navigate).not.toHaveBeenCalled()
   })
@@ -199,7 +195,7 @@ describe('MainStack', () => {
   })
 
   it('calls pairingPayloadToServiceLoginParams when there is a valid pending pairing', () => {
-    const payload = { serviceTitle: 'My Service', pairingCode: 'abc123' }
+    const payload: PairingPayload = { serviceTitle: 'My Service', pairingCode: 'abc123', source: 'manual' }
     mockConsumePendingPairing.mockReturnValue(payload)
 
     render(<MainStack />)
@@ -208,7 +204,7 @@ describe('MainStack', () => {
   })
 
   it('logs an error and skips pairingPayloadToServiceLoginParams when pending pairing is missing fields', () => {
-    mockConsumePendingPairing.mockReturnValue({ serviceTitle: null, pairingCode: null })
+    mockConsumePendingPairing.mockReturnValue({ serviceTitle: null, pairingCode: null } as unknown as PairingPayload)
 
     render(<MainStack />)
 

--- a/app/src/bcsc-theme/navigators/MainStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.test.tsx
@@ -195,7 +195,7 @@ describe('MainStack', () => {
   })
 
   it('calls pairingPayloadToServiceLoginParams when there is a valid pending pairing', () => {
-    const payload: PairingPayload = { serviceTitle: 'My Service', pairingCode: 'abc123', source: 'manual' }
+    const payload: PairingPayload = { serviceTitle: 'My Service', pairingCode: 'abc123', source: 'deep-link' }
     mockConsumePendingPairing.mockReturnValue(payload)
 
     render(<MainStack />)

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -28,7 +28,7 @@ import { DeviceInvalidated } from '../features/modal/DeviceInvalidated'
 import { InternetDisconnected } from '../features/modal/InternetDisconnected'
 import { MandatoryUpdate } from '../features/modal/MandatoryUpdate'
 import { ServiceOutage } from '../features/modal/ServiceOutage'
-import { usePairingService } from '../features/pairing'
+import { pairingPayloadToServiceLoginParams, usePairingService } from '../features/pairing'
 import ManualPairingCode from '../features/pairing/ManualPairing'
 import PairingConfirmation from '../features/pairing/PairingConfirmation'
 import { ServiceLoginScreen } from '../features/services/ServiceLoginScreen'
@@ -72,11 +72,7 @@ const MainStack: React.FC = () => {
       return undefined
     }
 
-    return {
-      serviceTitle,
-      pairingCode,
-      fromAppSwitch: pendingPairing.source === 'deep-link',
-    }
+    return pairingPayloadToServiceLoginParams(pendingPairing)
   }, [logger, pendingPairing])
   const initialRouteName = pairingInitialParams ? BCSCScreens.ServiceLogin : BCSCStacks.Tab
   useSystemChecks(SystemCheckScope.MAIN_STACK)

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -74,6 +74,7 @@ const MainStack: React.FC = () => {
 
     return pairingPayloadToServiceLoginParams(pendingPairing)
   }, [logger, pendingPairing])
+
   const initialRouteName = pairingInitialParams ? BCSCScreens.ServiceLogin : BCSCStacks.Tab
   useSystemChecks(SystemCheckScope.MAIN_STACK)
   useBCSCStack(BCSCStacks.Main)

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -75,6 +75,7 @@ const MainStack: React.FC = () => {
     return {
       serviceTitle,
       pairingCode,
+      fromAppSwitch: pendingPairing.source === 'deep-link',
     }
   }, [logger, pendingPairing])
   const initialRouteName = pairingInitialParams ? BCSCScreens.ServiceLogin : BCSCStacks.Tab

--- a/app/src/bcsc-theme/navigators/__snapshots__/MainStack.test.tsx.snap
+++ b/app/src/bcsc-theme/navigators/__snapshots__/MainStack.test.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MainStack renders correctly 1`] = `
+<View
+  importantForAccessibility="auto"
+  style={
+    {
+      "flex": 1,
+    }
+  }
+/>
+`;


### PR DESCRIPTION
# Summary of Changes

- added missing `source` check for cold start login prompts

# Testing Instructions

- convert to bcsc mode
- verify on iOS
- close the app
- on device navigate to https://idsit.gov.bc.ca/demo/ and select a login option
- follow login prompts and see arrow at the top of the "You're done in this app." screen  

# Acceptance Criteria

- back to browser arrow is visible from a cold start

# Screenshots, videos, or gifs
** this was recorded on an iPad
<img width="400" height="533" alt="ios-browser-arrow-login" src="https://github.com/user-attachments/assets/37580e81-92b9-4d05-83a8-b32e59c4667b" />


# Related Issues

[BCSC: 4074](https://github.com/bcgov/bc-wallet-mobile/issues/4074)
