### PR TITLE
refactor: map Pexip STUN url to WebRTC urls in buildIceServers

### DIFF
--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.test.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.test.ts
@@ -41,20 +41,20 @@ describe('buildIceServers', () => {
   it('should fall back to Google STUN when no STUN or TURN servers provided', () => {
     const result = buildIceServers(baseTokenResult, mockLogger)
 
-    expect(result).toEqual([{ url: 'stun:stun.l.google.com:19302' }])
+    expect(result).toEqual([{ urls: 'stun:stun.l.google.com:19302' }])
     expect(mockLogger.warn).toHaveBeenCalledWith('No ICE servers from Pexip, falling back to Google public STUN')
   })
 
   it('should fall back to Google STUN when stun and turn are empty arrays', () => {
     const result = buildIceServers({ ...baseTokenResult, stun: [], turn: [] }, mockLogger)
 
-    expect(result).toEqual([{ url: 'stun:stun.l.google.com:19302' }])
+    expect(result).toEqual([{ urls: 'stun:stun.l.google.com:19302' }])
   })
 
   it('should use STUN servers from token response', () => {
     const result = buildIceServers({ ...baseTokenResult, stun: [{ url: 'stun:pexip.example.com:3478' }] }, mockLogger)
 
-    expect(result).toEqual([{ url: 'stun:pexip.example.com:3478' }])
+    expect(result).toEqual([{ urls: 'stun:pexip.example.com:3478' }])
     expect(mockLogger.warn).not.toHaveBeenCalled()
   })
 
@@ -67,7 +67,7 @@ describe('buildIceServers', () => {
       mockLogger
     )
 
-    expect(result).toEqual([{ url: 'stun:stun1.example.com:3478' }, { url: 'stun:stun2.example.com:3478' }])
+    expect(result).toEqual([{ urls: 'stun:stun1.example.com:3478' }, { urls: 'stun:stun2.example.com:3478' }])
   })
 
   it('should include STUN entries with empty url (passes through from Pexip)', () => {
@@ -76,7 +76,7 @@ describe('buildIceServers', () => {
       mockLogger
     )
 
-    expect(result).toEqual([{ url: '' }, { url: 'stun:valid.com:3478' }])
+    expect(result).toEqual([{ urls: '' }, { urls: 'stun:valid.com:3478' }])
   })
 
   it('should use TURN servers with credentials', () => {
@@ -114,7 +114,7 @@ describe('buildIceServers', () => {
     )
 
     expect(result).toEqual([
-      { url: 'stun:stun.example.com:3478' },
+      { urls: 'stun:stun.example.com:3478' },
       { urls: ['turn:turn.example.com:3478'], credential: 'pass', username: undefined },
     ])
   })
@@ -130,7 +130,7 @@ describe('buildIceServers', () => {
     )
 
     expect(result).toEqual([
-      { url: 'stun:stun.example.com:3478' },
+      { urls: 'stun:stun.example.com:3478' },
       { urls: ['turn:turn.example.com:3478'], username: 'user', credential: undefined },
     ])
   })
@@ -146,7 +146,7 @@ describe('buildIceServers', () => {
     )
 
     expect(result).toEqual([
-      { url: 'stun:stun.example.com:3478' },
+      { urls: 'stun:stun.example.com:3478' },
       { urls: ['turn:turn.example.com:3478'], username: '', credential: '' },
     ])
   })
@@ -161,7 +161,7 @@ describe('buildIceServers', () => {
       mockLogger
     )
 
-    expect(result).toEqual([{ url: 'stun:stun.example.com:3478' }, { urls: [], username: 'user', credential: 'pass' }])
+    expect(result).toEqual([{ urls: 'stun:stun.example.com:3478' }, { urls: [], username: 'user', credential: 'pass' }])
   })
 
   it('should combine STUN and TURN servers', () => {
@@ -175,7 +175,7 @@ describe('buildIceServers', () => {
     )
 
     expect(result).toEqual([
-      { url: 'stun:stun.example.com:3478' },
+      { urls: 'stun:stun.example.com:3478' },
       { urls: ['turn:turn.example.com:3478'], username: 'user', credential: 'pass' },
     ])
   })
@@ -234,6 +234,6 @@ describe('createPeerConnection', () => {
     )
 
     const config = (RTCPeerConnection as jest.Mock).mock.calls[0][0]
-    expect(config.iceServers).toEqual([{ url: 'stun:example.com:3478' }])
+    expect(config.iceServers).toEqual([{ urls: 'stun:example.com:3478' }])
   })
 })

--- a/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/connect.ts
@@ -9,14 +9,18 @@ import {
   withPin,
   withToken,
 } from '@pexip/infinity-api'
-import type { Result as PexipTokenResult, Stun, Turn } from '@pexip/infinity-api/dist/token/types'
+import type { Result as PexipTokenResult } from '@pexip/infinity-api/dist/token/types'
 import { Platform } from 'react-native'
 import EventSource from 'react-native-sse'
 import { mediaDevices, MediaStream, RTCIceCandidate, RTCPeerConnection } from 'react-native-webrtc'
 import { RTCOfferOptions } from 'react-native-webrtc/lib/typescript/RTCUtil'
 import type { ConnectionRequest, ConnectResult } from '../types/live-call'
 
-type IceServer = Stun | Turn
+type IceServer = {
+  urls: string | string[]
+  username?: string
+  credential?: string
+}
 
 // WebRTC Events need handlers even if we don't do anything with some of them
 const noop = () => {}
@@ -325,7 +329,7 @@ export const buildIceServers = (tokenResult: PexipTokenResult, logger: BifoldLog
   // Use STUN servers from Pexip token response
   if (tokenResult.stun?.length) {
     for (const entry of tokenResult.stun) {
-      iceServers.push({ url: entry.url })
+      iceServers.push({ urls: entry.url })
     }
   }
 
@@ -343,7 +347,7 @@ export const buildIceServers = (tokenResult: PexipTokenResult, logger: BifoldLog
   // Fallback to Google public STUN if Pexip provided nothing
   if (iceServers.length === 0) {
     logger.warn('No ICE servers from Pexip, falling back to Google public STUN')
-    iceServers.push({ url: 'stun:stun.l.google.com:19302' })
+    iceServers.push({ urls: 'stun:stun.l.google.com:19302' })
   }
 
   logger.info('ICE servers configured:', { count: iceServers.length })


### PR DESCRIPTION
## What

The video-call connection code builds a list of ICE servers (STUN/TURN) to hand to WebRTC when setting up a live call. For STUN servers, it was passing them through using Pexip's field name (`url`) rather than the field name WebRTC itself expects (`urls`). This happened to work because the underlying WebRTC library still recognizes the old field name as a fallback, but that fallback is deprecated and isn't guaranteed to stick around.

This change makes the code speak WebRTC's field names directly, so STUN server configuration doesn't depend on a deprecated compatibility shim.

## Why

If the WebRTC library ever removes its fallback support for the old field name, STUN servers would silently stop being configured — which could cause verification video calls to fail to connect for some users, with no obvious error pointing at the cause. This is a low-risk hardening change identified during review of a related PR (#3475), addressed now as technical debt before it can cause a real incident.

## Decisions

- Replaced the local `IceServer` type (previously `Stun | Turn`, sourced from Pexip's own types) with a small local type shaped like WebRTC's `RTCIceServer`: `{ urls: string | string[]; username?: string; credential?: string }`. `react-native-webrtc` does not publicly export an `RTCIceServer` type, so importing one from its internal `lib/typescript/...` path was ruled out in favor of this local type.
- STUN entries (from Pexip and the Google public STUN fallback) now map `url` → `urls`. TURN entries were already using `urls` and needed no change.
- No behavior change: `entry.url` values pass straight through, just under the new field name.

## Tests

- `yarn test connect.test.ts` — updated result-side assertions (`url:` → `urls:`) to match the new output shape; input fixtures modeling Pexip's response shape (`stun: [{ url: ... }]`) were left unchanged since that's still what Pexip sends. 21 tests passed.
- Full app test suite (`yarn test`): 268 suites / 2517 tests passed.
- `yarn typecheck`: passed — confirms the unused `Stun`/`Turn` import removal and that all `IceServer[]` usages fit the new type.
- ESLint (`yarn lint:ts`) and Prettier (`yarn format:ts:check`) on the changed files: passed.

Fixes #3483