### PR TITLE
fix: send video prompts

### DIFF
--- a/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.test.ts
@@ -194,7 +194,8 @@ describe('useVerificationMethodModel', () => {
         await result.current.handlePressSendVideo()
       })
 
-      expect(mockLogger.error).toHaveBeenCalledWith('Error sending video:', mockError)
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('No verification request available'))
+      expect(mockVideoPromptsMissingAlert).toHaveBeenCalledTimes(1)
       expect(mockNavigation.navigate).not.toHaveBeenCalled()
       expect(mockDispatch).not.toHaveBeenCalled()
       expect(result.current.sendVideoLoading).toBe(false)
@@ -223,102 +224,9 @@ describe('useVerificationMethodModel', () => {
       expect(mockNavigation.navigate).toHaveBeenCalled()
     })
 
-    it('refetches prompts when the store holds an empty prompts array and a request id exists', async () => {
-      // Regression for #4018: an empty array is truthy, so the old `!store.bcsc.prompts` guard skipped
-      // the refetch and stranded the user. `?.length` must re-trigger the fetch.
-      const storeWithEmptyPrompts = {
-        ...mockStore,
-        bcsc: { ...mockStore.bcsc, prompts: [] },
-        bcscSecure: { ...mockStore.bcscSecure, verificationRequestId: 'existing-id' },
-      }
-      jest.mocked(Bifold).useStore.mockReturnValue([storeWithEmptyPrompts, mockDispatch])
-
-      const fetched = { id: 'existing-id', sha256: 'sha', prompts: [{ id: 1, prompt: 'Say your name' }] }
-      mockEvidenceApi.getVerificationRequestPrompts.mockResolvedValue(fetched)
-      jest.mocked(removeFileSafely).mockResolvedValue(undefined)
-
-      const { result } = renderHook(() => useVerificationMethodModel({ navigation: mockNavigation }))
-
-      await act(async () => {
-        await result.current.handlePressSendVideo()
-      })
-
-      expect(mockEvidenceApi.getVerificationRequestPrompts).toHaveBeenCalledWith('existing-id')
-      expect(mockEvidenceApi.createVerificationRequest).not.toHaveBeenCalled()
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: BCDispatchAction.UPDATE_VIDEO_PROMPTS,
-        payload: [fetched.prompts],
-      })
-      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.PhotoInstructions, { forLiveCall: false })
-      expect(mockVideoPromptsMissingAlert).not.toHaveBeenCalled()
-    })
-
-    it('refetches prompts when the request id is persisted but sha is missing (post app-cycle)', async () => {
-      const storeWithoutSha = {
-        ...mockStore,
-        bcsc: { ...mockStore.bcsc, prompts: [{ id: 1, prompt: 'Stale prompt' }] },
-        bcscSecure: {
-          ...mockStore.bcscSecure,
-          verificationRequestId: 'existing-id',
-          verificationRequestSha: undefined,
-        },
-      }
-      jest.mocked(Bifold).useStore.mockReturnValue([storeWithoutSha, mockDispatch])
-
-      const fetched = { id: 'existing-id', sha256: 'fresh-sha', prompts: [{ id: 1, prompt: 'Say your name' }] }
-      mockEvidenceApi.getVerificationRequestPrompts.mockResolvedValue(fetched)
-      jest.mocked(removeFileSafely).mockResolvedValue(undefined)
-
-      const { result } = renderHook(() => useVerificationMethodModel({ navigation: mockNavigation }))
-
-      await act(async () => {
-        await result.current.handlePressSendVideo()
-      })
-
-      expect(mockEvidenceApi.getVerificationRequestPrompts).toHaveBeenCalledWith('existing-id')
-      expect(mockEvidenceApi.createVerificationRequest).not.toHaveBeenCalled()
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_REQUEST_SHA,
-        payload: ['fresh-sha'],
-      })
-      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.PhotoInstructions, { forLiveCall: false })
-    })
-
-    it('recovers from a stale id by creating a fresh verification request when prompts fetch fails', async () => {
-      const storeWithStaleId = {
-        ...mockStore,
-        bcsc: { ...mockStore.bcsc, prompts: [] },
-        bcscSecure: { ...mockStore.bcscSecure, verificationRequestId: 'stale-id', verificationRequestSha: undefined },
-      }
-      jest.mocked(Bifold).useStore.mockReturnValue([storeWithStaleId, mockDispatch])
-
-      const serverError = new Error('Request failed with status code 500')
-      mockEvidenceApi.getVerificationRequestPrompts.mockRejectedValue(serverError)
-      const fresh = { id: 'fresh-id', sha256: 'fresh-sha', prompts: [{ id: 1, prompt: 'Say your name' }] }
-      mockEvidenceApi.createVerificationRequest.mockResolvedValue(fresh)
-      jest.mocked(removeFileSafely).mockResolvedValue(undefined)
-
-      const { result } = renderHook(() => useVerificationMethodModel({ navigation: mockNavigation }))
-
-      await act(async () => {
-        await result.current.handlePressSendVideo()
-      })
-
-      expect(mockEvidenceApi.getVerificationRequestPrompts).toHaveBeenCalledWith('stale-id')
-      expect(mockEvidenceApi.createVerificationRequest).toHaveBeenCalledTimes(1)
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_REQUEST_ID,
-        payload: ['fresh-id'],
-      })
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_REQUEST_SHA,
-        payload: ['fresh-sha'],
-      })
-      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.PhotoInstructions, { forLiveCall: false })
-      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('creating a fresh request'))
-    })
-
-    it('skips the refetch when both id, sha, and prompts are already in state', async () => {
+    it('does not rotate the prompts of a request that is already open', async () => {
+      // Prompts rotate on every GET, and the set the user records against is the one VideoInstructions
+      // issues immediately before recording. Spending one here would only be discarded.
       const fullyHydrated = {
         ...mockStore,
         bcsc: { ...mockStore.bcsc, prompts: [{ id: 1, prompt: 'Say your name' }] },
@@ -344,7 +252,8 @@ describe('useVerificationMethodModel', () => {
 
     it('aborts with a retryable alert and no navigation when no prompts are returned', async () => {
       // Regression for #4018: the server can return an empty prompt set; never walk the user into
-      // TakeVideoScreen (which hard-stops) — show a retryable alert and stay put instead.
+      // TakeVideoScreen (which hard-stops) — show a retryable alert and stay put instead. Catching it
+      // here saves the user the photo steps before they hit the wall on VideoInstructions.
       mockEvidenceApi.createVerificationRequest.mockResolvedValue({ id: 'test-id', sha256: 'sha', prompts: [] })
       jest.mocked(removeFileSafely).mockResolvedValue(undefined)
 

--- a/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useVerificationMethodModel.tsx
@@ -1,6 +1,6 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { ServiceHours, VideoDestinations } from '@/bcsc-theme/api/hooks/useVideoCallApi'
-import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
+import useVideoPrompts from '@/bcsc-theme/hooks/useVideoPrompts'
 import { removeFileSafely } from '@/bcsc-theme/utils/file-info'
 import { formatServiceAndUnavailableHours, isLiveCallAvailable } from '@/bcsc-theme/utils/service-hours-formatter'
 import { useAlerts } from '@/hooks/useAlerts'
@@ -23,9 +23,9 @@ const useVerificationMethodModel = ({ navigation }: useVerificationMethodModelPr
   const [hoursLoading, setHoursLoading] = useState(true)
   const [serviceHours, setServiceHours] = useState<ServiceHours | undefined>()
   const [destinations, setDestinations] = useState<VideoDestinations | undefined>()
-  const { evidence, video: videoCallApi } = useApi()
+  const { video: videoCallApi } = useApi()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
-  const { updateVerificationRequest } = useSecureActions()
+  const { ensureVerificationRequest } = useVideoPrompts()
   const { videoPromptsMissingAlert } = useAlerts(navigation)
 
   useEffect(() => {
@@ -46,39 +46,12 @@ const useVerificationMethodModel = ({ navigation }: useVerificationMethodModelPr
     try {
       setSendVideoLoading(true)
 
-      let verificationRequest
-      if (!store.bcscSecure.verificationRequestId) {
-        // NOTE: Making this request too many times will be rate limited by the server.
-        verificationRequest = await evidence.createVerificationRequest()
-      }
-
-      if (
-        store.bcscSecure.verificationRequestId &&
-        (!store.bcscSecure.verificationRequestSha || !store.bcsc.prompts?.length)
-      ) {
-        try {
-          verificationRequest = await evidence.getVerificationRequestPrompts(store.bcscSecure.verificationRequestId)
-        } catch (error) {
-          // IAS returns 500 for any call against a verification id that has been deleted
-          // server-side (TTL expired, agent cancelled, etc.). The local id is now useless —
-          // start a fresh request so the user isn't stuck on a stale id across cycles.
-          logger.warn(
-            `[useVerificationMethodModel] Failed to fetch prompts for stored verification id; creating a fresh request: ${error instanceof Error ? error.message : String(error)}`
-          )
-          verificationRequest = await evidence.createVerificationRequest()
-        }
-      }
-
-      if (verificationRequest) {
-        updateVerificationRequest(verificationRequest.id, verificationRequest.sha256)
-        dispatch({ type: BCDispatchAction.UPDATE_VIDEO_PROMPTS, payload: [verificationRequest.prompts] })
-      }
-
-      // Never advance into the video flow without prompts. The server can return an empty prompt set,
-      // and TakeVideoScreen hard-stops when prompts are missing — surface a retryable alert here instead.
-      const resolvedPrompts = verificationRequest?.prompts ?? store.bcsc.prompts
-      if (!resolvedPrompts?.length) {
-        logger.error('[useVerificationMethodModel] No verification prompts available; aborting Send Video')
+      // Opens a request only if one isn't already in flight. The prompt set the user records against is
+      // issued by VideoInstructions immediately beforehand, so entering the flow must not burn one here.
+      // This still catches a backend that can't issue prompts at all before the user does the photo steps.
+      const canProceed = await ensureVerificationRequest()
+      if (!canProceed) {
+        logger.error('[useVerificationMethodModel] No verification request available; aborting Send Video')
         videoPromptsMissingAlert()
         return
       }
@@ -101,17 +74,13 @@ const useVerificationMethodModel = ({ navigation }: useVerificationMethodModelPr
       setSendVideoLoading(false)
     }
   }, [
-    store.bcscSecure.verificationRequestId,
-    store.bcscSecure.verificationRequestSha,
-    store.bcsc.prompts,
     store.bcsc.videoPath,
     store.bcsc.photoPath,
     store.bcsc.videoThumbnailPath,
     logger,
     dispatch,
     navigation,
-    evidence,
-    updateVerificationRequest,
+    ensureVerificationRequest,
     videoPromptsMissingAlert,
   ])
 

--- a/app/src/bcsc-theme/features/verify/send-video/VideoInstructionsScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/VideoInstructionsScreen.test.tsx
@@ -2,7 +2,7 @@ import useVideoPrompts from '@/bcsc-theme/hooks/useVideoPrompts'
 import { useFocusEffect } from '@mocks/@react-navigation/native'
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { render, waitFor } from '@testing-library/react-native'
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native'
 import React, { useEffect } from 'react'
 import VideoInstructionsScreen from './VideoInstructionsScreen'
 
@@ -19,6 +19,8 @@ describe('VideoInstructions', () => {
   let mockNavigation: any
   const focusEffectMock = useFocusEffect as jest.Mock
   const mockRefreshPrompts = jest.fn()
+  // Callbacks currently registered through useFocusEffect, so a test can refocus a mounted screen.
+  const focusCallbacks = new Set<() => void | (() => void)>()
 
   const renderScreen = () =>
     render(
@@ -27,13 +29,35 @@ describe('VideoInstructions', () => {
       </BasicAppContext>
     )
 
+  /**
+   * Refocuses the mounted screen, as returning from TakeVideo or VideoReview does.
+   *
+   * The screen is never unmounted on those paths, so a stub that only fires on mount cannot tell a
+   * `useFocusEffect` apart from a plain mount effect — and refresh-on-return is the whole point here.
+   */
+  const refocus = async () => {
+    await act(async () => {
+      focusCallbacks.forEach((callback) => callback())
+    })
+  }
+
   beforeEach(() => {
     mockNavigation = useNavigation()
     jest.clearAllMocks()
-    // Run the focus callback as an effect, emulating the screen gaining focus after render
-    focusEffectMock.mockImplementation((callback: () => void) => {
+    focusCallbacks.clear()
+    // Emulate React Navigation's focus lifecycle: run on mount, and stay registered so `refocus` can
+    // fire the callback again on a screen that never unmounted.
+    focusEffectMock.mockImplementation((callback: () => void | (() => void)) => {
       // eslint-disable-next-line react-hooks/rules-of-hooks
-      useEffect(callback, [callback])
+      useEffect(() => {
+        const cleanup = callback()
+        focusCallbacks.add(callback)
+
+        return () => {
+          focusCallbacks.delete(callback)
+          cleanup?.()
+        }
+      }, [callback])
     })
     mockRefreshPrompts.mockResolvedValue(true)
     jest.mocked(useVideoPrompts).mockReturnValue({
@@ -51,22 +75,24 @@ describe('VideoInstructions', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  it('issues a fresh prompt set every time the screen is focused', async () => {
-    // Arriving here always precedes a recording — including after cancelling one — so the set the user
-    // is about to be asked has to be issued now rather than replayed from an earlier attempt.
+  it('issues a fresh prompt set when the screen is focused', async () => {
+    // Arriving here always precedes a recording, so the set the user is about to be asked has to be
+    // issued now rather than replayed from an earlier attempt.
     renderScreen()
 
     await waitFor(() => expect(mockRefreshPrompts).toHaveBeenCalledTimes(1))
   })
 
-  it('does not re-fetch when the refresh re-renders the screen', async () => {
-    // Refreshing writes the new prompts to the store, which re-renders this screen. If the focus effect
-    // depended on the refresh callback the write would re-arm it, looping the fetch.
+  it('issues another set when the screen is refocused', async () => {
+    // Returning here after cancelling a recording, or backing out of VideoReview, leaves this screen
+    // mounted. Reusing the set from the abandoned attempt is exactly the replay this flow guards
+    // against, so a refocus has to re-issue.
     renderScreen()
-
     await waitFor(() => expect(mockRefreshPrompts).toHaveBeenCalledTimes(1))
 
-    expect(mockRefreshPrompts).toHaveBeenCalledTimes(1)
+    await refocus()
+
+    expect(mockRefreshPrompts).toHaveBeenCalledTimes(2)
   })
 
   it('withholds the prompt list and blocks recording until a fresh set lands', async () => {
@@ -103,5 +129,31 @@ describe('VideoInstructions', () => {
 
     expect(tree.getByTestId('StartRecordingButton')).toBeDisabled()
     expect(tree.queryByText('Say your name')).toBeNull()
+  })
+
+  it('offers a retry instead of an endless spinner when the fetch fails', async () => {
+    // The alert is dismiss-only and this screen sits after every photo step, so without a retry the
+    // user's only escape is backing out and redoing the photos.
+    mockRefreshPrompts.mockResolvedValue(false)
+
+    const tree = renderScreen()
+
+    await waitFor(() => expect(tree.queryByTestId('RetryLoadPrompts')).not.toBeNull())
+    expect(tree.queryByTestId('PromptsLoading')).toBeNull()
+  })
+
+  it('recovers when the retry succeeds', async () => {
+    mockRefreshPrompts.mockResolvedValue(false)
+
+    const tree = renderScreen()
+    await waitFor(() => expect(tree.queryByTestId('RetryLoadPrompts')).not.toBeNull())
+
+    mockRefreshPrompts.mockResolvedValue(true)
+    fireEvent.press(tree.getByTestId('RetryLoadPrompts'))
+
+    await waitFor(() => expect(tree.getByTestId('StartRecordingButton')).toBeEnabled())
+    expect(mockRefreshPrompts).toHaveBeenCalledTimes(2)
+    expect(tree.queryByText('Say your name')).not.toBeNull()
+    expect(tree.queryByTestId('RetryLoadPrompts')).toBeNull()
   })
 })

--- a/app/src/bcsc-theme/features/verify/send-video/VideoInstructionsScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/VideoInstructionsScreen.test.tsx
@@ -4,6 +4,7 @@ import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native'
 import React, { useEffect } from 'react'
+import { ScrollView } from 'react-native'
 import VideoInstructionsScreen from './VideoInstructionsScreen'
 
 jest.mock('@/bcsc-theme/hooks/useVideoPrompts')
@@ -93,6 +94,21 @@ describe('VideoInstructions', () => {
     await refocus()
 
     expect(mockRefreshPrompts).toHaveBeenCalledTimes(2)
+  })
+
+  it('resets the scroll position to the top on refocus', async () => {
+    // The screen stays mounted beneath the camera, so backing out of a recording returns to it at the
+    // offset the user left — the fresh set should read from the start, not mid-list.
+    const scrollTo = jest.spyOn(ScrollView.prototype, 'scrollTo')
+
+    renderScreen()
+    await waitFor(() => expect(mockRefreshPrompts).toHaveBeenCalledTimes(1))
+    scrollTo.mockClear()
+
+    await refocus()
+
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ y: 0 }))
+    scrollTo.mockRestore()
   })
 
   it('withholds the prompt list and blocks recording until a fresh set lands', async () => {

--- a/app/src/bcsc-theme/features/verify/send-video/VideoInstructionsScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/VideoInstructionsScreen.test.tsx
@@ -1,29 +1,107 @@
+import useVideoPrompts from '@/bcsc-theme/hooks/useVideoPrompts'
+import { useFocusEffect } from '@mocks/@react-navigation/native'
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { render } from '@testing-library/react-native'
-import React from 'react'
+import { render, waitFor } from '@testing-library/react-native'
+import React, { useEffect } from 'react'
 import VideoInstructionsScreen from './VideoInstructionsScreen'
+
+jest.mock('@/bcsc-theme/hooks/useVideoPrompts')
+
+const mockVideoPromptsMissingAlert = jest.fn()
+jest.mock('@/hooks/useAlerts', () => ({
+  useAlerts: () => ({ videoPromptsMissingAlert: mockVideoPromptsMissingAlert }),
+}))
+
+const promptsState = { bcsc: { prompts: [{ id: 1, prompt: 'Say your name' }] } } as any
 
 describe('VideoInstructions', () => {
   let mockNavigation: any
+  const focusEffectMock = useFocusEffect as jest.Mock
+  const mockRefreshPrompts = jest.fn()
 
-  beforeEach(() => {
-    mockNavigation = useNavigation()
-    jest.clearAllMocks()
-    jest.useFakeTimers()
-  })
-
-  afterEach(() => {
-    jest.useRealTimers()
-  })
-
-  it('renders correctly', () => {
-    const tree = render(
-      <BasicAppContext>
+  const renderScreen = () =>
+    render(
+      <BasicAppContext initialStateOverride={promptsState}>
         <VideoInstructionsScreen navigation={mockNavigation as never} />
       </BasicAppContext>
     )
 
+  beforeEach(() => {
+    mockNavigation = useNavigation()
+    jest.clearAllMocks()
+    // Run the focus callback as an effect, emulating the screen gaining focus after render
+    focusEffectMock.mockImplementation((callback: () => void) => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useEffect(callback, [callback])
+    })
+    mockRefreshPrompts.mockResolvedValue(true)
+    jest.mocked(useVideoPrompts).mockReturnValue({
+      refreshPrompts: mockRefreshPrompts,
+      ensureVerificationRequest: jest.fn(),
+      isRefreshingPrompts: false,
+    })
+  })
+
+  it('renders correctly', async () => {
+    const tree = renderScreen()
+
+    await waitFor(() => expect(tree.queryByTestId('PromptsLoading')).toBeNull())
+
     expect(tree).toMatchSnapshot()
+  })
+
+  it('issues a fresh prompt set every time the screen is focused', async () => {
+    // Arriving here always precedes a recording — including after cancelling one — so the set the user
+    // is about to be asked has to be issued now rather than replayed from an earlier attempt.
+    renderScreen()
+
+    await waitFor(() => expect(mockRefreshPrompts).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not re-fetch when the refresh re-renders the screen', async () => {
+    // Refreshing writes the new prompts to the store, which re-renders this screen. If the focus effect
+    // depended on the refresh callback the write would re-arm it, looping the fetch.
+    renderScreen()
+
+    await waitFor(() => expect(mockRefreshPrompts).toHaveBeenCalledTimes(1))
+
+    expect(mockRefreshPrompts).toHaveBeenCalledTimes(1)
+  })
+
+  it('withholds the prompt list and blocks recording until a fresh set lands', async () => {
+    let resolveRefresh: (value: boolean) => void
+    mockRefreshPrompts.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveRefresh = resolve
+      })
+    )
+
+    const tree = renderScreen()
+
+    // Showing the cached set here would tell the user to expect prompts they won't be asked.
+    expect(tree.queryByTestId('PromptsLoading')).not.toBeNull()
+    expect(tree.queryByText('Say your name')).toBeNull()
+    expect(tree.getByTestId('StartRecordingButton')).toBeDisabled()
+
+    await waitFor(async () => {
+      resolveRefresh!(true)
+    })
+
+    await waitFor(() => expect(tree.getByTestId('StartRecordingButton')).toBeEnabled())
+    expect(tree.queryByText('Say your name')).not.toBeNull()
+  })
+
+  it('alerts and keeps recording blocked when a fresh set cannot be issued', async () => {
+    // Falling back to the cached set would put the user back in front of the camera answering a
+    // challenge the server already issued — the bug this screen guards against.
+    mockRefreshPrompts.mockResolvedValue(false)
+
+    const tree = renderScreen()
+
+    await waitFor(() => expect(mockVideoPromptsMissingAlert).toHaveBeenCalledTimes(1))
+
+    expect(tree.getByTestId('StartRecordingButton')).toBeDisabled()
+    expect(tree.queryByText('Say your name')).toBeNull()
   })
 })

--- a/app/src/bcsc-theme/features/verify/send-video/VideoInstructionsScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/VideoInstructionsScreen.tsx
@@ -7,9 +7,9 @@ import BrownHandHoldingPhone from '@assets/img/brown-hand-holding-phone.svg'
 import { Button, ButtonType, ScreenWrapper, ThemedText, useStore, useTheme } from '@bifold/core'
 import { useFocusEffect } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import { Fragment, useCallback, useState } from 'react'
+import { Fragment, useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ActivityIndicator, StyleSheet, View } from 'react-native'
+import { ActivityIndicator, ScrollView, StyleSheet, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
 type VideoInstructionsScreenProps = {
@@ -26,6 +26,7 @@ const VideoInstructionsScreen = ({ navigation }: VideoInstructionsScreenProps) =
   const { refreshPrompts } = useVideoPrompts()
   const { videoPromptsMissingAlert } = useAlerts(navigation)
   const [promptsStatus, setPromptsStatus] = useState<PromptsStatus>('loading')
+  const scrollViewRef = useRef<ScrollView>(null)
 
   /**
    * Issues the prompt set for the recording that is about to happen. The list below is what the user is
@@ -51,6 +52,10 @@ const VideoInstructionsScreen = ({ navigation }: VideoInstructionsScreenProps) =
   // review screen. `refreshPrompts` and the alert are stable, so this fires once per focus.
   useFocusEffect(
     useCallback(() => {
+      // This screen stays mounted beneath TakeVideo, so backing out of a recording returns to it at
+      // whatever scroll offset the user left it at. Snap back to the top so the fresh set reads from
+      // the start rather than mid-list.
+      scrollViewRef.current?.scrollTo({ y: 0, animated: false })
       loadPrompts()
     }, [loadPrompts])
   )
@@ -89,6 +94,7 @@ const VideoInstructionsScreen = ({ navigation }: VideoInstructionsScreenProps) =
       padded={false}
       edges={['top', 'bottom', 'left', 'right']}
       scrollViewContainerStyle={{ padding: Spacing.lg }}
+      scrollViewRef={scrollViewRef}
     >
       <BrownHandHoldingPhone style={styles.image} height={styles.image.height} width={styles.image.width} />
       <ThemedText variant={'headingThree'} style={{ marginBottom: Spacing.lg, textAlign: 'center' }}>

--- a/app/src/bcsc-theme/features/verify/send-video/VideoInstructionsScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/VideoInstructionsScreen.tsx
@@ -1,12 +1,15 @@
 import { VerificationPrompt } from '@/bcsc-theme/api/hooks/useEvidenceApi'
+import useVideoPrompts from '@/bcsc-theme/hooks/useVideoPrompts'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
+import { useAlerts } from '@/hooks/useAlerts'
 import { BCState } from '@/store'
 import BrownHandHoldingPhone from '@assets/img/brown-hand-holding-phone.svg'
 import { Button, ButtonType, ScreenWrapper, ThemedText, useStore, useTheme } from '@bifold/core'
+import { useFocusEffect } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import { Fragment } from 'react'
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, View } from 'react-native'
+import { ActivityIndicator, StyleSheet, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
 type VideoInstructionsScreenProps = {
@@ -17,6 +20,46 @@ const VideoInstructionsScreen = ({ navigation }: VideoInstructionsScreenProps) =
   const { Spacing, TextTheme, ColorPalette } = useTheme()
   const [store] = useStore<BCState>()
   const { t } = useTranslation()
+  const { refreshPrompts } = useVideoPrompts()
+  const { videoPromptsMissingAlert } = useAlerts(navigation)
+  const [promptsReady, setPromptsReady] = useState(false)
+
+  // Called from a focus effect that must fire exactly once per focus. Refreshing writes the new prompt
+  // set to the store, which re-renders this screen and would re-arm the effect if it depended on these
+  // callbacks directly — reading them through refs keeps the fetch off the render loop.
+  const refreshPromptsRef = useRef(refreshPrompts)
+  const videoPromptsMissingAlertRef = useRef(videoPromptsMissingAlert)
+  useEffect(() => {
+    refreshPromptsRef.current = refreshPrompts
+    videoPromptsMissingAlertRef.current = videoPromptsMissingAlert
+  }, [refreshPrompts, videoPromptsMissingAlert])
+
+  /**
+   * Issues the prompt set for the recording that is about to happen, on every arrival — including
+   * returning here after cancelling a recording. The list below is what the user is asked on camera, so
+   * it has to be the set that was just issued; recording against a set from an earlier attempt is the
+   * bug this guards against. Start stays disabled until a fresh set lands.
+   */
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false
+      setPromptsReady(false)
+
+      refreshPromptsRef.current().then((ready) => {
+        if (cancelled) {
+          return
+        }
+        setPromptsReady(ready)
+        if (!ready) {
+          videoPromptsMissingAlertRef.current()
+        }
+      })
+
+      return () => {
+        cancelled = true
+      }
+    }, [])
+  )
 
   const styles = StyleSheet.create({
     image: {
@@ -42,6 +85,7 @@ const VideoInstructionsScreen = ({ navigation }: VideoInstructionsScreenProps) =
         }}
         testID={'StartRecordingButton'}
         accessibilityLabel={t('BCSC.SendVideo.VideoInstructions.StartRecordingButton')}
+        disabled={!promptsReady}
       />
     </View>
   )
@@ -62,18 +106,23 @@ const VideoInstructionsScreen = ({ navigation }: VideoInstructionsScreenProps) =
       >
         {t('BCSC.SendVideo.VideoInstructions.Heading2')}
       </ThemedText>
-      {store.bcsc.prompts?.map(({ prompt, id }: VerificationPrompt, index) => (
-        <Fragment key={id}>
-          <ThemedText variant={'headingFour'} style={{ textAlign: 'center', color: ColorPalette.grayscale.black }}>
-            {index + 1}
-          </ThemedText>
-          <ThemedText
-            style={{ marginBottom: Spacing.xl, textAlign: 'center', fontSize: TextTheme.headingFour.fontSize }}
-          >
-            {prompt}
-          </ThemedText>
-        </Fragment>
-      ))}
+      {/* Held back until the refresh lands so the user is never shown a set from an earlier attempt. */}
+      {promptsReady ? (
+        store.bcsc.prompts?.map(({ prompt, id }: VerificationPrompt, index) => (
+          <Fragment key={id}>
+            <ThemedText variant={'headingFour'} style={{ textAlign: 'center', color: ColorPalette.grayscale.black }}>
+              {index + 1}
+            </ThemedText>
+            <ThemedText
+              style={{ marginBottom: Spacing.xl, textAlign: 'center', fontSize: TextTheme.headingFour.fontSize }}
+            >
+              {prompt}
+            </ThemedText>
+          </Fragment>
+        ))
+      ) : (
+        <ActivityIndicator style={{ marginBottom: Spacing.xl }} testID={'PromptsLoading'} />
+      )}
       <ThemedText variant={'headingFour'} style={{ marginVertical: Spacing.lg }}>
         {t('BCSC.SendVideo.VideoInstructions.Heading3')}
       </ThemedText>

--- a/app/src/bcsc-theme/features/verify/send-video/VideoInstructionsScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/VideoInstructionsScreen.tsx
@@ -7,7 +7,7 @@ import BrownHandHoldingPhone from '@assets/img/brown-hand-holding-phone.svg'
 import { Button, ButtonType, ScreenWrapper, ThemedText, useStore, useTheme } from '@bifold/core'
 import { useFocusEffect } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
+import { Fragment, useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, StyleSheet, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
@@ -16,49 +16,43 @@ type VideoInstructionsScreenProps = {
   navigation: StackNavigationProp<BCSCVerifyStackParams, BCSCScreens.VideoInstructions>
 }
 
+/** `failed` is distinct from `loading` so a failed fetch offers a retry instead of an endless spinner. */
+type PromptsStatus = 'loading' | 'ready' | 'failed'
+
 const VideoInstructionsScreen = ({ navigation }: VideoInstructionsScreenProps) => {
   const { Spacing, TextTheme, ColorPalette } = useTheme()
   const [store] = useStore<BCState>()
   const { t } = useTranslation()
   const { refreshPrompts } = useVideoPrompts()
   const { videoPromptsMissingAlert } = useAlerts(navigation)
-  const [promptsReady, setPromptsReady] = useState(false)
-
-  // Called from a focus effect that must fire exactly once per focus. Refreshing writes the new prompt
-  // set to the store, which re-renders this screen and would re-arm the effect if it depended on these
-  // callbacks directly — reading them through refs keeps the fetch off the render loop.
-  const refreshPromptsRef = useRef(refreshPrompts)
-  const videoPromptsMissingAlertRef = useRef(videoPromptsMissingAlert)
-  useEffect(() => {
-    refreshPromptsRef.current = refreshPrompts
-    videoPromptsMissingAlertRef.current = videoPromptsMissingAlert
-  }, [refreshPrompts, videoPromptsMissingAlert])
+  const [promptsStatus, setPromptsStatus] = useState<PromptsStatus>('loading')
 
   /**
-   * Issues the prompt set for the recording that is about to happen, on every arrival — including
-   * returning here after cancelling a recording. The list below is what the user is asked on camera, so
-   * it has to be the set that was just issued; recording against a set from an earlier attempt is the
-   * bug this guards against. Start stays disabled until a fresh set lands.
+   * Issues the prompt set for the recording that is about to happen. The list below is what the user is
+   * asked on camera, so it has to be the set that was just issued; recording against a set from an
+   * earlier attempt is the bug this guards against. Start stays disabled until a fresh set lands.
+   *
+   * A failure is a distinct state, not a stuck 'loading': the alert it raises is dismiss-only, and this
+   * screen sits after every photo step, so leaving a spinner up would strand the user somewhere they can
+   * only escape by redoing the photos. `failed` puts a retry in front of them instead.
    */
+  const loadPrompts = useCallback(async (): Promise<void> => {
+    setPromptsStatus('loading')
+
+    const ready = await refreshPrompts()
+
+    setPromptsStatus(ready ? 'ready' : 'failed')
+    if (!ready) {
+      videoPromptsMissingAlert()
+    }
+  }, [refreshPrompts, videoPromptsMissingAlert])
+
+  // Runs on every arrival, including returning here after cancelling a recording or backing out of the
+  // review screen. `refreshPrompts` and the alert are stable, so this fires once per focus.
   useFocusEffect(
     useCallback(() => {
-      let cancelled = false
-      setPromptsReady(false)
-
-      refreshPromptsRef.current().then((ready) => {
-        if (cancelled) {
-          return
-        }
-        setPromptsReady(ready)
-        if (!ready) {
-          videoPromptsMissingAlertRef.current()
-        }
-      })
-
-      return () => {
-        cancelled = true
-      }
-    }, [])
+      loadPrompts()
+    }, [loadPrompts])
   )
 
   const styles = StyleSheet.create({
@@ -85,7 +79,7 @@ const VideoInstructionsScreen = ({ navigation }: VideoInstructionsScreenProps) =
         }}
         testID={'StartRecordingButton'}
         accessibilityLabel={t('BCSC.SendVideo.VideoInstructions.StartRecordingButton')}
-        disabled={!promptsReady}
+        disabled={promptsStatus !== 'ready'}
       />
     </View>
   )
@@ -107,7 +101,7 @@ const VideoInstructionsScreen = ({ navigation }: VideoInstructionsScreenProps) =
         {t('BCSC.SendVideo.VideoInstructions.Heading2')}
       </ThemedText>
       {/* Held back until the refresh lands so the user is never shown a set from an earlier attempt. */}
-      {promptsReady ? (
+      {promptsStatus === 'ready' &&
         store.bcsc.prompts?.map(({ prompt, id }: VerificationPrompt, index) => (
           <Fragment key={id}>
             <ThemedText variant={'headingFour'} style={{ textAlign: 'center', color: ColorPalette.grayscale.black }}>
@@ -119,9 +113,18 @@ const VideoInstructionsScreen = ({ navigation }: VideoInstructionsScreenProps) =
               {prompt}
             </ThemedText>
           </Fragment>
-        ))
-      ) : (
+        ))}
+      {promptsStatus === 'loading' && (
         <ActivityIndicator style={{ marginBottom: Spacing.xl }} testID={'PromptsLoading'} />
+      )}
+      {promptsStatus === 'failed' && (
+        <Button
+          buttonType={ButtonType.Secondary}
+          title={t('Global.Retry')}
+          onPress={loadPrompts}
+          testID={'RetryLoadPrompts'}
+          accessibilityLabel={t('Global.Retry')}
+        />
       )}
       <ThemedText variant={'headingFour'} style={{ marginVertical: Spacing.lg }}>
         {t('BCSC.SendVideo.VideoInstructions.Heading3')}

--- a/app/src/bcsc-theme/features/verify/send-video/VideoReviewScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/VideoReviewScreen.test.tsx
@@ -1,16 +1,45 @@
+import useVideoPrompts from '@/bcsc-theme/hooks/useVideoPrompts'
+import { BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { render } from '@testing-library/react-native'
+import { useFocusEffect } from '@react-navigation/native'
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import VideoReviewScreen from './VideoReviewScreen'
 
+jest.mock('@/bcsc-theme/hooks/useVideoPrompts')
+
+const mockVideoPromptsMissingAlert = jest.fn()
+const mockFailedToReadFromLocalStorageAlert = jest.fn()
+jest.mock('@/hooks/useAlerts', () => ({
+  useAlerts: () => ({
+    videoPromptsMissingAlert: mockVideoPromptsMissingAlert,
+    failedToReadFromLocalStorageAlert: mockFailedToReadFromLocalStorageAlert,
+  }),
+}))
+
 describe('VideoReview', () => {
   let mockNavigation: any
+  const mockRefreshPrompts = jest.fn()
+  const route = { params: { videoPath: 'file://test.mp4', videoThumbnailPath: 'file://thumbnail.jpg' } }
+
+  const renderScreen = () =>
+    render(
+      <BasicAppContext>
+        <VideoReviewScreen navigation={mockNavigation as never} route={route as never} />
+      </BasicAppContext>
+    )
 
   beforeEach(() => {
     mockNavigation = useNavigation()
     jest.clearAllMocks()
     jest.useFakeTimers()
+    mockRefreshPrompts.mockResolvedValue(true)
+    jest.mocked(useVideoPrompts).mockReturnValue({
+      refreshPrompts: mockRefreshPrompts,
+      ensureVerificationRequest: jest.fn(),
+      isRefreshingPrompts: false,
+    })
   })
 
   afterEach(() => {
@@ -18,13 +47,94 @@ describe('VideoReview', () => {
   })
 
   it('renders correctly', () => {
-    const route = { params: { videoPath: 'file://test.mp4', videoThumbnailPath: 'file://thumbnail.jpg' } }
-    const tree = render(
-      <BasicAppContext>
-        <VideoReviewScreen navigation={mockNavigation as never} route={route as never} />
-      </BasicAppContext>
-    )
+    const tree = renderScreen()
 
     expect(tree).toMatchSnapshot()
+  })
+
+  it('issues a fresh prompt set before returning to the camera', async () => {
+    // The reported bug: retake replayed the cached set, so every attempt answered the same challenge.
+    // TakeVideo re-arms recording the moment it refocuses, so the set must be issued before goBack.
+    const tree = renderScreen()
+
+    fireEvent.press(tree.getByText('BCSC.SendVideo.VideoReview.RetakeVideo'))
+
+    await waitFor(() => expect(mockNavigation.goBack).toHaveBeenCalledTimes(1))
+    expect(mockRefreshPrompts).toHaveBeenCalledTimes(1)
+  })
+
+  it('holds the user on the review screen and alerts when a fresh set cannot be issued', async () => {
+    // Going back with the cached set would re-record against a challenge the server already issued.
+    mockRefreshPrompts.mockResolvedValue(false)
+
+    const tree = renderScreen()
+
+    fireEvent.press(tree.getByText('BCSC.SendVideo.VideoReview.RetakeVideo'))
+
+    await waitFor(() => expect(mockVideoPromptsMissingAlert).toHaveBeenCalledTimes(1))
+    expect(mockNavigation.goBack).not.toHaveBeenCalled()
+  })
+
+  it('blocks both actions while a refresh is in flight', async () => {
+    // A landed refresh rotates the sha this recording is bound to, so accepting it mid-refresh would
+    // finalize against a sha the server has already replaced.
+    jest.mocked(useVideoPrompts).mockReturnValue({
+      refreshPrompts: mockRefreshPrompts,
+      ensureVerificationRequest: jest.fn(),
+      isRefreshingPrompts: true,
+    })
+
+    const tree = renderScreen()
+
+    expect(tree.getByText('BCSC.SendVideo.VideoReview.UseVideo')).toBeDisabled()
+    expect(tree.getByText('BCSC.SendVideo.VideoReview.RetakeVideo')).toBeDisabled()
+  })
+
+  describe('back interception', () => {
+    // Popping to TakeVideo would re-arm recording against the set this video already answered. Redirecting
+    // to VideoInstructions instead lets its focus effect issue a fresh set before the next recording.
+    beforeEach(() => {
+      // Mocked as a no-op globally, so the listener is never registered until it actually runs the effect.
+      jest.mocked(useFocusEffect).mockImplementation((cb: any) => {
+        cb()
+      })
+    })
+
+    afterEach(() => {
+      jest.mocked(useFocusEffect).mockReset()
+    })
+
+    const captureBeforeRemove = () => {
+      renderScreen()
+
+      return mockNavigation.addListener.mock.calls.find(([event]: [string]) => event === 'beforeRemove')?.[1]
+    }
+
+    it('redirects the Android hardware back button to the instructions screen', () => {
+      const handler = captureBeforeRemove()
+      // The hardware back button reaches the container ref, so its action carries no source.
+      const event = { data: { action: { type: 'GO_BACK' } }, preventDefault: jest.fn() }
+
+      handler(event)
+
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.VideoInstructions)
+    })
+
+    it.each([
+      ['Retake', { type: 'GO_BACK', source: 'video-review-key' }],
+      ['the header back button', { type: 'NAVIGATE', source: 'video-review-key' }],
+      ['Use Video', { type: 'RESET', source: 'video-review-key' }],
+    ])('lets %s through untouched', (_label, action) => {
+      // These all dispatch through this screen's own navigation object, which stamps a source. Redirecting
+      // them would send Retake to the instructions screen and loop the header button on itself.
+      const handler = captureBeforeRemove()
+      const event = { data: { action }, preventDefault: jest.fn() }
+
+      handler(event)
+
+      expect(event.preventDefault).not.toHaveBeenCalled()
+      expect(mockNavigation.navigate).not.toHaveBeenCalled()
+    })
   })
 })

--- a/app/src/bcsc-theme/features/verify/send-video/VideoReviewScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/VideoReviewScreen.test.tsx
@@ -2,7 +2,7 @@ import useVideoPrompts from '@/bcsc-theme/hooks/useVideoPrompts'
 import { BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { useFocusEffect } from '@react-navigation/native'
+import { useNavigation as useContextNavigation, useFocusEffect } from '@react-navigation/native'
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import VideoReviewScreen from './VideoReviewScreen'
@@ -21,6 +21,8 @@ jest.mock('@/hooks/useAlerts', () => ({
 describe('VideoReview', () => {
   let mockNavigation: any
   const mockRefreshPrompts = jest.fn()
+  // usePreventGestureBack subscribes through useNavigation() (context), not the screen's prop.
+  const mockAddListener = jest.fn()
   const route = { params: { videoPath: 'file://test.mp4', videoThumbnailPath: 'file://thumbnail.jpg' } }
 
   const renderScreen = () =>
@@ -34,6 +36,7 @@ describe('VideoReview', () => {
     mockNavigation = useNavigation()
     jest.clearAllMocks()
     jest.useFakeTimers()
+    ;(useContextNavigation() as any).addListener = mockAddListener
     mockRefreshPrompts.mockResolvedValue(true)
     jest.mocked(useVideoPrompts).mockReturnValue({
       refreshPrompts: mockRefreshPrompts,
@@ -107,13 +110,15 @@ describe('VideoReview', () => {
     const captureBeforeRemove = () => {
       renderScreen()
 
-      return mockNavigation.addListener.mock.calls.find(([event]: [string]) => event === 'beforeRemove')?.[1]
+      return mockAddListener.mock.calls.find(([event]: [string]) => event === 'beforeRemove')?.[1]
     }
+
+    // Android's hardware back reaches the container ref, which stamps neither source nor target.
+    const hardwareBackEvent = () => ({ data: { action: { type: 'GO_BACK' } }, preventDefault: jest.fn() })
 
     it('redirects the Android hardware back button to the instructions screen', () => {
       const handler = captureBeforeRemove()
-      // The hardware back button reaches the container ref, so its action carries no source.
-      const event = { data: { action: { type: 'GO_BACK' } }, preventDefault: jest.fn() }
+      const event = hardwareBackEvent()
 
       handler(event)
 
@@ -121,19 +126,36 @@ describe('VideoReview', () => {
       expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.VideoInstructions)
     })
 
-    it.each([
-      ['Retake', { type: 'GO_BACK', source: 'video-review-key' }],
-      ['the header back button', { type: 'NAVIGATE', source: 'video-review-key' }],
-      ['Use Video', { type: 'RESET', source: 'video-review-key' }],
-    ])('lets %s through untouched', (_label, action) => {
-      // These all dispatch through this screen's own navigation object, which stamps a source. Redirecting
-      // them would send Retake to the instructions screen and loop the header button on itself.
+    it('lets this screen’s own dispatches through untouched', () => {
+      // Retake, Use Video and the header back button all dispatch through this route's navigation
+      // object, which stamps a source. Redirecting them would send Retake to the instructions screen
+      // instead of the camera. The source is the only thing separating them from a hardware back, so the
+      // action type is held identical here — varying it would let this pass on a type check alone.
       const handler = captureBeforeRemove()
-      const event = { data: { action }, preventDefault: jest.fn() }
+      const event = { data: { action: { type: 'GO_BACK', source: 'video-review-key' } }, preventDefault: jest.fn() }
 
       handler(event)
 
       expect(event.preventDefault).not.toHaveBeenCalled()
+      expect(mockNavigation.navigate).not.toHaveBeenCalled()
+    })
+
+    it('holds the user here while a retake refresh is in flight', () => {
+      // The buttons are disabled for this window but the hardware back is not. Leaving now would strand
+      // onPressRetake's goBack() on an unmounted screen: it carries a source but no target, so the router
+      // pops whatever replaced this route instead, dumping the user two screens back.
+      jest.mocked(useVideoPrompts).mockReturnValue({
+        refreshPrompts: mockRefreshPrompts,
+        ensureVerificationRequest: jest.fn(),
+        isRefreshingPrompts: true,
+      })
+
+      const handler = captureBeforeRemove()
+      const event = hardwareBackEvent()
+
+      handler(event)
+
+      expect(event.preventDefault).toHaveBeenCalled()
       expect(mockNavigation.navigate).not.toHaveBeenCalled()
     })
   })

--- a/app/src/bcsc-theme/features/verify/send-video/VideoReviewScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/VideoReviewScreen.tsx
@@ -1,4 +1,5 @@
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
+import useVideoPrompts from '@/bcsc-theme/hooks/useVideoPrompts'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { MediaCache } from '@/bcsc-theme/utils/media-cache'
 import { useAlerts } from '@/hooks/useAlerts'
@@ -16,9 +17,9 @@ import {
   useStore,
   useTheme,
 } from '@bifold/core'
-import { CommonActions } from '@react-navigation/native'
+import { CommonActions, useFocusEffect } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import { useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, TouchableOpacity, useWindowDimensions } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
@@ -48,7 +49,8 @@ const VideoReviewScreen = ({ navigation, route }: VideoReviewScreenProps) => {
   const videoRef = useRef<VideoRef>(null)
   const { videoPath, videoThumbnailPath } = route.params
   const { t } = useTranslation()
-  const { failedToReadFromLocalStorageAlert } = useAlerts(navigation)
+  const { failedToReadFromLocalStorageAlert, videoPromptsMissingAlert } = useAlerts(navigation)
+  const { refreshPrompts, isRefreshingPrompts } = useVideoPrompts()
 
   if (!videoPath || !videoThumbnailPath) {
     throw new Error(t('BCSC.SendVideo.VideoReview.VideoErrorPath'))
@@ -97,10 +99,55 @@ const VideoReviewScreen = ({ navigation, route }: VideoReviewScreenProps) => {
     setPaused((prev) => !prev)
   }
 
-  const onPressRetake = () => {
+  /**
+   * Retake drops the recording and goes straight back to the camera, so this is the only chance to issue
+   * the challenge set for the next attempt — TakeVideoScreen re-arms recording the moment it refocuses.
+   * Safe to rotate here because the video being discarded is the only one bound to the current sha.
+   */
+  const onPressRetake = async () => {
+    const promptsReady = await refreshPrompts()
+    if (!promptsReady) {
+      // Recording against the current set would replay a challenge the server already issued, so hold the
+      // user here rather than sending them back to the camera with stale prompts.
+      videoPromptsMissingAlert()
+      return
+    }
+
     dispatch({ type: BCDispatchAction.SAVE_VIDEO_THUMBNAIL, payload: [''] })
     navigation.goBack()
   }
+
+  /**
+   * Sends Android's hardware back to VideoInstructions rather than letting it pop to TakeVideo, which
+   * re-arms recording on focus against the set this video already answered — the replay `onPressRetake`
+   * refreshes to avoid, reachable without ever pressing Retake. VideoInstructions sits below TakeVideo, so
+   * navigating there pops the camera off the stack, and its own focus effect issues the next set and shows
+   * it to the user before recording can start. That keeps the fetch out of this listener: refreshing here
+   * would mean holding the screen through a network call with no way to signal it, and every repeat press
+   * would burn another set against the rate limit.
+   *
+   * Only a GO_BACK/POP without a source is redirected. The hardware back button reaches the container ref
+   * without a source, while this screen's own dispatches — Retake, Use Video, and the header back button
+   * in VerifyStack — all carry one and must pass through untouched. The iOS swipe is disabled there rather
+   * than redirected: it reveals the camera underneath as you drag, so landing elsewhere would contradict
+   * the gesture.
+   */
+  useFocusEffect(
+    useCallback(() => {
+      const unsubscribe = navigation.addListener('beforeRemove', (event) => {
+        const { action } = event.data
+        if ((action.type !== 'GO_BACK' && action.type !== 'POP') || action.source) {
+          return
+        }
+
+        event.preventDefault()
+        dispatch({ type: BCDispatchAction.SAVE_VIDEO_THUMBNAIL, payload: [''] })
+        navigation.navigate(BCSCScreens.VideoInstructions)
+      })
+
+      return unsubscribe
+    }, [dispatch, navigation])
+  )
 
   /**
    * Optimistically caches the video and extracts its metadata in the background,
@@ -136,12 +183,15 @@ const VideoReviewScreen = ({ navigation, route }: VideoReviewScreenProps) => {
 
   const controls = (
     <ControlContainer>
+      {/* A refresh in flight is about to rotate the sha this recording is bound to, so accepting the video
+          mid-refresh would finalize it against a sha the server has already replaced. */}
       <Button
         buttonType={ButtonType.Primary}
         onPress={onPressUse}
         testID={testIdWithKey('UseVideo')}
         title={t('BCSC.SendVideo.VideoReview.UseVideo')}
         accessibilityLabel={t('BCSC.SendVideo.VideoReview.UseVideo')}
+        disabled={isRefreshingPrompts}
       />
       <Button
         buttonType={ButtonType.Secondary}
@@ -149,6 +199,7 @@ const VideoReviewScreen = ({ navigation, route }: VideoReviewScreenProps) => {
         testID={testIdWithKey('RetakeVideo')}
         title={t('BCSC.SendVideo.VideoReview.RetakeVideo')}
         accessibilityLabel={t('BCSC.SendVideo.VideoReview.RetakeVideo')}
+        disabled={isRefreshingPrompts}
       />
     </ControlContainer>
   )

--- a/app/src/bcsc-theme/features/verify/send-video/VideoReviewScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/VideoReviewScreen.tsx
@@ -3,6 +3,7 @@ import useVideoPrompts from '@/bcsc-theme/hooks/useVideoPrompts'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { MediaCache } from '@/bcsc-theme/utils/media-cache'
 import { useAlerts } from '@/hooks/useAlerts'
+import usePreventGestureBack from '@/hooks/usePreventGestureBack'
 import { BCDispatchAction, BCState } from '@/store'
 import { withAlert } from '@/utils/alert'
 import readFileInChunks from '@/utils/read-file'
@@ -17,7 +18,7 @@ import {
   useStore,
   useTheme,
 } from '@bifold/core'
-import { CommonActions, useFocusEffect } from '@react-navigation/native'
+import { CommonActions } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -122,31 +123,24 @@ const VideoReviewScreen = ({ navigation, route }: VideoReviewScreenProps) => {
    * re-arms recording on focus against the set this video already answered — the replay `onPressRetake`
    * refreshes to avoid, reachable without ever pressing Retake. VideoInstructions sits below TakeVideo, so
    * navigating there pops the camera off the stack, and its own focus effect issues the next set and shows
-   * it to the user before recording can start. That keeps the fetch out of this listener: refreshing here
-   * would mean holding the screen through a network call with no way to signal it, and every repeat press
-   * would burn another set against the rate limit.
+   * it to the user before recording can start. That keeps the fetch out of here: refreshing on the way out
+   * would mean holding the screen through a network call with no way to signal it.
    *
-   * Only a GO_BACK/POP without a source is redirected. The hardware back button reaches the container ref
-   * without a source, while this screen's own dispatches — Retake, Use Video, and the header back button
-   * in VerifyStack — all carry one and must pass through untouched. The iOS swipe is disabled there rather
-   * than redirected: it reveals the camera underneath as you drag, so landing elsewhere would contradict
-   * the gesture.
+   * The iOS swipe is disabled in VerifyStack rather than redirected: it reveals the camera underneath as
+   * you drag, so landing elsewhere would contradict the gesture.
    */
-  useFocusEffect(
+  usePreventGestureBack(
     useCallback(() => {
-      const unsubscribe = navigation.addListener('beforeRemove', (event) => {
-        const { action } = event.data
-        if ((action.type !== 'GO_BACK' && action.type !== 'POP') || action.source) {
-          return
-        }
+      if (isRefreshingPrompts) {
+        // `onPressRetake` is mid-refresh and will goBack() once it lands. Leaving now would fire that
+        // goBack() from an unmounted screen: it carries a source but no target, so the router falls back
+        // to popping whatever is on top rather than this route, dumping the user two screens back. The
+        // buttons below are disabled for the same window.
+        return
+      }
 
-        event.preventDefault()
-        dispatch({ type: BCDispatchAction.SAVE_VIDEO_THUMBNAIL, payload: [''] })
-        navigation.navigate(BCSCScreens.VideoInstructions)
-      })
-
-      return unsubscribe
-    }, [dispatch, navigation])
+      navigation.navigate(BCSCScreens.VideoInstructions)
+    }, [isRefreshingPrompts, navigation])
   )
 
   /**

--- a/app/src/bcsc-theme/features/verify/send-video/VideoTooLongScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/VideoTooLongScreen.test.tsx
@@ -1,16 +1,40 @@
+import useVideoPrompts from '@/bcsc-theme/hooks/useVideoPrompts'
+import usePreventGestureBack from '@/hooks/usePreventGestureBack'
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { render } from '@testing-library/react-native'
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import VideoTooLongScreen from './VideoTooLongScreen'
 
+jest.mock('@/bcsc-theme/hooks/useVideoPrompts')
+jest.mock('@/hooks/usePreventGestureBack')
+
+const mockVideoPromptsMissingAlert = jest.fn()
+jest.mock('@/hooks/useAlerts', () => ({
+  useAlerts: () => ({ videoPromptsMissingAlert: mockVideoPromptsMissingAlert }),
+}))
+
 describe('VideoTooLong', () => {
   let mockNavigation: any
+  const mockRefreshPrompts = jest.fn()
+
+  const renderScreen = () =>
+    render(
+      <BasicAppContext>
+        <VideoTooLongScreen navigation={mockNavigation as never} route={{ params: { videoLengthSeconds: 60 } }} />
+      </BasicAppContext>
+    )
 
   beforeEach(() => {
     mockNavigation = useNavigation()
     jest.clearAllMocks()
     jest.useFakeTimers()
+    mockRefreshPrompts.mockResolvedValue(true)
+    jest.mocked(useVideoPrompts).mockReturnValue({
+      refreshPrompts: mockRefreshPrompts,
+      ensureVerificationRequest: jest.fn(),
+      isRefreshingPrompts: false,
+    })
   })
 
   afterEach(() => {
@@ -18,12 +42,39 @@ describe('VideoTooLong', () => {
   })
 
   it('renders correctly', () => {
-    const tree = render(
-      <BasicAppContext>
-        <VideoTooLongScreen navigation={mockNavigation as never} route={{ params: { videoLengthSeconds: 60 } }} />
-      </BasicAppContext>
-    )
+    const tree = renderScreen()
 
     expect(tree).toMatchSnapshot()
+  })
+
+  it('issues a fresh prompt set before returning to the camera', async () => {
+    // Retake goes straight back to TakeVideo, which re-arms recording on focus — this is the last point
+    // at which the next attempt's challenge set can be issued.
+    const tree = renderScreen()
+
+    fireEvent.press(tree.getByText('BCSC.SendVideo.VideoTooLong.ButtonText'))
+
+    await waitFor(() => expect(mockNavigation.goBack).toHaveBeenCalledTimes(1))
+    expect(mockRefreshPrompts).toHaveBeenCalledTimes(1)
+  })
+
+  it('holds the user here and alerts when a fresh set cannot be issued', async () => {
+    mockRefreshPrompts.mockResolvedValue(false)
+
+    const tree = renderScreen()
+
+    fireEvent.press(tree.getByText('BCSC.SendVideo.VideoTooLong.ButtonText'))
+
+    await waitFor(() => expect(mockVideoPromptsMissingAlert).toHaveBeenCalledTimes(1))
+    expect(mockNavigation.goBack).not.toHaveBeenCalled()
+  })
+
+  it('closes the back path around Retake', () => {
+    // Back would pop to TakeVideo and re-record against the set this over-long attempt already answered.
+    // Retake and Cancel are the deliberate exits; the hook covers Android's hardware back, and
+    // gestureEnabled: false in VerifyStack covers the iOS swipe.
+    renderScreen()
+
+    expect(usePreventGestureBack).toHaveBeenCalled()
   })
 })

--- a/app/src/bcsc-theme/features/verify/send-video/VideoTooLongScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/VideoTooLongScreen.tsx
@@ -72,7 +72,12 @@ const VideoTooLongScreen = ({ navigation, route }: VideoTooLongScreenProps) => {
   )
 
   return (
-    <ScreenWrapper controls={controls} padded={false} edges={['top', 'bottom', 'left', 'right']} scrollViewContainerStyle={{ padding: Spacing.lg }}>
+    <ScreenWrapper
+      controls={controls}
+      padded={false}
+      edges={['top', 'bottom', 'left', 'right']}
+      scrollViewContainerStyle={{ padding: Spacing.lg }}
+    >
       <ThemedText variant={'headingThree'} style={{ marginBottom: Spacing.md }}>
         {t('BCSC.SendVideo.VideoTooLong.Heading')}
       </ThemedText>

--- a/app/src/bcsc-theme/features/verify/send-video/VideoTooLongScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/VideoTooLongScreen.tsx
@@ -1,5 +1,8 @@
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
+import useVideoPrompts from '@/bcsc-theme/hooks/useVideoPrompts'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
+import { useAlerts } from '@/hooks/useAlerts'
+import usePreventGestureBack from '@/hooks/usePreventGestureBack'
 import { Button, ButtonType, ScreenWrapper, ThemedText, useTheme } from '@bifold/core'
 import { CommonActions } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -18,16 +21,38 @@ const VideoTooLongScreen = ({ navigation, route }: VideoTooLongScreenProps) => {
   const { Spacing } = useTheme()
   const { videoLengthSeconds } = route.params
   const { t } = useTranslation()
+  const { refreshPrompts, isRefreshingPrompts } = useVideoPrompts()
+  const { videoPromptsMissingAlert } = useAlerts(navigation)
+
+  // A plain back pops to TakeVideo, which re-arms recording on focus against the set the discarded
+  // recording already answered — the replay Retake refreshes to avoid, reached without pressing Retake.
+  // The two buttons below are this screen's deliberate exits, so back has nothing to offer here. This
+  // covers Android's hardware back (it dispatches without a source, which is what the hook keys on, so
+  // both buttons still navigate normally); `gestureEnabled: false` in VerifyStack covers the iOS swipe.
+  usePreventGestureBack()
+
+  /**
+   * Goes straight back to the camera, which re-arms recording on focus, so the next attempt needs its
+   * challenge set issued here. The over-long recording is discarded, so rotating the sha costs nothing.
+   */
+  const onPressRetake = async () => {
+    const promptsReady = await refreshPrompts()
+    if (!promptsReady) {
+      videoPromptsMissingAlert()
+      return
+    }
+
+    navigation.goBack()
+  }
 
   const controls = (
     <ControlContainer>
       <Button
         buttonType={ButtonType.Primary}
         title={t('BCSC.SendVideo.VideoTooLong.ButtonText')}
-        onPress={() => {
-          navigation.goBack()
-        }}
+        onPress={onPressRetake}
         accessibilityLabel={t('BCSC.SendVideo.VideoTooLong.ButtonText')}
+        disabled={isRefreshingPrompts}
       />
       <Button
         buttonType={ButtonType.Secondary}
@@ -47,7 +72,7 @@ const VideoTooLongScreen = ({ navigation, route }: VideoTooLongScreenProps) => {
   )
 
   return (
-    <ScreenWrapper controls={controls} edges={['top', 'bottom', 'left', 'right']}>
+    <ScreenWrapper controls={controls} padded={false} edges={['top', 'bottom', 'left', 'right']} scrollViewContainerStyle={{ padding: Spacing.lg }}>
       <ThemedText variant={'headingThree'} style={{ marginBottom: Spacing.md }}>
         {t('BCSC.SendVideo.VideoTooLong.Heading')}
       </ThemedText>

--- a/app/src/bcsc-theme/features/verify/send-video/__snapshots__/VideoInstructionsScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/send-video/__snapshots__/VideoInstructionsScreen.test.tsx.snap
@@ -93,6 +93,45 @@ exports[`VideoInstructions renders correctly 1`] = `
               "fontWeight": "bold",
             },
             {
+              "color": "#000000",
+              "textAlign": "center",
+            },
+          ]
+        }
+      >
+        1
+      </Text>
+      <Text
+        maxFontSizeMultiplier={2}
+        style={
+          [
+            {
+              "color": "#313132",
+              "fontFamily": "BCSans-Regular",
+              "fontSize": 18,
+              "fontWeight": "normal",
+            },
+            {
+              "fontSize": 21,
+              "marginBottom": 32,
+              "textAlign": "center",
+            },
+          ]
+        }
+      >
+        Say your name
+      </Text>
+      <Text
+        maxFontSizeMultiplier={2}
+        style={
+          [
+            {
+              "color": "#313132",
+              "fontFamily": "BCSans-Regular",
+              "fontSize": 21,
+              "fontWeight": "bold",
+            },
+            {
               "marginVertical": 24,
             },
           ]

--- a/app/src/bcsc-theme/features/verify/send-video/__snapshots__/VideoTooLongScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/send-video/__snapshots__/VideoTooLongScreen.test.tsx.snap
@@ -23,10 +23,10 @@ exports[`VideoTooLong renders correctly 1`] = `
   <RCTScrollView
     contentContainerStyle={
       [
+        false,
         {
-          "padding": 16,
+          "padding": 24,
         },
-        undefined,
       ]
     }
     showsVerticalScrollIndicator={false}
@@ -90,10 +90,7 @@ exports[`VideoTooLong renders correctly 1`] = `
         {
           "gap": 16,
         },
-        {
-          "paddingBottom": 16,
-          "paddingHorizontal": 16,
-        },
+        false,
         undefined,
       ]
     }

--- a/app/src/bcsc-theme/hooks/useVideoPrompts.test.ts
+++ b/app/src/bcsc-theme/hooks/useVideoPrompts.test.ts
@@ -1,0 +1,292 @@
+import useApi from '@/bcsc-theme/api/hooks/useApi'
+import useVideoPrompts from '@/bcsc-theme/hooks/useVideoPrompts'
+import { BCDispatchAction } from '@/store'
+import * as Bifold from '@bifold/core'
+import { act, renderHook } from '@testing-library/react-native'
+
+jest.mock('@/bcsc-theme/api/hooks/useApi')
+jest.mock('@bifold/core', () => {
+  const actual = jest.requireActual('@bifold/core')
+  return {
+    ...actual,
+    useStore: jest.fn(),
+    useServices: jest.fn(),
+  }
+})
+
+describe('useVideoPrompts', () => {
+  const mockDispatch = jest.fn()
+  const mockLogger = {
+    error: jest.fn(),
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  }
+
+  const mockEvidenceApi = {
+    createVerificationRequest: jest.fn(),
+    getVerificationRequestPrompts: jest.fn(),
+  }
+
+  const baseStore: any = {
+    bcsc: { prompts: [] },
+    bcscSecure: { verificationRequestId: undefined, verificationRequestSha: undefined },
+  }
+
+  const mockStoreWith = (overrides: any = {}) => {
+    jest.mocked(Bifold).useStore.mockReturnValue([
+      {
+        ...baseStore,
+        ...overrides,
+        bcscSecure: { ...baseStore.bcscSecure, ...(overrides.bcscSecure ?? {}) },
+      },
+      mockDispatch,
+    ])
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    jest.mocked(useApi).mockReturnValue({ evidence: mockEvidenceApi } as any)
+    jest.mocked(Bifold).useServices.mockReturnValue([mockLogger] as any)
+    mockStoreWith()
+  })
+
+  describe('refreshPrompts', () => {
+    it('rotates the prompt set of an open request, persisting the new sha alongside it', async () => {
+      // The sha is bound to the prompts it arrived with — persisting one without the other strands the
+      // upload, which finalizes against the stored sha.
+      mockStoreWith({ bcscSecure: { verificationRequestId: 'existing-id', verificationRequestSha: 'old-sha' } })
+      const fetched = { id: 'existing-id', sha256: 'fresh-sha', prompts: [{ id: 1, prompt: 'Say your name' }] }
+      mockEvidenceApi.getVerificationRequestPrompts.mockResolvedValue(fetched)
+
+      const { result } = renderHook(() => useVideoPrompts())
+
+      let ready: boolean | undefined
+      await act(async () => {
+        ready = await result.current.refreshPrompts()
+      })
+
+      expect(ready).toBe(true)
+      expect(mockEvidenceApi.getVerificationRequestPrompts).toHaveBeenCalledWith('existing-id')
+      expect(mockEvidenceApi.createVerificationRequest).not.toHaveBeenCalled()
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_REQUEST_SHA,
+        payload: ['fresh-sha'],
+      })
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_VIDEO_PROMPTS,
+        payload: [fetched.prompts],
+      })
+    })
+
+    it('refreshes even when a full prompt set is already cached', async () => {
+      // The whole point of the control: a retake must answer a challenge the user has not seen. A cached
+      // set is exactly what must not be reused.
+      mockStoreWith({
+        bcsc: { prompts: [{ id: 1, prompt: 'Stale prompt' }] },
+        bcscSecure: { verificationRequestId: 'existing-id', verificationRequestSha: 'cached-sha' },
+      })
+      mockEvidenceApi.getVerificationRequestPrompts.mockResolvedValue({
+        id: 'existing-id',
+        sha256: 'fresh-sha',
+        prompts: [{ id: 2, prompt: 'Look left' }],
+      })
+
+      const { result } = renderHook(() => useVideoPrompts())
+
+      await act(async () => {
+        await result.current.refreshPrompts()
+      })
+
+      expect(mockEvidenceApi.getVerificationRequestPrompts).toHaveBeenCalledWith('existing-id')
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_VIDEO_PROMPTS,
+        payload: [[{ id: 2, prompt: 'Look left' }]],
+      })
+    })
+
+    it('creates a request when none is open yet', async () => {
+      mockEvidenceApi.createVerificationRequest.mockResolvedValue({
+        id: 'new-id',
+        sha256: 'new-sha',
+        prompts: [{ id: 1, prompt: 'Say your name' }],
+      })
+
+      const { result } = renderHook(() => useVideoPrompts())
+
+      let ready: boolean | undefined
+      await act(async () => {
+        ready = await result.current.refreshPrompts()
+      })
+
+      expect(ready).toBe(true)
+      expect(mockEvidenceApi.getVerificationRequestPrompts).not.toHaveBeenCalled()
+      expect(mockEvidenceApi.createVerificationRequest).toHaveBeenCalledTimes(1)
+    })
+
+    it('recovers from a stale id by creating a fresh verification request when the fetch fails', async () => {
+      // IAS returns 500 for a verification id it has already deleted (TTL, agent cancelled).
+      mockStoreWith({ bcscSecure: { verificationRequestId: 'stale-id' } })
+      mockEvidenceApi.getVerificationRequestPrompts.mockRejectedValue(new Error('Request failed with status code 500'))
+      mockEvidenceApi.createVerificationRequest.mockResolvedValue({
+        id: 'fresh-id',
+        sha256: 'fresh-sha',
+        prompts: [{ id: 1, prompt: 'Say your name' }],
+      })
+
+      const { result } = renderHook(() => useVideoPrompts())
+
+      let ready: boolean | undefined
+      await act(async () => {
+        ready = await result.current.refreshPrompts()
+      })
+
+      expect(ready).toBe(true)
+      expect(mockEvidenceApi.getVerificationRequestPrompts).toHaveBeenCalledWith('stale-id')
+      expect(mockEvidenceApi.createVerificationRequest).toHaveBeenCalledTimes(1)
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_REQUEST_ID,
+        payload: ['fresh-id'],
+      })
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('creating a fresh request'))
+    })
+
+    it('reports failure without clearing the cached prompts when the server returns an empty set', async () => {
+      // Regression for #4018, and TakeVideoScreen hard-throws on an empty set while still mounted beneath
+      // the retake screens — clearing here would crash the screen the caller is about to return to.
+      mockStoreWith({
+        bcsc: { prompts: [{ id: 1, prompt: 'Previous prompt' }] },
+        bcscSecure: { verificationRequestId: 'existing-id', verificationRequestSha: 'old-sha' },
+      })
+      mockEvidenceApi.getVerificationRequestPrompts.mockResolvedValue({ id: 'existing-id', sha256: 'sha', prompts: [] })
+
+      const { result } = renderHook(() => useVideoPrompts())
+
+      let ready: boolean | undefined
+      await act(async () => {
+        ready = await result.current.refreshPrompts()
+      })
+
+      expect(ready).toBe(false)
+      expect(mockDispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: BCDispatchAction.UPDATE_VIDEO_PROMPTS })
+      )
+    })
+
+    it('keeps the request id of an unusable response so the next attempt can recover without a create', async () => {
+      // Dropping the id would send the next Send Video press back through createVerificationRequest,
+      // which the server rate limits.
+      mockEvidenceApi.createVerificationRequest.mockResolvedValue({ id: 'new-id', sha256: 'new-sha', prompts: [] })
+
+      const { result } = renderHook(() => useVideoPrompts())
+
+      await act(async () => {
+        await result.current.refreshPrompts()
+      })
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_REQUEST_ID,
+        payload: ['new-id'],
+      })
+    })
+
+    it('reports failure when both the fetch and the fallback create fail', async () => {
+      mockStoreWith({ bcscSecure: { verificationRequestId: 'existing-id' } })
+      mockEvidenceApi.getVerificationRequestPrompts.mockRejectedValue(new Error('offline'))
+      mockEvidenceApi.createVerificationRequest.mockRejectedValue(new Error('offline'))
+
+      const { result } = renderHook(() => useVideoPrompts())
+
+      let ready: boolean | undefined
+      await act(async () => {
+        ready = await result.current.refreshPrompts()
+      })
+
+      expect(ready).toBe(false)
+      expect(mockDispatch).not.toHaveBeenCalled()
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to refresh verification prompts'),
+        expect.any(Error)
+      )
+    })
+
+    it('tracks the in-flight refresh so callers can block actions bound to the outgoing sha', async () => {
+      mockStoreWith({ bcscSecure: { verificationRequestId: 'existing-id' } })
+      let resolveFetch: (value: any) => void
+      mockEvidenceApi.getVerificationRequestPrompts.mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve
+        })
+      )
+
+      const { result } = renderHook(() => useVideoPrompts())
+
+      expect(result.current.isRefreshingPrompts).toBe(false)
+
+      act(() => {
+        result.current.refreshPrompts()
+      })
+
+      expect(result.current.isRefreshingPrompts).toBe(true)
+
+      await act(async () => {
+        resolveFetch!({ id: 'existing-id', sha256: 'sha', prompts: [{ id: 1, prompt: 'Say your name' }] })
+      })
+
+      expect(result.current.isRefreshingPrompts).toBe(false)
+    })
+  })
+
+  describe('ensureVerificationRequest', () => {
+    it('creates a request when none is open', async () => {
+      mockEvidenceApi.createVerificationRequest.mockResolvedValue({
+        id: 'new-id',
+        sha256: 'new-sha',
+        prompts: [{ id: 1, prompt: 'Say your name' }],
+      })
+
+      const { result } = renderHook(() => useVideoPrompts())
+
+      let ready: boolean | undefined
+      await act(async () => {
+        ready = await result.current.ensureVerificationRequest()
+      })
+
+      expect(ready).toBe(true)
+      expect(mockEvidenceApi.createVerificationRequest).toHaveBeenCalledTimes(1)
+    })
+
+    it('makes no request at all when one is already open', async () => {
+      mockStoreWith({ bcscSecure: { verificationRequestId: 'existing-id', verificationRequestSha: 'sha' } })
+
+      const { result } = renderHook(() => useVideoPrompts())
+
+      let ready: boolean | undefined
+      await act(async () => {
+        ready = await result.current.ensureVerificationRequest()
+      })
+
+      expect(ready).toBe(true)
+      expect(mockEvidenceApi.createVerificationRequest).not.toHaveBeenCalled()
+      expect(mockEvidenceApi.getVerificationRequestPrompts).not.toHaveBeenCalled()
+    })
+
+    it('reports failure when the create fails', async () => {
+      mockEvidenceApi.createVerificationRequest.mockRejectedValue(new Error('rate limited'))
+
+      const { result } = renderHook(() => useVideoPrompts())
+
+      let ready: boolean | undefined
+      await act(async () => {
+        ready = await result.current.ensureVerificationRequest()
+      })
+
+      expect(ready).toBe(false)
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to create verification request'),
+        expect.any(Error)
+      )
+    })
+  })
+})

--- a/app/src/bcsc-theme/hooks/useVideoPrompts.test.ts
+++ b/app/src/bcsc-theme/hooks/useVideoPrompts.test.ts
@@ -1,8 +1,12 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import useVideoPrompts from '@/bcsc-theme/hooks/useVideoPrompts'
+import { AppError } from '@/errors/appError'
+import { ErrorRegistry } from '@/errors/errorRegistry'
 import { BCDispatchAction } from '@/store'
 import * as Bifold from '@bifold/core'
 import { act, renderHook } from '@testing-library/react-native'
+import { AxiosError } from 'axios'
+import { setAuthorizationRequest } from 'react-native-bcsc-core'
 
 jest.mock('@/bcsc-theme/api/hooks/useApi')
 jest.mock('@bifold/core', () => {
@@ -26,6 +30,19 @@ describe('useVideoPrompts', () => {
   const mockEvidenceApi = {
     createVerificationRequest: jest.fn(),
     getVerificationRequestPrompts: jest.fn(),
+  }
+
+  /**
+   * The shape the API client actually throws: an AppError wrapping the AxiosError.
+   *
+   * The status matters — only a 500 means IAS has deleted the request server-side. Anything else leaves
+   * the id usable, so the hook must not replace it.
+   */
+  const apiError = (status: number) => {
+    const cause = new AxiosError(`Request failed with status code ${status}`)
+    cause.response = { status } as any
+
+    return new AppError('api failure', ErrorRegistry.SERVER_ERROR, { cause, track: false })
   }
 
   const baseStore: any = {
@@ -125,10 +142,10 @@ describe('useVideoPrompts', () => {
       expect(mockEvidenceApi.createVerificationRequest).toHaveBeenCalledTimes(1)
     })
 
-    it('recovers from a stale id by creating a fresh verification request when the fetch fails', async () => {
+    it('recovers from a stale id by creating a fresh verification request on a 500', async () => {
       // IAS returns 500 for a verification id it has already deleted (TTL, agent cancelled).
       mockStoreWith({ bcscSecure: { verificationRequestId: 'stale-id' } })
-      mockEvidenceApi.getVerificationRequestPrompts.mockRejectedValue(new Error('Request failed with status code 500'))
+      mockEvidenceApi.getVerificationRequestPrompts.mockRejectedValue(apiError(500))
       mockEvidenceApi.createVerificationRequest.mockResolvedValue({
         id: 'fresh-id',
         sha256: 'fresh-sha',
@@ -150,6 +167,30 @@ describe('useVideoPrompts', () => {
         payload: ['fresh-id'],
       })
       expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('creating a fresh request'))
+    })
+
+    it.each([
+      ['a timeout', 408],
+      ['an expired token', 401],
+      ['a transient gateway failure', 502],
+    ])('keeps the open request and does not burn a create on %s', async (_label, status) => {
+      // Only a 500 means the id is gone. Replacing it for anything else orphans a live request and
+      // spends rate-limit budget the server enforces — on every focus and every retake.
+      mockStoreWith({ bcscSecure: { verificationRequestId: 'existing-id' } })
+      mockEvidenceApi.getVerificationRequestPrompts.mockRejectedValue(apiError(status))
+
+      const { result } = renderHook(() => useVideoPrompts())
+
+      let ready: boolean | undefined
+      await act(async () => {
+        ready = await result.current.refreshPrompts()
+      })
+
+      expect(ready).toBe(false)
+      expect(mockEvidenceApi.createVerificationRequest).not.toHaveBeenCalled()
+      expect(mockDispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_REQUEST_ID })
+      )
     })
 
     it('reports failure without clearing the cached prompts when the server returns an empty set', async () => {
@@ -174,6 +215,88 @@ describe('useVideoPrompts', () => {
       )
     })
 
+    it('nulls the sha of an unusable response rather than pairing it with the cached prompts', async () => {
+      // The prompts above are deliberately kept, so committing this response's sha would leave the store
+      // holding a pair the server never issued: a recording answering the old prompts would finalize
+      // against the new sha. useEvidenceUploadModel recovers from a missing sha but cannot see a wrong
+      // one, so null is the only safe value here.
+      mockStoreWith({
+        bcsc: { prompts: [{ id: 1, prompt: 'Previous prompt' }] },
+        bcscSecure: { verificationRequestId: 'existing-id', verificationRequestSha: 'old-sha' },
+      })
+      mockEvidenceApi.getVerificationRequestPrompts.mockResolvedValue({
+        id: 'existing-id',
+        sha256: 'rotated-sha',
+        prompts: [],
+      })
+
+      const { result } = renderHook(() => useVideoPrompts())
+
+      await act(async () => {
+        await result.current.refreshPrompts()
+      })
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_REQUEST_SHA,
+        payload: [null],
+      })
+      expect(mockDispatch).not.toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_REQUEST_SHA,
+        payload: ['rotated-sha'],
+      })
+    })
+
+    it('joins a refresh already in flight rather than rotating the set a second time', async () => {
+      // Every GET rotates the server's set. Each screen holds its own instance of this hook, so without
+      // sharing the in-flight call two gateways refreshing at once would each rotate, and their store
+      // writes would race — landing the sha from one response beside the prompts from another.
+      mockStoreWith({ bcscSecure: { verificationRequestId: 'existing-id' } })
+      let resolveFetch: (value: any) => void
+      mockEvidenceApi.getVerificationRequestPrompts.mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve
+        })
+      )
+
+      const first = renderHook(() => useVideoPrompts())
+      const second = renderHook(() => useVideoPrompts())
+
+      let firstReady: boolean | undefined
+      let secondReady: boolean | undefined
+      await act(async () => {
+        const firstCall = first.result.current.refreshPrompts().then((ready) => (firstReady = ready))
+        const secondCall = second.result.current.refreshPrompts().then((ready) => (secondReady = ready))
+
+        resolveFetch!({ id: 'existing-id', sha256: 'sha', prompts: [{ id: 1, prompt: 'Say your name' }] })
+        await Promise.all([firstCall, secondCall])
+      })
+
+      expect(mockEvidenceApi.getVerificationRequestPrompts).toHaveBeenCalledTimes(1)
+      expect(firstReady).toBe(true)
+      expect(secondReady).toBe(true)
+    })
+
+    it('starts a new rotation once the previous refresh has settled', async () => {
+      // The in-flight call is shared, not cached — a later gateway still needs its own fresh set.
+      mockStoreWith({ bcscSecure: { verificationRequestId: 'existing-id' } })
+      mockEvidenceApi.getVerificationRequestPrompts.mockResolvedValue({
+        id: 'existing-id',
+        sha256: 'sha',
+        prompts: [{ id: 1, prompt: 'Say your name' }],
+      })
+
+      const { result } = renderHook(() => useVideoPrompts())
+
+      await act(async () => {
+        await result.current.refreshPrompts()
+      })
+      await act(async () => {
+        await result.current.refreshPrompts()
+      })
+
+      expect(mockEvidenceApi.getVerificationRequestPrompts).toHaveBeenCalledTimes(2)
+    })
+
     it('keeps the request id of an unusable response so the next attempt can recover without a create', async () => {
       // Dropping the id would send the next Send Video press back through createVerificationRequest,
       // which the server rate limits.
@@ -192,8 +315,8 @@ describe('useVideoPrompts', () => {
     })
 
     it('reports failure when both the fetch and the fallback create fail', async () => {
-      mockStoreWith({ bcscSecure: { verificationRequestId: 'existing-id' } })
-      mockEvidenceApi.getVerificationRequestPrompts.mockRejectedValue(new Error('offline'))
+      mockStoreWith({ bcscSecure: { verificationRequestId: 'stale-id' } })
+      mockEvidenceApi.getVerificationRequestPrompts.mockRejectedValue(apiError(500))
       mockEvidenceApi.createVerificationRequest.mockRejectedValue(new Error('offline'))
 
       const { result } = renderHook(() => useVideoPrompts())
@@ -204,11 +327,48 @@ describe('useVideoPrompts', () => {
       })
 
       expect(ready).toBe(false)
+      expect(mockEvidenceApi.createVerificationRequest).toHaveBeenCalledTimes(1)
       expect(mockDispatch).not.toHaveBeenCalled()
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining('Failed to refresh verification prompts'),
         expect.any(Error)
       )
+    })
+
+    it('keeps a stable identity across a re-render once the request id lands', async () => {
+      // Callers drive this from a focus effect. An identity that changed when the id arrived would
+      // re-arm the effect and fetch a second time, rotating the set the user is already reading.
+      const { result, rerender } = renderHook(() => useVideoPrompts())
+      const before = result.current.refreshPrompts
+
+      mockStoreWith({ bcscSecure: { verificationRequestId: 'new-id' } })
+      rerender({})
+
+      expect(result.current.refreshPrompts).toBe(before)
+    })
+
+    it('still reports success when persisting the request id fails', async () => {
+      // The id and sha are dispatched to the store before native storage is touched, and the sha is
+      // memory-only by design, so a failed write costs the id on the next app cycle and nothing more.
+      // Failing the refresh over it would block Send Video, Retake and VideoInstructions outright.
+      mockStoreWith({ bcscSecure: { verificationRequestId: 'existing-id' } })
+      const fetched = { id: 'existing-id', sha256: 'fresh-sha', prompts: [{ id: 1, prompt: 'Say your name' }] }
+      mockEvidenceApi.getVerificationRequestPrompts.mockResolvedValue(fetched)
+      jest.mocked(setAuthorizationRequest).mockRejectedValueOnce(new Error('device storage is full'))
+
+      const { result } = renderHook(() => useVideoPrompts())
+
+      let ready: boolean | undefined
+      await act(async () => {
+        ready = await result.current.refreshPrompts()
+      })
+
+      expect(ready).toBe(true)
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_VIDEO_PROMPTS,
+        payload: [fetched.prompts],
+      })
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to persist'))
     })
 
     it('tracks the in-flight refresh so callers can block actions bound to the outgoing sha', async () => {
@@ -284,7 +444,7 @@ describe('useVideoPrompts', () => {
 
       expect(ready).toBe(false)
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to create verification request'),
+        expect.stringContaining('Failed to refresh verification prompts'),
         expect.any(Error)
       )
     })

--- a/app/src/bcsc-theme/hooks/useVideoPrompts.tsx
+++ b/app/src/bcsc-theme/hooks/useVideoPrompts.tsx
@@ -1,0 +1,123 @@
+import useApi from '@/bcsc-theme/api/hooks/useApi'
+import { VerificationResponseData } from '@/bcsc-theme/api/hooks/useEvidenceApi'
+import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
+import { BCDispatchAction, BCState } from '@/store'
+import { TOKENS, useServices, useStore } from '@bifold/core'
+import { useCallback, useState } from 'react'
+
+/**
+ * Issues the verification prompt set for a single recording attempt.
+ *
+ * IAS rotates the prompts — and the request sha256 they are bound to — on every GET /prompts. That
+ * rotation is the point of the control: a video is only accepted against the challenge set the server
+ * issued for it, so every path that starts a new recording has to ask for a fresh set. Reusing the
+ * cached set across retakes lets one performance answer a challenge indefinitely.
+ *
+ * Refresh only ever runs BEFORE a recording, never after one. Refreshing once a video exists swaps the
+ * sha out from under it and finalize fails with "invalid sha256" — which is why `useEvidenceUploadModel`
+ * recovers from a missing sha by clearing state and bouncing the user out rather than refetching.
+ */
+const useVideoPrompts = () => {
+  const [store, dispatch] = useStore<BCState>()
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const { evidence } = useApi()
+  const { updateVerificationRequest } = useSecureActions()
+  const [isRefreshingPrompts, setIsRefreshingPrompts] = useState(false)
+  const { verificationRequestId } = store.bcscSecure
+
+  /**
+   * Persists a request and its prompts, or reports that the response is unusable.
+   *
+   * A usable response lands its sha and prompts together — a video recorded against these prompts can
+   * only be finalized with the sha they arrived with, so storing one without the other strands the flow.
+   */
+  const _storeVerificationRequest = useCallback(
+    async (verificationRequest: VerificationResponseData): Promise<boolean> => {
+      // Persisted even for an unusable response: holding the id lets the next attempt recover through
+      // GET /prompts rather than burning another create, which the server rate limits.
+      await updateVerificationRequest(verificationRequest.id, verificationRequest.sha256)
+
+      if (!verificationRequest.prompts?.length) {
+        // The previous prompts stay in the store deliberately. TakeVideoScreen hard-throws on an empty
+        // set and is still mounted underneath on the retake paths, so clearing here would crash the
+        // screen the caller is about to send the user back to. Callers block the attempt instead.
+        logger.error('[useVideoPrompts] Server returned an empty prompt set')
+        return false
+      }
+
+      dispatch({ type: BCDispatchAction.UPDATE_VIDEO_PROMPTS, payload: [verificationRequest.prompts] })
+      return true
+    },
+    [dispatch, logger, updateVerificationRequest]
+  )
+
+  /**
+   * Fetches a fresh prompt set for the next recording. Call this from every gateway into TakeVideo.
+   *
+   * @returns {Promise<boolean>} Whether a usable prompt set is now in the store. On `false` the caller
+   * must not start a recording — the previous prompts are still cached and would replay a stale challenge.
+   */
+  const refreshPrompts = useCallback(async (): Promise<boolean> => {
+    setIsRefreshingPrompts(true)
+    try {
+      let verificationRequest: VerificationResponseData
+
+      if (verificationRequestId) {
+        try {
+          verificationRequest = await evidence.getVerificationRequestPrompts(verificationRequestId)
+        } catch (error) {
+          // IAS returns 500 for any call against a verification id that has been deleted
+          // server-side (TTL expired, agent cancelled, etc.). The local id is now useless —
+          // start a fresh request so the user isn't stuck on a stale id across cycles.
+          logger.warn(
+            `[useVideoPrompts] Failed to fetch prompts for stored verification id; creating a fresh request: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          )
+          verificationRequest = await evidence.createVerificationRequest()
+        }
+      } else {
+        // NOTE: Making this request too many times will be rate limited by the server.
+        verificationRequest = await evidence.createVerificationRequest()
+      }
+
+      return await _storeVerificationRequest(verificationRequest)
+    } catch (error) {
+      logger.error('[useVideoPrompts] Failed to refresh verification prompts', error as Error)
+      return false
+    } finally {
+      setIsRefreshingPrompts(false)
+    }
+  }, [_storeVerificationRequest, evidence, logger, verificationRequestId])
+
+  /**
+   * Starts the verification request if one isn't open yet, without rotating an existing one.
+   *
+   * Entering the flow shouldn't burn a prompt set — the user still has the photo steps ahead of them, and
+   * VideoInstructions refreshes immediately before recording. This exists so the entry point can still
+   * surface a backend that can't issue prompts at all, before the user works through the photo steps.
+   *
+   * @returns {Promise<boolean>} Whether the flow can proceed.
+   */
+  const ensureVerificationRequest = useCallback(async (): Promise<boolean> => {
+    if (verificationRequestId) {
+      return true
+    }
+
+    setIsRefreshingPrompts(true)
+    try {
+      // NOTE: Making this request too many times will be rate limited by the server.
+      const verificationRequest = await evidence.createVerificationRequest()
+      return await _storeVerificationRequest(verificationRequest)
+    } catch (error) {
+      logger.error('[useVideoPrompts] Failed to create verification request', error as Error)
+      return false
+    } finally {
+      setIsRefreshingPrompts(false)
+    }
+  }, [_storeVerificationRequest, evidence, logger, verificationRequestId])
+
+  return { refreshPrompts, ensureVerificationRequest, isRefreshingPrompts }
+}
+
+export default useVideoPrompts

--- a/app/src/bcsc-theme/hooks/useVideoPrompts.tsx
+++ b/app/src/bcsc-theme/hooks/useVideoPrompts.tsx
@@ -127,11 +127,9 @@ const useVideoPrompts = () => {
    * must not start a recording — the previous prompts are still cached and would replay a stale challenge.
    */
   const refreshPrompts = useCallback(async (): Promise<boolean> => {
-    if (!inFlightRefresh) {
-      inFlightRefresh = _refresh().finally(() => {
-        inFlightRefresh = null
-      })
-    }
+    inFlightRefresh ??= _refresh().finally(() => {
+      inFlightRefresh = null
+    })
 
     const refresh = inFlightRefresh
     setIsRefreshingPrompts(true)

--- a/app/src/bcsc-theme/hooks/useVideoPrompts.tsx
+++ b/app/src/bcsc-theme/hooks/useVideoPrompts.tsx
@@ -1,9 +1,10 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { VerificationResponseData } from '@/bcsc-theme/api/hooks/useEvidenceApi'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
+import { isAxiosAppError } from '@/errors/appError'
 import { BCDispatchAction, BCState } from '@/store'
 import { TOKENS, useServices, useStore } from '@bifold/core'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 /**
  * Issues the verification prompt set for a single recording attempt.
@@ -17,6 +18,20 @@ import { useCallback, useState } from 'react'
  * sha out from under it and finalize fails with "invalid sha256" — which is why `useEvidenceUploadModel`
  * recovers from a missing sha by clearing state and bouncing the user out rather than refetching.
  */
+
+/**
+ * The refresh in flight, shared across every instance of this hook.
+ *
+ * Each screen calls `useVideoPrompts()` separately, so per-instance state cannot serialize refreshes:
+ * two gateways refreshing at once would each rotate the server's set, and their store writes would
+ * race — landing the sha from one response beside the prompts from another. Every caller wants the same
+ * thing, a fresh set in the store, so a second call joins the first rather than starting a rotation.
+ */
+let inFlightRefresh: Promise<boolean> | null = null
+
+/** IAS returns 500 for a verification id it has already deleted server-side. */
+const DELETED_VERIFICATION_REQUEST_STATUS = 500
+
 const useVideoPrompts = () => {
   const [store, dispatch] = useStore<BCState>()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
@@ -25,19 +40,42 @@ const useVideoPrompts = () => {
   const [isRefreshingPrompts, setIsRefreshingPrompts] = useState(false)
   const { verificationRequestId } = store.bcscSecure
 
+  // Read through a ref so `refreshPrompts` keeps a stable identity: callers drive it from focus effects,
+  // and an identity that changed when the id landed would re-arm the effect and fetch a second time.
+  const verificationRequestIdRef = useRef(verificationRequestId)
+  useEffect(() => {
+    verificationRequestIdRef.current = verificationRequestId
+  }, [verificationRequestId])
+
   /**
-   * Persists a request and its prompts, or reports that the response is unusable.
+   * Commits a response, or reports that it is unusable.
    *
    * A usable response lands its sha and prompts together — a video recorded against these prompts can
    * only be finalized with the sha they arrived with, so storing one without the other strands the flow.
    */
   const _storeVerificationRequest = useCallback(
     async (verificationRequest: VerificationResponseData): Promise<boolean> => {
-      // Persisted even for an unusable response: holding the id lets the next attempt recover through
-      // GET /prompts rather than burning another create, which the server rate limits.
-      await updateVerificationRequest(verificationRequest.id, verificationRequest.sha256)
+      const usable = Boolean(verificationRequest.prompts?.length)
 
-      if (!verificationRequest.prompts?.length) {
+      try {
+        // The id is worth holding even for an unusable response: it lets the next attempt recover
+        // through GET /prompts rather than burning another create, which the server rate limits. This
+        // response's sha is not — pairing it with the prompts already in the store would let a
+        // recording finalize against a challenge it never answered, and `useEvidenceUploadModel` can
+        // only detect a sha that is missing, never one that is merely wrong. Null it instead.
+        await updateVerificationRequest(verificationRequest.id, usable ? verificationRequest.sha256 : null)
+      } catch (error) {
+        // Best-effort. `updateVerificationRequest` dispatches both values before it touches native
+        // storage and the sha is memory-only by design, so a failed write costs the id on the next app
+        // cycle and nothing more. A full disk must not sink a refresh whose response arrived intact.
+        logger.warn(
+          `[useVideoPrompts] Failed to persist the verification request id: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        )
+      }
+
+      if (!usable) {
         // The previous prompts stay in the store deliberately. TakeVideoScreen hard-throws on an empty
         // set and is still mounted underneath on the retake paths, so clearing here would crash the
         // screen the caller is about to send the user back to. Callers block the attempt instead.
@@ -51,29 +89,23 @@ const useVideoPrompts = () => {
     [dispatch, logger, updateVerificationRequest]
   )
 
-  /**
-   * Fetches a fresh prompt set for the next recording. Call this from every gateway into TakeVideo.
-   *
-   * @returns {Promise<boolean>} Whether a usable prompt set is now in the store. On `false` the caller
-   * must not start a recording — the previous prompts are still cached and would replay a stale challenge.
-   */
-  const refreshPrompts = useCallback(async (): Promise<boolean> => {
-    setIsRefreshingPrompts(true)
+  const _refresh = useCallback(async (): Promise<boolean> => {
     try {
       let verificationRequest: VerificationResponseData
+      const requestId = verificationRequestIdRef.current
 
-      if (verificationRequestId) {
+      if (requestId) {
         try {
-          verificationRequest = await evidence.getVerificationRequestPrompts(verificationRequestId)
+          verificationRequest = await evidence.getVerificationRequestPrompts(requestId)
         } catch (error) {
-          // IAS returns 500 for any call against a verification id that has been deleted
-          // server-side (TTL expired, agent cancelled, etc.). The local id is now useless —
-          // start a fresh request so the user isn't stuck on a stale id across cycles.
-          logger.warn(
-            `[useVideoPrompts] Failed to fetch prompts for stored verification id; creating a fresh request: ${
-              error instanceof Error ? error.message : String(error)
-            }`
-          )
+          // Only a 500 means the id is gone (TTL expired, agent cancelled) and worth replacing. A
+          // timeout, a 401 or a transient 502 leaves it perfectly usable, and creating a fresh request
+          // for those orphans the live one and spends rate-limit budget the server enforces.
+          if (!isAxiosAppError(error, DELETED_VERIFICATION_REQUEST_STATUS)) {
+            throw error
+          }
+
+          logger.warn('[useVideoPrompts] Stored verification id was rejected by the server; creating a fresh request')
           verificationRequest = await evidence.createVerificationRequest()
         }
       } else {
@@ -85,37 +117,47 @@ const useVideoPrompts = () => {
     } catch (error) {
       logger.error('[useVideoPrompts] Failed to refresh verification prompts', error as Error)
       return false
+    }
+  }, [_storeVerificationRequest, evidence, logger])
+
+  /**
+   * Fetches a fresh prompt set for the next recording. Call this from every gateway into TakeVideo.
+   *
+   * @returns {Promise<boolean>} Whether a usable prompt set is now in the store. On `false` the caller
+   * must not start a recording — the previous prompts are still cached and would replay a stale challenge.
+   */
+  const refreshPrompts = useCallback(async (): Promise<boolean> => {
+    if (!inFlightRefresh) {
+      inFlightRefresh = _refresh().finally(() => {
+        inFlightRefresh = null
+      })
+    }
+
+    const refresh = inFlightRefresh
+    setIsRefreshingPrompts(true)
+    try {
+      return await refresh
     } finally {
       setIsRefreshingPrompts(false)
     }
-  }, [_storeVerificationRequest, evidence, logger, verificationRequestId])
+  }, [_refresh])
 
   /**
-   * Starts the verification request if one isn't open yet, without rotating an existing one.
+   * Opens a verification request if one isn't already open, without rotating an existing one.
    *
-   * Entering the flow shouldn't burn a prompt set — the user still has the photo steps ahead of them, and
-   * VideoInstructions refreshes immediately before recording. This exists so the entry point can still
-   * surface a backend that can't issue prompts at all, before the user works through the photo steps.
+   * Entering the flow shouldn't burn a prompt set — the user still has the photo steps ahead of them,
+   * and VideoInstructions refreshes immediately before recording. An id that is already open is taken
+   * at face value rather than probed: it is persisted while its sha is not, so every resumed journey
+   * would pay a rotation here. The cost is that a dead id or an unreachable backend surfaces at
+   * VideoInstructions, after the photo steps, rather than on this press; `refreshPrompts` recovers
+   * from both there.
    *
    * @returns {Promise<boolean>} Whether the flow can proceed.
    */
   const ensureVerificationRequest = useCallback(async (): Promise<boolean> => {
-    if (verificationRequestId) {
-      return true
-    }
-
-    setIsRefreshingPrompts(true)
-    try {
-      // NOTE: Making this request too many times will be rate limited by the server.
-      const verificationRequest = await evidence.createVerificationRequest()
-      return await _storeVerificationRequest(verificationRequest)
-    } catch (error) {
-      logger.error('[useVideoPrompts] Failed to create verification request', error as Error)
-      return false
-    } finally {
-      setIsRefreshingPrompts(false)
-    }
-  }, [_storeVerificationRequest, evidence, logger, verificationRequestId])
+    // refreshPrompts creates a request when no id is stored, which is exactly this call.
+    return verificationRequestId ? true : refreshPrompts()
+  }, [refreshPrompts, verificationRequestId])
 
   return { refreshPrompts, ensureVerificationRequest, isRefreshingPrompts }
 }

--- a/app/src/bcsc-theme/navigators/VerifyStack.tsx
+++ b/app/src/bcsc-theme/navigators/VerifyStack.tsx
@@ -92,6 +92,20 @@ const VerifyResumeHeaderBackButton = (props: HeaderBackButtonProps) => {
   )
 }
 
+/**
+ * Back button for VideoReview. A plain pop lands on TakeVideo, which re-arms recording on focus against
+ * the prompt set the reviewed video already answered — a video is only accepted against the challenge set
+ * the server issued for it, so every route into a recording has to ask for a fresh one. VideoInstructions
+ * sits below TakeVideo, so navigating there pops the camera off the stack and lets that screen's focus
+ * effect issue and display the next set before recording starts. Retake still goes straight to the camera;
+ * it refreshes on its own.
+ */
+const VideoReviewBackButton = (props: HeaderBackButtonProps) => {
+  const navigation = useNavigation<StackNavigationProp<BCSCVerifyStackParams>>()
+
+  return <HeaderBackButton {...props} onPress={() => navigation.navigate(BCSCScreens.VideoInstructions)} />
+}
+
 // When PendingReview is the initial route (entered from the home screen notification),
 // there is no navigation history — dispatch UNVERIFIED to swap back to MainStack instead.
 const PendingReviewBackButton = (props: HeaderBackButtonProps) => {
@@ -301,7 +315,13 @@ const VerifyStack = ({ showVerifyPrompt = false, onVerifyPromptAnswered }: Verif
       <Stack.Screen
         name={BCSCScreens.VideoReview}
         component={VideoReviewScreen}
-        options={{ header: createProgressHeader(5, 50) }}
+        options={{
+          header: createProgressHeader(5, 50),
+          headerLeft: VideoReviewBackButton,
+          // The swipe drags TakeVideo into view as it goes, so it can't be redirected to
+          // VideoInstructions without contradicting what the user is looking at. Back is the button.
+          gestureEnabled: false,
+        }}
       />
       <Stack.Screen
         name={BCSCScreens.PendingReview}
@@ -317,7 +337,13 @@ const VerifyStack = ({ showVerifyPrompt = false, onVerifyPromptAnswered }: Verif
         component={CancelledReview}
         options={{ header: createProgressHeader(5, 80) }}
       />
-      <Stack.Screen name={BCSCScreens.VideoTooLong} component={VideoTooLongScreen} options={{ headerShown: false }} />
+      <Stack.Screen
+        name={BCSCScreens.VideoTooLong}
+        component={VideoTooLongScreen}
+        // Retake and Cancel are the only ways out; back would pop to TakeVideo and re-record against the
+        // prompt set the over-long recording already answered. Pairs with usePreventGestureBack for Android.
+        options={{ headerShown: false, gestureEnabled: false }}
+      />
       <Stack.Screen
         name={BCSCScreens.EvidenceUploading}
         component={UploadingScreen}

--- a/app/src/hooks/usePreventGestureBack.test.ts
+++ b/app/src/hooks/usePreventGestureBack.test.ts
@@ -48,6 +48,35 @@ describe('usePreventGestureBack', () => {
     expect(event.preventDefault).not.toHaveBeenCalled()
   })
 
+  it('invokes onPrevented after blocking a sourceless back', () => {
+    // Lets a screen redirect somewhere of its own choosing rather than just holding the user in place.
+    mockUseFocusEffect.mockImplementation((cb) => cb())
+    mockAddListener.mockReturnValue(jest.fn())
+    const onPrevented = jest.fn()
+
+    renderHook(() => usePreventGestureBack(onPrevented))
+
+    const handler = mockAddListener.mock.calls[0][1]
+    const event = { data: { action: {} }, preventDefault: jest.fn() }
+    handler(event)
+
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(onPrevented).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not invoke onPrevented for programmatic navigation', () => {
+    mockUseFocusEffect.mockImplementation((cb) => cb())
+    mockAddListener.mockReturnValue(jest.fn())
+    const onPrevented = jest.fn()
+
+    renderHook(() => usePreventGestureBack(onPrevented))
+
+    const handler = mockAddListener.mock.calls[0][1]
+    handler({ data: { action: { source: 'some-screen' } }, preventDefault: jest.fn() })
+
+    expect(onPrevented).not.toHaveBeenCalled()
+  })
+
   it('returns unsubscribe function from useFocusEffect cleanup', () => {
     const mockUnsubscribe = jest.fn()
     mockAddListener.mockReturnValue(mockUnsubscribe)

--- a/app/src/hooks/usePreventGestureBack.ts
+++ b/app/src/hooks/usePreventGestureBack.ts
@@ -1,20 +1,30 @@
 import { useFocusEffect, useNavigation } from '@react-navigation/native'
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 /**
  * Prevents gesture-based back navigation (Android hardware back, swipe) while
  * still allowing programmatic navigation (e.g. navigation.goBack()).
  *
  * gestureEnabled: false handles iOS; this hook handles Android's beforeRemove.
+ *
+ * @param onPrevented Called after a back is blocked. Lets a screen send the user somewhere of its own
+ * choosing instead of simply holding them in place. Read through a ref, so passing an inline callback
+ * does not re-subscribe the listener.
  */
-const usePreventGestureBack = () => {
+const usePreventGestureBack = (onPrevented?: () => void) => {
   const navigation = useNavigation()
+  const onPreventedRef = useRef(onPrevented)
+
+  useEffect(() => {
+    onPreventedRef.current = onPrevented
+  }, [onPrevented])
 
   useFocusEffect(
     useCallback(() => {
       const unsubscribe = navigation.addListener('beforeRemove', (event) => {
         if (!event.data.action.source) {
           event.preventDefault()
+          onPreventedRef.current?.()
         }
       })
       return unsubscribe


### PR DESCRIPTION
# Summary of Changes

IAS rotates the selfie-video prompts — and the request sha256 they're bound to — on every fetch, so a recording is only accepted against the set the server just issued. Retakes and back-navigation could send the user to the camera with a stale prompt set, letting one recording answer the same challenge repeatedly.

Prompt fetching is centralized in a new `useVideoPrompts` hook, called from every gateway into recording. Back-navigation out of the review and too-long screens no longer lands on the armed camera with stale prompts: VideoReview redirects back to the instructions screen (which refetches), and VideoTooLong blocks gesture/hardware back so its Retake/Cancel buttons are the only exits.

Also fixes several edge cases surfaced in review: the rotated sha is no longer committed alongside an empty prompt set, concurrent refreshes are de-duplicated, a stale request id is only recreated on a 500 (not on any error), and a failed fetch now shows a Retry instead of an endless spinner.

# Testing Instructions

1. Start selfie-video verification and record a video.
2. On the review screen, tap **Retake** → confirm you return to the camera with a fresh set of prompts (not the previous ones).
3. From the review screen, use the header back button and Android hardware back → confirm both land on the instructions screen and it refetches before recording.
4. Record a video longer than the max duration → on the "too long" screen, confirm back gestures are blocked and only Retake/Cancel work.
5. With the network off, arrive at the instructions screen → confirm a Retry button appears (not a stuck spinner) and that retrying recovers once the network is back.

# Acceptance Criteria

- Every path into recording issues a fresh prompt set; no path reaches the camera with a stale one.
- Back-navigation from the review and too-long screens cannot reach the armed camera with stale prompts.
- A failed prompt fetch is recoverable in-place (Retry), not a dead end.
- An empty prompt set never leaves the store with a mismatched sha/prompts pair.

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A
