### PR TITLE
fix: use correct extenion payload property matching v3

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useEvidenceApi.test.ts
+++ b/app/src/bcsc-theme/api/hooks/useEvidenceApi.test.ts
@@ -25,8 +25,11 @@ jest.mock('@bifold/core', () => {
   return { ...actual, useStore: jest.fn() }
 })
 
-describe('useEvidenceApi - reconcileVerificationDeadline', () => {
+describe('useEvidenceApi - verification deadline reconciliation', () => {
   const CURRENT_EXPIRY = new Date('2026-06-08T12:00:00Z')
+  const TWO_DAYS = 172800
+
+  const submitPayload = { upload_uris: ['u1'], sha256: 'sha' }
 
   const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
   const mockDispatch = jest.fn()
@@ -75,54 +78,57 @@ describe('useEvidenceApi - reconcileVerificationDeadline', () => {
     expect(mockUpdateDeviceCodes).not.toHaveBeenCalled()
   })
 
-  it('extends the deadline (existing expiry + expires_in, pinned to end of day) when it pushes later', async () => {
-    apiClient.get.mockResolvedValue({ data: { id: 'v1', status: 'pending', expires_in: '172800' } }) // 2 days
+  it('extends the deadline (existing expiry + expiry_extended_by, pinned to end of day) on the submit PUT', async () => {
+    apiClient.put.mockResolvedValue({ data: { id: 'v1', status: 'pending', expiry_extended_by: TWO_DAYS } })
     const result = renderApi()
 
     await act(async () => {
-      await result.current.getVerificationRequestStatus('v1')
+      await result.current.sendVerificationRequest('v1', submitPayload)
     })
 
-    const expected = new Date(CURRENT_EXPIRY.getTime() + 172800 * 1000)
+    const expected = new Date(CURRENT_EXPIRY.getTime() + TWO_DAYS * 1000)
     expected.setHours(23, 59, 59, 0)
     expect(mockUpdateDeviceCodes).toHaveBeenCalledWith({ deviceCodeExpiresAt: expected })
     expect(cancelVerificationReminders).not.toHaveBeenCalled()
   })
 
-  it('also applies the extension on the evidence-submit PUT response', async () => {
-    apiClient.put.mockResolvedValue({ data: { id: 'v1', status: 'pending', expires_in: '172800' } })
+  it('never extends the deadline from a status GET, even if the response carries an extension field', async () => {
+    // The status GET carries no expiry field on the wire; polling it must not compound the deadline.
+    apiClient.get.mockResolvedValue({ data: { id: 'v1', status: 'pending', expiry_extended_by: TWO_DAYS } })
     const result = renderApi()
 
     await act(async () => {
-      await result.current.sendVerificationRequest('v1', { upload_uris: ['u1'], sha256: 'sha' })
-    })
-
-    const expected = new Date(CURRENT_EXPIRY.getTime() + 172800 * 1000)
-    expected.setHours(23, 59, 59, 0)
-    expect(mockUpdateDeviceCodes).toHaveBeenCalledWith({ deviceCodeExpiresAt: expected })
-  })
-
-  it('does nothing when the response carries no expires_in', async () => {
-    apiClient.get.mockResolvedValue({ data: { id: 'v1', status: 'pending' } })
-    const result = renderApi()
-
-    await act(async () => {
+      await result.current.getVerificationRequestStatus('v1')
       await result.current.getVerificationRequestStatus('v1')
     })
 
     expect(mockUpdateDeviceCodes).not.toHaveBeenCalled()
   })
 
-  it('does nothing when expires_in is not a finite, positive number', async () => {
-    apiClient.get.mockResolvedValue({ data: { id: 'v1', status: 'pending', expires_in: 'not-a-number' } })
+  it('does nothing when the submit response carries no expiry_extended_by', async () => {
+    apiClient.put.mockResolvedValue({ data: { id: 'v1', status: 'pending' } })
     const result = renderApi()
 
     await act(async () => {
-      await result.current.getVerificationRequestStatus('v1')
+      await result.current.sendVerificationRequest('v1', submitPayload)
     })
 
     expect(mockUpdateDeviceCodes).not.toHaveBeenCalled()
   })
+
+  it.each([['not-a-number'], [Number.NaN], [Number.POSITIVE_INFINITY], [0], [-1]])(
+    'does nothing when expiry_extended_by is %p',
+    async (expiryExtendedBy) => {
+      apiClient.put.mockResolvedValue({ data: { id: 'v1', status: 'pending', expiry_extended_by: expiryExtendedBy } })
+      const result = renderApi()
+
+      await act(async () => {
+        await result.current.sendVerificationRequest('v1', submitPayload)
+      })
+
+      expect(mockUpdateDeviceCodes).not.toHaveBeenCalled()
+    }
+  )
 
   it('does not move the deadline earlier when the extension would not push it later', async () => {
     // Existing expiry already near end-of-day; a tiny extension pins back to the same day's 23:59:59,
@@ -134,11 +140,11 @@ describe('useEvidenceApi - reconcileVerificationDeadline', () => {
       } as Bifold.State,
       mockDispatch,
     ])
-    apiClient.get.mockResolvedValue({ data: { id: 'v1', status: 'pending', expires_in: '0.4' } })
+    apiClient.put.mockResolvedValue({ data: { id: 'v1', status: 'pending', expiry_extended_by: 0.4 } })
     const result = renderApi()
 
     await act(async () => {
-      await result.current.getVerificationRequestStatus('v1')
+      await result.current.sendVerificationRequest('v1', submitPayload)
     })
 
     expect(mockUpdateDeviceCodes).not.toHaveBeenCalled()
@@ -152,23 +158,37 @@ describe('useEvidenceApi - reconcileVerificationDeadline', () => {
       } as Bifold.State,
       mockDispatch,
     ])
-    apiClient.get.mockResolvedValue({ data: { id: 'v1', status: 'pending', expires_in: '172800' } })
+    apiClient.put.mockResolvedValue({ data: { id: 'v1', status: 'pending', expiry_extended_by: TWO_DAYS } })
     const result = renderApi()
 
     await act(async () => {
-      await result.current.getVerificationRequestStatus('v1')
+      await result.current.sendVerificationRequest('v1', submitPayload)
     })
 
     expect(mockUpdateDeviceCodes).not.toHaveBeenCalled()
   })
 
-  it('logs and does not throw when persisting the extended expiry fails', async () => {
-    mockUpdateDeviceCodes.mockRejectedValueOnce(new Error('storage boom'))
-    apiClient.get.mockResolvedValue({ data: { id: 'v1', status: 'pending', expires_in: '172800' } })
+  it('cancels reminders and skips the extension when the submit response is terminal', async () => {
+    apiClient.put.mockResolvedValue({ data: { id: 'v1', status: 'cancelled', expiry_extended_by: TWO_DAYS } })
     const result = renderApi()
 
     await act(async () => {
-      await expect(result.current.getVerificationRequestStatus('v1')).resolves.toMatchObject({ status: 'pending' })
+      await result.current.sendVerificationRequest('v1', submitPayload)
+    })
+
+    expect(cancelVerificationReminders).toHaveBeenCalledWith(mockLogger)
+    expect(mockUpdateDeviceCodes).not.toHaveBeenCalled()
+  })
+
+  it('logs and does not throw when persisting the extended expiry fails', async () => {
+    mockUpdateDeviceCodes.mockRejectedValueOnce(new Error('storage boom'))
+    apiClient.put.mockResolvedValue({ data: { id: 'v1', status: 'pending', expiry_extended_by: TWO_DAYS } })
+    const result = renderApi()
+
+    await act(async () => {
+      await expect(result.current.sendVerificationRequest('v1', submitPayload)).resolves.toMatchObject({
+        status: 'pending',
+      })
     })
 
     expect(mockLogger.warn).toHaveBeenCalledWith(

--- a/app/src/bcsc-theme/api/hooks/useEvidenceApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useEvidenceApi.tsx
@@ -33,8 +33,11 @@ export interface VerificationStatusResponseData {
   id: string
   status: 'pending' | 'verified' | 'cancelled'
   status_message?: string
-  expires_in?: string
   avg_turnaround_time_message?: string
+}
+
+export interface VerificationSubmitResponseData extends VerificationStatusResponseData {
+  expiry_extended_by?: number
 }
 
 export interface VerificationPhotoUploadPayload {
@@ -79,33 +82,40 @@ const useEvidenceApi = (apiClient: BCSCApiClient) => {
   const { updateDeviceCodes } = useSecureActions()
 
   /**
-   * Reconciles local verification deadline state against a verification response.
+   * A terminal `status` means the session is over, so any pending "verify by ..." reminders are
+   * cleared. (Completion is also caught when the device_code is exchanged for tokens; this just
+   * clears them sooner, and covers an agent-cancelled video.)
    *
-   * The evidence-submit (PUT) and status (GET) responses share this shape. Two things ride on them:
-   *
-   *  - A terminal `status` (`verified`/`cancelled`) means the session is over, so any pending
-   *    "verify by ..." reminders are cleared. (Completion is also caught when the device_code is
-   *    exchanged for tokens; this just clears them sooner, and covers an agent-cancelled video.)
-   *  - A possibly-refreshed `expires_in` (seconds). It is how the server communicates the
-   *    video-submission and agent-approval extensions. Mirroring ias-ios (the source of truth where it
-   *    disagrees with the API docs), this value extends the EXISTING deadline: it is a delta added to the
-   *    current expiry, pinned to end-of-day local, and only ever pushes the deadline later — so a
-   *    stale/shorter value can never cut an in-progress session short. With no existing expiry there is
-   *    nothing to extend. See ias-ios PreBackcheckVideoChecks / `dateBeforeMidnightWithSeconds`.
+   * Returns whether the status was terminal.
    */
-  const reconcileVerificationDeadline = useCallback(
-    async (data: VerificationStatusResponseData) => {
-      if (data.status === 'verified' || data.status === 'cancelled') {
-        // doesn't throw
-        await cancelVerificationReminders(apiClient.logger)
-        return
+  const cancelRemindersOnTerminalStatus = useCallback(
+    async (data: VerificationStatusResponseData): Promise<boolean> => {
+      if (data.status !== 'verified' && data.status !== 'cancelled') {
+        return false
       }
+      // doesn't throw
+      await cancelVerificationReminders(apiClient.logger)
+      return true
+    },
+    [apiClient.logger]
+  )
 
-      if (data.expires_in === undefined) {
-        return
-      }
-      const seconds = Number(data.expires_in)
-      if (!Number.isFinite(seconds) || seconds <= 0) {
+  /**
+   * Applies the server's video-submission deadline extension.
+   *
+   * `expiry_extended_by` is a delta in seconds added to the EXISTING deadline, pinned to end-of-day
+   * local, and only ever pushed later — a stale/shorter value can never cut an in-progress session
+   * short. With no existing expiry there is nothing to extend. It rides only on the evidence-submit
+   * PUT, never on the status GET, so repeated status polls cannot compound the deadline.
+   *
+   * Mirrors ias-ios PreBackcheckVideoChecks / `dateBeforeMidnightWithSeconds` and ias-android
+   * DocumentUploadViewModel. Note both name their local variable `expiresIn`, but the wire field is
+   * `expiry_extended_by` — it is NOT the OAuth `expires_in` seconds-from-now convention.
+   */
+  const applyExpiryExtension = useCallback(
+    async (data: VerificationSubmitResponseData) => {
+      const seconds = data.expiry_extended_by
+      if (seconds === undefined || !Number.isFinite(seconds) || seconds <= 0) {
         return
       }
       const currentExpiry = store.bcscSecure.deviceCodeExpiresAt
@@ -122,7 +132,7 @@ const useEvidenceApi = (apiClient: BCSCApiClient) => {
       try {
         await updateDeviceCodes({ deviceCodeExpiresAt: extendedExpiry })
       } catch (error) {
-        apiClient.logger.warn('[reconcileVerificationDeadline] Failed to persist extended expiry', {
+        apiClient.logger.warn('[applyExpiryExtension] Failed to persist extended expiry', {
           error,
         })
       }
@@ -213,10 +223,10 @@ const useEvidenceApi = (apiClient: BCSCApiClient) => {
     async (
       verificationRequestId: string,
       payload: SendVerificationPayload
-    ): Promise<VerificationStatusResponseData> => {
+    ): Promise<VerificationSubmitResponseData> => {
       return withAccount(async (account) => {
         const token = await createPreVerificationJWT(_getDeviceCode(), account.clientID)
-        const { data } = await apiClient.put<VerificationStatusResponseData>(
+        const { data } = await apiClient.put<VerificationSubmitResponseData>(
           `${apiClient.endpoints.evidence}/v1/verifications/${verificationRequestId}`,
           payload,
           {
@@ -226,11 +236,14 @@ const useEvidenceApi = (apiClient: BCSCApiClient) => {
             skipBearerAuth: true,
           }
         )
-        await reconcileVerificationDeadline(data)
+        const isTerminal = await cancelRemindersOnTerminalStatus(data)
+        if (!isTerminal) {
+          await applyExpiryExtension(data)
+        }
         return data
       })
     },
-    [_getDeviceCode, apiClient, reconcileVerificationDeadline]
+    [_getDeviceCode, apiClient, applyExpiryExtension, cancelRemindersOnTerminalStatus]
   )
 
   const getVerificationRequestPrompts = useCallback(
@@ -265,11 +278,11 @@ const useEvidenceApi = (apiClient: BCSCApiClient) => {
             skipBearerAuth: true,
           }
         )
-        await reconcileVerificationDeadline(data)
+        await cancelRemindersOnTerminalStatus(data)
         return data
       })
     },
-    [_getDeviceCode, apiClient, reconcileVerificationDeadline]
+    [_getDeviceCode, apiClient, cancelRemindersOnTerminalStatus]
   )
 
   // This is only valid once sendVerificationRequest has been called


### PR DESCRIPTION
# Summary of Changes

This PR fixes an issue where we were using the wrong payload property to extend verification deadlines

# Testing Instructions

N/A

# Acceptance Criteria

Send video still works

# Screenshots, videos, or gifs

N/A

# Related Issues

#4144 