### PR TITLE
fix: env is authority on mediator

### DIFF
--- a/app/container-imp.ts
+++ b/app/container-imp.ts
@@ -415,9 +415,18 @@ export class AppContainer implements Container {
       bcsc.showAccountExpiryNotification = undefined
       bcsc.showCardRenewalNotification = undefined
 
+      const preferencesState = { ...initialState.preferences, ...preferences }
+
+      if (Config.MEDIATOR_URL) {
+        preferencesState.selectedMediator = Config.MEDIATOR_URL
+        if (!preferencesState.availableMediators?.includes(Config.MEDIATOR_URL)) {
+          preferencesState.availableMediators = [Config.MEDIATOR_URL, ...(preferencesState.availableMediators ?? [])]
+        }
+      }
+
       const state = {
         loginAttempt: { ...initialState.loginAttempt, ...loginAttempt },
-        preferences: { ...initialState.preferences, ...preferences },
+        preferences: preferencesState,
         migration: { ...initialState.migration, ...migration },
         tours: { ...initialState.tours, ...tours },
         onboarding: { ...initialState.onboarding, ...onboarding },


### PR DESCRIPTION
# Summary of Changes

The configurable mediator feature was persisting the current mediator and ignoring MEDIATOR_URL, even if it changed. This makes it impossible to effectively update your MEDIATOR_URL.

# Testing Instructions

Change your MEDIATOR URL and do a new build, agent should initialize successfully with the new mediator

# Acceptance Criteria

Works

# Screenshots, videos, or gifs

N/A

# Related Issues

#4215 