### PR TITLE
feat: back home button

### DIFF
--- a/app/src/bcsc-theme/components/FloatingHelpMenuHeaderButton.tsx
+++ b/app/src/bcsc-theme/components/FloatingHelpMenuHeaderButton.tsx
@@ -4,16 +4,25 @@ import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { ReactNode, useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useLeaveVerification } from '../hooks/useLeaveVerification'
 import { useRestartVerification } from '../hooks/useRestartVerification'
 import { BCSCScreens } from '../types/navigators'
 import FloatingHelpMenu, { FloatingHelpMenuRef } from './FloatingHelpMenu'
 import { ListButton, ListButtonGroup, ListButtonProps } from './ListButton'
 import { ReportProblemModal } from './ReportProblemModal'
 
+// Header trigger icons. Every stack uses the question-mark help icon except the verification flow,
+// whose menu also offers navigation actions ("Back to home", "Restart") and so reads better as a
+// vertical-ellipsis "more options" affordance.
+const DEFAULT_HELP_ICON = 'help-circle-outline'
+const VERIFY_HELP_ICON = 'dots-vertical'
+
 type FloatingHelpMenuButtonProps = {
   // ListButton rows; falsy children are filtered out by ListButtonGroup so rows can be conditional
   children: ReactNode
   ref?: React.Ref<FloatingHelpMenuRef>
+  /** Header trigger icon (MaterialCommunityIcons/MaterialIcons glyph name). */
+  icon: string
 }
 
 /**
@@ -30,7 +39,7 @@ const FloatingHelpMenuButton = (props: FloatingHelpMenuButtonProps) => {
     <>
       <IconButton
         buttonLocation={ButtonLocation.Right}
-        icon={'help-circle-outline'}
+        icon={props.icon}
         accessibilityLabel={t('BCSC.HelpMenu.AccessibilityLabel')}
         testID={testIdWithKey('HelpMenu')}
         onPress={() => setOpen(true)}
@@ -39,6 +48,82 @@ const FloatingHelpMenuButton = (props: FloatingHelpMenuButtonProps) => {
         <ListButtonGroup>{props.children}</ListButtonGroup>
       </FloatingHelpMenu>
     </>
+  )
+}
+
+/**
+ * Report-a-problem modal state for a help menu. `open` closes the menu first and only shows the
+ * modal once the dismissal completes (via the menu's `close(onClosed)` callback, then a frame
+ * later): presenting both in the same commit triggers an iOS "attempt to present while a
+ * presentation is in progress" race that can leave the report modal not showing. The modal itself
+ * is rendered by the factory — outside the menu — so it outlives the menu's dismissal.
+ */
+const useReportProblem = (menuRef: React.RefObject<FloatingHelpMenuRef | null>) => {
+  const [visible, setVisible] = useState(false)
+
+  const open = useCallback(() => {
+    menuRef.current?.close(() => requestAnimationFrame(() => setVisible(true)))
+  }, [menuRef])
+
+  const hide = useCallback(() => setVisible(false), [])
+
+  return { visible, open, hide }
+}
+
+/**
+ * Shared props for the self-contained verify-flow menu rows below. `position` is injected by
+ * ListButtonGroup (for border-radius grouping); `onClose` lets a row dismiss the menu it lives in.
+ */
+type MenuRowProps = {
+  /** Closes the owning menu (e.g. after the row's action runs). */
+  onClose: () => void
+} & Pick<ListButtonProps, 'position'>
+
+/**
+ * "Report a problem" menu row. Shared by the default and verification help menus. Opening the
+ * report modal is owned by the factory (the modal must outlive the menu's dismissal), so this row
+ * just forwards the press.
+ */
+const ReportProblemListButton = ({
+  onPress,
+  position,
+}: { onPress: () => void } & Pick<ListButtonProps, 'position'>) => {
+  const { t } = useTranslation()
+
+  return (
+    <ListButton position={position} onPress={onPress}>
+      {t('BCSC.HelpMenu.ReportProblem')}
+    </ListButton>
+  )
+}
+
+/**
+ * "Back to home" menu row (verify flow only). Leaves the in-progress verification and returns to
+ * the app home screen, keeping progress so the user can resume later (see {@link useLeaveVerification}).
+ */
+const BackToHomeListButton = ({ onClose, position }: MenuRowProps) => {
+  const { t } = useTranslation()
+  const leaveVerification = useLeaveVerification()
+
+  return (
+    <ListButton position={position} onPress={() => leaveVerification(onClose)}>
+      {t('BCSC.HelpMenu.BackToHome')}
+    </ListButton>
+  )
+}
+
+/**
+ * "Restart verification process" menu row (verify flow only). Kept as its own component so the
+ * verification-reset hook only runs in menus that render it.
+ */
+const RestartVerificationListButton = ({ onClose, position }: MenuRowProps) => {
+  const { t } = useTranslation()
+  const promptRestartVerification = useRestartVerification()
+
+  return (
+    <ListButton position={position} onPress={() => promptRestartVerification(onClose)}>
+      {t('BCSC.HelpMenu.RestartVerification')}
+    </ListButton>
   )
 }
 
@@ -53,75 +138,41 @@ type WebViewParamList = {
   [BCSCScreens.VerifyWebView]: { url: string; title: string }
 }
 
-type FloatingHelpMenuButtonOptions = {
+export type FloatingHelpMenuButtonOptions = {
   /** The current stack's WebView screen that the "Learn More" option should open. */
   webViewScreen: keyof WebViewParamList
   /** Help centre article opened by "Learn More". Defaults to the help centre home page. */
   learnMoreUrl?: HelpCentreUrl
-  /** Show the "Restart verification process" option. Only valid within the verification flow. */
-  showRestartVerification?: boolean
-}
-
-type RestartVerificationListButtonProps = {
-  /** Called when the user confirms the restart, so the owning menu can close itself. */
-  onConfirm: () => void
-} & Pick<ListButtonProps, 'position'>
-
-/**
- * "Restart verification process" menu row. Kept as its own component so the verification-reset
- * hooks only run in menus that opt in via `showRestartVerification` (i.e. the verify flow).
- */
-const RestartVerificationListButton = ({ onConfirm, position }: RestartVerificationListButtonProps) => {
-  const { t } = useTranslation()
-  const promptRestartVerification = useRestartVerification()
-
-  return (
-    <ListButton position={position} onPress={() => promptRestartVerification(onConfirm)}>
-      {t('BCSC.HelpMenu.RestartVerification')}
-    </ListButton>
-  )
 }
 
 /**
- * Factory function to create a floating help menu button for a stack header.
+ * Factory for the default stack help menu button: "Learn more" (opens the given help centre
+ * article in the stack's WebView screen), "Give feedback", and "Report a problem".
  *
- * The returned header component renders a help menu whose "Learn More" option opens the given
- * help centre article in the stack's WebView screen.
+ * The verification flow uses {@link createVerifyHelpMenuButton} instead, which offers a different
+ * set of actions and a different trigger icon.
  *
  * @param options - The stack's WebView screen and the optional help centre article for "Learn More".
- * @returns A React component that renders a floating help menu button.
+ * @returns A React component that renders the help menu button.
  */
 export const createFloatingHelpMenuButton = ({
   webViewScreen,
   learnMoreUrl = HelpCentreUrl.HOME,
-  showRestartVerification = false,
 }: FloatingHelpMenuButtonOptions) => {
   const FloatingHelpMenuHeaderRight = () => {
     const { t } = useTranslation()
     const navigation = useNavigation<StackNavigationProp<WebViewParamList>>()
     const floatingHelpMenuRef = useRef<FloatingHelpMenuRef>(null)
-    const [reportProblemVisible, setReportProblemVisible] = useState(false)
+    const reportProblem = useReportProblem(floatingHelpMenuRef)
 
     const handleLearnMore = useCallback(() => {
       navigation.navigate(webViewScreen, { url: learnMoreUrl, title: t('HelpCentre.Title') })
       floatingHelpMenuRef.current?.close()
     }, [navigation, t])
 
-    // Opens the report modal on the next frame. Deferring to a later tick than the menu modal's dismissal
-    // avoids the iOS "attempt to present while a presentation is in progress" race — presenting both in the
-    // same commit can leave the report modal not showing.
-    const showReportProblemModal = useCallback(() => {
-      requestAnimationFrame(() => setReportProblemVisible(true))
-    }, [])
-
-    const handleReportProblem = useCallback(() => {
-      // Close the help menu first, then open the report modal once the dismissal completes.
-      floatingHelpMenuRef.current?.close(showReportProblemModal)
-    }, [showReportProblemModal])
-
     return (
       <>
-        <FloatingHelpMenuButton ref={floatingHelpMenuRef}>
+        <FloatingHelpMenuButton ref={floatingHelpMenuRef} icon={DEFAULT_HELP_ICON}>
           <ListButton onPress={handleLearnMore}>{t('BCSC.HelpMenu.LearnMore')}</ListButton>
           <ListButton
             onPress={() => {
@@ -131,15 +182,49 @@ export const createFloatingHelpMenuButton = ({
           >
             {t('BCSC.HelpMenu.GiveFeedback')}
           </ListButton>
-          <ListButton onPress={handleReportProblem}>{t('BCSC.HelpMenu.ReportProblem')}</ListButton>
-          {showRestartVerification && (
-            <RestartVerificationListButton onConfirm={() => floatingHelpMenuRef.current?.close()} />
-          )}
+          <ReportProblemListButton onPress={reportProblem.open} />
         </FloatingHelpMenuButton>
-        <ReportProblemModal visible={reportProblemVisible} onClose={() => setReportProblemVisible(false)} />
+        <ReportProblemModal visible={reportProblem.visible} onClose={reportProblem.hide} />
       </>
     )
   }
 
   return FloatingHelpMenuHeaderRight
+}
+
+export type VerifyHelpMenuButtonOptions = {
+  /**
+   * Show the "Restart verification process" row. Off for the initial verify prompt (verification
+   * hasn't started yet), on for the rest of the flow.
+   */
+  showRestartVerification?: boolean
+}
+
+/**
+ * Factory for the verification flow's help menu button. Uses the vertical-ellipsis trigger icon and
+ * offers "Report a problem", "Back to home" (leave the flow, keeping progress), and — once
+ * verification is underway — "Restart verification process".
+ *
+ * @param options - Whether to show the "Restart verification process" row.
+ * @returns A React component that renders the verification help menu button.
+ */
+export const createVerifyHelpMenuButton = ({ showRestartVerification = false }: VerifyHelpMenuButtonOptions = {}) => {
+  const VerifyHelpMenuHeaderRight = () => {
+    const floatingHelpMenuRef = useRef<FloatingHelpMenuRef>(null)
+    const closeMenu = useCallback(() => floatingHelpMenuRef.current?.close(), [])
+    const reportProblem = useReportProblem(floatingHelpMenuRef)
+
+    return (
+      <>
+        <FloatingHelpMenuButton ref={floatingHelpMenuRef} icon={VERIFY_HELP_ICON}>
+          <ReportProblemListButton onPress={reportProblem.open} />
+          <BackToHomeListButton onClose={closeMenu} />
+          {showRestartVerification && <RestartVerificationListButton onClose={closeMenu} />}
+        </FloatingHelpMenuButton>
+        <ReportProblemModal visible={reportProblem.visible} onClose={reportProblem.hide} />
+      </>
+    )
+  }
+
+  return VerifyHelpMenuHeaderRight
 }

--- a/app/src/bcsc-theme/hooks/useLeaveVerification.test.tsx
+++ b/app/src/bcsc-theme/hooks/useLeaveVerification.test.tsx
@@ -1,0 +1,59 @@
+import { BCDispatchAction, VerificationStatus } from '@/store'
+import * as Bifold from '@bifold/core'
+import { act, renderHook } from '@testing-library/react-native'
+import { useLeaveVerification } from './useLeaveVerification'
+
+jest.mock('@bifold/core')
+
+const mockDispatch = jest.fn()
+
+describe('useLeaveVerification', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.mocked(Bifold.useStore).mockReturnValue([{} as any, mockDispatch])
+  })
+
+  it('marks the verify prompt seen and moves status out of IN_PROGRESS so the RootStack shows home', () => {
+    const { result } = renderHook(() => useLeaveVerification())
+
+    act(() => {
+      result.current()
+    })
+
+    expect(mockDispatch).toHaveBeenCalledWith({ type: BCDispatchAction.SEEN_VERIFY_PROMPT, payload: [true] })
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: BCDispatchAction.UPDATE_SECURE_VERIFIED_STATUS,
+      payload: [VerificationStatus.UNVERIFIED],
+    })
+  })
+
+  it('preserves progress — it does not dispatch any verification-data reset', () => {
+    const { result } = renderHook(() => useLeaveVerification())
+
+    act(() => {
+      result.current()
+    })
+
+    // Only the two routing dispatches; nothing that clears evidence/credential/auth-request.
+    expect(mockDispatch).toHaveBeenCalledTimes(2)
+  })
+
+  it('runs the optional onLeave callback before leaving (e.g. to close the menu)', () => {
+    const onLeave = jest.fn()
+    const { result } = renderHook(() => useLeaveVerification())
+
+    act(() => {
+      result.current(onLeave)
+    })
+
+    expect(onLeave).toHaveBeenCalledTimes(1)
+    // onLeave fires before the dispatches that unmount the VerifyStack.
+    expect(onLeave.mock.invocationCallOrder[0]).toBeLessThan(mockDispatch.mock.invocationCallOrder[0])
+  })
+
+  it('does not throw when called without an onLeave callback', () => {
+    const { result } = renderHook(() => useLeaveVerification())
+
+    expect(() => act(() => result.current())).not.toThrow()
+  })
+})

--- a/app/src/bcsc-theme/hooks/useLeaveVerification.tsx
+++ b/app/src/bcsc-theme/hooks/useLeaveVerification.tsx
@@ -1,0 +1,33 @@
+import { BCDispatchAction, BCState, VerificationStatus } from '@/store'
+import { useStore } from '@bifold/core'
+import { useCallback } from 'react'
+
+/**
+ * Returns a callback that leaves the in-progress verification flow and returns the user to the app
+ * home screen, *preserving* their verification progress so they can resume later — unlike
+ * {@link useRestartVerification}, which wipes progress.
+ *
+ * Marking the one-time prompt seen and moving the verification status out of IN_PROGRESS makes the
+ * RootStack render the MainStack instead of the VerifyStack (see RootStack `showVerifyStack`). No
+ * verification data is cleared, so the user can pick up where they left off via the home screen's
+ * "continue verification" notification (which dispatches IN_PROGRESS again).
+ *
+ * @returns {(onLeave?: () => void) => void} Callback that leaves the flow. The optional `onLeave`
+ * runs first (e.g. to close the menu the action was triggered from).
+ */
+export const useLeaveVerification = () => {
+  const [, dispatch] = useStore<BCState>()
+
+  return useCallback(
+    (onLeave?: () => void) => {
+      onLeave?.()
+      // Seen-prompt guards the RootStack's first `showVerifyStack` clause; UNVERIFIED clears the
+      // second (IN_PROGRESS) clause, together swapping the VerifyStack for the MainStack (home).
+      dispatch({ type: BCDispatchAction.SEEN_VERIFY_PROMPT, payload: [true] })
+      dispatch({ type: BCDispatchAction.UPDATE_SECURE_VERIFIED_STATUS, payload: [VerificationStatus.UNVERIFIED] })
+    },
+    [dispatch]
+  )
+}
+
+export default useLeaveVerification

--- a/app/src/bcsc-theme/navigators/VerifyStack.tsx
+++ b/app/src/bcsc-theme/navigators/VerifyStack.tsx
@@ -4,13 +4,13 @@ import { createProgressHeader } from '@/bcsc-theme/components/VerifyProgressHead
 import { useVerificationResponseListener } from '@/bcsc-theme/features/verification-response/useVerificationResponseListener'
 import { getDefaultModalOptions } from '@/bcsc-theme/navigators/stack-utils'
 import { BCSCModals, BCSCScreens, BCSCStacks, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
-import { DEFAULT_HEADER_TITLE_CONTAINER_STYLE, HelpCentreUrl } from '@/constants'
+import { DEFAULT_HEADER_TITLE_CONTAINER_STYLE } from '@/constants'
 import { BCState } from '@/store'
 import { testIdWithKey, useDefaultStackOptions, useStore, useTheme } from '@bifold/core'
 import { createStackNavigator } from '@react-navigation/stack'
 import { useTranslation } from 'react-i18next'
 import Developer from '../../screens/Developer'
-import { createFloatingHelpMenuButton } from '../components/FloatingHelpMenuHeaderButton'
+import { createVerifyHelpMenuButton } from '../components/FloatingHelpMenuHeaderButton'
 import { createHeaderBackButton } from '../components/HeaderBackButton'
 import { useBCSCStack } from '../contexts/BCSCStackContext'
 import TransferInstructionsScreen from '../features/account-transfer/transferee/TransferInstructionsScreen'
@@ -101,10 +101,7 @@ const VerifyStack = () => {
         headerBackTestID: testIdWithKey('Back'),
         headerBackTitleVisible: false,
         header: createHeaderWithoutBanner,
-        headerRight: createFloatingHelpMenuButton({
-          webViewScreen: BCSCScreens.VerifyWebView,
-          showRestartVerification: true,
-        }),
+        headerRight: createVerifyHelpMenuButton({ showRestartVerification: true }),
       }}
     >
       <Stack.Screen
@@ -113,10 +110,7 @@ const VerifyStack = () => {
           // First screen of the verify journey — no back destination; help menu without "restart"
           // since verification hasn't started yet.
           headerLeft: () => null,
-          headerRight: createFloatingHelpMenuButton({
-            webViewScreen: BCSCScreens.VerifyWebView,
-            learnMoreUrl: HelpCentreUrl.HOW_TO_SETUP,
-          }),
+          headerRight: createVerifyHelpMenuButton(),
         }}
       >
         {({ navigation }) => <VerifyPromptScreen onContinue={() => navigation.navigate(BCSCScreens.AccountSetup)} />}
@@ -139,11 +133,6 @@ const VerifyStack = () => {
         options={{
           header: createProgressHeader(1, 10),
           headerLeft: createVerifySettingsHeaderButton(),
-          headerRight: createFloatingHelpMenuButton({
-            webViewScreen: BCSCScreens.VerifyWebView,
-            learnMoreUrl: HelpCentreUrl.HOW_TO_SETUP,
-            showRestartVerification: true,
-          }),
         }}
       />
       <Stack.Screen
@@ -213,24 +202,12 @@ const VerifyStack = () => {
         options={{
           header: createProgressHeader(5, 20),
           headerLeft: createVerifySettingsHeaderButton(),
-          headerRight: createFloatingHelpMenuButton({
-            webViewScreen: BCSCScreens.VerifyWebView,
-            learnMoreUrl: HelpCentreUrl.VERIFICATION_METHODS,
-            showRestartVerification: true,
-          }),
         }}
       />
       <Stack.Screen
         name={BCSCScreens.VerifyInPerson}
         component={VerifyInPersonScreen}
-        options={{
-          header: createProgressHeader(5, 70),
-          headerRight: createFloatingHelpMenuButton({
-            webViewScreen: BCSCScreens.VerifyWebView,
-            learnMoreUrl: HelpCentreUrl.VERIFY_IN_PERSON,
-            showRestartVerification: true,
-          }),
-        }}
+        options={{ header: createProgressHeader(5, 70) }}
       />
       <Stack.Screen
         name={BCSCScreens.PhotoInstructions}
@@ -281,24 +258,12 @@ const VerifyStack = () => {
         options={{
           header: createProgressHeader(2, 30),
           headerLeft: createVerifySettingsHeaderButton(),
-          headerRight: createFloatingHelpMenuButton({
-            webViewScreen: BCSCScreens.VerifyWebView,
-            learnMoreUrl: HelpCentreUrl.ACCEPTED_IDENTITY_DOCUMENTS,
-            showRestartVerification: true,
-          }),
         }}
       />
       <Stack.Screen
         name={BCSCScreens.DualIdentificationRequired}
         component={DualIdentificationRequiredScreen}
-        options={{
-          header: createProgressHeader(2, 30),
-          headerRight: createFloatingHelpMenuButton({
-            webViewScreen: BCSCScreens.VerifyWebView,
-            learnMoreUrl: HelpCentreUrl.ACCEPTED_IDENTITY_DOCUMENTS,
-            showRestartVerification: true,
-          }),
-        }}
+        options={{ header: createProgressHeader(2, 30) }}
       />
       <Stack.Screen
         name={BCSCScreens.IDPhotoInformation}

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -240,6 +240,7 @@ const translation = {
       "LearnMore": "Learn more",
       "GiveFeedback": "Give feedback",
       "ReportProblem": "Report a problem",
+      "BackToHome": "Back to home",
       "RestartVerification": "Restart verification process",
     },
     "ReportProblem": {

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -230,6 +230,7 @@ const translation = {
       "LearnMore": "Learn about BCSC app (FR)",
       "GiveFeedback": "Give feedback (FR)",
       "ReportProblem": "Report a problem (FR)",
+      "BackToHome": "Back to home (FR)",
       "RestartVerification": "Restart verification process (FR)",
     },
     "ReportProblem": {

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -230,6 +230,7 @@ const translation = {
       "LearnMore": "Learn about BCSC app (PT-BR)",
       "GiveFeedback": "Give feedback (PT-BR)",
       "ReportProblem": "Report a problem (PT-BR)",
+      "BackToHome": "Back to home (PT-BR)",
       "RestartVerification": "Restart verification process (PT-BR)",
     },
     "ReportProblem": {


### PR DESCRIPTION
# Summary of Changes

Adds a **Back to home** option to the verification flow's help menu so users can leave an in-progress verification and return to the home screen **without losing progress** — they can resume from the home "Start/Continue verification" notification. The verification menu is now its own variant with a vertical-ellipsis (⋮) "more options" trigger offering Report a problem / Back to home / Restart verification; every other stack keeps the question-mark (?) menu (Learn more / Give feedback / Report a problem) unchanged.

Leaving is handled by a new `useLeaveVerification` hook, which moves verification status out of `IN_PROGRESS` so the RootStack renders the main stack instead of the verify stack. Splitting the help menu into default vs. verify variants also moved the shared report-problem modal wiring into a `useReportProblem` hook used by both.

# Testing Instructions

1. Start identity verification so the verify stack is shown.
2. On a verification screen, open the **⋮** menu (top-right) and tap **Back to home**.
3. Confirm you land on Home with no lost data and a "Continue verification" notification appears.
4. Tap the notification and confirm verification resumes at the step you left off.
5. Reopen the ⋮ menu: confirm **Report a problem** still opens the report modal and **Restart verification** still works.
6. On a non-verify screen (e.g. Home/Settings help), confirm the trigger is still the **?** icon with Learn more / Give feedback / Report a problem.

# Acceptance Criteria

- [ ] Verification help trigger is the ⋮ icon; all other stacks keep the ? icon.
- [ ] Verify menu shows Report a problem, Back to home, and — once verification has started — Restart verification.
- [ ] Back to home exits to Home, preserves progress, and verification can be resumed from the home notification.
- [ ] Default menu (Learn more / Give feedback / Report a problem) and the report-problem modal are unchanged for other stacks.

# Screenshots, videos, or gifs

<img width="350" height="757" alt="image" src="https://github.com/user-attachments/assets/c7cff71d-564d-49ea-839d-2f659e78caea" />


# Related Issues

N/A
