### PR TITLE
fix: gate features behind dev mode

### DIFF
--- a/app/src/bcsc-theme/features/settings/SettingsContent.tsx
+++ b/app/src/bcsc-theme/features/settings/SettingsContent.tsx
@@ -265,6 +265,8 @@ const AuthenticatedSection: React.FC<AuthenticatedSectionProps> = ({
   const { status: notificationStatus } = useNotificationPermissionStatus()
 
   const showChangePIN = accountSecurityMethod !== AccountSecurityMethod.DeviceAuth && onChangePIN
+  const { developerModeEnabled } = store.preferences
+  const showFeaturesSection = Boolean(onContacts) || developerModeEnabled
   const analyticsOptInText = store.bcsc.analyticsOptIn ? 'ON' : 'OFF'
   // No adornment while the async permission check is unresolved (or failed) — only
   // assert ON/OFF for explicitly known states.
@@ -287,25 +289,35 @@ const AuthenticatedSection: React.FC<AuthenticatedSectionProps> = ({
         onEditNickname={onEditNickname}
       />
 
-      <SectionHeader title={t('BCSC.Settings.Features.Header')} iconName="bullhorn-outline" styles={styles}>
-        <View style={styles.sectionContainer}>
-          <ListButtonGroup>
-            {[
-              onContacts ? (
-                <ListButton key="contacts" onPress={onContacts} testID={testIdWithKey('Contacts')}>
-                  {t('BCSC.Settings.Features.Contacts')}
-                </ListButton>
-              ) : null,
-              <ListButton key="scanqr" onPress={onScanMyQR ?? noop} testID={testIdWithKey('ScanQR')}>
-                {t('BCSC.Settings.Features.ScanQR')}
-              </ListButton>,
-              <ListButton key="proof" onPress={onSendProofRequest ?? noop} testID={testIdWithKey('SendProofRequest')}>
-                {t('BCSC.Settings.Features.SendProofRequest')}
-              </ListButton>,
-            ]}
-          </ListButtonGroup>
-        </View>
-      </SectionHeader>
+      {showFeaturesSection ? (
+        <SectionHeader title={t('BCSC.Settings.Features.Header')} iconName="bullhorn-outline" styles={styles}>
+          <View style={styles.sectionContainer}>
+            <ListButtonGroup>
+              {[
+                onContacts ? (
+                  <ListButton key="contacts" onPress={onContacts} testID={testIdWithKey('Contacts')}>
+                    {t('BCSC.Settings.Features.Contacts')}
+                  </ListButton>
+                ) : null,
+                developerModeEnabled ? (
+                  <ListButton key="scanqr" onPress={onScanMyQR ?? noop} testID={testIdWithKey('ScanQR')}>
+                    {t('BCSC.Settings.Features.ScanQR')}
+                  </ListButton>
+                ) : null,
+                developerModeEnabled ? (
+                  <ListButton
+                    key="proof"
+                    onPress={onSendProofRequest ?? noop}
+                    testID={testIdWithKey('SendProofRequest')}
+                  >
+                    {t('BCSC.Settings.Features.SendProofRequest')}
+                  </ListButton>
+                ) : null,
+              ]}
+            </ListButtonGroup>
+          </View>
+        </SectionHeader>
+      ) : null}
 
       <SectionHeader title={t('BCSC.Settings.HeaderA')} iconName="cog-outline" styles={styles}>
         <View style={styles.sectionContainer}>

--- a/app/src/bcsc-theme/navigators/QRCoreStack.tsx
+++ b/app/src/bcsc-theme/navigators/QRCoreStack.tsx
@@ -5,7 +5,8 @@ import QRScanner from '@/bcsc-theme/features/qr-core/QRScanner'
 import { useVerificationStatus } from '@/bcsc-theme/hooks/useVerificationStatus'
 import { BCSCMainStackParams, BCSCQRCoreScreens, BCSCQRCoreTabParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { HelpCentreUrl } from '@/constants'
-import { ButtonLocation, IconButton, testIdWithKey, TOKENS, useServices, useTheme } from '@bifold/core'
+import { BCState } from '@/store'
+import { ButtonLocation, IconButton, testIdWithKey, TOKENS, useServices, useStore, useTheme } from '@bifold/core'
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -82,6 +83,7 @@ const QRCoreStack: React.FC = () => {
   const navigation = useNavigation<StackNavigationProp<BCSCMainStackParams>>()
   const { isVerified } = useVerificationStatus()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const [store] = useStore<BCState>()
 
   const styles = StyleSheet.create({
     tabBarIcon: {
@@ -137,18 +139,20 @@ const QRCoreStack: React.FC = () => {
             }),
           }}
         />
-        <Tab.Screen
-          name={BCSCQRCoreScreens.Display}
-          component={QRDisplay}
-          options={{
-            title: t('Scan.MyQRCode'),
-            tabBarIconStyle: styles.tabBarIcon,
-            tabBarIcon: createTabBarIcon(t('Scan.MyQRCode'), 'qrcode'),
-            tabBarShowLabel: false,
-            tabBarAccessibilityLabel: t('Scan.MyQRCode'),
-            tabBarTestID: testIdWithKey('MyQRCode'),
-          }}
-        />
+        {store.preferences.developerModeEnabled ? (
+          <Tab.Screen
+            name={BCSCQRCoreScreens.Display}
+            component={QRDisplay}
+            options={{
+              title: t('Scan.MyQRCode'),
+              tabBarIconStyle: styles.tabBarIcon,
+              tabBarIcon: createTabBarIcon(t('Scan.MyQRCode'), 'qrcode'),
+              tabBarShowLabel: false,
+              tabBarAccessibilityLabel: t('Scan.MyQRCode'),
+              tabBarTestID: testIdWithKey('MyQRCode'),
+            }}
+          />
+        ) : null}
         <Tab.Screen
           name={BCSCQRCoreScreens.PairingCode}
           component={ManualPairing}


### PR DESCRIPTION
# Summary of Changes

This PR gates two features behind developer mode

# Testing Instructions

View the menu once logged in
Tap the QR FAB once logged in

# Acceptance Criteria
They are gated

# Screenshots, videos, or gifs

<img width="284" height="614" alt="tabs" src="https://github.com/user-attachments/assets/d4fcf472-f93c-439f-a23e-5853e127a803" />
<img width="284" height="614" alt="menu" src="https://github.com/user-attachments/assets/57b9e1c5-7e53-4ec9-8422-1be6aabd6823" />

# Related Issues

#4190 