### PR TITLE
fix: proper error modal for residential screen

### DIFF
--- a/app/src/bcsc-theme/features/auth/AccountLandingScreen.tsx
+++ b/app/src/bcsc-theme/features/auth/AccountLandingScreen.tsx
@@ -63,7 +63,7 @@ const AccountLandingScreen = ({ navigation }: AccountLandingScreenProps) => {
           <BCSCLogo width={120} height={120} />
         </View>
         <ThemedText variant={'headingFour'} style={{ textAlign: 'center' }}>
-          {t('BCSC.AccountSetup.Title')}
+          {t('BCSC.Title')}
         </ThemedText>
       </ScreenWrapper>
     </>

--- a/app/src/bcsc-theme/features/auth/__snapshots__/AccountLandingScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/auth/__snapshots__/AccountLandingScreen.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`AccountLanding renders Unlock button 1`] = `
             ]
           }
         >
-          BCSC.AccountSetup.Title
+          BCSC.Title
         </Text>
       </View>
     </RCTScrollView>

--- a/app/src/bcsc-theme/features/verify/_models/useResidentialAddressModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/_models/useResidentialAddressModel.test.ts
@@ -3,9 +3,7 @@ import useResidentialAddressModel from '@/bcsc-theme/features/verify/_models/use
 import { isCanadianPostalCode } from '@/bcsc-theme/utils/address-utils'
 import { BCState } from '@/store'
 import * as Bifold from '@bifold/core'
-import { ToastType } from '@bifold/core'
 import { act, renderHook } from '@testing-library/react-native'
-import Toast from 'react-native-toast-message'
 
 jest.mock('@/bcsc-theme/api/hooks/useApi')
 jest.mock('@/bcsc-theme/utils/address-utils')
@@ -21,6 +19,14 @@ jest.mock('@bifold/core', () => {
     useTheme: jest.fn(),
   }
 })
+
+const mockEmitErrorModal = jest.fn()
+jest.mock('@/contexts/ErrorAlertContext', () => ({
+  useErrorAlert: jest.fn(() => ({
+    emitErrorModal: mockEmitErrorModal,
+    emitAlert: jest.fn(),
+  })),
+}))
 
 const mockUpdateUserMetadata = jest.fn().mockResolvedValue(undefined)
 const mockUpdateDeviceCodes = jest.fn().mockResolvedValue(undefined)
@@ -336,14 +342,6 @@ describe('useResidentialAddressModel', () => {
       })
       expect(mockUpdateVerificationOptions).toHaveBeenCalledWith(['video_call', 'back_check'])
 
-      expect(Toast.show).toHaveBeenCalledWith({
-        type: ToastType.Success,
-        text1: expect.any(String),
-        bottomOffset: 16,
-        autoHide: true,
-        visibilityTime: 1500,
-      })
-
       expect(mockNavigation.dispatch).toHaveBeenCalled()
       expect(mockUpdateCardProcess).toHaveBeenCalledWith('test-process')
     })
@@ -448,7 +446,7 @@ describe('useResidentialAddressModel', () => {
       expect(result.current.isSubmitting).toBe(false)
     })
 
-    it('should handle authorization error and show toast', async () => {
+    it('should handle authorization error and show error modal', async () => {
       const mockError = new Error('Authorization failed')
       mockAuthorizationApi.authorizeDeviceWithUnknownBCSC.mockRejectedValue(mockError)
 
@@ -471,12 +469,11 @@ describe('useResidentialAddressModel', () => {
         'ResidentialAddressScreen.handleSubmit -> device authorization failed',
         { error: mockError }
       )
-      expect(Toast.show).toHaveBeenCalledWith({
-        type: 'error',
-        text1: expect.any(String),
-        text2: expect.any(String),
-        position: 'bottom',
-      })
+      expect(mockEmitErrorModal).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({ cause: mockError })
+      )
       expect(result.current.isSubmitting).toBe(false)
     })
 

--- a/app/src/bcsc-theme/features/verify/_models/useResidentialAddressModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useResidentialAddressModel.tsx
@@ -4,14 +4,16 @@ import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { isCanadianPostalCode, ProvinceCode } from '@/bcsc-theme/utils/address-utils'
 import { getResumeStepRoute } from '@/bcsc-theme/utils/resume-step-route'
+import { useErrorAlert } from '@/contexts/ErrorAlertContext'
+import { ensureAppError } from '@/errors/errorHandler'
+import { AppEventCode } from '@/events/appEventCode'
 import { BCState, NonBCSCUserMetadata } from '@/store'
-import { ToastType, TOKENS, useServices, useStore, useTheme } from '@bifold/core'
+import { TOKENS, useServices, useStore } from '@bifold/core'
 import { CommonActions } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import moment from 'moment'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Toast from 'react-native-toast-message'
 
 export type ResidentialAddressFormState = {
   streetAddress: string
@@ -41,10 +43,10 @@ type useResidentialAddressModelProps = {
  */
 const useResidentialAddressModel = ({ navigation }: useResidentialAddressModelProps) => {
   const { t } = useTranslation()
-  const { Spacing } = useTheme()
   const [store] = useStore<BCState>()
   const { authorization } = useApi()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const { emitErrorModal } = useErrorAlert()
   const { updateCardProcess, updateUserMetadata, updateDeviceCodes, updateVerificationOptions } = useSecureActions()
 
   const [formState, setFormState] = useState<ResidentialAddressFormState>({
@@ -178,14 +180,6 @@ const useResidentialAddressModel = ({ navigation }: useResidentialAddressModelPr
         return
       }
 
-      Toast.show({
-        type: ToastType.Success,
-        text1: t('BCSC.Address.AddressSaved'),
-        bottomOffset: Spacing.lg,
-        autoHide: true,
-        visibilityTime: 1500,
-      })
-
       logger.info(`Updating deviceCode: ${deviceAuth.device_code}`)
 
       const expiresAt = new Date(Date.now() + deviceAuth.expires_in * 1000)
@@ -211,12 +205,11 @@ const useResidentialAddressModel = ({ navigation }: useResidentialAddressModelPr
       navigation.dispatch(CommonActions.reset({ index: 0, routes: [getResumeStepRoute(predictedStore)] }))
     } catch (error) {
       logger.error('ResidentialAddressScreen.handleSubmit -> device authorization failed', { error })
-      Toast.show({
-        type: 'error',
-        text1: t('BCSC.Address.AuthorizationErrorTitle'),
-        text2: t('BCSC.Address.AuthorizationErrorMessage'),
-        position: 'bottom',
-      })
+      emitErrorModal(
+        t('BCSC.Address.AuthorizationErrorTitle'),
+        t('BCSC.Address.AuthorizationErrorMessage'),
+        ensureAppError(error, AppEventCode.DEVICE_AUTHORIZATION_ERROR)
+      )
     } finally {
       setIsSubmitting(false)
     }
@@ -227,9 +220,9 @@ const useResidentialAddressModel = ({ navigation }: useResidentialAddressModelPr
     updateUserMetadata,
     navigation,
     logger,
+    emitErrorModal,
     t,
     authorization,
-    Spacing.lg,
     updateDeviceCodes,
     updateVerificationOptions,
     updateCardProcess,

--- a/app/src/bcsc-theme/navigators/AuthStack.tsx
+++ b/app/src/bcsc-theme/navigators/AuthStack.tsx
@@ -52,7 +52,7 @@ const AuthStack = (): React.ReactElement => {
         name={BCSCScreens.AccountLanding}
         component={AccountLanding}
         options={{
-          title: t('BCSC.Title'),
+          title: '',
           headerLeft: createAuthSettingsHeaderButton(),
         }}
       />


### PR DESCRIPTION
# Summary of Changes

This PR:
- uses a proper error modal instead of a toast on failure in the residential address screen
- fixes the unlock screen text as per UX recommendation

# Testing Instructions

Put a `throw new Error('Bahumbug')` on line 164 in useResidentialAddressModel.tsx
Go through non-BCSC flow
Confirm an error modal pops up on submit on res address screen

# Acceptance Criteria

Proper error modal

# Screenshots, videos, or gifs

<img width="284" height="614" alt="error" src="https://github.com/user-attachments/assets/37259e7b-5cc3-409b-99b3-64efe07f0b42" />

# Related Issues

#4090 