### PR TITLE
fix: prevent verify prompt from showing except after onboarding

### DIFF
--- a/app/src/bcsc-theme/features/onboarding/VerifyPromptScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/VerifyPromptScreen.tsx
@@ -10,43 +10,49 @@ import { Edges } from 'react-native-safe-area-context'
 /**
  * One-time prompt shown after onboarding completes (PIN created) and before the
  * user enters the main app. Lets them choose to start identity verification now
- * or defer it until later. The choice is recorded via `SEEN_VERIFY_PROMPT` so
- * the screen is not shown again on subsequent launches.
+ * or defer it until later. Also reachable from the main app (without the skip
+ * button) for a user who deferred.
  */
 interface VerifyPromptScreenProps {
   showSkip?: boolean
   edges?: Edges
   /**
-   * Optional callback fired right after "Continue" records the choice. When the prompt is the
-   * entry screen of VerifyStack, this navigates (with a slide) to the next step within the same
-   * navigator instead of relying on a RootStack stack swap, which would jump.
+   * Fired when either button is pressed, marking the one-time prompt answered for this session.
+   * Set by VerifyStack; the main-app copy of this screen has nothing to dismiss.
+   */
+  onAnswered?: () => void
+  /**
+   * Optional callback fired right after "Continue". When the prompt is the entry screen of
+   * VerifyStack, this navigates (with a slide) to the next step within the same navigator
+   * instead of relying on a RootStack stack swap, which would jump.
    */
   onContinue?: () => void
 }
 
-export const VerifyPromptScreen: React.FC<VerifyPromptScreenProps> = ({ showSkip = true, edges, onContinue }) => {
+export const VerifyPromptScreen: React.FC<VerifyPromptScreenProps> = ({
+  showSkip = true,
+  edges,
+  onAnswered,
+  onContinue,
+}) => {
   const { t } = useTranslation()
   const { Spacing, ColorPalette } = useTheme()
   const [, dispatch] = useStore<BCState>()
 
-  const markPromptSeen = useCallback(() => {
-    dispatch({ type: BCDispatchAction.SEEN_VERIFY_PROMPT, payload: [true] })
-  }, [dispatch])
-
   const handleVerifyNow = useCallback(() => {
-    markPromptSeen()
+    onAnswered?.()
     dispatch({
       type: BCDispatchAction.UPDATE_SECURE_VERIFIED_STATUS,
       payload: [VerificationStatus.IN_PROGRESS],
     })
-    // These dispatches keep VerifyStack mounted (verification is now in progress), so onContinue
-    // can navigate within it for a normal slide transition.
+    // Verification is now in progress, which keeps VerifyStack mounted, so onContinue can navigate
+    // within it for a normal slide transition.
     onContinue?.()
-  }, [dispatch, markPromptSeen, onContinue])
+  }, [dispatch, onAnswered, onContinue])
 
   const handleLater = useCallback(() => {
-    markPromptSeen()
-  }, [markPromptSeen])
+    onAnswered?.()
+  }, [onAnswered])
 
   const controls = (
     <ControlContainer>

--- a/app/src/bcsc-theme/hooks/useLeaveVerification.test.tsx
+++ b/app/src/bcsc-theme/hooks/useLeaveVerification.test.tsx
@@ -13,14 +13,13 @@ describe('useLeaveVerification', () => {
     jest.mocked(Bifold.useStore).mockReturnValue([{} as any, mockDispatch])
   })
 
-  it('marks the verify prompt seen and moves status out of IN_PROGRESS so the RootStack shows home', () => {
+  it('moves status out of IN_PROGRESS so the RootStack shows home', () => {
     const { result } = renderHook(() => useLeaveVerification())
 
     act(() => {
       result.current()
     })
 
-    expect(mockDispatch).toHaveBeenCalledWith({ type: BCDispatchAction.SEEN_VERIFY_PROMPT, payload: [true] })
     expect(mockDispatch).toHaveBeenCalledWith({
       type: BCDispatchAction.UPDATE_SECURE_VERIFIED_STATUS,
       payload: [VerificationStatus.UNVERIFIED],
@@ -34,8 +33,8 @@ describe('useLeaveVerification', () => {
       result.current()
     })
 
-    // Only the two routing dispatches; nothing that clears evidence/credential/auth-request.
-    expect(mockDispatch).toHaveBeenCalledTimes(2)
+    // Only the routing dispatch; nothing that clears evidence/credential/auth-request.
+    expect(mockDispatch).toHaveBeenCalledTimes(1)
   })
 
   it('runs the optional onLeave callback before leaving (e.g. to close the menu)', () => {

--- a/app/src/bcsc-theme/hooks/useLeaveVerification.tsx
+++ b/app/src/bcsc-theme/hooks/useLeaveVerification.tsx
@@ -7,10 +7,10 @@ import { useCallback } from 'react'
  * home screen, *preserving* their verification progress so they can resume later — unlike
  * {@link useRestartVerification}, which wipes progress.
  *
- * Marking the one-time prompt seen and moving the verification status out of IN_PROGRESS makes the
- * RootStack render the MainStack instead of the VerifyStack (see RootStack `showVerifyStack`). No
- * verification data is cleared, so the user can pick up where they left off via the home screen's
- * "continue verification" notification (which dispatches IN_PROGRESS again).
+ * Moving the verification status out of IN_PROGRESS makes the RootStack render the MainStack instead
+ * of the VerifyStack (see RootStack `showVerifyStack`). No verification data is cleared, so the user
+ * can pick up where they left off via the home screen's "continue verification" notification (which
+ * dispatches IN_PROGRESS again).
  *
  * @returns {(onLeave?: () => void) => void} Callback that leaves the flow. The optional `onLeave`
  * runs first (e.g. to close the menu the action was triggered from).
@@ -21,9 +21,6 @@ export const useLeaveVerification = () => {
   return useCallback(
     (onLeave?: () => void) => {
       onLeave?.()
-      // Seen-prompt guards the RootStack's first `showVerifyStack` clause; UNVERIFIED clears the
-      // second (IN_PROGRESS) clause, together swapping the VerifyStack for the MainStack (home).
-      dispatch({ type: BCDispatchAction.SEEN_VERIFY_PROMPT, payload: [true] })
       dispatch({ type: BCDispatchAction.UPDATE_SECURE_VERIFIED_STATUS, payload: [VerificationStatus.UNVERIFIED] })
     },
     [dispatch]

--- a/app/src/bcsc-theme/navigators/RootStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.test.tsx
@@ -225,7 +225,7 @@ describe('BCSCRootStack', () => {
     const mockDispatch = jest.fn()
     jest.mocked(Bifold.useStore).mockReturnValue([
       mockStore({
-        bcsc: { hasAccount: true, hasSeenVerifyPrompt: true },
+        bcsc: { hasAccount: true },
         authentication: { didAuthenticate: true },
         bcscSecure: { verified: undefined },
       }),
@@ -237,11 +237,41 @@ describe('BCSCRootStack', () => {
     expect(toJSON()).toBe('MainStack')
   })
 
-  it('renders VerifyStack (which opens on the verify prompt) when the user has not seen the prompt and is not verified', () => {
+  it('renders VerifyStack (which opens on the verify prompt) when onboarding completes', () => {
     const mockDispatch = jest.fn()
     jest.mocked(Bifold.useStore).mockReturnValue([
       mockStore({
-        bcsc: { hasAccount: true, hasSeenVerifyPrompt: false },
+        bcsc: { hasAccount: false },
+        authentication: { didAuthenticate: false },
+        bcscSecure: { verified: false },
+      }),
+      mockDispatch,
+    ] as any)
+
+    const { toJSON, rerender } = render(<BCSCRootStack />)
+    expect(toJSON()).toBe('OnboardingStack')
+
+    // Creating the PIN completes onboarding: SUCCESSFUL_AUTH sets both flags at once.
+    jest.mocked(Bifold.useStore).mockReturnValue([
+      mockStore({
+        bcsc: { hasAccount: true },
+        authentication: { didAuthenticate: true },
+        bcscSecure: { verified: false },
+      }),
+      mockDispatch,
+    ] as any)
+    rerender(<BCSCRootStack />)
+
+    expect(toJSON()).toBe('VerifyStack')
+  })
+
+  it('renders MainStack when an existing unverified account unlocks', () => {
+    const mockDispatch = jest.fn()
+    // No OnboardingStack render this session — the user is returning, so the one-time prompt has
+    // passed them by. They start verification from the MainStack instead.
+    jest.mocked(Bifold.useStore).mockReturnValue([
+      mockStore({
+        bcsc: { hasAccount: true },
         authentication: { didAuthenticate: true },
         bcscSecure: { verified: false },
       }),
@@ -250,7 +280,7 @@ describe('BCSCRootStack', () => {
 
     const { toJSON } = render(<BCSCRootStack />)
 
-    expect(toJSON()).toBe('VerifyStack')
+    expect(toJSON()).toBe('MainStack')
   })
 
   it('calls loadState when stateLoaded is false', () => {

--- a/app/src/bcsc-theme/navigators/RootStack.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.tsx
@@ -3,7 +3,7 @@ import { useNavigationContainer } from '@/contexts/NavigationContainerContext'
 import { ErrorRegistry } from '@/errors'
 import { BCState } from '@/store'
 import { TOKENS, useServices, useStore } from '@bifold/core'
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useInitializeAccountStatus } from '../api/hooks/useInitializeAccountStatus'
 import useThirdPartyKeyboardWarning from '../api/hooks/useThirdPartyKeyboardWarning'
@@ -32,6 +32,8 @@ const BCSCRootStack: React.FC = () => {
   const { isNavigationReady } = useNavigationContainer()
   const { initializingAccount } = useInitializeAccountStatus()
   const { needsVerification, isVerified, isVerificationInProgress } = useVerificationStatus()
+  const onboardedThisSession = useRef(false)
+  const [verifyPromptAnswered, setVerifyPromptAnswered] = useState(false)
   useSystemChecks(SystemCheckScope.STARTUP)
   useThirdPartyKeyboardWarning()
 
@@ -61,6 +63,7 @@ const BCSCRootStack: React.FC = () => {
   }
 
   if (store.bcsc.hasAccount === false) {
+    onboardedThisSession.current = true
     return <OnboardingStack />
   }
 
@@ -76,18 +79,25 @@ const BCSCRootStack: React.FC = () => {
     )
   }
 
-  // Render the verify journey (which now opens on the one-time verify prompt) when the user hasn't
-  // seen the prompt yet, OR whenever verification is actively in progress. Combining both into a
-  // single VerifyStack render keeps it mounted across the prompt → in-progress transition, so
-  // VerifyPrompt → AccountSetup animates as an in-stack slide instead of a RootStack swap.
-  const showVerifyStack =
-    (!store.bcsc.hasSeenVerifyPrompt && needsVerification) || (!isVerified && isVerificationInProgress)
+  // The prompt is a one-time hand-off from onboarding into verification: offer it only to a user who
+  // just finished onboarding, has yet to answer it, and has no verification to finish or resume.
+  // Everyone else reaches verification from the MainStack, which resumes them at their current step.
+  const showVerifyPrompt = onboardedThisSession.current && !verifyPromptAnswered && needsVerification
+
+  // Render the verify journey when the prompt is due, OR whenever verification is actively in
+  // progress. Combining both into a single VerifyStack render keeps it mounted across the prompt →
+  // in-progress transition, so VerifyPrompt → AccountSetup animates as an in-stack slide instead of
+  // a RootStack swap.
+  const showVerifyStack = showVerifyPrompt || (!isVerified && isVerificationInProgress)
 
   return (
     <BCSCAgentProvider>
       {showVerifyStack ? (
         <BCSCActivityProvider>
-          <VerifyStack />
+          <VerifyStack
+            showVerifyPrompt={showVerifyPrompt}
+            onVerifyPromptAnswered={() => setVerifyPromptAnswered(true)}
+          />
         </BCSCActivityProvider>
       ) : (
         <BCSCActivityProvider>

--- a/app/src/bcsc-theme/navigators/VerifyStack.tsx
+++ b/app/src/bcsc-theme/navigators/VerifyStack.tsx
@@ -67,24 +67,27 @@ import VideoReviewScreen from '../features/verify/send-video/VideoReviewScreen'
 import VideoTooLongScreen from '../features/verify/send-video/VideoTooLongScreen'
 import { WebViewScreen } from '../features/webview/WebViewScreen'
 import { SystemCheckScope, useSystemChecks } from '../hooks/useSystemChecks'
-import { useVerificationStatus } from '../hooks/useVerificationStatus'
 import { getResumeStepRoute } from '../utils/resume-step-route'
 
-const VerifyStack = () => {
+interface VerifyStackProps {
+  /**
+   * Opens the stack on the one-time verify prompt rather than the user's resume step. Set by
+   * RootStack for the single mount of the prompt that follows onboarding
+   */
+  showVerifyPrompt?: boolean
+  onVerifyPromptAnswered?: () => void
+}
+
+const VerifyStack = ({ showVerifyPrompt = false, onVerifyPromptAnswered }: VerifyStackProps) => {
   const Stack = createStackNavigator<BCSCVerifyStackParams>()
   const theme = useTheme()
   const { t } = useTranslation()
   const defaultStackOptions = useDefaultStackOptions(theme)
   const [store] = useStore<BCState>()
-  const { needsVerification } = useVerificationStatus()
   const resumeRoute = getResumeStepRoute(store)
-  // Show the verify prompt as the first screen the first time the user enters the verify journey
-  // (post-PIN, not yet verified, prompt unseen) so that prompt → setup question animates as an
-  // in-stack slide rather than a RootStack swap. Session recovery always takes precedence.
-  const initialRouteName =
-    !store.bcscSecure.sessionRecoveryRequired && !store.bcsc.hasSeenVerifyPrompt && needsVerification
-      ? BCSCScreens.VerifyPrompt
-      : resumeRoute.name
+  // Opening on the prompt (rather than swapping stacks to reach it) lets prompt → setup question
+  // animate as an in-stack slide. Everyone else resumes at the step they left off on.
+  const initialRouteName = showVerifyPrompt ? BCSCScreens.VerifyPrompt : resumeRoute.name
   useBCSCStack(BCSCStacks.Verify)
 
   // Listen for verification approval push notifications and navigate to success screen
@@ -119,7 +122,12 @@ const VerifyStack = () => {
           headerRight: createVerifyHelpMenuButton(),
         }}
       >
-        {({ navigation }) => <VerifyPromptScreen onContinue={() => navigation.navigate(BCSCScreens.AccountSetup)} />}
+        {({ navigation }) => (
+          <VerifyPromptScreen
+            onAnswered={onVerifyPromptAnswered}
+            onContinue={() => navigation.navigate(BCSCScreens.AccountSetup)}
+          />
+        )}
       </Stack.Screen>
       <Stack.Screen
         name={BCSCScreens.AccountSetup}

--- a/app/src/store.tsx
+++ b/app/src/store.tsx
@@ -95,7 +95,6 @@ export interface BCSCState {
   hasDismissedDeviceAuthInfo?: boolean
   deviceLimitBannerDismissedAt?: string
   credentialMetadata?: CredentialMetadata
-  hasSeenVerifyPrompt?: boolean
   hasSeenOnboardingIntro?: boolean
   showAccountExpiryNotification?: boolean
   showCardRenewalNotification?: boolean
@@ -280,7 +279,6 @@ enum BCSCDispatchAction {
   DISMISSED_EXPIRY_ALERT = 'bcsc/dismissedExpiryAlert',
   DISMISSED_THIRD_PARTY_KEYBOARD_ALERT = 'bcsc/dismissedThirdPartyKeyboardAlert',
   DISMISSED_DEVICE_LIMIT_BANNER = 'bcsc/dismissedDeviceLimitBanner',
-  SEEN_VERIFY_PROMPT = 'bcsc/seenVerifyPrompt',
   SEEN_ONBOARDING_INTRO = 'bcsc/seenOnboardingIntro',
   SET_ACCOUNT_EXPIRY_NOTIFICATION = 'bcsc/setAccountExpiryNotification',
   SET_CARD_RENEWAL_NOTIFICATION = 'bcsc/setCardRenewalNotification',
@@ -775,13 +773,6 @@ const bcReducer = (state: BCState, action: ReducerAction<BCDispatchAction>): BCS
     case BCSCDispatchAction.DISMISSED_DEVICE_LIMIT_BANNER: {
       const dismissedAt = (action?.payload || []).pop() ?? undefined
       const bcsc = { ...state.bcsc, deviceLimitBannerDismissedAt: dismissedAt }
-      const newState = { ...state, bcsc }
-      PersistentStorage.storeValueForKey<BCSCState>(BCLocalStorageKeys.BCSC, bcsc)
-      return newState
-    }
-    case BCSCDispatchAction.SEEN_VERIFY_PROMPT: {
-      const hasSeen = (action?.payload || []).pop() ?? true
-      const bcsc = { ...state.bcsc, hasSeenVerifyPrompt: hasSeen }
       const newState = { ...state, bcsc }
       PersistentStorage.storeValueForKey<BCSCState>(BCLocalStorageKeys.BCSC, bcsc)
       return newState


### PR DESCRIPTION
# Summary of Changes

VerifyPromptScreen only shows after onboarding. VerifyPromptScreenNoSkip still shows where it did before.

# Testing Instructions

Get 4.0.2 from Testflight, send a video request, don't approve it. Then build this branch overtop, and verify you don't see the VerifyPromptScreen after logging in.

Delete your account and go through onboarding again, check that you do see the VerifyPromptScreen at the end.

# Acceptance Criteria

Works

# Screenshots, videos, or gifs

N/A

# Related Issues

#4155 