### PR TITLE
fix: province selector color and spacing

### DIFF
--- a/app/src/bcsc-theme/components/DropdownWithValidation.tsx
+++ b/app/src/bcsc-theme/components/DropdownWithValidation.tsx
@@ -114,7 +114,10 @@ export const DropdownWithValidation = <T extends string | number>({
       borderBottomColor: ColorPalette.grayscale.lightGrey,
     },
     optionItemSelected: {
-      backgroundColor: ColorPalette.brand.secondaryBackground,
+      // primaryLight, not secondaryBackground: the latter is white in Light theme (== the modal's
+      // primaryBackground), so the selected/pressed highlight would be invisible. primaryLight is the
+      // app's highlighted-surface token and contrasts in both themes.
+      backgroundColor: ColorPalette.brand.primaryLight,
     },
     optionText: {
       fontSize: 16,

--- a/app/src/bcsc-theme/components/DropdownWithValidation.tsx
+++ b/app/src/bcsc-theme/components/DropdownWithValidation.tsx
@@ -2,7 +2,7 @@ import { testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FlatList, Modal, Pressable, StyleProp, StyleSheet, TextStyle, View } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
 import { PressableOpacity } from '@/components/PressableOpacity'
@@ -49,6 +49,10 @@ export const DropdownWithValidation = <T extends string | number>({
   errorProps,
 }: DropdownWithValidationProps<T>) => {
   const { Inputs, ColorPalette, Spacing } = useTheme()
+  // RN's <Modal> renders in a separate native window where react-native-safe-area-context's native
+  // <SafeAreaView> measures zero insets, so the header would collide with the status bar. The
+  // useSafeAreaInsets() context value does cross the modal boundary, so apply it as padding instead.
+  const insets = useSafeAreaInsets()
   const { t } = useTranslation()
   const [isOpen, setIsOpen] = useState(false)
 
@@ -93,7 +97,7 @@ export const DropdownWithValidation = <T extends string | number>({
     modalTitle: {
       fontSize: 18,
       fontWeight: '600',
-      color: ColorPalette.brand.secondary,
+      color: ColorPalette.brand.headerText,
       flex: 1,
       textAlign: 'center',
     },
@@ -114,7 +118,8 @@ export const DropdownWithValidation = <T extends string | number>({
     },
     optionText: {
       fontSize: 16,
-      color: ColorPalette.brand.secondary,
+      // No explicit color: ThemedText applies the theme foreground (dark on white in Light,
+      // light on dark-blue in Dark), which is legible on the modal's primaryBackground in both themes.
     },
     optionTextSelected: {
       fontWeight: '600',
@@ -199,7 +204,10 @@ export const DropdownWithValidation = <T extends string | number>({
       ) : null}
 
       <Modal visible={isOpen} transparent animationType="slide" onRequestClose={handleClose}>
-        <SafeAreaView style={styles.modalContent} testID={testIdWithKey(`${id}-modal-content`)}>
+        <View
+          style={[styles.modalContent, { paddingTop: insets.top, paddingBottom: insets.bottom }]}
+          testID={testIdWithKey(`${id}-modal-content`)}
+        >
           <View style={styles.modalHeader}>
             <View style={{ width: 32 }} />
             <ThemedText style={styles.modalTitle}>{subtext}</ThemedText>
@@ -211,7 +219,7 @@ export const DropdownWithValidation = <T extends string | number>({
               accessibilityRole="button"
               hitSlop={hitSlop}
             >
-              <Icon name="close" size={24} color={ColorPalette.brand.secondary} />
+              <Icon name="close" size={24} color={ColorPalette.brand.icon} />
             </PressableOpacity>
           </View>
           <FlatList
@@ -220,7 +228,7 @@ export const DropdownWithValidation = <T extends string | number>({
             keyExtractor={(item) => String(item.value)}
             accessibilityRole="menu"
           />
-        </SafeAreaView>
+        </View>
       </Modal>
     </View>
   )


### PR DESCRIPTION
# Summary of Changes

Fixes the BC Services Card Province picker (Residential Address screen). In Light theme the modal title, province rows, and close (×) icon were invisible — they used `brand.secondary`, which is white in both themes, on a white modal background. They now use foreground-resolving tokens (`ThemedText` default, `brand.headerText`, `brand.icon`) that are legible in both themes. Also fixes the modal header overlapping the status bar: `<SafeAreaView>` measures zero insets inside a RN `Modal`, so the modal now applies `useSafeAreaInsets()` as top/bottom padding instead.

# Testing Instructions

1. Run the BCSC build in **Light** theme.
2. Proceed through verification to the **Residential Address** screen.
3. Tap the **Province** dropdown.
4. Confirm the modal title, all province names, and the close (×) icon are legible, and the header sits **below** the status bar.
5. Switch to **Dark** theme and repeat — everything remains legible.

# Acceptance Criteria

- Province rows, modal title, and close icon are legible in both Light and Dark themes.
- Modal header clears the status bar/notch; bottom content clears the home indicator.
- Selected row keeps its highlight + checkmark.
- Existing `DropdownWithValidation` / `ResidentialAddressScreen` tests pass.

# Screenshots, videos, or gifs

<img width="350" height="757" alt="image" src="https://github.com/user-attachments/assets/612ec8f5-78d3-479e-bda4-0d0ac98dfd95" />


# Related Issues

N/A
