### PR TITLE
fix: disable e2e smoke tests pending v4.1 stack fixes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1215,16 +1215,24 @@ jobs:
   #       (e2e-nightly.yml) which checks for merges in the last 24h
   #       before running. This keeps SauceLabs devices free during the
   #       day when multiple PRs merge.
+  #
+  # DISABLED: smoke suite fails on every PR post v4.1 stack merge —
+  # the specs haven't been updated for the new root-stack/first-screen
+  # flow. Not a required status check, so this doesn't affect
+  # mergeability. Tracking: https://github.com/bcgov/bc-wallet-mobile/issues/4148
+  #
+  # To re-enable once the specs are fixed, restore:
+  #   if: >-
+  #     always() && !cancelled() &&
+  #     github.event_name == 'pull_request' &&
+  #     github.event.pull_request.head.repo.fork != true &&
+  #     !startsWith(github.base_ref, 'release/') &&
+  #     needs.early-exit-check.outputs.should_skip_build != 'true'
   e2e:
     needs: [ship-to-saucelabs, compute-variants, early-exit-check]
     permissions:
       contents: read
-    if: >-
-      always() && !cancelled() &&
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.fork != true &&
-      !startsWith(github.base_ref, 'release/') &&
-      needs.early-exit-check.outputs.should_skip_build != 'true'
+    if: false
     uses: ./.github/workflows/e2e.yml
     with:
       suite: smoke

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1147,17 +1147,8 @@ jobs:
 
   ship-to-saucelabs:
     name: 'Ship to SauceLabs - ${{ matrix.variant }} - ${{ matrix.platform }}'
-    # PR-triggered uploads are skipped while the `e2e` smoke job below is
-    # disabled (#4148) — it was the only PR-side consumer. Push-to-main
-    # uploads still run: e2e-nightly.yml's full-regression suite depends
-    # on them. Restore alongside the `e2e` job once #4148 lands.
-    if: >-
-      always() && !cancelled() &&
-      github.event_name != 'pull_request' &&
-      github.event.pull_request.head.repo.fork != true &&
-      !startsWith(github.base_ref, 'release/') &&
-      !startsWith(github.ref_name, 'release/') &&
-      needs.early-exit-check.outputs.should_skip_build != 'true'
+    # Temporarily disable until e2e fixed
+    if: false
     needs: [build-ios, build-android, compute-variants, early-exit-check]
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1147,8 +1147,13 @@ jobs:
 
   ship-to-saucelabs:
     name: 'Ship to SauceLabs - ${{ matrix.variant }} - ${{ matrix.platform }}'
+    # PR-triggered uploads are skipped while the `e2e` smoke job below is
+    # disabled (#4148) — it was the only PR-side consumer. Push-to-main
+    # uploads still run: e2e-nightly.yml's full-regression suite depends
+    # on them. Restore alongside the `e2e` job once #4148 lands.
     if: >-
       always() && !cancelled() &&
+      github.event_name != 'pull_request' &&
       github.event.pull_request.head.repo.fork != true &&
       !startsWith(github.base_ref, 'release/') &&
       !startsWith(github.ref_name, 'release/') &&


### PR DESCRIPTION
## Summary
- `e2e / smoke - iOS` and `e2e / smoke - Android` fail on every PR since `main` was re-pointed to the v4.1.0 release line (#4099) — the smoke spec targets the pre-v4.1 first-screen flow and can't find `AddAccount`.
- Disables the `e2e` job in `.github/workflows/main.yaml` (`if: false`) rather than deleting it, with the original trigger condition kept in a comment for easy restore.
- Confirmed via `main`'s ruleset that `e2e / smoke` is **not** a required status check, so this doesn't change mergeability — it just removes a permanently-red, uninformative check.

## Follow-up
Tracked in #4148 — fix the smoke (and verify happy-path/full-regression) specs for the v4.1 stack, then restore the `if:` condition.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/main.yaml'))"` — YAML still valid
- [ ] CI on this PR shows `e2e` skipped rather than failed