### PR TITLE
ci: publish only the DEV build from release/v4.1.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -808,7 +808,8 @@ jobs:
           output_artifact_ref: ios-${{ matrix.variant }}
 
       - name: Ship to Apple App Store
-        if: github.ref_name == 'main'
+        # release/v4.1.0 publishes only the DEV (bcsc-dev) build — issue #3965
+        if: github.ref_name == 'main' || (github.ref_name == 'release/v4.1.0' && matrix.variant == 'bcsc-dev')
         uses: ./.github/workflows/actions/ship-to-itunes
         with:
           app_store_connect_issuer_id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
@@ -1029,7 +1030,8 @@ jobs:
           retention-days: 7
 
       - name: Ship to Google Play
-        if: github.ref_name == 'main'
+        # release/v4.1.0 publishes only the DEV (bcsc-dev) build — issue #3965
+        if: github.ref_name == 'main' || (github.ref_name == 'release/v4.1.0' && matrix.variant == 'bcsc-dev')
         # working-directory: app/android
         env:
           GOOGLE_API_CREDENTIALS_BASE64: ${{ secrets.GOOGLE_API_CREDENTIALS_BASE64 }}
@@ -1106,7 +1108,9 @@ jobs:
   # blocks the iOS build critical path.
   distribute-testflight:
     name: 'Distribute TestFlight - ${{ matrix.variant }}'
-    if: ${{ always() && !cancelled() && github.ref_name == 'main' }}
+    # Branch gate here (job-level if cannot read matrix); the bcsc-dev
+    # restriction for release/v4.1.0 lives on the inner steps below — issue #3965
+    if: ${{ always() && !cancelled() && (github.ref_name == 'main' || github.ref_name == 'release/v4.1.0') }}
     needs: [build-ios, compute-variants]
     runs-on: ubuntu-22.04
     permissions:
@@ -1125,16 +1129,16 @@ jobs:
           path: ${{ runner.temp }}/probe
 
       - uses: actions/checkout@v6
-        if: steps.probe.outcome == 'success'
+        if: steps.probe.outcome == 'success' && (github.ref_name == 'main' || matrix.variant == 'bcsc-dev')
 
       - name: Load variant config
-        if: steps.probe.outcome == 'success'
+        if: steps.probe.outcome == 'success' && (github.ref_name == 'main' || matrix.variant == 'bcsc-dev')
         uses: ./.github/workflows/actions/load-variant-config
         with:
           variant: ${{ matrix.variant }}
 
       - name: Distribute to TestFlight
-        if: steps.probe.outcome == 'success'
+        if: steps.probe.outcome == 'success' && (github.ref_name == 'main' || matrix.variant == 'bcsc-dev')
         uses: ./.github/workflows/actions/distribute-testflight
         with:
           app_store_connect_issuer_id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}


### PR DESCRIPTION
## Summary

First increment of #3965. Enables app-store publishing on the `release/v4.1.0` branch, but restricts it to the **DEV build (`bcsc-dev`) only**. Every other variant continues to build without publishing, and `main` behaviour is unchanged (all variants still publish as before).

The `bcsc-dev` build reuses its existing channels — no group/track changes:
- **iOS/TestFlight:** `IDIM testers for DEV env`
- **Android/Google Play:** `internal` track ("Internal Testing")

## Changes (`.github/workflows/main.yaml`)

Publish was previously gated on `github.ref_name == 'main'` in three places; each now also allows `release/v4.1.0` for `bcsc-dev`:

- `build-ios` → **Ship to Apple App Store**
- `build-android` → **Ship to Google Play**
- **distribute-testflight** job — branch gate at job level (job-level `if` can't read `matrix`), with the `bcsc-dev` restriction on its inner steps (`checkout`, `Load variant config`, `Distribute to TestFlight`)

| Ref | bcsc-dev | bcwallet-prod | bcsc-qa/test/prod |
|-----|----------|---------------|-------------------|
| `main` | publish (unchanged) | publish (unchanged) | publish (unchanged) |
| `release/v4.1.0` | **publish** → TF `IDIM testers for DEV env` + Play `internal` | build only, no publish | not in matrix |
| PRs / other | build only | build only | not in matrix |

## Verification

- YAML parses clean; `if:` expressions valid GHA (step-level sees `matrix`; job-level does not — handled).
- Live check: `workflow_dispatch` on `release/v4.1.0` → expect `bcsc-dev` to ship both platforms and `bcwallet-prod` ship/distribute steps to show **skipped**.

## Out of scope (later steps of #3965)

- Creating/wiring the `v4.1.0 - QA` and `v4.1.0 - RC` groups/tracks.
- Trimming `bcwallet-prod` from the `release/*` build matrix.
- Manual-vs-auto track promotion.

Refs #3965