### PR TITLE
chore: back-port remaining main fixes into release/v4.1.0

### DIFF
--- a/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
@@ -21,6 +21,7 @@ import {
   noTokensReturnedErrorPolicy,
   pairingCodeErrorPolicy,
   unexpectedServerErrorPolicy,
+  unsupportedOsOnAssertionErrorPolicy,
   updateRequiredErrorPolicy,
   verificationSessionExpiredErrorPolicy,
   verifyDeviceAssertionErrorPolicy,
@@ -132,22 +133,90 @@ describe('clientErrorPolicies', () => {
         expect(mockAlert).toHaveBeenCalledWith(error)
       })
 
-      it('should show dynamic registration alert when technicalMessage indicates unsupported os', () => {
+      it('should show the unsupported OS alert (basic, no report) when technicalMessage indicates unsupported os', () => {
         const error = newError('invalid_client_metadata')
         error.cause = new Error('unsupported os version') as AxiosError
         const mockAlert = jest.fn()
-        const context = { alerts: { dynamicRegistrationErrorAlert: mockAlert } }
+        const context = { alerts: { unsupportedOsAlert: mockAlert } }
         invalidClientMetadataErrorPolicy.handle(error, context as any)
-        expect(mockAlert).toHaveBeenCalledWith(error)
+        expect(mockAlert).toHaveBeenCalled()
       })
 
-      it('should match unsupported os check case-insensitively', () => {
+      it('should match the unsupported os check case-insensitively', () => {
         const error = newError('invalid_client_metadata')
         error.cause = new Error('Client registration failed: Unsupported OS Version detected') as AxiosError
         const mockAlert = jest.fn()
-        const context = { alerts: { dynamicRegistrationErrorAlert: mockAlert } }
+        const context = { alerts: { unsupportedOsAlert: mockAlert } }
         invalidClientMetadataErrorPolicy.handle(error, context as any)
-        expect(mockAlert).toHaveBeenCalledWith(error)
+        expect(mockAlert).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('unsupportedOsOnAssertionErrorPolicy', () => {
+    const assertionContext = {
+      endpoint: '/api/cardTap/v3/mobile/assertion',
+      statusCode: 401,
+      apiEndpoints: { cardTap: '/api/cardTap' },
+    }
+
+    // Build an ERR_210_UNAUTHORIZED error whose raw response body carries (or omits) the errorMessage marker.
+    const unauthorizedWithErrorMessage = (errorMessage?: unknown): AxiosAppError => {
+      const error = newError('err_210_unauthorized')
+      error.cause = { response: { data: errorMessage === undefined ? {} : { errorMessage } } } as AxiosError
+      return error
+    }
+
+    describe('matches', () => {
+      it('should match a 401 on the assertion endpoint whose errorMessage indicates unsupported OS', () => {
+        const error = unauthorizedWithErrorMessage('unsupported OS')
+        expect(unsupportedOsOnAssertionErrorPolicy.matches(error, assertionContext as any)).toBeTruthy()
+      })
+
+      it('should match case-insensitively', () => {
+        const error = unauthorizedWithErrorMessage('Unsupported OS version detected')
+        expect(unsupportedOsOnAssertionErrorPolicy.matches(error, assertionContext as any)).toBeTruthy()
+      })
+
+      it('should NOT match a genuine 401 with no errorMessage marker', () => {
+        const error = unauthorizedWithErrorMessage()
+        expect(unsupportedOsOnAssertionErrorPolicy.matches(error, assertionContext as any)).toBeFalsy()
+      })
+
+      it('should NOT match the marker on a different endpoint', () => {
+        const error = unauthorizedWithErrorMessage('unsupported OS')
+        const context = { endpoint: '/api/other-endpoint', statusCode: 401, apiEndpoints: { cardTap: '/api/cardTap' } }
+        expect(unsupportedOsOnAssertionErrorPolicy.matches(error, context as any)).toBeFalsy()
+      })
+
+      it('should NOT match a non-401 error even with the marker present', () => {
+        const error = newError('invalid_pairing_code')
+        error.cause = { response: { data: { errorMessage: 'unsupported OS' } } } as AxiosError
+        expect(unsupportedOsOnAssertionErrorPolicy.matches(error, assertionContext as any)).toBeFalsy()
+      })
+    })
+
+    describe('handle', () => {
+      it('should show the unsupported OS alert', () => {
+        const error = unauthorizedWithErrorMessage('unsupported OS')
+        const mockAlert = jest.fn()
+        const context = { alerts: { unsupportedOsAlert: mockAlert }, logger: { info: jest.fn() } }
+        unsupportedOsOnAssertionErrorPolicy.handle(error, context as any)
+        expect(mockAlert).toHaveBeenCalled()
+      })
+    })
+
+    describe('ClientErrorHandlingPolicies find', () => {
+      it('should resolve to unsupportedOsOnAssertionErrorPolicy (before iasErrorPolicy) for an unsupported-OS 401', () => {
+        const error = unauthorizedWithErrorMessage('unsupported OS')
+        const policy = ClientErrorHandlingPolicies.find((p) => p.matches(error, assertionContext as any))
+        expect(policy).toBe(unsupportedOsOnAssertionErrorPolicy)
+      })
+
+      it('should resolve to iasErrorPolicy for a genuine 401 with no marker (Report path preserved)', () => {
+        const error = unauthorizedWithErrorMessage()
+        const policy = ClientErrorHandlingPolicies.find((p) => p.matches(error, assertionContext as any))
+        expect(policy).toBe(iasErrorPolicy)
       })
     })
   })
@@ -825,13 +894,12 @@ describe('clientErrorPolicies', () => {
     })
 
     describe('handle', () => {
-      it('should call failedToRetrieveStringResourceAlert and mark error as handled', () => {
+      it('should call failedToRetrieveStringResourceAlert', () => {
         const error = newError('err_400_failed_to_retrieve_string_resource')
         const mockAlert = jest.fn()
         const context = { alerts: { failedToRetrieveStringResourceAlert: mockAlert } }
         failedToRetrieveStringResourceErrorPolicy.handle(error, context as any)
         expect(mockAlert).toHaveBeenCalled()
-        expect(error.handled).toBe(true)
       })
     })
   })
@@ -850,13 +918,12 @@ describe('clientErrorPolicies', () => {
     })
 
     describe('handle', () => {
-      it('should call invalidUrlAlert and mark error as handled', () => {
+      it('should call invalidUrlAlert', () => {
         const error = newError('err_500_invalid_url')
         const mockAlert = jest.fn()
         const context = { alerts: { invalidUrlAlert: mockAlert } }
         invalidUrlErrorPolicy.handle(error, context as any)
         expect(mockAlert).toHaveBeenCalled()
-        expect(error.handled).toBe(true)
       })
     })
   })
@@ -875,13 +942,12 @@ describe('clientErrorPolicies', () => {
     })
 
     describe('handle', () => {
-      it('should call invalidRegistrationRequestAlert and mark error as handled', () => {
+      it('should call invalidRegistrationRequestAlert', () => {
         const error = newError('err_501_invalid_registration_request')
         const mockAlert = jest.fn()
         const context = { alerts: { invalidRegistrationRequestAlert: mockAlert } }
         invalidRegistrationRequestErrorPolicy.handle(error, context as any)
         expect(mockAlert).toHaveBeenCalled()
-        expect(error.handled).toBe(true)
       })
     })
   })
@@ -1099,7 +1165,6 @@ describe('clientErrorPolicies', () => {
           }
           verifyDeviceAssertionErrorPolicy.handle(error, context as any)
           expect(mockAlert).toHaveBeenCalled()
-          expect(error.handled).toBe(true)
         })
 
         it('should emit the problem with account alert', () => {
@@ -1110,7 +1175,6 @@ describe('clientErrorPolicies', () => {
           }
           verifyDeviceAssertionErrorPolicy.handle(error, context as any)
           expect(mockAlert).toHaveBeenCalled()
-          expect(error.handled).toBe(true)
         })
 
         it('should emit the invalid pairing code alert', () => {
@@ -1121,7 +1185,6 @@ describe('clientErrorPolicies', () => {
           }
           verifyDeviceAssertionErrorPolicy.handle(error, context as any)
           expect(mockAlert).toHaveBeenCalled()
-          expect(error.handled).toBe(true)
         })
 
         it('should emit the login remembered pairing code code alert', () => {
@@ -1132,7 +1195,6 @@ describe('clientErrorPolicies', () => {
           }
           verifyDeviceAssertionErrorPolicy.handle(error, context as any)
           expect(mockAlert).toHaveBeenCalled()
-          expect(error.handled).toBe(true)
         })
 
         it('should emit the login remembered device invalid pairing code alert', () => {
@@ -1143,7 +1205,6 @@ describe('clientErrorPolicies', () => {
           }
           verifyDeviceAssertionErrorPolicy.handle(error, context as any)
           expect(mockAlert).toHaveBeenCalled()
-          expect(error.handled).toBe(true)
         })
       })
     })

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -13,6 +13,9 @@ import { ResumeStepRoute } from '../utils/resume-step-route'
 import { BCSCEndpoints } from './client'
 
 const UNSUPPORTED_OS_TECHNICAL_MESSAGE = 'unsupported os version'
+// Assertion-401 unsupported-OS marker lives in the response body's `errorMessage` field (V3 parity);
+// V3 matched the looser "unsupported os" substring (the server sends e.g. "unsupported OS").
+const ASSERTION_UNSUPPORTED_OS_MARKER = 'unsupported os'
 
 export type ErrorMatcherContext = {
   endpoint: string // current route name for context
@@ -129,8 +132,9 @@ export const invalidClientMetadataErrorPolicy: ErrorHandlingPolicy = {
     return error.appEvent === AppEventCode.INVALID_CLIENT_METADATA
   },
   handle: (error, context) => {
+    // Unsupported-OS rejection (issue #4091): show the basic alert (no "Report a Problem"), matching V3.
     if (error.technicalMessage?.toLowerCase().includes(UNSUPPORTED_OS_TECHNICAL_MESSAGE)) {
-      return context.alerts.dynamicRegistrationErrorAlert(error)
+      return context.alerts.unsupportedOsAlert()
     }
 
     context.alerts.invalidClientMetadataAlert(error)
@@ -355,6 +359,28 @@ export const birthdateLockoutErrorPolicy: ErrorHandlingPolicy = {
   },
 }
 
+// Error policy for unsupported-OS rejection on the pairing-code login (assertion) endpoint (issue #4091).
+// Mirrors V3: the assertion 401 carries the marker in the response body's `errorMessage` field, which the
+// V4 error pipeline does not surface into `technicalMessage` — so match it from the raw body. Show the basic
+// unsupported-OS alert (no "Report a Problem") instead of the generic "Something went wrong" modal. Genuine
+// auth failures carry no such marker and fall through to the normal unauthorized path.
+export const unsupportedOsOnAssertionErrorPolicy: ErrorHandlingPolicy = {
+  matches: (error, context) => {
+    const responseData = error.cause.response?.data as { errorMessage?: unknown } | undefined
+    const errorMessage = responseData?.errorMessage
+    return (
+      error.appEvent === AppEventCode.ERR_210_UNAUTHORIZED &&
+      context.endpoint === `${context.apiEndpoints.cardTap}/${VERIFY_DEVICE_ASSERTION_PATH}` &&
+      typeof errorMessage === 'string' &&
+      errorMessage.toLowerCase().includes(ASSERTION_UNSUPPORTED_OS_MARKER)
+    )
+  },
+  handle: (_error, context) => {
+    context.logger.info('[UnsupportedOsOnAssertionErrorPolicy] OS-unsupported 401 on assertion — showing basic alert')
+    context.alerts.unsupportedOsAlert()
+  },
+}
+
 // Error policy for verify device assertion endpoint errors
 export const verifyDeviceAssertionErrorPolicy: ErrorHandlingPolicy = {
   matches: (error, context) => {
@@ -372,7 +398,6 @@ export const verifyDeviceAssertionErrorPolicy: ErrorHandlingPolicy = {
     }
 
     alert(error)
-    error.handled = true
   },
 }
 
@@ -456,9 +481,8 @@ export const failedToRetrieveStringResourceErrorPolicy: ErrorHandlingPolicy = {
   matches: (error) => {
     return error.appEvent === AppEventCode.ERR_400_FAILED_TO_RETRIEVE_STRING_RESOURCE
   },
-  handle: (error, context) => {
+  handle: (_error, context) => {
     context.alerts.failedToRetrieveStringResourceAlert()
-    error.handled = true
   },
 }
 
@@ -469,7 +493,6 @@ export const invalidUrlErrorPolicy: ErrorHandlingPolicy = {
   },
   handle: (error, context) => {
     context.alerts.invalidUrlAlert(error)
-    error.handled = true
   },
 }
 
@@ -480,7 +503,6 @@ export const invalidRegistrationRequestErrorPolicy: ErrorHandlingPolicy = {
   },
   handle: (error, context) => {
     context.alerts.invalidRegistrationRequestAlert(error)
-    error.handled = true
   },
 }
 
@@ -497,6 +519,7 @@ export const ClientErrorHandlingPolicies: ErrorHandlingPolicy[] = [
   noTokensReturnedErrorPolicy,
   updateRequiredErrorPolicy,
   verifyNotCompletedErrorPolicy,
+  unsupportedOsOnAssertionErrorPolicy,
   verifyDeviceAssertionErrorPolicy,
   expiredAppSetupErrorPolicy,
   loginRejectedOnClientMetadataErrorPolicy,

--- a/app/src/bcsc-theme/features/pairing/PairingService.ts
+++ b/app/src/bcsc-theme/features/pairing/PairingService.ts
@@ -1,6 +1,12 @@
 import { AbstractBifoldLogger } from '@bifold/core'
 import { BCSCScreens } from '../../types/navigators'
-import { PairingNavigationEvent, PairingNavigationListener, PairingPayload, PendingPairingListener } from './types'
+import {
+  PairingNavigationEvent,
+  PairingNavigationListener,
+  PairingPayload,
+  PendingPairingListener,
+  pairingPayloadToServiceLoginParams,
+} from './types'
 
 /**
  * Central service for handling pairing requests from any source.
@@ -110,11 +116,7 @@ export class PairingService {
   private emitNavigation(payload: PairingPayload) {
     const event: PairingNavigationEvent = {
       screen: BCSCScreens.ServiceLogin,
-      params: {
-        serviceTitle: payload.serviceTitle,
-        pairingCode: payload.pairingCode,
-        fromAppSwitch: payload.source === 'deep-link',
-      },
+      params: pairingPayloadToServiceLoginParams(payload),
     }
     this.navigationListeners.forEach((listener) => listener(event))
   }

--- a/app/src/bcsc-theme/features/pairing/index.ts
+++ b/app/src/bcsc-theme/features/pairing/index.ts
@@ -1,4 +1,5 @@
 export { PairingService } from './PairingService'
 export { PairingServiceProvider, usePairingService } from './PairingServiceContext'
+export { pairingPayloadToServiceLoginParams } from './types'
 export type { PairingNavigationEvent, PairingNavigationListener, PairingPayload, PendingPairingListener } from './types'
 export { usePendingPairing } from './usePendingPairing'

--- a/app/src/bcsc-theme/features/pairing/types.ts
+++ b/app/src/bcsc-theme/features/pairing/types.ts
@@ -26,3 +26,14 @@ export type PairingNavigationEvent = {
 
 export type PairingNavigationListener = (event: PairingNavigationEvent) => void
 export type PendingPairingListener = (hasPending: boolean) => void
+
+/**
+ * Converts a PairingPayload to the parameters required for service login
+ * @param payload The pairing payload to convert
+ * @returns PairingNavigationEvent['params'] containing serviceTitle, pairingCode, and optional fromAppSwitch
+ */
+export const pairingPayloadToServiceLoginParams = (payload: PairingPayload): PairingNavigationEvent['params'] => ({
+  serviceTitle: payload.serviceTitle,
+  pairingCode: payload.pairingCode,
+  fromAppSwitch: payload.source === 'deep-link',
+})

--- a/app/src/bcsc-theme/navigators/MainStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.test.tsx
@@ -1,0 +1,231 @@
+import { isAccountExpired } from '@/services/system-checks/AccountExpiryWarningBannerSystemCheck'
+import * as Bifold from '@bifold/core'
+import { useNavigation } from '@react-navigation/native'
+import { render } from '@testing-library/react-native'
+import React from 'react'
+import * as PairingModule from '../features/pairing'
+import { PairingNavigationListener, PairingPayload } from '../features/pairing/types'
+import { BCSCScreens } from '../types/navigators'
+import MainStack from './MainStack'
+
+let capturedNavigationListener: PairingNavigationListener | undefined
+
+const mockUnsubscribe = jest.fn()
+const mockOnNavigationRequest = jest.fn((listener: PairingNavigationListener) => {
+  capturedNavigationListener = listener
+  return mockUnsubscribe
+})
+const mockConsumePendingPairing = jest.fn((): PairingPayload | null => null)
+const mockLogger = { error: jest.fn() }
+
+const makePairingService = () => ({
+  consumePendingPairing: mockConsumePendingPairing,
+  onNavigationRequest: mockOnNavigationRequest,
+})
+
+jest.mock('@bifold/core')
+jest.mock('@react-navigation/native')
+jest.mock('@react-navigation/stack', () => {
+  const Screen = ({ children }: any) => children
+  Screen.displayName = 'Screen'
+  const Navigator = ({ children }: any) => children
+  Navigator.displayName = 'Navigator'
+  return {
+    createStackNavigator: () => ({
+      Navigator,
+      Screen,
+    }),
+  }
+})
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+jest.mock('@/constants', () => ({
+  DEFAULT_HEADER_TITLE_CONTAINER_STYLE: {},
+  HelpCentreUrl: { COMPUTER_LOGIN: 'https://example.com' },
+}))
+jest.mock('@/services/system-checks/AccountExpiryWarningBannerSystemCheck', () => ({
+  isAccountExpired: jest.fn(),
+}))
+jest.mock('../contexts/BCSCStackContext', () => ({
+  useBCSCStack: jest.fn(),
+}))
+jest.mock('../contexts/BCSCAccountContext', () => ({
+  useAccount: jest.fn(),
+}))
+jest.mock('../hooks/useSystemChecks', () => ({
+  SystemCheckScope: { MAIN_STACK: 'MAIN_STACK' },
+  useSystemChecks: jest.fn(),
+}))
+jest.mock('../features/pairing', () => ({
+  usePairingService: jest.fn(),
+  pairingPayloadToServiceLoginParams: jest.fn(),
+}))
+jest.mock('../components/HeaderBackButton', () => ({
+  createHeaderBackButton: jest.fn(() => null),
+}))
+jest.mock('../components/HeaderWithBanner', () => ({
+  createHeaderWithoutBanner: jest.fn(() => null),
+}))
+jest.mock('../components/HelpHeaderButton', () => ({
+  createMainHelpHeaderButton: jest.fn(() => () => null),
+}))
+jest.mock('./stack-utils', () => ({
+  getDefaultModalOptions: jest.fn(() => ({})),
+}))
+jest.mock('./TabStack', () => 'BCSCTabStack')
+jest.mock('../../screens/Developer', () => 'Developer')
+jest.mock('../features/account-transfer/transferer/TransferQRDisplayScreen', () => 'TransferQRDisplayScreen')
+jest.mock('../features/account-transfer/transferer/TransferQRInformationScreen', () => 'TransferQRInformationScreen')
+jest.mock('../features/account-transfer/transferer/TransferSuccessScreen', () => 'TransferSuccessScreen')
+jest.mock('../features/account/AccountExpiredScreen', () => ({ AccountExpiredScreen: 'AccountExpiredScreen' }))
+jest.mock('../features/account/AccountRenewalFinalWarningScreen', () => ({
+  AccountRenewalFinalWarningScreen: 'AccountRenewalFinalWarningScreen',
+}))
+jest.mock('../features/account/AccountRenewalFirstWarningScreen', () => ({
+  AccountRenewalFirstWarningScreen: 'AccountRenewalFirstWarningScreen',
+}))
+jest.mock('../features/account/AccountRenewalInformationScreen', () => ({
+  AccountRenewalInformationScreen: 'AccountRenewalInformationScreen',
+}))
+jest.mock('../features/account/EditNicknameScreen', () => 'EditNicknameScreen')
+jest.mock('../features/account/RemoveAccountConfirmationScreen', () => ({
+  MainRemoveAccountConfirmationScreen: 'MainRemoveAccountConfirmationScreen',
+}))
+jest.mock('../features/account/TransferAgeRestrictionScreen', () => 'TransferAgeRestrictionScreen')
+jest.mock('../features/auth/MainChangePINScreen', () => ({ MainChangePINScreen: 'MainChangePINScreen' }))
+jest.mock('../features/auth/MainChangeSecurityScreen', () => ({
+  MainChangeSecurityScreen: 'MainChangeSecurityScreen',
+}))
+jest.mock('../features/modal/DeviceInvalidated', () => ({ DeviceInvalidated: 'DeviceInvalidated' }))
+jest.mock('../features/modal/InternetDisconnected', () => ({ InternetDisconnected: 'InternetDisconnected' }))
+jest.mock('../features/modal/MandatoryUpdate', () => ({ MandatoryUpdate: 'MandatoryUpdate' }))
+jest.mock('../features/modal/ServiceOutage', () => ({ ServiceOutage: 'ServiceOutage' }))
+jest.mock('../features/pairing/ManualPairing', () => 'ManualPairingCode')
+jest.mock('../features/pairing/PairingConfirmation', () => 'PairingConfirmation')
+jest.mock('../features/services/ServiceLoginScreen', () => ({ ServiceLoginScreen: 'ServiceLoginScreen' }))
+jest.mock('../features/settings/AutoLockScreen', () => ({ AutoLockScreen: 'AutoLockScreen' }))
+jest.mock('../features/settings/ContactUsScreen', () => ({ ContactUsScreen: 'ContactUsScreen' }))
+jest.mock('../features/settings/ForgetAllPairingsScreen', () => ({
+  ForgetAllPairingsScreen: 'ForgetAllPairingsScreen',
+}))
+jest.mock('../features/settings/MainPrivacyPolicyScreen', () => ({
+  MainPrivacyPolicyScreen: 'MainPrivacyPolicyScreen',
+}))
+jest.mock('../features/settings/MainSettingsScreen', () => ({ MainSettingsScreen: 'MainSettingsScreen' }))
+jest.mock('../features/webview/WebViewScreen', () => ({ WebViewScreen: 'WebViewScreen' }))
+
+describe('MainStack', () => {
+  let mockNavigation: { dispatch: (...args: any[]) => void; navigate: (...args: any[]) => void }
+
+  beforeEach(() => {
+    capturedNavigationListener = undefined
+    jest.clearAllMocks()
+    mockNavigation = useNavigation() as typeof mockNavigation
+    jest.mocked(Bifold.useDefaultStackOptions).mockReturnValue({} as any)
+    jest.mocked(Bifold.useTheme).mockReturnValue({} as any)
+    jest.mocked(Bifold.useTour).mockReturnValue({ currentStep: undefined } as any)
+    jest.mocked(Bifold.useServices).mockReturnValue([mockLogger] as any)
+    jest.mocked(Bifold.testIdWithKey).mockImplementation((key: string) => key)
+    jest.mocked(PairingModule.usePairingService).mockReturnValue(makePairingService() as any)
+    jest.mocked(PairingModule.pairingPayloadToServiceLoginParams).mockReturnValue({ pairingCode: 'code' } as any)
+    jest.requireMock('../contexts/BCSCAccountContext').useAccount.mockReturnValue({ account: null })
+    jest.mocked(isAccountExpired).mockReturnValue(false)
+  })
+
+  it('renders correctly', () => {
+    const { toJSON } = render(<MainStack />)
+    expect(toJSON()).toMatchSnapshot()
+  })
+
+  it('navigates to AccountExpired when account is expired', () => {
+    jest.requireMock('../contexts/BCSCAccountContext').useAccount.mockReturnValue({
+      account: { account_expiration_date: '2020-01-01' },
+    })
+    jest.mocked(isAccountExpired).mockReturnValue(true)
+
+    render(<MainStack />)
+
+    expect(mockNavigation.dispatch).toHaveBeenCalledWith({
+      type: 'RESET',
+      payload: { index: 0, routes: [{ name: BCSCScreens.AccountExpired }] },
+    })
+  })
+
+  it('does not navigate to AccountExpired when account is not expired', () => {
+    jest.requireMock('../contexts/BCSCAccountContext').useAccount.mockReturnValue({
+      account: { account_expiration_date: '2099-01-01' },
+    })
+    jest.mocked(isAccountExpired).mockReturnValue(false)
+
+    render(<MainStack />)
+
+    expect(mockNavigation.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('does not navigate to AccountExpired when there is no account', () => {
+    jest.requireMock('../contexts/BCSCAccountContext').useAccount.mockReturnValue({ account: null })
+
+    render(<MainStack />)
+
+    expect(mockNavigation.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('navigates to ServiceLogin when pairing service emits a navigation request', () => {
+    render(<MainStack />)
+
+    const params = { serviceTitle: 'My Service', pairingCode: 'abc123' }
+    capturedNavigationListener!({ screen: BCSCScreens.ServiceLogin, params })
+
+    expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.ServiceLogin, params)
+  })
+
+  it('does not navigate when pairing service emits a non-ServiceLogin screen', () => {
+    render(<MainStack />)
+    capturedNavigationListener!({ screen: 'SomeOtherScreen' as any, params: {} as any })
+
+    expect(mockNavigation.navigate).not.toHaveBeenCalled()
+  })
+
+  it('unsubscribes from pairing navigation requests on unmount', () => {
+    const { unmount } = render(<MainStack />)
+    unmount()
+
+    expect(mockUnsubscribe).toHaveBeenCalled()
+  })
+
+  it('calls pairingPayloadToServiceLoginParams when there is a valid pending pairing', () => {
+    const payload: PairingPayload = { serviceTitle: 'My Service', pairingCode: 'abc123', source: 'manual' }
+    mockConsumePendingPairing.mockReturnValue(payload)
+
+    render(<MainStack />)
+
+    expect(PairingModule.pairingPayloadToServiceLoginParams).toHaveBeenCalledWith(payload)
+  })
+
+  it('calls pairingPayloadToServiceLoginParams for a deep-link pending pairing (cold start)', () => {
+    const payload: PairingPayload = { serviceTitle: 'My Service', pairingCode: 'abc123', source: 'deep-link' }
+    mockConsumePendingPairing.mockReturnValue(payload)
+
+    render(<MainStack />)
+
+    expect(PairingModule.pairingPayloadToServiceLoginParams).toHaveBeenCalledWith(payload)
+  })
+
+  it('logs an error and skips pairingPayloadToServiceLoginParams when pending pairing is missing fields', () => {
+    mockConsumePendingPairing.mockReturnValue({ serviceTitle: null, pairingCode: null } as unknown as PairingPayload)
+
+    render(<MainStack />)
+
+    expect(mockLogger.error).toHaveBeenCalled()
+    expect(PairingModule.pairingPayloadToServiceLoginParams).not.toHaveBeenCalled()
+  })
+
+  it('does not call pairingPayloadToServiceLoginParams when there is no pending pairing', () => {
+    mockConsumePendingPairing.mockReturnValue(null)
+
+    render(<MainStack />)
+
+    expect(PairingModule.pairingPayloadToServiceLoginParams).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/bcsc-theme/navigators/MainStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.test.tsx
@@ -61,10 +61,25 @@ jest.mock('../features/pairing', () => ({
   usePairingService: jest.fn(),
   pairingPayloadToServiceLoginParams: jest.fn(),
 }))
+jest.mock('../features/connection-invitation', () => ({
+  useConnectionInvitationDeepLink: jest.fn(),
+}))
+jest.mock('../features/agent', () => ({
+  AgentReadyGate: ({ children }: any) => children,
+  BifoldScope: ({ children }: any) => children,
+  withAgentReadyGate: (Component: any) => Component,
+}))
+jest.mock('../hooks/useBCSCApiClient', () => ({
+  useBCSCApiClient: jest.fn(() => ({ endpoints: { accountDevices: 'https://example.com/devices' } })),
+}))
+jest.mock('../components/FloatingHelpMenuHeaderButton', () => ({
+  createFloatingHelpMenuButton: jest.fn(() => () => null),
+}))
 jest.mock('../components/HeaderBackButton', () => ({
   createHeaderBackButton: jest.fn(() => null),
 }))
 jest.mock('../components/HeaderWithBanner', () => ({
+  createHeaderWithBanner: jest.fn(() => () => null),
   createHeaderWithoutBanner: jest.fn(() => null),
 }))
 jest.mock('../components/HelpHeaderButton', () => ({
@@ -126,6 +141,7 @@ describe('MainStack', () => {
     jest.mocked(Bifold.useTheme).mockReturnValue({} as any)
     jest.mocked(Bifold.useTour).mockReturnValue({ currentStep: undefined } as any)
     jest.mocked(Bifold.useServices).mockReturnValue([mockLogger] as any)
+    jest.mocked(Bifold.useStore).mockReturnValue([{ bcsc: { bannerMessages: [] } }, jest.fn()] as any)
     jest.mocked(Bifold.testIdWithKey).mockImplementation((key: string) => key)
     jest.mocked(PairingModule.usePairingService).mockReturnValue(makePairingService() as any)
     jest.mocked(PairingModule.pairingPayloadToServiceLoginParams).mockReturnValue({ pairingCode: 'code' } as any)

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -51,7 +51,7 @@ import { InternetDisconnected } from '../features/modal/InternetDisconnected'
 import { MandatoryUpdate } from '../features/modal/MandatoryUpdate'
 import { ServiceOutage } from '../features/modal/ServiceOutage'
 import { TermsOfUseUpdated } from '../features/modal/TermsOfUseUpdated'
-import { usePairingService } from '../features/pairing'
+import { pairingPayloadToServiceLoginParams, usePairingService } from '../features/pairing'
 import ManualPairingCode from '../features/pairing/ManualPairing'
 import PairingConfirmation from '../features/pairing/PairingConfirmation'
 import ConnectionLoadingScreen from '../features/qr-core/ConnectionLoadingScreen'
@@ -116,10 +116,7 @@ const MainStack: React.FC = () => {
       return undefined
     }
 
-    return {
-      serviceTitle,
-      pairingCode,
-    }
+    return pairingPayloadToServiceLoginParams(pendingPairing)
   }, [logger, pendingPairing])
 
   const apiClient = useBCSCApiClient()

--- a/app/src/bcsc-theme/navigators/__snapshots__/MainStack.test.tsx.snap
+++ b/app/src/bcsc-theme/navigators/__snapshots__/MainStack.test.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MainStack renders correctly 1`] = `
+<View
+  importantForAccessibility="auto"
+  style={
+    {
+      "flex": 1,
+    }
+  }
+/>
+`;

--- a/app/src/hooks/useAlerts.test.tsx
+++ b/app/src/hooks/useAlerts.test.tsx
@@ -1475,6 +1475,28 @@ describe('useAlerts', () => {
       })
     })
 
+    describe('unsupportedOsAlert', () => {
+      it('should show a basic alert (no error modal) with the unsupported OS copy', () => {
+        const mockNavigation = { navigate: jest.fn(), dispatch: jest.fn() }
+        const mockEmitAlert = jest.fn()
+        const mockEmitErrorModal = jest.fn()
+        jest
+          .spyOn(ErrorAlertContext, 'useErrorAlert')
+          .mockReturnValue({ emitAlert: mockEmitAlert, emitErrorModal: mockEmitErrorModal } as any)
+
+        const { result } = renderHook(() => useAlerts(mockNavigation as any))
+
+        result.current.unsupportedOsAlert()
+
+        expect(mockEmitAlert).toHaveBeenCalledWith(
+          'Alerts.DynamicRegistrationError.Title',
+          'Alerts.DynamicRegistrationError.Description',
+          expect.objectContaining({ event: AppEventCode.ADD_CARD_DYNAMIC_REGISTRATION })
+        )
+        expect(mockEmitErrorModal).not.toHaveBeenCalled()
+      })
+    })
+
     describe('termsOfUseErrorAlert', () => {
       it('should show an alert with the correct title and message', () => {
         const mockNavigation = { navigate: jest.fn(), dispatch: jest.fn() }

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -366,6 +366,10 @@ export const useAlerts = (navigation: NavigationProp<any>) => {
       invalidClientMetadataAlert: _createBasicErrorModal(AppEventCode.INVALID_CLIENT_METADATA, 'SomethingWentWrong'),
       serverConfigurationAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_SERVER_CONFIGURATION, 'ProblemWithService', { errorCode: '201' }),
       dynamicRegistrationErrorAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_DYNAMIC_REGISTRATION, 'DynamicRegistrationError', { errorCode: '202' }),
+      // Unsupported-OS rejection (issue #4091): basic alert (OK only, no "Report a Problem"),
+      // matching V3. Reuses the DynamicRegistrationError "(error 202)" copy. Shared by the
+      // registration (2824) and pairing-login (2208) unsupported-OS paths — see clientErrorPolicies.ts.
+      unsupportedOsAlert: _createBasicAlert(AppEventCode.ADD_CARD_DYNAMIC_REGISTRATION, 'DynamicRegistrationError', { errorCode: '202' }),
       termsOfUseErrorAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_TERMS_OF_USE, 'ProblemWithService', { errorCode: '203' }),
       incorrectOsAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_INCORRECT_OS, 'DynamicRegistrationError', { errorCode: '204' }),
       addCardNotAvailableAlert: _createBasicErrorModal(AppEventCode.ADD_CARD_PROVIDER, 'AddCardNotAvailable'),


### PR DESCRIPTION
## Summary

Follow-up to #4124: back-ports the two fixes that landed on `main` after the previous sync point (#4087) into `release/v4.1.0`, as individual cherry-picks with attribution.

**Applied (2):**
- #4094 — fix: show basic alert for unsupported-OS rejections (#4091) — clean auto-merge, including `clientErrorPolicies.ts`
- #4099 — fix: added source check for cold start login — one conflict in `MainStack.tsx`, resolved

**Plus one reconciliation commit:** adapts #4099's new `MainStack.test.tsx` to v4.1's richer MainStack (mocks for `useStore` banner messages, `useBCSCApiClient`, `createHeaderWithBanner`, `useConnectionInvitationDeepLink`, agent gate components, floating help menu button).

## Conflict resolution (MainStack.tsx)

Same "v4.1 evolved past main" pattern as #4124:
- **Imports:** union — kept v4.1's `TermsOfUseUpdated`, took main's added `pairingPayloadToServiceLoginParams`.
- **Body:** kept v4.1's manage-devices / banner-header block that main doesn't have.
- #4099's actual fix (cold-start pairing routed through `pairingPayloadToServiceLoginParams`) landed intact via auto-merge.

## Test status

- `yarn typecheck` clean
- Full suite: **253/253 suites, 2354 passed, 0 failed** (153 snapshots pass)
- eslint + prettier clean on touched files
- No native or dependency changes (TS-only), so no lockfile/pod updates needed

## Notes

- After this, `release/v4.1.0` is fully caught up with `main` (tip `457a6eead`).
- Known inherited issues #4144 / #4145 are tracked for fixing on `main` and are unaffected by this PR.
