### PR TITLE
fix: surface JSON server reason in evidence 4xx errors

### DIFF
--- a/app/src/errors/appError.test.ts
+++ b/app/src/errors/appError.test.ts
@@ -83,7 +83,7 @@ describe('AppError', () => {
       expect(error.technicalMessage).toBe('Request failed with status code 400: email_address is invalid')
     })
 
-    it('should not append the response body for AxiosErrors when it is not a string', () => {
+    it('should not append the response body for objects without a string message', () => {
       const identity = {
         category: ErrorCategory.NETWORK,
         appEvent: AppEventCode.ERR_209_BAD_REQUEST,
@@ -96,6 +96,68 @@ describe('AppError', () => {
       const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
 
       expect(error.technicalMessage).toBe('Request failed with status code 400')
+    })
+
+    it('should not append the response body when the JSON message field is not a string', () => {
+      const identity = {
+        category: ErrorCategory.NETWORK,
+        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
+        statusCode: 2107,
+      }
+      const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
+        isAxiosError: true,
+        response: { data: { message: 42 } },
+      })
+      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+
+      expect(error.technicalMessage).toBe('Request failed with status code 400')
+    })
+
+    it('should append the JSON message field for AxiosErrors when the response body is an object (e.g. IAS 4xx evidence rejections)', () => {
+      const identity = {
+        category: ErrorCategory.NETWORK,
+        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
+        statusCode: 2107,
+      }
+      const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
+        isAxiosError: true,
+        response: { data: { message: 'unexpected images count' } },
+      })
+      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+
+      expect(error.technicalMessage).toBe('Request failed with status code 400: unexpected images count')
+    })
+
+    it('should truncate a JSON message field longer than 500 chars', () => {
+      const identity = {
+        category: ErrorCategory.NETWORK,
+        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
+        statusCode: 2107,
+      }
+      const longMessage = 'x'.repeat(600)
+      const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
+        isAxiosError: true,
+        response: { data: { message: longMessage } },
+      })
+      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+
+      expect(error.technicalMessage).toBe(`Request failed with status code 400: ${'x'.repeat(500)}`)
+    })
+
+    it('should truncate a string response body longer than 500 chars', () => {
+      const identity = {
+        category: ErrorCategory.NETWORK,
+        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
+        statusCode: 2107,
+      }
+      const longBody = 'y'.repeat(600)
+      const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
+        isAxiosError: true,
+        response: { data: longBody },
+      })
+      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+
+      expect(error.technicalMessage).toBe(`Request failed with status code 400: ${'y'.repeat(500)}`)
     })
   })
 
@@ -122,6 +184,28 @@ describe('AppError', () => {
 
       expect(error.fullMessage).toBe(
         'Something went wrong\nDebug: [general.unknown_server_error.1234] Technical details about the error'
+      )
+    })
+
+    it('carries the JSON message field from an evidence 4xx rejection into fullMessage for problem reports', () => {
+      // Mirrors an IAS evidence API rejection (e.g. POST /evidence/v1/documents): the body is
+      // JSON `{"message":"unexpected images count"}`. fullMessage embeds technicalMessage, and
+      // fullMessage is what ErrorAlertContext.emitErrorModal forwards as `message` to
+      // ErrorModal.handleReport -> logger.reportProblem, which is what reaches Loki when the
+      // user taps "Report a problem". The server's real reason must survive that whole path.
+      const identity = {
+        category: ErrorCategory.NETWORK,
+        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
+        statusCode: 2107,
+      }
+      const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
+        isAxiosError: true,
+        response: { data: { message: 'unexpected images count' } },
+      })
+      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+
+      expect(error.fullMessage).toBe(
+        'Bad request\nDebug: [network.err_209_bad_request.2107] Request failed with status code 400: unexpected images count'
       )
     })
 
@@ -327,6 +411,26 @@ describe('AppError', () => {
         code: 'ERR_BAD_REQUEST',
         responseData: 'email_address is invalid',
       })
+    })
+
+    it('includes the JSON message field in the serialized technicalMessage for evidence 4xx rejections', () => {
+      // toJSON().technicalMessage is what client.ts and ErrorAlertContext auto-log to Loki for
+      // every AppError (not just user-initiated "Report a problem"), so the lifted JSON `message`
+      // must survive serialization too.
+      const identity = {
+        category: ErrorCategory.NETWORK,
+        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
+        statusCode: 2107,
+      }
+      const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
+        isAxiosError: true,
+        response: { status: 400, data: { message: 'unexpected images count' } },
+      })
+      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+
+      const json = error.toJSON()
+
+      expect(json.technicalMessage).toBe('Request failed with status code 400: unexpected images count')
     })
 
     it('keeps native-module userInfo diagnostics on the summarized cause', () => {

--- a/app/src/errors/appError.test.ts
+++ b/app/src/errors/appError.test.ts
@@ -159,6 +159,30 @@ describe('AppError', () => {
 
       expect(error.technicalMessage).toBe(`Request failed with status code 400: ${'y'.repeat(500)}`)
     })
+
+    it('carries the server reason through re-wrapping when the cause is itself an AppError', () => {
+      // Mirrors useEvidenceUploadModel: an inner 2107 BAD_REQUEST AppError (caused by an IAS
+      // 400 with a JSON `{message}` body, e.g. "invalid duration" for an out-of-range video) is
+      // caught and re-wrapped as an outer 2404 FILE_UPLOAD_ERROR AppError. The outer error's
+      // `cause` is the inner AppError (no `.response` of its own), so without preferring the
+      // inner error's technicalMessage, the server's reason would be lost behind the generic
+      // FILE_UPLOAD_ERROR message.
+      const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
+        isAxiosError: true,
+        response: { data: { message: 'invalid duration' } },
+      })
+      const innerError = AppError.fromErrorDefinition(ErrorRegistry.BAD_REQUEST, { cause: axiosLike, track: false })
+      const outerError = AppError.fromErrorDefinition(ErrorRegistry.FILE_UPLOAD_ERROR, {
+        cause: innerError,
+        track: false,
+      })
+
+      expect(innerError.technicalMessage).toBe('Request failed with status code 400: invalid duration')
+      expect(outerError.technicalMessage).toContain('invalid duration')
+      expect(outerError.technicalMessage).toBe(
+        'network.err_209_bad_request.2107: Request failed with status code 400: invalid duration'
+      )
+    })
   })
 
   describe('fullMessage', () => {
@@ -206,6 +230,30 @@ describe('AppError', () => {
 
       expect(error.fullMessage).toBe(
         'Bad request\nDebug: [network.err_209_bad_request.2107] Request failed with status code 400: unexpected images count'
+      )
+    })
+
+    it('carries the server reason through re-wrapping into fullMessage for problem reports (evidence upload re-wrap)', () => {
+      // Mirrors useEvidenceUploadModel.tsx: uploadVideoEvidenceMetadata throws an inner 2107
+      // BAD_REQUEST AppError from an IAS 400 (`{"message":"invalid duration"}`), which the
+      // catch block re-wraps as an outer 2404 FILE_UPLOAD_ERROR AppError before showing
+      // fileUploadErrorAlert. fullMessage is what reaches Loki via "Report a problem" — the
+      // real server reason must survive this second layer of wrapping, not just the first.
+      const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
+        isAxiosError: true,
+        response: { data: { message: 'invalid duration' } },
+      })
+      const innerError = AppError.fromErrorDefinition(ErrorRegistry.BAD_REQUEST, { cause: axiosLike, track: false })
+      const outerError = AppError.fromErrorDefinition(ErrorRegistry.FILE_UPLOAD_ERROR, {
+        cause: innerError,
+        track: false,
+      })
+
+      expect(outerError.fullMessage).toContain('invalid duration')
+      expect(outerError.fullMessage).toBe(
+        'File upload request failed — network error or server rejection\n' +
+          'Debug: [verification.file_upload_error.2404] network.err_209_bad_request.2107: ' +
+          'Request failed with status code 400: invalid duration'
       )
     })
 

--- a/app/src/errors/appError.ts
+++ b/app/src/errors/appError.ts
@@ -135,7 +135,13 @@ export class AppError extends Error {
     // Include the server's reason: a string body (truncated to the cap), or the `message` field of a JSON body
     const serverReason = extractServerReason(isAxiosError ? cause.response?.data : undefined)
 
-    return [code, cause.message, serverReason].filter(Boolean).join(': ')
+    // When the cause is itself an AppError (e.g. a 2107 client error re-wrapped as a
+    // 2404 file-upload error), its `technicalMessage` already carries the server reason;
+    // the generic `message` does not. Prefer it so the reason survives re-wrapping.
+    const causeDetail =
+      this.cause instanceof AppError ? (this.cause.technicalMessage ?? this.cause.message) : cause.message
+
+    return [code, causeDetail, serverReason].filter(Boolean).join(': ')
   }
 
   /**

--- a/app/src/errors/appError.ts
+++ b/app/src/errors/appError.ts
@@ -51,20 +51,23 @@ const summarizeCause = (cause: unknown): unknown => {
   return summary
 }
 
+/** Cap on the server reason lifted by {@link extractServerReason}, so oversized bodies never bloat logs. */
+const MAX_SERVER_REASON_LENGTH = 500
+
 /**
  * Lift a human-readable reason from an HTTP error response body.
  * Handles plain-string bodies (e.g. "email_address is invalid", 5xx HTML pages)
  * and JSON bodies with a string `message` (e.g. {"message":"unexpected images count"}).
- * Capped at 500 chars so oversized bodies never bloat logs.
+ * Truncated to {@link MAX_SERVER_REASON_LENGTH} chars so oversized bodies never bloat logs.
  */
 const extractServerReason = (responseData: unknown): string | undefined => {
   if (typeof responseData === 'string' && responseData.length > 0) {
-    return responseData.slice(0, 500)
+    return responseData.slice(0, MAX_SERVER_REASON_LENGTH)
   }
   if (responseData && typeof responseData === 'object') {
     const message = (responseData as { message?: unknown }).message
     if (typeof message === 'string' && message.length > 0) {
-      return message.slice(0, 500)
+      return message.slice(0, MAX_SERVER_REASON_LENGTH)
     }
   }
   return undefined
@@ -129,7 +132,7 @@ export class AppError extends Error {
     // For non-Axios errors (e.g. native module errors), cause.code is a meaningful prefix like "E_KEY_NOT_FOUND"
     const code = !isAxiosError && typeof cause.code === 'string' ? cause.code : undefined
 
-    // Include the server's reason: a short string body, or the `message` field of a JSON body
+    // Include the server's reason: a string body (truncated to the cap), or the `message` field of a JSON body
     const serverReason = extractServerReason(isAxiosError ? cause.response?.data : undefined)
 
     return [code, cause.message, serverReason].filter(Boolean).join(': ')

--- a/app/src/errors/appError.ts
+++ b/app/src/errors/appError.ts
@@ -52,6 +52,25 @@ const summarizeCause = (cause: unknown): unknown => {
 }
 
 /**
+ * Lift a human-readable reason from an HTTP error response body.
+ * Handles plain-string bodies (e.g. "email_address is invalid", 5xx HTML pages)
+ * and JSON bodies with a string `message` (e.g. {"message":"unexpected images count"}).
+ * Capped at 500 chars so oversized bodies never bloat logs.
+ */
+const extractServerReason = (responseData: unknown): string | undefined => {
+  if (typeof responseData === 'string' && responseData.length > 0) {
+    return responseData.slice(0, 500)
+  }
+  if (responseData && typeof responseData === 'object') {
+    const message = (responseData as { message?: unknown }).message
+    if (typeof message === 'string' && message.length > 0) {
+      return message.slice(0, 500)
+    }
+  }
+  return undefined
+}
+
+/**
  * Custom application error class with structured information.
  *
  * @extends {Error}
@@ -110,9 +129,8 @@ export class AppError extends Error {
     // For non-Axios errors (e.g. native module errors), cause.code is a meaningful prefix like "E_KEY_NOT_FOUND"
     const code = !isAxiosError && typeof cause.code === 'string' ? cause.code : undefined
 
-    // Include the server's response body when it's a short plain string (e.g. "email_address is invalid")
-    const responseData = isAxiosError ? cause.response?.data : undefined
-    const serverReason = typeof responseData === 'string' && responseData.length <= 500 ? responseData : undefined
+    // Include the server's reason: a short string body, or the `message` field of a JSON body
+    const serverReason = extractServerReason(isAxiosError ? cause.response?.data : undefined)
 
     return [code, cause.message, serverReason].filter(Boolean).join(': ')
   }


### PR DESCRIPTION
## What

When the identity-verification server rejects a submission (photo, video, or document upload) with a 4xx error, it includes a reason in the response body — e.g. `{"message":"unexpected images count"}`. The app was discarding that reason and only keeping a generic message, so every rejection looked identical in our logs and in "Report a problem" submissions. This change keeps the server's actual reason so it shows up in both places.

<img width="256" alt="Screenshot_20260710-215141" src="https://github.com/user-attachments/assets/46ce34e4-aaaf-4eb0-9df6-c57628ed67c7" />

## Why

- Support and engineering couldn't tell different 4xx rejections apart from our own logs — every one looked the same.
- The reason was already on the device; the app just wasn't reading it out of the JSON body.
- This directly unblocks diagnosing evidence-upload failures (see #4159), and the reason now flows into "Report a problem" submissions sent to our remote logs, per the request on the issue.
- No user-facing copy changes — this is purely additive to logging/diagnostics.

## Decisions

- Fixed the single choke point: `AppError.technicalMessage` (`app/src/errors/appError.ts`). Added a module-level `extractServerReason` helper that lifts either a short string body (existing behavior, e.g. 5xx HTML pages) or a JSON body's string `message` field (new). Both paths cap at 500 characters.
- Deliberately did not touch `formatIasAxiosResponseError` or `getClientErrorDefinitionFromStatus` — rewriting error classification there for the IAS `{message}` shape (which carries no error code) would risk reclassifying errors for no benefit. This fix is purely additive.
- Verified the three existing `technicalMessage`-based error-policy matchers in `clientErrorPolicies.ts` are unaffected: two use `.includes()` (safe by construction), and the exact-match `cardExpiredErrorPolicy` (`technicalMessage === 'card_expired'`) only ever sees a bare-message `AxiosError` with no `.response` body in practice, so the new JSON-lifting branch never engages for it — confirmed by re-running its full test suite (153/153 passing).
- Traced the "Report a problem" path end-to-end per the issue's comment: `fullMessage` (embeds `technicalMessage`) → `ErrorAlertContext.emitErrorModal` → `ErrorModal.handleReport` → `logger.reportProblem`, whose Loki payload includes `message`. The fix lights this up automatically, as does the auto-logged `toJSON().technicalMessage` path.
- Only top-level `{ "message": "..." }` bodies are handled (per plan scope) — nested shapes are out of scope.
- String bodies longer than 500 characters now get truncated (previously dropped entirely) — strictly more informative than before, and matches the JSON-message truncation behavior.
- The server reason now propagates through error re-wrapping: when an `AppError`'s `cause` is itself an `AppError` (e.g. the evidence-upload flow catching an inner 2107 `BAD_REQUEST` error and re-wrapping it as an outer 2404 `file_upload_error` via `AppError.fromErrorDefinition(ErrorRegistry.FILE_UPLOAD_ERROR, { cause: error })` in `useEvidenceUploadModel.tsx`), `technicalMessage` now prefers the inner error's own `technicalMessage` over its generic `message`. Without this, the reason surfaced correctly on the inner error but was lost the moment the UI layer re-wrapped it — confirmed live on-device before/after. Re-wrapped errors now carry the server's reason into `technicalMessage`/`fullMessage` and the "Report a problem" Loki payload, not just single-layer errors.

## Tests

Extended `app/src/errors/appError.test.ts`:
- JSON `{ message: '...' }` body is lifted into `technicalMessage`, `fullMessage`, and `toJSON().technicalMessage`.
- Existing string-body behavior is unchanged.
- Object bodies without a string `message` field (including a non-string `message` value) still fall back to the bare cause message.
- Both string bodies and JSON `message` values longer than 500 characters are truncated at 500.
- Re-wrapped errors (an outer `AppError` whose `cause` is itself an `AppError`, mirroring the evidence-upload flow's 2107→2404 re-wrap) carry the inner server reason through into both `technicalMessage` and `fullMessage`.

## Verification

- `yarn jest src/errors/appError.test.ts` — 36/36 passed.
- `yarn jest src/bcsc-theme/api/clientErrorPolicies.test.ts` — 153/153 passed (confirms no regression to the `technicalMessage`-based policy matchers).
- `yarn typecheck`, `lint:ts`, `format:ts:check` (app + bcsc-core), and the full app test suite (263 suites / 2450 tests / 157 snapshots) all pass. `packages/bcsc-core`'s Swift lint/format-check fails on files this branch never touches — confirmed pre-existing and unrelated to this diff (identical to `origin/main`, a local SwiftFormat version mismatch).

## Manual testing (reproducing a JSON 4xx locally)

The evidence endpoints only return their JSON `{ "message": "..." }` reason on a real 4xx, and the app is otherwise built to avoid the images-count rejection (the #4159 clamp prevents an over-count). To exercise this fix end-to-end, temporarily force a server rejection with a small **uncommitted** tamper — revert it before committing.

**Force `invalid duration` on the send-video flow** (the simplest reachable path). In `app/src/bcsc-theme/features/verify/send-video/useEvidenceUploadModel.tsx`, inside `uploadEvidenceMetadata`, just before the `Promise.all`:

```ts
videoMetadata.duration = 3600 // TEMP — force POST /evidence/v1/videos to return a 400
```

Run the `bcsc` target against SIT, record + send the video, then confirm in Metro:
- `[POST] …/evidence/v1/videos` → 400 with body `{"message":"invalid duration"}`.
- The re-wrapped `file_upload_error` (2404) — i.e. the "Report a problem" / Loki payload — now carries `invalid duration` in its `Debug:` line, not just the generic string. (Before this PR the reason was lost at the re-wrap; that is exactly what the propagation change above fixes.)

Revert with:

```
git restore app/src/bcsc-theme/features/verify/send-video/useEvidenceUploadModel.tsx
```

_Alternative — the images-count path (`POST /evidence/v1/documents`, "unexpected images count"): run a non-photo / non-BCSC verification that captures a 2-sided secondary ID, then duplicate an entry in `metadataPayload.images` in `useEvidenceUpload.tsx` (after the `clampEvidenceImagesToSides` guard). The send-video tamper above is the easier reproducer._

Fixes #4160
