### PR TITLE
fix: contact details buttons

### DIFF
--- a/app/src/bcsc-theme/features/contacts/ContactDetailsScreen.tsx
+++ b/app/src/bcsc-theme/features/contacts/ContactDetailsScreen.tsx
@@ -121,14 +121,6 @@ const ContactDetailsScreen = ({ navigation, route }: ContactDetailsScreenProps) 
     navigation.navigate(BCSCScreens.EditContactName, { connectionId })
   }, [navigation, connectionId])
 
-  const onViewHistory = useCallback(() => {
-    const blob = JSON.stringify(connection?.toJSON?.() ?? connection ?? {}, null, 2)
-    navigation.navigate(BCSCScreens.ContactJSONDetails, {
-      jsonBlob: blob,
-      title: t('BCSC.Contacts.Details.ViewHistory'),
-    })
-  }, [connection, navigation, t])
-
   const onViewJSON = useCallback(() => {
     const blob = JSON.stringify(connection?.toJSON?.() ?? connection ?? {}, null, 2)
     navigation.navigate(BCSCScreens.ContactJSONDetails, { jsonBlob: blob })
@@ -181,24 +173,17 @@ const ContactDetailsScreen = ({ navigation, route }: ContactDetailsScreenProps) 
           cardStyle={styles.actionCard}
           labelStyle={styles.actionLabel}
         />
-        <ActionCard
-          icon="history"
-          label={t('BCSC.Contacts.Details.ViewHistory')}
-          onPress={onViewHistory}
-          testID={testIdWithKey('ViewHistory')}
-          iconColor={ColorPalette.brand.primary}
-          cardStyle={styles.actionCard}
-          labelStyle={styles.actionLabel}
-        />
-        <ActionCard
-          icon="code-braces"
-          label={t('BCSC.Contacts.Details.ViewJSON')}
-          onPress={onViewJSON}
-          testID={testIdWithKey('ViewJSON')}
-          iconColor={ColorPalette.brand.primary}
-          cardStyle={styles.actionCard}
-          labelStyle={styles.actionLabel}
-        />
+        {store.preferences.developerModeEnabled ? (
+          <ActionCard
+            icon="code-braces"
+            label={t('BCSC.Contacts.Details.ViewJSON')}
+            onPress={onViewJSON}
+            testID={testIdWithKey('ViewJSON')}
+            iconColor={ColorPalette.brand.primary}
+            cardStyle={styles.actionCard}
+            labelStyle={styles.actionLabel}
+          />
+        ) : null}
       </View>
 
       <Pressable

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -282,7 +282,6 @@ const translation = {
         "PinContact": "Pin contact",
         "UnpinContact": "Unpin contact",
         "EditName": "Edit Contact Name",
-        "ViewHistory": "View history",
         "ViewJSON": "View JSON details",
         "RemoveContact": "Remove Contact",
       },

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -272,7 +272,6 @@ const translation = {
         "PinContact": "Pin contact (FR)",
         "UnpinContact": "Unpin contact (FR)",
         "EditName": "Edit Contact Name (FR)",
-        "ViewHistory": "View history (FR)",
         "ViewJSON": "View JSON details (FR)",
         "RemoveContact": "Remove Contact (FR)",
       },

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -272,7 +272,6 @@ const translation = {
         "PinContact": "Pin contact (PT-BR)",
         "UnpinContact": "Unpin contact (PT-BR)",
         "EditName": "Edit Contact Name (PT-BR)",
-        "ViewHistory": "View history (PT-BR)",
         "ViewJSON": "View JSON details (PT-BR)",
         "RemoveContact": "Remove Contact (PT-BR)",
       },


### PR DESCRIPTION
# Summary of Changes

The contact Details screen had two buttons that opened the same raw-JSON screen, with only the title differing. "View history" was misleading — there is no history view. Removed the "View history" button and gated the remaining "View JSON details" button behind Developer Mode so production users no longer see the dev-only JSON blob.

# Testing Instructions

1. Open any contact's Details screen with Developer Mode **off**: confirm there is no "View history" button and no "View JSON details" button (only Message, Pin, Edit Name, Remove).
2. Enable Developer Mode, reopen the Details screen, and confirm "View JSON details" now appears and opens the JSON screen.

# Acceptance Criteria

- "View history" button is removed from the contact Details screen.
- "View JSON details" is hidden unless Developer Mode is enabled.
- With Developer Mode on, "View JSON details" opens the JSON screen as before.
- Remaining actions (Message, Pin/Unpin, Edit Name, Remove) are unchanged.

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A
