### PR TITLE
fix: remove placeholder email from email entry field

### DIFF
--- a/app/src/bcsc-theme/features/verify/email/EnterEmailScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EnterEmailScreen.test.tsx
@@ -125,6 +125,22 @@ describe('EnterEmailScreen', () => {
 
       expect(queryByTestId('SkipButton')).toBeNull()
     })
+
+    it('should render the email input with no placeholder text', () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <ErrorAlertProvider>
+            <EnterEmailScreen
+              navigation={mockNavigation}
+              route={{ params: { cardProcess: BCSCCardProcess.NonBCSC } }}
+            />
+          </ErrorAlertProvider>
+        </BasicAppContext>
+      )
+
+      const emailInput = getByTestId('com.ariesbifold:id/email-input')
+      expect(emailInput.props.placeholder).toBeUndefined()
+    })
   })
 
   describe('Email validation', () => {

--- a/app/src/bcsc-theme/features/verify/email/EnterEmailScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EnterEmailScreen.tsx
@@ -150,7 +150,6 @@ const EnterEmailScreen = ({ navigation, route }: EnterEmailScreenProps) => {
           autoCorrect: false,
           autoComplete: 'email',
           textContentType: 'emailAddress',
-          placeholder: t('BCSC.EnterEmail.EmailExample'),
         }}
       />
 

--- a/app/src/bcsc-theme/features/verify/email/__snapshots__/EnterEmailScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/email/__snapshots__/EnterEmailScreen.test.tsx.snap
@@ -155,7 +155,6 @@ exports[`EnterEmailScreen Rendering should match snapshot 1`] = `
                   onChange={[Function]}
                   onChangeText={[Function]}
                   onFocus={[Function]}
-                  placeholder="BCSC.EnterEmail.EmailExample"
                   placeholderTextColor="#606060"
                   style={
                     [

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -961,7 +961,6 @@ const translation = {
       "EmailSkipButton2": "Skip",
       "EnterEmailAddress": "Enter an email address",
       "EmailAddress": "Email address",
-      "EmailExample": "laurie.beaumont@gov.bc.ca",
       "EmailDescription1": "Adding an email to your account allows you to stay informed about account activity, and is recommended for security purposes.",
       "EmailDescription2": "You will receive notifications for:",
       "NotificationsBullet1": "Security alerts",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -942,7 +942,6 @@ const translation = {
       "EmailSkipButton2": "Skip (FR)",
       "EnterEmailAddress": "Enter an email address (FR)",
       "EmailAddress": "Email address (FR)",
-      "EmailExample": "laurie.beaumont@gov.bc.ca",
       "EmailDescription1": "Adding an email to your account allows you to stay informed about account activity, and is recommended for security purposes. (FR)",
       "EmailDescription2": "You will receive notifications for: (FR)",
       "NotificationsBullet1": "Security alerts (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -942,7 +942,6 @@ const translation = {
       "EmailSkipButton2": "Skip (PT-BR)",
       "EnterEmailAddress": "Enter an email address (PT-BR)",
       "EmailAddress": "Email address (PT-BR)",
-      "EmailExample": "laurie.beaumont@gov.bc.ca",
       "EmailDescription1": "Adding an email to your account allows you to stay informed about account activity, and is recommended for security purposes. (PT-BR)",
       "EmailDescription2": "You will receive notifications for: (PT-BR)",
       "NotificationsBullet1": "Security alerts (PT-BR)",


### PR DESCRIPTION
## What

The email address screen shown during BC Services Card verification (and account setup) displayed "l*****.b*****@gov.bc.ca" as example text in the input field. This change removes that example text so the field appears blank, matching the legacy native apps' behaviour.

## Why

Testers on SIT flagged the placeholder text as looking like a real, pre-filled email address rather than a hint — it read as if someone else's data was showing up in the field. Removing it avoids that confusion and matches how the legacy native BC Services Card apps handled this field (blank, no example text).

## Decisions

- This was placeholder/hint text (`BCSC.EnterEmail.EmailExample`, rendered via the `TextInput`'s `placeholder` prop), not pre-filled or persisted user data — no data leak, just an input hint.
- Decision (confirmed with product): remove the placeholder entirely rather than substitute different example text, since the legacy apps left the field blank.
- Removed the now-unused `EmailExample` localization key from all three locale files (`en`, `fr`, `pt-br`) — grep-confirmed no other references exist in the codebase.
- Affects the `bcsc` build target only (`EnterEmailScreen` lives in `bcsc-theme`, serves both BCSC and non-BCSC card flows). `bcwallet` target is unaffected.

## Tests

- Added a test asserting the email input renders with `placeholder` `undefined` (using the ticket's `NonBCSC` flow).
- Regenerated the `EnterEmailScreen` snapshot; diff is exactly the one removed `placeholder` line, nothing else.
- Full suite: `yarn typecheck`, `yarn lint:ts` (app + bcsc-core), `yarn format:check` (TS), and `yarn test` all pass (268/268 suites, 2534/2534 tests, 158/158 snapshots).

Fixes #4227