### PR TITLE
fix: e2e cidc and video call

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -22,8 +22,13 @@
 # the regression. If no viable run exists in the 24h window, the workflow
 # fails rather than testing stale artifacts.
 #
-# NOTE: Nightly schedule is disabled until SauceLabs IPs are whitelisted.
-# To re-enable, uncomment the schedule trigger below.
+# Runner egress allowlist: the in-person verification step runs the SiteMinder /
+# IDcheck approval flow in-process on the runner (e2e/scripts/login.mjs), so it
+# is the RUNNER's egress IP — not SauceLabs — that BC Gov SIT must allowlist. The
+# e2e job runs on the whitelisted `large` runner (the default `runner_label` in
+# e2e.yml), whose egress ranges (20.10.68.0/28, 130.131.47.80/28) are opened on
+# the ID Broker / IDcheck firewalls. Use the "Verify Allowlist Connectivity"
+# workflow to confirm reachability before relying on a scheduled run.
 name: E2E Nightly
 
 permissions:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,6 +39,11 @@ on:
         description: 'JSON array of {platform, device, os_version} objects'
         type: string
         required: true
+      runner_label:
+        description: 'Label of the large runner with whitelisted egress IPs'
+        type: string
+        required: false
+        default: 'large'
     secrets:
       SAUCE_USERNAME:
         required: true
@@ -69,6 +74,10 @@ on:
         description: 'JSON array of {platform, device, os_version} objects'
         type: string
         default: '[{"platform":"iOS","device":"iPhone.*","os_version":""},{"platform":"Android","device":"Google.*","os_version":""}]'
+      runner_label:
+        description: 'Label of the large runner with whitelisted egress IPs'
+        type: string
+        default: 'large'
 
 jobs:
   # ─── E2E Tests ─────────────────────────────────────────────────────
@@ -81,7 +90,7 @@ jobs:
   # do not gate the pipeline.
   e2e-tests:
     name: '${{ inputs.suite }} - ${{ matrix.device.platform }} ${{ matrix.device.os_version }}'
-    runs-on: ubuntu-latest-m
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: read
     timeout-minutes: 45

--- a/.github/workflows/verify-allowlist-connectivity.yml
+++ b/.github/workflows/verify-allowlist-connectivity.yml
@@ -31,8 +31,11 @@ jobs:
         run: |
           set -uo pipefail
           IP=""
+          # Force IPv4 (-4): the egress IP is compared against IPv4 allowlist
+          # ranges, and on a dual-stack runner these services may otherwise
+          # return the runner's IPv6 address.
           for SRC in https://api.ipify.org https://ifconfig.me https://icanhazip.com; do
-            IP=$(curl -fsS --max-time 10 "$SRC" 2>/dev/null | tr -d '[:space:]' || true)
+            IP=$(curl -4 -fsS --max-time 10 "$SRC" 2>/dev/null | tr -d '[:space:]' || true)
             if [[ -n "$IP" ]]; then
               echo "Egress IP (resolved via $SRC): $IP"
               break
@@ -47,10 +50,13 @@ jobs:
           # Verify the egress IP falls within the whitelisted ranges
           IN_RANGE="unknown"
           if [[ "$IP" != "unknown" ]]; then
-            if python3 - <<PY
-          import ipaddress, sys
+            # Pass IP via the environment and read it with os.environ; the quoted
+            # heredoc (<<'PY') stops the shell interpolating the externally
+            # resolved value into the Python source. Avoids code injection.
+            if CHECK_IP="$IP" python3 - <<'PY'
+          import ipaddress, os, sys
           try:
-              ip = ipaddress.ip_address("$IP")
+              ip = ipaddress.ip_address(os.environ["CHECK_IP"])
           except ValueError:
               sys.exit(2)
           ranges = ["20.10.68.0/28", "130.131.47.80/28"]
@@ -69,6 +75,14 @@ jobs:
       - name: Verify endpoint reachability
         id: verify
         shell: bash
+        env:
+          # Bind expression values to env vars so untrusted input — the
+          # workflow_dispatch runner_label and the externally-resolved egress
+          # IP — reaches the script as data rather than text spliced into it at
+          # expression-expansion time. Avoids shell injection.
+          RUNNER_LABEL: ${{ inputs.runner_label }}
+          EGRESS_IP: ${{ steps.egress.outputs.egress_ip }}
+          IN_RANGE: ${{ steps.egress.outputs.in_range }}
         run: |
           set -uo pipefail
 
@@ -87,9 +101,9 @@ jobs:
           {
             echo "## Allowlist Connectivity Verification"
             echo
-            echo "**Runner label:** \`${{ inputs.runner_label }}\`  "
-            echo "**Egress IP:** \`${{ steps.egress.outputs.egress_ip }}\`  "
-            echo "**In whitelisted range:** \`${{ steps.egress.outputs.in_range }}\`  "
+            echo "**Runner label:** \`${RUNNER_LABEL}\`  "
+            echo "**Egress IP:** \`${EGRESS_IP}\`  "
+            echo "**In whitelisted range:** \`${IN_RANGE}\`  "
             echo "**Expected ranges:** \`$EXPECTED_RANGES\`"
             echo
             echo "| Endpoint | DNS | TCP:443 | HTTPS | Result |"
@@ -106,7 +120,9 @@ jobs:
             echo "::group::Checking ${LABEL} (${URL})"
 
             # ---- DNS ---------------------------------------------------------
-            DNS_IPS=$(getent hosts "$HOST" 2>/dev/null | awk '{print $1}' | paste -sd',' -)
+            # IPv4-only (ahostsv4) so reported addresses match the IPv4 allowlist
+            # ranges; sort -u collapses ahostsv4's per-socktype duplicate rows.
+            DNS_IPS=$(getent ahostsv4 "$HOST" 2>/dev/null | awk '{print $1}' | sort -u | paste -sd',' -)
             if [[ -n "$DNS_IPS" ]]; then
               DNS_CELL="✅ ${DNS_IPS}"
               echo "DNS: $DNS_IPS"
@@ -116,7 +132,10 @@ jobs:
             fi
 
             # ---- TCP/443 -----------------------------------------------------
-            if timeout 5 bash -c "</dev/tcp/${HOST}/443" 2>/dev/null; then
+            # Connect to the resolved IPv4 (not the hostname) so the probe can't
+            # fall back to IPv6 on a dual-stack runner.
+            IPV4="${DNS_IPS%%,*}"
+            if timeout 5 bash -c "</dev/tcp/${IPV4:-$HOST}/443" 2>/dev/null; then
               TCP_CELL="✅"
               TCP_OK=1
               echo "TCP/443: open"
@@ -127,7 +146,7 @@ jobs:
             fi
 
             # ---- HTTPS -------------------------------------------------------
-            if HTTP_CODE=$(curl -sS -o /dev/null -w "%{http_code}" \
+            if HTTP_CODE=$(curl -4 -sS -o /dev/null -w "%{http_code}" \
               --max-time 15 --connect-timeout 10 \
               -A "bcgov-connectivity-check/1.0" \
               "$URL" 2>/dev/null); then

--- a/.github/workflows/verify-allowlist-connectivity.yml
+++ b/.github/workflows/verify-allowlist-connectivity.yml
@@ -1,0 +1,171 @@
+name: Verify Allowlist Connectivity
+
+# Manual-only workflow. Confirms the large runner has network reach to the
+# ID Broker / IDcheck endpoints whose firewalls have been opened for the
+# runner's egress IP ranges (20.10.68.0/28 and 130.131.47.80/28).
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner_label:
+        description: 'Label of the large runner with whitelisted egress IPs'
+        required: true
+        default: 'large'
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify connectivity to ID servers
+    runs-on: ${{ inputs.runner_label }}
+    timeout-minutes: 10
+
+    env:
+      EXPECTED_RANGES: '20.10.68.0/28, 130.131.47.80/28'
+
+    steps:
+      - name: Report runner egress IP
+        id: egress
+        shell: bash
+        run: |
+          set -uo pipefail
+          IP=""
+          for SRC in https://api.ipify.org https://ifconfig.me https://icanhazip.com; do
+            IP=$(curl -fsS --max-time 10 "$SRC" 2>/dev/null | tr -d '[:space:]' || true)
+            if [[ -n "$IP" ]]; then
+              echo "Egress IP (resolved via $SRC): $IP"
+              break
+            fi
+          done
+          if [[ -z "$IP" ]]; then
+            IP="unknown"
+            echo "::warning::Could not determine egress IP from any source"
+          fi
+          echo "egress_ip=$IP" >> "$GITHUB_OUTPUT"
+
+          # Verify the egress IP falls within the whitelisted ranges
+          IN_RANGE="unknown"
+          if [[ "$IP" != "unknown" ]]; then
+            if python3 - <<PY
+          import ipaddress, sys
+          try:
+              ip = ipaddress.ip_address("$IP")
+          except ValueError:
+              sys.exit(2)
+          ranges = ["20.10.68.0/28", "130.131.47.80/28"]
+          sys.exit(0 if any(ip in ipaddress.ip_network(r) for r in ranges) else 1)
+          PY
+            then
+              IN_RANGE="yes"
+              echo "Egress IP is within whitelisted ranges ✅"
+            else
+              IN_RANGE="no"
+              echo "::warning::Egress IP $IP is NOT within $EXPECTED_RANGES"
+            fi
+          fi
+          echo "in_range=$IN_RANGE" >> "$GITHUB_OUTPUT"
+
+      - name: Verify endpoint reachability
+        id: verify
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          # endpoint definitions: "label|host|path"
+          # Any HTTP response (2xx/3xx/4xx/5xx) proves reachability; only
+          # network-level failures (curl exit / code 000) count as a failure.
+          ENDPOINTS=(
+            "iddev /idcheck|iddev.gov.bc.ca|/idcheck"
+            "support.iddev|support.iddev.gov.bc.ca|/"
+            "idsit /idcheck|idsit.gov.bc.ca|/idcheck"
+            "support.idsit|support.idsit.gov.bc.ca|/"
+          )
+
+          OVERALL=0
+          SUMMARY="$RUNNER_TEMP/summary.md"
+          {
+            echo "## Allowlist Connectivity Verification"
+            echo
+            echo "**Runner label:** \`${{ inputs.runner_label }}\`  "
+            echo "**Egress IP:** \`${{ steps.egress.outputs.egress_ip }}\`  "
+            echo "**In whitelisted range:** \`${{ steps.egress.outputs.in_range }}\`  "
+            echo "**Expected ranges:** \`$EXPECTED_RANGES\`"
+            echo
+            echo "| Endpoint | DNS | TCP:443 | HTTPS | Result |"
+            echo "|---|---|---|---|---|"
+          } > "$SUMMARY"
+
+          for entry in "${ENDPOINTS[@]}"; do
+            LABEL="${entry%%|*}"
+            REST="${entry#*|}"
+            HOST="${REST%%|*}"
+            URL_PATH="${REST#*|}"
+            URL="https://${HOST}${URL_PATH}"
+
+            echo "::group::Checking ${LABEL} (${URL})"
+
+            # ---- DNS ---------------------------------------------------------
+            DNS_IPS=$(getent hosts "$HOST" 2>/dev/null | awk '{print $1}' | paste -sd',' -)
+            if [[ -n "$DNS_IPS" ]]; then
+              DNS_CELL="✅ ${DNS_IPS}"
+              echo "DNS: $DNS_IPS"
+            else
+              DNS_CELL="❌"
+              echo "::error::DNS resolution failed for $HOST"
+            fi
+
+            # ---- TCP/443 -----------------------------------------------------
+            if timeout 5 bash -c "</dev/tcp/${HOST}/443" 2>/dev/null; then
+              TCP_CELL="✅"
+              TCP_OK=1
+              echo "TCP/443: open"
+            else
+              TCP_CELL="❌"
+              TCP_OK=0
+              echo "::error::TCP/443 connection failed for $HOST"
+            fi
+
+            # ---- HTTPS -------------------------------------------------------
+            if HTTP_CODE=$(curl -sS -o /dev/null -w "%{http_code}" \
+              --max-time 15 --connect-timeout 10 \
+              -A "bcgov-connectivity-check/1.0" \
+              "$URL" 2>/dev/null); then
+              :
+            else
+              HTTP_CODE="000"
+            fi
+            if [[ "$HTTP_CODE" == "000" ]]; then
+              HTTPS_CELL="❌ no response"
+              HTTPS_OK=0
+            else
+              HTTPS_CELL="✅ HTTP ${HTTP_CODE}"
+              HTTPS_OK=1
+            fi
+            echo "HTTPS: $HTTPS_CELL"
+
+            # ---- Verdict -----------------------------------------------------
+            # Pass if we got either a TCP handshake or any HTTP response.
+            if [[ "$TCP_OK" -eq 1 || "$HTTPS_OK" -eq 1 ]]; then
+              RESULT="**PASS**"
+            else
+              RESULT="**FAIL**"
+              OVERALL=1
+            fi
+            echo "Result: $RESULT"
+            echo "::endgroup::"
+
+            echo "| \`${LABEL}\` | ${DNS_CELL} | ${TCP_CELL} | ${HTTPS_CELL} | ${RESULT} |" >> "$SUMMARY"
+          done
+
+          {
+            echo
+            if [[ "$OVERALL" -eq 0 ]]; then
+              echo "### ✅ Overall: all endpoints reachable"
+            else
+              echo "### ❌ Overall: one or more endpoints unreachable"
+            fi
+          } >> "$SUMMARY"
+
+          cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+          exit $OVERALL

--- a/e2e/src/testIDs.ts
+++ b/e2e/src/testIDs.ts
@@ -223,14 +223,6 @@ export const BCSC_TestIDs = {
   SuccessfullySent: {
     Ok: 'com.ariesbifold:id/Ok',
   },
-  BeforeYouCall: {
-    BeforeYouCallTitle: 'com.ariesbifold:id/BeforeYouCallTitle',
-    HoursOfServiceTitle: 'com.ariesbifold:id/HoursOfServiceTitle',
-    Continue: 'com.ariesbifold:id/Continue',
-    Assistance: 'com.ariesbifold:id/Assistance',
-    Help: 'com.ariesbifold:id/Help',
-    Back: 'com.ariesbifold:id/Back',
-  },
   StartCall: {
     Help: 'com.ariesbifold:id/Help',
   },

--- a/e2e/test/bcsc/verify/interaction-sweep/verify-video-detour.spec.ts
+++ b/e2e/test/bcsc/verify/interaction-sweep/verify-video-detour.spec.ts
@@ -1,60 +1,75 @@
 /**
- * Step 5 → VerificationMethodSelection.Help (WebView) and the VideoCall side
- * of the verification method picker: BeforeYouCall.Help, BeforeYouCall.Assistance.
- * Stops short of StartCall (which would dial out) and backs out to SetupSteps.
+ * VideoCall side of the verification method picker.
  *
- * The VideoReview recording detour (record / retake / play-pause) lives in
- * `verify/components/send-video-verification.spec.ts` because video capture
- * is unreliable on Sauce devices and is exercised only in the manual flow.
+ * Tapping "Video call" routes to one of two destinations depending on live-call
+ * availability (see `handlePressLiveCall` in
+ * app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.tsx):
+ *   - CallBusyOrClosed — when the video queue is empty, the current time is
+ *     outside service hours, or the service-hours API errors. The nightly hits
+ *     this branch because it runs at 00:00 PT (outside service hours).
+ *   - PhotoInstructions — when a live call is available (within service hours).
+ *
+ * This spec branches on whichever destination the app actually shows so it
+ * passes regardless of when it runs, and backs out to SetupSteps without dialing
+ * out (it never advances past the destination into StartCall/LiveCall).
  *
  * Pre: SetupSteps with Step 5 ready. Post: SetupSteps anchor.
  */
+import { Timeouts } from '../../../../src/constants.js'
+import { navigateBack } from '../../../../src/helpers/gestures.js'
 import { BaseScreen } from '../../../../src/screens/BaseScreen.js'
 import { BCSC_TestIDs } from '../../../../src/testIDs.js'
 
 const SetupSteps = new BaseScreen(BCSC_TestIDs.SetupSteps)
 const VerificationMethodSelection = new BaseScreen(BCSC_TestIDs.VerificationMethodSelection)
-const BeforeYouCall = new BaseScreen(BCSC_TestIDs.BeforeYouCall)
-const WebView = new BaseScreen(BCSC_TestIDs.WebView)
-const ContactUs = new BaseScreen(BCSC_TestIDs.ContactUs)
+const CallBusyOrClosed = new BaseScreen(BCSC_TestIDs.CallBusyOrClosed)
+const PhotoInstructions = new BaseScreen(BCSC_TestIDs.PhotoInstructions)
 
 describe('VerificationMethod + VideoCall detour', () => {
   it('enters Step 5 → VerificationMethodSelection', async () => {
     await SetupSteps.waitFor('Step5')
     await SetupSteps.tap('Step5')
-    await VerificationMethodSelection.waitFor('Help')
-  })
-
-  it('opens VerificationMethodSelection Help WebView and returns', async () => {
-    await VerificationMethodSelection.tap('Help')
-    await WebView.waitFor('Back')
-    await WebView.tap('Back')
     await VerificationMethodSelection.waitFor('VideoCall')
   })
 
-  it('enters BeforeYouCall via VideoCall', async () => {
+  it('routes Video call to the destination for the current service hours', async () => {
     await VerificationMethodSelection.tap('VideoCall')
-    await BeforeYouCall.waitFor('Help')
+
+    // The destination depends on real-time service hours / queue state, so wait
+    // for whichever screen the app renders rather than assuming one. The tap
+    // kicks off a service-hours API call before navigating, hence the longer
+    // transition timeout.
+    let onCallBusyOrClosed = false
+    await driver.waitUntil(
+      async () => {
+        onCallBusyOrClosed = await CallBusyOrClosed.isDisplayed('CallStatusTitle')
+        if (onCallBusyOrClosed) {
+          return true
+        }
+        return PhotoInstructions.isDisplayed('TakePhotoButton')
+      },
+      {
+        timeout: Timeouts.SCREEN_TRANSITION,
+        timeoutMsg: 'After tapping Video call, neither CallBusyOrClosed nor PhotoInstructions appeared',
+      }
+    )
+
+    if (onCallBusyOrClosed) {
+      // Outside service hours / no queue available — closed-or-busy screen.
+      await CallBusyOrClosed.waitFor('CallStatusTitle')
+    } else {
+      // Within service hours — live-call photo-instructions screen.
+      await PhotoInstructions.waitFor('TakePhotoButton')
+    }
   })
 
-  it('opens BeforeYouCall Help WebView and returns', async () => {
-    await BeforeYouCall.tap('Help')
-    await WebView.waitFor('Back')
-    await WebView.tap('Back')
-    await BeforeYouCall.waitFor('Assistance')
-  })
-
-  it('exercises BeforeYouCall.Assistance and returns', async () => {
-    await BeforeYouCall.tap('Assistance')
-    await ContactUs.waitFor('Back')
-    await ContactUs.tap('Back')
-    await BeforeYouCall.waitFor('Back')
-  })
-
-  it('backs out to SetupSteps without continuing the call', async () => {
-    await BeforeYouCall.tap('Back')
-    await VerificationMethodSelection.waitFor('Back')
-    await VerificationMethodSelection.tap('Back')
+  it('backs out to SetupSteps without dialing out', async () => {
+    // Neither destination exposes an in-app back control, and
+    // VerificationMethodSelection shows a settings menu in place of a back
+    // arrow, so pop each frame with the platform-native back affordance.
+    await navigateBack() // destination → VerificationMethodSelection
+    await VerificationMethodSelection.waitFor('VideoCall')
+    await navigateBack() // VerificationMethodSelection → SetupSteps
     await SetupSteps.waitFor('Step5')
   })
 })


### PR DESCRIPTION
# Summary of Changes

Two related e2e fixes:

- **Runner egress allowlist.** The in-person IDcheck approval flow runs in-process on the runner (`e2e/scripts/login.mjs`), so it's the runner's egress IP — not SauceLabs — that BC Gov SIT must allowlist. Move the e2e job off `ubuntu-latest-m` onto the whitelisted `large` runner via a new `runner_label` input (default `large`), and add a manual **Verify Allowlist Connectivity** workflow to confirm the runner's egress IP and reach to the ID Broker / IDcheck endpoints before relying on a scheduled run.
- **Video-call routing.** The old `BeforeYouCall` screen is gone; tapping "Video call" now routes to `CallBusyOrClosed` (outside service hours / empty queue) or `PhotoInstructions` (within hours). Rewrite `verify-video-detour.spec.ts` to branch on whichever destination the app renders so it passes at any time of day (the nightly runs at 00:00 PT), and remove the dead `BeforeYouCall` test IDs.

# Testing Instructions

1. Run the **Verify Allowlist Connectivity** workflow (`workflow_dispatch`, `runner_label=large`). Confirm the egress IP falls within `20.10.68.0/28, 130.131.47.80/28` and all endpoints report PASS.
2. Trigger the e2e workflow and confirm the job runs on the `large` runner.

# Acceptance Criteria

- [ ] e2e job runs on the `large` runner via `runner_label` (defaults to `large`).
- [ ] Verify Allowlist Connectivity workflow reports egress IP, in-range check, and per-endpoint reachability.

# Screenshots, videos, or gifs

N/A — CI and e2e test changes only.

# Related Issues

N/A
