### PR TITLE
refactor(bcsc): route native errors through the unified mapper

### DIFF
--- a/app/src/bcsc-theme/api/client.test.ts
+++ b/app/src/bcsc-theme/api/client.test.ts
@@ -8,7 +8,7 @@ import { initLanguages } from '@bifold/core'
 import { AxiosError } from 'axios'
 import { jwtDecode } from 'jwt-decode'
 import { DeviceEventEmitter } from 'react-native'
-import { getAccount, getToken, TokenType } from 'react-native-bcsc-core'
+import { getAccount, getRefreshTokenRequestBody, getToken, TokenType } from 'react-native-bcsc-core'
 
 jest.mock('jwt-decode', () => ({
   jwtDecode: jest.fn(),
@@ -228,6 +228,41 @@ describe('BCSC Client', () => {
         appEvent: AppEventCode.ERR_119_TOKEN_UNEXPECTEDLY_NULL,
       })
       expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('no refresh token in secure storage'))
+    })
+  })
+
+  describe('native error mapping', () => {
+    const nativeError = (code: string) => Object.assign(new Error(`native ${code}`), { code })
+
+    beforeEach(() => {
+      // Earlier suites replace the prototype `fetchTokens` via jest.spyOn without restoring it;
+      // restore so these tests exercise the real method (and its native-error `.catch`).
+      const proto = BCSCApiClient.prototype as any
+      if (jest.isMockFunction(proto.fetchTokens)) {
+        proto.fetchTokens.mockRestore()
+      }
+    })
+
+    it('maps a native getRefreshTokenRequestBody rejection during fetchTokens', async () => {
+      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const client = new BCSCApiClient('https://example.com', mockLogger as any)
+      ;(getAccount as jest.Mock).mockResolvedValueOnce({ clientID: 'c', issuer: 'https://issuer' })
+      ;(getRefreshTokenRequestBody as jest.Mock).mockRejectedValueOnce(nativeError('E_NO_KEYS_FOUND'))
+
+      await expect(client.getTokensForRefreshToken('refresh-token')).rejects.toMatchObject({
+        appEvent: AppEventCode.NO_SIGNING_KEYS,
+      })
+    })
+
+    it('maps a native getToken rejection during recoverTokens', async () => {
+      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const client = new BCSCApiClient('https://example.com', mockLogger as any)
+      client.tokens = undefined
+      ;(getToken as jest.Mock).mockRejectedValueOnce(nativeError('E_KEYSTORE_UNAVAILABLE'))
+
+      await expect(client.recoverTokens()).rejects.toMatchObject({
+        appEvent: AppEventCode.ERR_120_KEYCHAIN_UNAVAILABLE_ERROR,
+      })
     })
   })
 

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -1,3 +1,4 @@
+import { throwNativeBcscError } from '@/bcsc-theme/utils/native-error-map'
 import { AppError } from '@/errors/appError'
 import { ErrorRegistry } from '@/errors/errorRegistry'
 import { BCSCEventTypes } from '@/events/eventTypes'
@@ -334,7 +335,9 @@ class BCSCApiClient {
 
   private fetchTokens(refreshToken: string): Promise<TokenResponse> {
     return withAccount(async (account) => {
-      const tokenBody = await getRefreshTokenRequestBody(account.issuer, account.clientID, refreshToken)
+      const tokenBody = await getRefreshTokenRequestBody(account.issuer, account.clientID, refreshToken).catch(
+        (error) => throwNativeBcscError(error)
+      )
 
       const tokensResponse = await this.post<TokenResponse>(this.endpoints.token, tokenBody, {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -382,7 +385,7 @@ class BCSCApiClient {
       return this.tokens
     }
 
-    const storedRefreshToken = (await getToken(TokenType.Refresh))?.token
+    const storedRefreshToken = (await getToken(TokenType.Refresh).catch((error) => throwNativeBcscError(error)))?.token
     if (!storedRefreshToken) {
       this.logger.error('[BCSCApiClient] Token cache empty and no refresh token in secure storage')
       throw AppError.fromErrorDefinition(ErrorRegistry.TOKEN_NULL, {

--- a/app/src/bcsc-theme/api/hooks/usePairingApi.test.tsx
+++ b/app/src/bcsc-theme/api/hooks/usePairingApi.test.tsx
@@ -1,0 +1,119 @@
+import { VERIFY_DEVICE_ASSERTION_PATH } from '@/constants'
+import { AppEventCode } from '@/events/appEventCode'
+import { renderHook } from '@testing-library/react-native'
+import { signPairingCode } from 'react-native-bcsc-core'
+import usePairingApi from './usePairingApi'
+import { withAccount } from './withAccountGuard'
+
+// Prettier automatically adds a ; at the start of some lines, which causes eslint no-extra-semi to complain
+/* eslint-disable no-extra-semi */
+
+const mockLogger = {
+  info: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}
+
+jest.mock('@/contexts/NavigationContainerContext', () => ({
+  navigationRef: { isReady: () => false, getCurrentRoute: () => undefined },
+}))
+
+jest.mock('@bifold/core', () => ({
+  useServices: () => [mockLogger],
+  TOKENS: { UTIL_LOGGER: 'UTIL_LOGGER' },
+}))
+
+jest.mock('react-native-bcsc-core', () => ({
+  signPairingCode: jest.fn(),
+  // Delegate to the central manual mock so the predicate can't drift from the real implementation.
+  isBcscNativeError: jest.requireActual('../../../../__mocks__/react-native-bcsc-core').isBcscNativeError,
+}))
+
+jest.mock('./withAccountGuard', () => ({
+  withAccount: jest.fn(),
+}))
+
+jest.mock('@/bcsc-theme/utils/push-notification-tokens', () => ({
+  getNotificationTokens: jest.fn().mockResolvedValue({
+    fcmDeviceToken: 'mock-fcm-token',
+    deviceToken: 'mock-device-token',
+  }),
+}))
+
+const mockAccount = { clientID: 'mock-client-id', issuer: 'mock-issuer' }
+
+const mockApiClient = {
+  endpoints: { cardTap: 'https://mock-api.example.com/cardtap' },
+  post: jest.fn(),
+  delete: jest.fn(),
+} as any
+
+describe('usePairingApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(withAccount as jest.Mock).mockImplementation(async (callback) => callback(mockAccount))
+  })
+
+  describe('loginByPairingCode', () => {
+    it('signs the pairing code and returns the client metadata', async () => {
+      const metadata = { transaction_id: 'txn-1', client_name: 'Test Client' }
+      ;(signPairingCode as jest.Mock).mockResolvedValue('signed-assertion')
+      mockApiClient.post.mockResolvedValue({ data: metadata })
+
+      const { result } = renderHook(() => usePairingApi(mockApiClient))
+      const response = await result.current.loginByPairingCode('pairing-code')
+
+      expect(signPairingCode).toHaveBeenCalledWith(
+        'pairing-code',
+        mockAccount.issuer,
+        mockAccount.clientID,
+        'mock-fcm-token',
+        'mock-device-token'
+      )
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        `${mockApiClient.endpoints.cardTap}/${VERIFY_DEVICE_ASSERTION_PATH}`,
+        { assertion: 'signed-assertion' },
+        { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+      )
+      expect(response).toEqual(metadata)
+    })
+
+    it('maps a native signPairingCode rejection through the native mapper', async () => {
+      ;(signPairingCode as jest.Mock).mockRejectedValue(
+        Object.assign(new Error('native failure'), { code: 'E_JWT_SIGN_FAILED' })
+      )
+
+      const { result } = renderHook(() => usePairingApi(mockApiClient))
+
+      await expect(result.current.loginByPairingCode('pairing-code')).rejects.toMatchObject({
+        appEvent: AppEventCode.ERR_207_UNABLE_TO_SIGN_CLAIMS_SET,
+      })
+      expect(mockApiClient.post).not.toHaveBeenCalled()
+    })
+
+    it('throws SIGN_CLAIMS_ERROR when signPairingCode resolves null', async () => {
+      ;(signPairingCode as jest.Mock).mockResolvedValue(null)
+
+      const { result } = renderHook(() => usePairingApi(mockApiClient))
+
+      await expect(result.current.loginByPairingCode('pairing-code')).rejects.toMatchObject({
+        appEvent: AppEventCode.ERR_207_UNABLE_TO_SIGN_CLAIMS_SET,
+      })
+      expect(mockApiClient.post).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('forgetAllPairings', () => {
+    it('deletes the device pairings for the current account', async () => {
+      mockApiClient.delete.mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => usePairingApi(mockApiClient))
+      await result.current.forgetAllPairings()
+
+      expect(mockApiClient.delete).toHaveBeenCalledWith(
+        `${mockApiClient.endpoints.cardTap}/v3/devices/${mockAccount.clientID}/pairings`
+      )
+    })
+  })
+})

--- a/app/src/bcsc-theme/api/hooks/usePairingApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/usePairingApi.tsx
@@ -1,4 +1,4 @@
-import { throwAppError } from '@/bcsc-theme/utils/native-error-map'
+import { throwAppError, throwNativeBcscError } from '@/bcsc-theme/utils/native-error-map'
 import { getNotificationTokens } from '@/bcsc-theme/utils/push-notification-tokens'
 import { VERIFY_DEVICE_ASSERTION_PATH } from '@/constants'
 import { ErrorRegistry } from '@/errors/errorRegistry'
@@ -37,7 +37,7 @@ const usePairingApi = (apiClient: BCSCApiClient) => {
         try {
           signedCode = await signPairingCode(code, issuer, clientID, fcmDeviceToken, deviceToken)
         } catch (error) {
-          return throwAppError(error, ErrorRegistry.SIGN_CLAIMS_ERROR)
+          return throwNativeBcscError(error)
         }
         if (!signedCode) {
           return throwAppError(new Error('signPairingCode returned null'), ErrorRegistry.SIGN_CLAIMS_ERROR)

--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
@@ -178,7 +178,7 @@ describe('useRegistrationApi', () => {
       }
     })
 
-    it('should fall through to CLIENT_REGISTRATION_FAILURE for unknown native errors', async () => {
+    it('maps an unmapped native error code to UNMAPPED_NATIVE_ERROR', async () => {
       const unknownError = { code: 'E_UNKNOWN', message: 'unknown native error' }
       jest.mocked(getDynamicClientRegistrationBody).mockRejectedValue(unknownError)
       jest.mocked(isBcscNativeError).mockReturnValue(true)
@@ -190,11 +190,11 @@ describe('useRegistrationApi', () => {
         fail('Expected an error to be thrown')
       } catch (error) {
         expect(error).toBeInstanceOf(AppError)
-        expect((error as AppError).appEvent).toBe(AppEventCode.ERR_120_CLIENT_REGISTRATION_FAILURE)
+        expect((error as AppError).appEvent).toBe(AppEventCode.UNMAPPED_NATIVE_ERROR)
       }
     })
 
-    it('should fall through to CLIENT_REGISTRATION_FAILURE for non-native errors', async () => {
+    it('maps a non-native error to UNMAPPED_NATIVE_ERROR', async () => {
       jest.mocked(getDynamicClientRegistrationBody).mockRejectedValue(new Error('generic JS error'))
       jest.mocked(isBcscNativeError).mockReturnValue(false)
 
@@ -205,7 +205,7 @@ describe('useRegistrationApi', () => {
         fail('Expected an error to be thrown')
       } catch (error) {
         expect(error).toBeInstanceOf(AppError)
-        expect((error as AppError).appEvent).toBe(AppEventCode.ERR_120_CLIENT_REGISTRATION_FAILURE)
+        expect((error as AppError).appEvent).toBe(AppEventCode.UNMAPPED_NATIVE_ERROR)
       }
     })
   })

--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
@@ -129,7 +129,7 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
    * @throws AppError with code `ERR_120_KEYCHAIN_KEY_DOESNT_EXIST_ERROR` if keychain key not found
    * @throws AppError with code `ERR_120_KEYCHAIN_KEY_GENERATION_ERROR` if keypair generation fails
    * @throws AppError with code `ERR_120_JWT_DEVICE_INFO_ERROR` if device info JWT creation fails
-   * @throws AppError with code `ERR_120_CLIENT_REGISTRATION_FAILURE` if building the registration body fails
+   * @throws AppError with code `DCR_BODY_BUILD_FAILED` (or `UNMAPPED_NATIVE_ERROR` for unmapped native codes) if building the registration body fails
    * @throws AppError with code `ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL` if registration response is null
    * @throws AppError with code `ERR_115_FAILED_TO_SERIALIZE_JSON` if native JSON serialization fails
    *
@@ -218,7 +218,7 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
    * @throws AppError with code `ERR_120_KEYCHAIN_KEY_DOESNT_EXIST_ERROR` if keychain key not found
    * @throws AppError with code `ERR_120_KEYCHAIN_KEY_GENERATION_ERROR` if keypair generation fails
    * @throws AppError with code `ERR_120_JWT_DEVICE_INFO_ERROR` if device info JWT creation fails
-   * @throws AppError with code `ERR_120_CLIENT_REGISTRATION_FAILURE` if building the registration body fails
+   * @throws AppError with code `DCR_BODY_BUILD_FAILED` (or `UNMAPPED_NATIVE_ERROR` for unmapped native codes) if building the registration body fails
    * @throws AppError with code `ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL` if registration response is null
    * @throws AppError with code `ERR_109_FAILED_TO_DESERIALIZE_JSON` if response body cannot be parsed as JSON
    * @throws AppError with code `ERR_115_FAILED_TO_SERIALIZE_JSON` if native JSON serialization fails

--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.tsx
@@ -1,21 +1,19 @@
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { getAttestationErrorLogContext } from '@/bcsc-theme/utils/attestation'
+import { throwNativeBcscError } from '@/bcsc-theme/utils/native-error-map'
 import { getNotificationTokens } from '@/bcsc-theme/utils/push-notification-tokens'
 import { AppError, ErrorRegistry } from '@/errors'
-import { ErrorDefinition } from '@/errors/errorRegistry'
 import { TOKENS, useServices } from '@bifold/core'
 import { getAppStoreReceipt, googleAttestation } from '@bifold/react-native-attestation'
 import { useCallback, useMemo } from 'react'
 import { Platform } from 'react-native'
 import {
   AccountSecurityMethod,
-  BcscNativeErrorCodes,
   getAccount,
   getAccountSecurityMethod,
   getDeviceId,
   getDynamicClientRegistrationBody,
   isAccountRegistered,
-  isBcscNativeError,
   setAccount,
 } from 'react-native-bcsc-core'
 import BCSCApiClient from '../client'
@@ -59,32 +57,6 @@ export interface NonceResponseData {
 }
 
 export type RegistrationApi = ReturnType<typeof useRegistrationApi>
-
-/**
- * Maps native error codes from `getDynamicClientRegistrationBody` to their
- * corresponding ErrorRegistry definitions. Unmatched codes fall through
- * to CLIENT_REGISTRATION_FAILURE.
- */
-const dcrNativeErrorMap = new Map<string, ErrorDefinition>([
-  [BcscNativeErrorCodes.KEYCHAIN_KEY_GENERATION_ERROR, ErrorRegistry.KEYCHAIN_KEY_GENERATION_ERROR],
-  [BcscNativeErrorCodes.TOJSON_METHOD_FAILURE, ErrorRegistry.TOJSON_METHOD_FAILURE],
-  [BcscNativeErrorCodes.TOJSONSTRING_METHOD_FAILURE, ErrorRegistry.TOJSONSTRING_METHOD_FAILURE],
-  [BcscNativeErrorCodes.KEYCHAIN_KEY_EXISTS, ErrorRegistry.KEYCHAIN_KEY_EXISTS],
-  [BcscNativeErrorCodes.KEYCHAIN_KEY_DOESNT_EXIST, ErrorRegistry.KEYCHAIN_KEY_NOT_FOUND],
-  [BcscNativeErrorCodes.KEYCHAIN_UNAVAILABLE, ErrorRegistry.KEYCHAIN_UNAVAILABLE],
-  [BcscNativeErrorCodes.JWT_DEVICE_INFO_ERROR, ErrorRegistry.JWT_DEVICE_INFO_ERROR],
-  [BcscNativeErrorCodes.JSON_SERIALIZATION_FAILED, ErrorRegistry.SERIALIZE_JSON_ERROR],
-])
-
-function throwDcrNativeError(error: unknown): never {
-  if (isBcscNativeError(error)) {
-    const definition = dcrNativeErrorMap.get(error.code)
-    if (definition) {
-      throw AppError.fromErrorDefinition(definition, { cause: error })
-    }
-  }
-  throw AppError.fromErrorDefinition(ErrorRegistry.CLIENT_REGISTRATION_FAILURE, { cause: error })
-}
 
 // The registration API is a special case because it gets called during initialization,
 // so its params are adjusted to account for an api client that may not be ready yet
@@ -174,12 +146,9 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
         getNotificationTokens(logger),
       ])
 
-      let body: string | null
-      try {
-        body = await getDynamicClientRegistrationBody(fcmDeviceToken, deviceToken, attestation)
-      } catch (error) {
-        throwDcrNativeError(error)
-      }
+      const body = await getDynamicClientRegistrationBody(fcmDeviceToken, deviceToken, attestation).catch((error) =>
+        throwNativeBcscError(error)
+      )
 
       if (!body) {
         throw AppError.fromErrorDefinition(ErrorRegistry.CLIENT_REGISTRATION_NULL)
@@ -278,12 +247,12 @@ const useRegistrationApi = (apiClient: BCSCApiClient | null, isClientReady: bool
           getNotificationTokens(logger),
         ])
 
-        let body: string | null
-        try {
-          body = await getDynamicClientRegistrationBody(fcmDeviceToken, deviceToken, attestation, selectedNickname)
-        } catch (error) {
-          throwDcrNativeError(error)
-        }
+        const body = await getDynamicClientRegistrationBody(
+          fcmDeviceToken,
+          deviceToken,
+          attestation,
+          selectedNickname
+        ).catch((error) => throwNativeBcscError(error))
 
         if (!body) {
           throw AppError.fromErrorDefinition(ErrorRegistry.CLIENT_REGISTRATION_NULL)

--- a/app/src/bcsc-theme/api/hooks/useTokens.test.ts
+++ b/app/src/bcsc-theme/api/hooks/useTokens.test.ts
@@ -4,7 +4,7 @@ import { AppError, ErrorRegistry } from '@/errors'
 import { AppEventCode } from '@/events/appEventCode'
 import { renderHook } from '@testing-library/react-native'
 import { BasicAppContext } from '__mocks__/helpers/app'
-import { getDeviceCodeRequestBody } from 'react-native-bcsc-core'
+import { getDeviceCodeRequestBody, setToken } from 'react-native-bcsc-core'
 import BCSCApiClient from '../client'
 import useTokenApi, { TokenResponse } from './useTokens'
 import { withAccount } from './withAccountGuard'
@@ -23,6 +23,8 @@ jest.mock('react-native-bcsc-core', () => ({
   getToken: jest.fn().mockResolvedValue(null),
   setToken: jest.fn().mockResolvedValue(true),
   deleteToken: jest.fn().mockResolvedValue(true),
+  // Delegate to the central manual mock so the predicate can't drift from the real implementation.
+  isBcscNativeError: jest.requireActual('../../../../__mocks__/react-native-bcsc-core').isBcscNativeError,
 }))
 
 jest.mock('./withAccountGuard', () => ({
@@ -159,6 +161,47 @@ describe('useTokenApi', () => {
 
       await expect(result.current.checkDeviceCodeStatus('test_device_code', 'test_confirmation')).rejects.toThrow(
         'Account not found'
+      )
+    })
+
+    it('maps a native getDeviceCodeRequestBody rejection to a distinct AppError', async () => {
+      const mockAccount = { clientID: 'mock_client_id', issuer: 'mock_issuer' }
+      ;(withAccount as jest.Mock).mockImplementation(async (callback) => callback(mockAccount))
+      ;(getDeviceCodeRequestBody as jest.Mock).mockRejectedValueOnce(
+        Object.assign(new Error('native failure'), { code: 'E_DEVICE_CODE_ERROR' })
+      )
+
+      const { result } = renderHook(() => useTokenApi(mockApiClient), { wrapper: BasicAppContext })
+
+      await expect(result.current.checkDeviceCodeStatus('test_device_code', 'test_confirmation')).rejects.toMatchObject(
+        {
+          appEvent: AppEventCode.DEVICE_CODE_REQUEST_FAILED,
+        }
+      )
+      expect(mockApiClient.post).not.toHaveBeenCalled()
+    })
+
+    it('re-throws the mapped token-persistence error as-is when updateTokens fails', async () => {
+      const mockAccount = { clientID: 'mock_client_id', issuer: 'mock_issuer' }
+      ;(withAccount as jest.Mock).mockImplementation(async (callback) => callback(mockAccount))
+      ;(getDeviceCodeRequestBody as jest.Mock).mockResolvedValue('mock-body')
+      mockApiClient.post.mockResolvedValue(mockAxiosResponse)
+      // Native token write fails → real updateTokens maps it to TOKEN_SAVE_FAILED, which
+      // checkDeviceCodeStatus must re-throw unchanged (not re-wrap under a storage catch-all).
+      ;(setToken as jest.Mock).mockRejectedValue(
+        Object.assign(new Error('native failure'), { code: 'E_TOKEN_SAVE_ERROR' })
+      )
+
+      const { result } = renderHook(() => useTokenApi(mockApiClient), { wrapper: BasicAppContext })
+
+      await expect(result.current.checkDeviceCodeStatus('test_device_code', 'test_confirmation')).rejects.toMatchObject(
+        {
+          appEvent: AppEventCode.TOKEN_SAVE_FAILED,
+        }
+      )
+      expect(mockApiClient.logger.error).toHaveBeenCalledWith(
+        '[checkDeviceCodeStatus] Failed to update tokens',
+        expect.anything()
       )
     })
   })

--- a/app/src/bcsc-theme/api/hooks/useTokens.tsx
+++ b/app/src/bcsc-theme/api/hooks/useTokens.tsx
@@ -1,7 +1,6 @@
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { getIdTokenMetadata } from '@/bcsc-theme/utils/id-token'
-import { throwAppError } from '@/bcsc-theme/utils/native-error-map'
-import { ErrorRegistry } from '@/errors/errorRegistry'
+import { throwNativeBcscError } from '@/bcsc-theme/utils/native-error-map'
 import { cancelVerificationReminders } from '@/services/notifications/verificationReminders'
 import { useCallback, useMemo } from 'react'
 import { getDeviceCodeRequestBody } from 'react-native-bcsc-core'
@@ -55,7 +54,12 @@ const useTokenApi = (apiClient: BCSCApiClient) => {
   const checkDeviceCodeStatus = useCallback(
     async (deviceCode: string, confirmationCode: string) => {
       return withAccount<TokenResponse>(async (account) => {
-        const body = await getDeviceCodeRequestBody(deviceCode, account.clientID, account.issuer, confirmationCode)
+        const body = await getDeviceCodeRequestBody(
+          deviceCode,
+          account.clientID,
+          account.issuer,
+          confirmationCode
+        ).catch((error) => throwNativeBcscError(error))
 
         const { data } = await apiClient.post<TokenResponse>(apiClient.endpoints.token, body, {
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -66,8 +70,9 @@ const useTokenApi = (apiClient: BCSCApiClient) => {
           apiClient.tokens = data
           await updateTokens({ refreshToken: data.refresh_token, accessToken: data.access_token })
         } catch (error) {
+          // updateTokens → persistTokens already maps native rejections to a distinct AppError; re-throw as-is.
           apiClient.logger.error(`[checkDeviceCodeStatus] Failed to update tokens`, error as Error)
-          throwAppError(error, ErrorRegistry.STORAGE_WRITE_ERROR)
+          throw error
         }
 
         // doesn't throw

--- a/app/src/bcsc-theme/hooks/useAuthentication.test.tsx
+++ b/app/src/bcsc-theme/hooks/useAuthentication.test.tsx
@@ -1,4 +1,6 @@
 import { BCSCScreens } from '@/bcsc-theme/types/navigators'
+import { AppError } from '@/errors/appError'
+import { ErrorRegistry } from '@/errors/errorRegistry'
 import * as useAlertsModule from '@/hooks/useAlerts'
 import * as Bifold from '@bifold/core'
 import { act, renderHook } from '@testing-library/react-native'
@@ -25,7 +27,8 @@ jest.mock('react-native-bcsc-core', () => ({
   isAccountLocked: jest.fn(),
   canPerformDeviceAuthentication: jest.fn(),
   unlockWithDeviceSecurity: jest.fn(),
-  isBcscNativeError: jest.fn((error: unknown) => error instanceof Error && 'code' in error),
+  // Delegate to the central manual mock so the predicate can't drift from the real implementation.
+  isBcscNativeError: jest.requireActual('../../../__mocks__/react-native-bcsc-core').isBcscNativeError,
 }))
 
 jest.mock('@/bcsc-theme/hooks/useSecureActions')
@@ -328,15 +331,17 @@ describe('useAuthentication', () => {
       expect(mockLogger.error).toHaveBeenCalled()
     })
 
-    it('treats E_DEVICE_AUTH_CANCELLED as a user cancel — no error alert', async () => {
+    it('preserves the specific appEvent when handleSuccessfulAuth throws an already-mapped AppError', async () => {
       const mockAlert = jest.fn()
       jest.mocked(useAlertsModule.useAlerts).mockReturnValue({
         deviceAuthenticationErrorAlert: mockAlert,
       } as any)
       jest.mocked(canPerformDeviceAuthentication).mockResolvedValue(true)
-      jest
-        .mocked(unlockWithDeviceSecurity)
-        .mockRejectedValue(Object.assign(new Error('cancelled'), { code: 'E_DEVICE_AUTH_CANCELLED' }))
+      jest.mocked(unlockWithDeviceSecurity).mockResolvedValue({ success: true, walletKey: 'key' })
+      const mappedError = AppError.fromErrorDefinition(ErrorRegistry.TOKEN_SAVE_FAILED, { track: false })
+      jest.mocked(useSecureActionsModule.default).mockReturnValue({
+        handleSuccessfulAuth: jest.fn().mockRejectedValue(mappedError),
+      } as any)
 
       const navigation = { navigate: jest.fn(), dispatch: jest.fn() } as any
       const { result } = renderHook(() => useAuthentication(navigation))
@@ -345,7 +350,9 @@ describe('useAuthentication', () => {
         await result.current.performDeviceAuth()
       })
 
-      expect(mockAlert).not.toHaveBeenCalled()
+      // The mapper passes already-mapped errors through — the alert surfaces TOKEN_SAVE_FAILED,
+      // not a re-wrapped UNMAPPED_NATIVE_ERROR.
+      expect(mockAlert).toHaveBeenCalledWith(mappedError)
     })
   })
 

--- a/app/src/bcsc-theme/hooks/useAuthentication.test.tsx
+++ b/app/src/bcsc-theme/hooks/useAuthentication.test.tsx
@@ -1,6 +1,7 @@
 import { BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { AppError } from '@/errors/appError'
 import { ErrorRegistry } from '@/errors/errorRegistry'
+import { AppEventCode } from '@/events/appEventCode'
 import * as useAlertsModule from '@/hooks/useAlerts'
 import * as Bifold from '@bifold/core'
 import { act, renderHook } from '@testing-library/react-native'
@@ -92,6 +93,29 @@ describe('useAuthentication', () => {
             routes: [{ name: BCSCScreens.Lockout }],
           }),
         })
+      )
+    })
+  })
+
+  describe('native error mapping', () => {
+    it('routes an unexpected native failure in unlockApp through the native mapper', async () => {
+      const errorSpy = jest.fn()
+      jest.mocked(Bifold.useServices).mockReturnValue([{ info: jest.fn(), error: errorSpy }] as any)
+      jest
+        .mocked(getAccountSecurityMethod)
+        .mockRejectedValue(Object.assign(new Error('native failure'), { code: 'E_GET_SECURITY_METHOD_ERROR' }))
+
+      const navigation = { navigate: jest.fn(), dispatch: jest.fn() } as any
+      const { result } = renderHook(() => useAuthentication(navigation))
+
+      // unlockApp swallows the error (no throw), but must log the mapped AppError with its distinct appEvent.
+      await act(async () => {
+        await result.current.unlockApp()
+      })
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(AppEventCode.PIN_OPERATION_ERROR),
+        expect.objectContaining({ appEvent: AppEventCode.PIN_OPERATION_ERROR })
       )
     })
   })

--- a/app/src/bcsc-theme/hooks/useAuthentication.test.tsx
+++ b/app/src/bcsc-theme/hooks/useAuthentication.test.tsx
@@ -25,6 +25,7 @@ jest.mock('react-native-bcsc-core', () => ({
   isAccountLocked: jest.fn(),
   canPerformDeviceAuthentication: jest.fn(),
   unlockWithDeviceSecurity: jest.fn(),
+  isBcscNativeError: jest.fn((error: unknown) => error instanceof Error && 'code' in error),
 }))
 
 jest.mock('@/bcsc-theme/hooks/useSecureActions')
@@ -325,6 +326,26 @@ describe('useAuthentication', () => {
       })
 
       expect(mockLogger.error).toHaveBeenCalled()
+    })
+
+    it('treats E_DEVICE_AUTH_CANCELLED as a user cancel — no error alert', async () => {
+      const mockAlert = jest.fn()
+      jest.mocked(useAlertsModule.useAlerts).mockReturnValue({
+        deviceAuthenticationErrorAlert: mockAlert,
+      } as any)
+      jest.mocked(canPerformDeviceAuthentication).mockResolvedValue(true)
+      jest
+        .mocked(unlockWithDeviceSecurity)
+        .mockRejectedValue(Object.assign(new Error('cancelled'), { code: 'E_DEVICE_AUTH_CANCELLED' }))
+
+      const navigation = { navigate: jest.fn(), dispatch: jest.fn() } as any
+      const { result } = renderHook(() => useAuthentication(navigation))
+
+      await act(async () => {
+        await result.current.performDeviceAuth()
+      })
+
+      expect(mockAlert).not.toHaveBeenCalled()
     })
   })
 

--- a/app/src/bcsc-theme/hooks/useAuthentication.tsx
+++ b/app/src/bcsc-theme/hooks/useAuthentication.tsx
@@ -10,7 +10,6 @@ import {
   getAccountSecurityMethod,
   getHideDeviceAuthPrepFlag,
   isAccountLocked,
-  isBcscNativeError,
   unlockWithDeviceSecurity,
 } from 'react-native-bcsc-core'
 import { useLoadingScreen } from '../contexts/BCSCLoadingContext'
@@ -61,11 +60,8 @@ export const useAuthentication = (navigation: StackNavigationProp<BCSCAuthStackP
       await handleSuccessfulAuth(walletKey)
       logger.info('[Authentication:performDeviceAuth] Device authentication successful')
     } catch (error) {
-      // A user cancel is control flow, not an error — do not surface an alert or track it.
-      if (isBcscNativeError(error) && error.code === 'E_DEVICE_AUTH_CANCELLED') {
-        logger.info('[Authentication:performDeviceAuth] Device authentication cancelled by user')
-        return
-      }
+      // Note: a user cancel never lands here — unlockWithDeviceSecurity resolves
+      // { success: false } on cancel (both platforms), handled above.
       const appError = mapNativeBcscError(error)
       logger.error(`[Authentication:performDeviceAuth] Device authentication error [${appError.appEvent}]`, appError)
       deviceAuthenticationErrorAlert(appError)

--- a/app/src/bcsc-theme/hooks/useAuthentication.tsx
+++ b/app/src/bcsc-theme/hooks/useAuthentication.tsx
@@ -1,5 +1,4 @@
-import { toAppError } from '@/bcsc-theme/utils/native-error-map'
-import { ErrorRegistry } from '@/errors/errorRegistry'
+import { mapNativeBcscError } from '@/bcsc-theme/utils/native-error-map'
 import { useAlerts } from '@/hooks/useAlerts'
 import { TOKENS, useServices } from '@bifold/core'
 import { CommonActions } from '@react-navigation/native'
@@ -11,6 +10,7 @@ import {
   getAccountSecurityMethod,
   getHideDeviceAuthPrepFlag,
   isAccountLocked,
+  isBcscNativeError,
   unlockWithDeviceSecurity,
 } from 'react-native-bcsc-core'
 import { useLoadingScreen } from '../contexts/BCSCLoadingContext'
@@ -61,7 +61,12 @@ export const useAuthentication = (navigation: StackNavigationProp<BCSCAuthStackP
       await handleSuccessfulAuth(walletKey)
       logger.info('[Authentication:performDeviceAuth] Device authentication successful')
     } catch (error) {
-      const appError = toAppError(error, ErrorRegistry.DEVICE_AUTHENTICATION_ERROR)
+      // A user cancel is control flow, not an error — do not surface an alert or track it.
+      if (isBcscNativeError(error) && error.code === 'E_DEVICE_AUTH_CANCELLED') {
+        logger.info('[Authentication:performDeviceAuth] Device authentication cancelled by user')
+        return
+      }
+      const appError = mapNativeBcscError(error)
       logger.error(`[Authentication:performDeviceAuth] Device authentication error [${appError.appEvent}]`, appError)
       deviceAuthenticationErrorAlert(appError)
     } finally {
@@ -118,7 +123,7 @@ export const useAuthentication = (navigation: StackNavigationProp<BCSCAuthStackP
 
       await performDeviceAuth()
     } catch (error) {
-      const appError = toAppError(error, ErrorRegistry.DEVICE_AUTHORIZATION_ERROR)
+      const appError = mapNativeBcscError(error)
       logger.error(`[Authentication:UnlockApp] Device authentication error [${appError.appEvent}]`, appError)
     }
   }, [logger, navigation, performDeviceAuth])

--- a/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
@@ -9,6 +9,7 @@ import { act, renderHook } from '@testing-library/react-native'
 import {
   AccountSecurityMethod,
   deleteAuthorizationRequest,
+  deleteEvidence,
   EvidenceMetadata,
   getAccount,
   getAccountFlags,
@@ -125,6 +126,52 @@ describe('useSecureActions', () => {
 
       await expect(result.current.updateAccountFlags({ isEmailVerified: true })).rejects.toMatchObject({
         appEvent: AppEventCode.NATIVE_STORAGE_WRITE_FAILED,
+      })
+    })
+
+    it('maps an authorization-request write rejection to NATIVE_STORAGE_WRITE_FAILED', async () => {
+      jest.mocked(getAuthorizationRequest).mockResolvedValueOnce(undefined as any)
+      jest.mocked(setAuthorizationRequest).mockRejectedValueOnce(nativeError('E_SET_AUTH_REQUEST_ERROR'))
+      const { result } = renderHook(() => useSecureActions())
+
+      await expect(result.current.updateVerificationOptions([])).rejects.toMatchObject({
+        appEvent: AppEventCode.NATIVE_STORAGE_WRITE_FAILED,
+      })
+    })
+
+    it('maps an evidence write rejection to NATIVE_STORAGE_WRITE_FAILED', async () => {
+      jest.mocked(setEvidence).mockRejectedValueOnce(nativeError('E_SET_EVIDENCE_ERROR'))
+      const { result } = renderHook(() => useSecureActions())
+
+      await expect(result.current.addEvidenceType({ evidence_type: 'drivers_licence' } as any)).rejects.toMatchObject({
+        appEvent: AppEventCode.NATIVE_STORAGE_WRITE_FAILED,
+      })
+    })
+
+    it('maps a native read rejection during hydration to NATIVE_STORAGE_READ_FAILED', async () => {
+      jest.mocked(getAccount).mockRejectedValueOnce(nativeError('E_GET_ACCOUNT_ERROR'))
+      const { result } = renderHook(() => useSecureActions())
+
+      await expect(result.current.hydrateSecureState()).rejects.toMatchObject({
+        appEvent: AppEventCode.NATIVE_STORAGE_READ_FAILED,
+      })
+    })
+
+    it('maps a delete rejection during deleteSecureData to NATIVE_STORAGE_DELETE_FAILED', async () => {
+      jest.mocked(deleteAuthorizationRequest).mockRejectedValueOnce(nativeError('E_DELETE_AUTH_REQUEST_ERROR'))
+      const { result } = renderHook(() => useSecureActions())
+
+      await expect(result.current.deleteSecureData()).rejects.toMatchObject({
+        appEvent: AppEventCode.NATIVE_STORAGE_DELETE_FAILED,
+      })
+    })
+
+    it('maps a delete rejection during deleteVerificationData to NATIVE_STORAGE_DELETE_FAILED', async () => {
+      jest.mocked(deleteEvidence).mockRejectedValueOnce(nativeError('E_DELETE_EVIDENCE_ERROR'))
+      const { result } = renderHook(() => useSecureActions())
+
+      await expect(result.current.deleteVerificationData()).rejects.toMatchObject({
+        appEvent: AppEventCode.NATIVE_STORAGE_DELETE_FAILED,
       })
     })
   })

--- a/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
@@ -41,7 +41,8 @@ jest.mock('react-native-bcsc-core', () => ({
   setAccountFlags: jest.fn(),
   setAuthorizationRequest: jest.fn(),
   setToken: jest.fn(),
-  isBcscNativeError: jest.fn((error: unknown) => error instanceof Error && 'code' in error),
+  // Delegate to the central manual mock so the predicate can't drift from the real implementation.
+  isBcscNativeError: jest.requireActual('../../../__mocks__/react-native-bcsc-core').isBcscNativeError,
   getAccount: jest.fn(),
   getAccountFlags: jest.fn(),
   getAccountSecurityMethod: jest.fn(),

--- a/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
@@ -1,3 +1,4 @@
+import { AppEventCode } from '@/events/appEventCode'
 import {
   cancelVerificationReminders,
   scheduleVerificationReminders,
@@ -21,6 +22,7 @@ import {
   setAccountFlags,
   setAuthorizationRequest,
   setEvidence,
+  setToken,
   TokenType,
 } from 'react-native-bcsc-core'
 import * as useBCSCApiClientModule from './useBCSCApiClient'
@@ -39,6 +41,7 @@ jest.mock('react-native-bcsc-core', () => ({
   setAccountFlags: jest.fn(),
   setAuthorizationRequest: jest.fn(),
   setToken: jest.fn(),
+  isBcscNativeError: jest.fn((error: unknown) => error instanceof Error && 'code' in error),
   getAccount: jest.fn(),
   getAccountFlags: jest.fn(),
   getAccountSecurityMethod: jest.fn(),
@@ -99,6 +102,30 @@ describe('useSecureActions', () => {
       isClientReady: false,
       error: undefined,
     } as any)
+  })
+
+  // #3419: persistence failures surface the distinct native error code instead of a STORAGE_WRITE_ERROR catch-all.
+  describe('native error mapping', () => {
+    const nativeError = (code: string) => Object.assign(new Error(`native ${code}`), { code })
+
+    it('maps a native token-save rejection to TOKEN_SAVE_FAILED', async () => {
+      jest.mocked(setToken).mockRejectedValueOnce(nativeError('E_TOKEN_SAVE_ERROR'))
+      const { result } = renderHook(() => useSecureActions())
+
+      await expect(result.current.updateTokens({ refreshToken: 'abc' })).rejects.toMatchObject({
+        appEvent: AppEventCode.TOKEN_SAVE_FAILED,
+      })
+    })
+
+    it('groups an Android account-flags write rejection under NATIVE_STORAGE_WRITE_FAILED', async () => {
+      jest.mocked(getAccountFlags).mockResolvedValueOnce({} as any)
+      jest.mocked(setAccountFlags).mockRejectedValueOnce(nativeError('E_SET_ACCOUNT_FLAGS_ERROR'))
+      const { result } = renderHook(() => useSecureActions())
+
+      await expect(result.current.updateAccountFlags({ isEmailVerified: true })).rejects.toMatchObject({
+        appEvent: AppEventCode.NATIVE_STORAGE_WRITE_FAILED,
+      })
+    })
   })
 
   describe('removeIncompleteEvidence', () => {

--- a/app/src/bcsc-theme/hooks/useSecureActions.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.tsx
@@ -1,4 +1,3 @@
-import { isAppError } from '@/errors/appError'
 import {
   cancelVerificationReminders,
   scheduleVerificationReminders,
@@ -1008,10 +1007,7 @@ export const useSecureActions = () => {
     } catch (error) {
       logger.error('Failed to hydrate secure state:', error as Error)
       // Native read failures map to a distinct storage error (raw code preserved); an error already
-      // mapped downstream (e.g. token persistence) is an AppError — re-throw it unchanged.
-      if (isAppError(error)) {
-        throw error
-      }
+      // mapped downstream (e.g. token persistence) passes through the mapper unchanged.
       throwNativeBcscError(error)
     }
   }, [logger, apiClient, isClientReady, updateTokens, removeIncompleteEvidence, dispatch])

--- a/app/src/bcsc-theme/hooks/useSecureActions.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.tsx
@@ -1,10 +1,10 @@
-import { ErrorRegistry } from '@/errors/errorRegistry'
+import { isAppError } from '@/errors/appError'
 import {
   cancelVerificationReminders,
   scheduleVerificationReminders,
 } from '@/services/notifications/verificationReminders'
 import { BCDispatchAction, BCSCSecureState, BCState, NonBCSCUserMetadata, VerificationStatus } from '@/store'
-import { throwAppError } from '@bcsc-theme/utils/native-error-map'
+import { throwNativeBcscError } from '@bcsc-theme/utils/native-error-map'
 import { DispatchAction, TOKENS, useServices, useStore } from '@bifold/core'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -124,7 +124,7 @@ export const useSecureActions = () => {
         logger.info(`Tokens persisted to native storage successfully`)
       } catch (error) {
         logger.error('Failed to persist tokens:', error as Error)
-        throwAppError(error, ErrorRegistry.STORAGE_WRITE_ERROR)
+        throwNativeBcscError(error)
       }
     },
     [logger]
@@ -144,7 +144,7 @@ export const useSecureActions = () => {
         logger.info('Authorization request persisted to native storage')
       } catch (error) {
         logger.error('Failed to persist authorization request:', error as Error)
-        throwAppError(error, ErrorRegistry.STORAGE_WRITE_ERROR)
+        throwNativeBcscError(error)
       }
     },
     [logger]
@@ -164,7 +164,7 @@ export const useSecureActions = () => {
         logger.info('Account flags persisted to native storage')
       } catch (error) {
         logger.error('Failed to persist account flags:', error as Error)
-        throwAppError(error, ErrorRegistry.STORAGE_WRITE_ERROR)
+        throwNativeBcscError(error)
       }
     },
     [logger]
@@ -181,7 +181,7 @@ export const useSecureActions = () => {
         logger.info('Evidence persisted to native storage')
       } catch (error) {
         logger.error('Failed to persist evidence metadata:', error as Error)
-        throwAppError(error, ErrorRegistry.STORAGE_WRITE_ERROR)
+        throwNativeBcscError(error)
       }
     },
     [logger]
@@ -381,7 +381,7 @@ export const useSecureActions = () => {
       logger.info('Device authorization codes cleared from native storage')
     } catch (error) {
       logger.error('Failed to clear device authorization codes:', error as Error)
-      throwAppError(error, ErrorRegistry.STORAGE_WRITE_ERROR)
+      throwNativeBcscError(error)
     }
   }, [dispatch, logger])
 
@@ -1007,7 +1007,12 @@ export const useSecureActions = () => {
       logger.info('Secure state hydrated successfully')
     } catch (error) {
       logger.error('Failed to hydrate secure state:', error as Error)
-      throwAppError(error, ErrorRegistry.STORAGE_READ_ERROR)
+      // Native read failures map to a distinct storage error (raw code preserved); an error already
+      // mapped downstream (e.g. token persistence) is an AppError — re-throw it unchanged.
+      if (isAppError(error)) {
+        throw error
+      }
+      throwNativeBcscError(error)
     }
   }, [logger, apiClient, isClientReady, updateTokens, removeIncompleteEvidence, dispatch])
 
@@ -1061,7 +1066,7 @@ export const useSecureActions = () => {
       logger.info('Secure data deleted from native storage')
     } catch (error) {
       logger.error('Failed to delete secure data:', error as Error)
-      throwAppError(error, ErrorRegistry.STORAGE_WRITE_ERROR)
+      throwNativeBcscError(error)
     }
   }, [logger])
 
@@ -1077,7 +1082,7 @@ export const useSecureActions = () => {
       logger.info('Verification data deleted from native storage')
     } catch (error) {
       logger.error('Failed to delete verification data:', error as Error)
-      throwAppError(error, ErrorRegistry.STORAGE_WRITE_ERROR)
+      throwNativeBcscError(error)
     }
   }, [logger])
 

--- a/app/src/bcsc-theme/services/hooks/useRegistrationService.test.tsx
+++ b/app/src/bcsc-theme/services/hooks/useRegistrationService.test.tsx
@@ -190,6 +190,30 @@ describe('useRegistrationService', () => {
       })
     })
 
+    // #3419: the unified native mapper replaced the old CLIENT_REGISTRATION_FAILURE fallback with
+    // DCR_BODY_BUILD_FAILED / UNMAPPED_NATIVE_ERROR — both must still surface the generic modal.
+    describe.each([AppEventCode.DCR_BODY_BUILD_FAILED, AppEventCode.UNMAPPED_NATIVE_ERROR])(
+      'App error %s',
+      (appEvent) => {
+        it('should show clientRegistrationFailureAlert', async () => {
+          const mockError = mockAppError(appEvent)
+          const registrationApi = {
+            register: jest.fn().mockRejectedValue(mockError),
+          } as any
+          const clientRegistrationFailureAlert = jest.fn()
+          const mockAlerts = { clientRegistrationFailureAlert }
+
+          jest.spyOn(useRegistrationApiModule, 'default').mockReturnValue(registrationApi)
+          jest.spyOn(useAlertsModule, 'useAlerts').mockReturnValue(mockAlerts as any)
+
+          const { result } = renderHook(() => useRegistrationService())
+
+          await expect(result.current.register('deviceAuth' as any)).rejects.toThrow(mockError)
+          expect(clientRegistrationFailureAlert).toHaveBeenCalledWith(mockError)
+        })
+      }
+    )
+
     describe('App error ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL', () => {
       it('should show the alert for the app error', async () => {
         const mockError = mockAppError(AppEventCode.ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL)

--- a/app/src/bcsc-theme/services/hooks/useRegistrationService.tsx
+++ b/app/src/bcsc-theme/services/hooks/useRegistrationService.tsx
@@ -20,6 +20,10 @@ const getRegistrationAlertMap = (alerts: AppAlerts): Partial<Record<AppEventCode
   [AppEventCode.ERR_120_KEYCHAIN_UNAVAILABLE_ERROR]: alerts.keychainUnavailableAlert,
   [AppEventCode.ERR_120_JWT_DEVICE_INFO_ERROR]: alerts.jwtDeviceInfoAlert,
   [AppEventCode.ERR_120_CLIENT_REGISTRATION_FAILURE]: alerts.clientRegistrationFailureAlert,
+  // #3419: the unified native mapper replaced the old CLIENT_REGISTRATION_FAILURE fallback with
+  // these events for registration-body failures — same generic modal as before.
+  [AppEventCode.DCR_BODY_BUILD_FAILED]: alerts.clientRegistrationFailureAlert,
+  [AppEventCode.UNMAPPED_NATIVE_ERROR]: alerts.clientRegistrationFailureAlert,
   [AppEventCode.ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL]: alerts.clientRegistrationNullAlert,
   [AppEventCode.ERR_109_FAILED_TO_DESERIALIZE_JSON]: alerts.failedToDeserializeJsonAlert,
   [AppEventCode.ERR_115_FAILED_TO_SERIALIZE_JSON]: alerts.failedToSerializeJsonAlert,

--- a/app/src/bcsc-theme/utils/key-recovery.test.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.test.ts
@@ -205,4 +205,26 @@ describe('performKeyRecovery', () => {
     expect(mockedDeleteKey).toHaveBeenCalledWith('rsa3')
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining(`failed to prune 'rsa2'`))
   })
+
+  it('logs a non-fatal post-prune verification failure via the describeError string fallback', async () => {
+    const apiClient = makeApiClient({ keys: [{ kid: 'rsa1' }] })
+    mockedGetAllKeys.mockResolvedValueOnce([
+      { id: 'rsa1', algorithm: 'RSA', size: 4096, created: 1000 } as any,
+      { id: 'rsa2', algorithm: 'RSA', size: 4096, created: 2000 } as any,
+    ])
+    // Post-prune verification re-fetch rejects with a bare (non-Error) value, exercising
+    // describeError's String(err) fallback rather than the code/message extraction path.
+    mockedGetAllKeys.mockRejectedValueOnce('keystore unavailable')
+    mockedSetActive.mockResolvedValue(undefined as any)
+    mockedDeleteKey.mockResolvedValue(undefined as any)
+    const logger = makeLogger()
+
+    const ok = await performKeyRecovery(apiClient, CLIENT_ID, REG_TOKEN, logger)
+
+    // Verification is best-effort; recovery still reports success.
+    expect(ok).toBe(true)
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('post-prune verification failed: keystore unavailable')
+    )
+  })
 })

--- a/app/src/bcsc-theme/utils/key-recovery.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.ts
@@ -2,6 +2,15 @@ import { BifoldLogger } from '@bifold/core'
 import { deleteKey, getAllKeys, setActiveKeyAlias } from 'react-native-bcsc-core'
 import BCSCApiClient from '../api/client'
 
+/** Format a caught error for logging, surfacing the native error code (e.g. E_KEY_NOT_FOUND) when present. */
+const describeError = (err: unknown): string => {
+  if (err instanceof Error) {
+    const code = (err as { code?: unknown }).code
+    return typeof code === 'string' ? `${code}: ${err.message}` : err.message
+  }
+  return String(err)
+}
+
 interface ServerJwk {
   kid: string
   kty?: string
@@ -83,8 +92,7 @@ export async function performKeyRecovery(
         logger.info(`[performKeyRecovery] pruned local kid '${k.id}'`)
       } catch (err) {
         pruneFailures++
-        const m = err instanceof Error ? err.message : String(err)
-        logger.warn(`[performKeyRecovery] failed to prune '${k.id}': ${m}`)
+        logger.warn(`[performKeyRecovery] failed to prune '${k.id}': ${describeError(err)}`)
       }
     }
     // Post-prune invariant check. On iOS, setActiveKeyAlias is validate-only
@@ -104,16 +112,14 @@ export async function performKeyRecovery(
         )
       }
     } catch (verifyErr) {
-      const m = verifyErr instanceof Error ? verifyErr.message : String(verifyErr)
-      logger.warn(`[performKeyRecovery] post-prune verification failed: ${m}`)
+      logger.warn(`[performKeyRecovery] post-prune verification failed: ${describeError(verifyErr)}`)
     }
     logger.info(
       `[performKeyRecovery] event=succeeded active='${matched.id}' pruned=${prunedCount} prune_failures=${pruneFailures}`
     )
     return true
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    logger.error(`[performKeyRecovery] event=failed_probe recovery probe failed: ${message}`)
+    logger.error(`[performKeyRecovery] event=failed_probe recovery probe failed: ${describeError(error)}`)
     return false
   }
 }

--- a/app/src/bcsc-theme/utils/key-recovery.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.ts
@@ -2,11 +2,18 @@ import { BifoldLogger } from '@bifold/core'
 import { deleteKey, getAllKeys, setActiveKeyAlias } from 'react-native-bcsc-core'
 import BCSCApiClient from '../api/client'
 
-/** Format a caught error for logging, surfacing the native error code (e.g. E_KEY_NOT_FOUND) when present. */
+/**
+ * Format a caught error for logging, surfacing the native error code (e.g. E_KEY_NOT_FOUND) when
+ * present. Handles plain-object rejections ({ code, message }) as well as Error instances, so the
+ * code is never lost to an "[object Object]" string.
+ */
 const describeError = (err: unknown): string => {
-  if (err instanceof Error) {
-    const code = (err as { code?: unknown }).code
-    return typeof code === 'string' ? `${code}: ${err.message}` : err.message
+  if (err && typeof err === 'object') {
+    const { code, message } = err as { code?: unknown; message?: unknown }
+    const parts = [code, message].filter((part): part is string => typeof part === 'string')
+    if (parts.length > 0) {
+      return parts.join(': ')
+    }
   }
   return String(err)
 }

--- a/app/src/bcsc-theme/utils/native-error-map.test.ts
+++ b/app/src/bcsc-theme/utils/native-error-map.test.ts
@@ -148,6 +148,12 @@ describe('native-error-map', () => {
       expect(mapNativeBcscError(new Error('plain')).appEvent).toBe(ErrorRegistry.UNMAPPED_NATIVE_ERROR.appEvent)
       expect(mapNativeBcscError('a string').appEvent).toBe(ErrorRegistry.UNMAPPED_NATIVE_ERROR.appEvent)
     })
+
+    it('returns an already-mapped AppError unchanged (no re-wrap, no second analytics event)', () => {
+      const alreadyMapped = mapNativeBcscError(nativeError('E_TOKEN_SAVE_FAILED'))
+
+      expect(mapNativeBcscError(alreadyMapped)).toBe(alreadyMapped)
+    })
   })
 
   describe('throwNativeBcscError', () => {

--- a/app/src/bcsc-theme/utils/native-error-map.ts
+++ b/app/src/bcsc-theme/utils/native-error-map.ts
@@ -1,4 +1,5 @@
 import { AppError, ErrorRegistry } from '@/errors'
+import { isAppError } from '@/errors/appError'
 import { ErrorDefinition } from '@/errors/errorRegistry'
 import { isBcscNativeError } from 'react-native-bcsc-core'
 
@@ -118,7 +119,8 @@ export const nativeBcscErrorMap: ReadonlyMap<string, ErrorDefinition> = new Map<
   ['E_DELETE_SAVED_SERVICES_ERROR', ErrorRegistry.NATIVE_STORAGE_DELETE_FAILED],
 
   // --- Device auth / security. NOTE: E_DEVICE_AUTH_CANCELLED is intentionally NOT mapped — a user
-  // cancel is control flow, handled at the call site, never surfaced as an error. ---
+  // cancel is control flow, never surfaced as an error. Only Android's performDeviceAuthentication
+  // rejects it; unlockWithDeviceSecurity resolves { success: false } on cancel on both platforms. ---
   ['E_CAN_DEVICE_AUTH_ERROR', ErrorRegistry.DEVICE_AUTH_UNAVAILABLE],
   ['E_NO_ACTIVITY', ErrorRegistry.DEVICE_AUTH_UNAVAILABLE],
   ['E_DEVICE_AUTH_ERROR', ErrorRegistry.DEVICE_SECURITY_SETUP_FAILED],
@@ -160,8 +162,17 @@ export const nativeBcscErrorMap: ReadonlyMap<string, ErrorDefinition> = new Map<
  * Mapped native codes become their specific AppError. Unmapped native codes — and non-native errors
  * — fall back to {@link ErrorRegistry.UNMAPPED_NATIVE_ERROR}; the raw native code is never lost
  * because it is preserved on the error `cause` and surfaced by `AppError.technicalMessage`.
+ *
+ * An error that is already an {@link AppError} is returned unchanged.
  */
 export const mapNativeBcscError = (error: unknown): AppError => {
+  // An AppError also satisfies isBcscNativeError (it's an Error with a `code`), but its dotted
+  // code never matches the map — re-wrapping would bury the specific code under
+  // UNMAPPED_NATIVE_ERROR and fire a second analytics event for the same failure.
+  if (isAppError(error)) {
+    return error
+  }
+
   if (isBcscNativeError(error)) {
     const definition = nativeBcscErrorMap.get(error.code)
     if (definition) {


### PR DESCRIPTION
**This was originally PR #4113 which I merged into the wrong branch. This PR is a duplicate targeting the correct branch.**

## What

Route every native `bcsc-core` call through the unified error mapper (added in #4077) so each native failure surfaces as its own distinct app error instead of a generic one.

## Why

Today almost every native failure collapses into one of a few generic "something went wrong" buckets that throw away the real cause — so when something breaks in production, the problem report and the analytics dashboard can't tell *what* actually failed. This makes each distinct native failure traceable end-to-end and removes the catch-all buckets.

## Current Behavior

Most call sites that talk to the native module wrap failures in one of five broad buckets (`CLIENT_REGISTRATION_FAILURE`, `STORAGE_READ_ERROR`, `STORAGE_WRITE_ERROR`, `SIGN_CLAIMS_ERROR`, `DEVICE_AUTHENTICATION_ERROR`). The underlying native error code is discarded, so different root causes look identical in the report and in analytics. Only the registration path mapped a handful of codes.

## Proposed Change

Every `bcsc-core` call site — registration, tokens, pairing, the API client, secure-storage save/load, device auth, and key recovery — now goes through the shared mapper. Each native failure becomes a distinct app error; anything not explicitly mapped still carries its raw native code through to the report (nothing is hidden). The key-recovery path logs the native code without creating a tracked error.

Self-review fixes folded in:

- The registration alert map now covers `DCR_BODY_BUILD_FAILED` and `UNMAPPED_NATIVE_ERROR` (the events that replaced the old `CLIENT_REGISTRATION_FAILURE` fallback), so DCR body-build failures keep showing the generic modal instead of failing silently.
- `mapNativeBcscError` passes an already-mapped `AppError` through unchanged — previously it would re-wrap it as `UNMAPPED_NATIVE_ERROR` and fire a duplicate analytics event.
- User cancel of device auth needs no special handling here: `unlockWithDeviceSecurity` resolves `{ success: false }` on cancel on both platforms (it never rejects with `E_DEVICE_AUTH_CANCELLED`), and the existing resolve path already treats it silently.

Follow-up cleanup (not in this PR): `ErrorRegistry.CLIENT_REGISTRATION_FAILURE`, `STORAGE_READ_ERROR`, `STORAGE_WRITE_ERROR`, and `DEVICE_AUTHENTICATION_ERROR` no longer have production throw sites after this change; they're kept for now (tests use them as fixtures) and can be retired alongside the native follow-up work in #4078.

Depends on #4077 (merged). Part of #3419.

Fixes #3453
Fixes #3419