### PR TITLE
fix: change app security screen

### DIFF
--- a/app/src/bcsc-theme/components/CardButton.tsx
+++ b/app/src/bcsc-theme/components/CardButton.tsx
@@ -47,6 +47,15 @@ interface CardProps {
    */
   disabled?: boolean
   /**
+   * Whether the card is shown in a selected/highlighted state (e.g. the current selection).
+   * A selected card is a non-interactive status indicator: it renders an accent border with a
+   * trailing check icon (not dimmed like a disabled card), announces its title and subtext together
+   * with a "selected" state to screen readers, and does not respond to presses.
+   *
+   * @type {boolean}
+   */
+  selected?: boolean
+  /**
    * Test ID for the button
    *
    * @type {string}
@@ -74,6 +83,11 @@ export const CardButton = (props: CardProps): React.ReactElement => {
       padding: Spacing.md,
       backgroundColor: ColorPalette.brand.tertiaryBackground,
       borderRadius: Spacing.xs,
+      borderWidth: 2,
+      borderColor: 'transparent',
+    },
+    cardContainerSelected: {
+      borderColor: ColorPalette.brand.primary,
     },
     cardOuterRow: {
       flexDirection: 'row',
@@ -104,6 +118,43 @@ export const CardButton = (props: CardProps): React.ReactElement => {
     },
   })
 
+  const cardContent = (
+    <View style={styles.cardOuterRow}>
+      {props.startIcon ? <Icon name={props.startIcon} style={styles.cardIcon} size={Spacing.xxl} /> : null}
+      <View style={styles.cardContentContainer}>
+        <View style={styles.cardTitleContainer}>
+          <ThemedText variant={props.startIcon ? 'bold' : 'headingFour'} style={styles.cardTitle}>
+            {props.title}
+          </ThemedText>
+          {!props.selected && props.endIcon ? (
+            <Icon name={props.endIcon} style={styles.cardIcon} size={Spacing.xl} />
+          ) : null}
+        </View>
+        {props.subtext ? <ThemedText style={styles.cardSubtext}>{props.subtext}</ThemedText> : null}
+      </View>
+      {/* Rendered as a sibling of the content so it stays vertically centered across title + subtext */}
+      {props.selected ? <Icon name="check-circle" color={ColorPalette.brand.primary} size={Spacing.xl} /> : null}
+    </View>
+  )
+
+  // A selected card represents the already-active choice: it is a non-interactive status indicator,
+  // not a button. Render it as a plain accessible container so screen readers announce the full
+  // label (title + the method name carried in the subtext) with a "selected" state — not "disabled"
+  // — and so it produces no press feedback.
+  if (props.selected) {
+    return (
+      <View
+        accessible={true}
+        accessibilityLabel={a11yLabel(props.subtext ? `${props.title}. ${props.subtext}` : props.title)}
+        accessibilityState={{ selected: true }}
+        style={[styles.cardContainer, styles.cardContainerSelected]}
+        testID={props.testID ?? testIdWithKey(`CardButton-${props.title}`)}
+      >
+        {cardContent}
+      </View>
+    )
+  }
+
   return (
     <PressableOpacity
       accessible={true}
@@ -116,18 +167,7 @@ export const CardButton = (props: CardProps): React.ReactElement => {
       disabled={props.disabled}
       testID={props.testID ?? testIdWithKey(`CardButton-${props.title}`)}
     >
-      <View style={styles.cardOuterRow}>
-        {props.startIcon ? <Icon name={props.startIcon} style={styles.cardIcon} size={Spacing.xxl} /> : null}
-        <View style={styles.cardContentContainer}>
-          <View style={styles.cardTitleContainer}>
-            <ThemedText variant={props.startIcon ? 'bold' : 'headingFour'} style={styles.cardTitle}>
-              {props.title}
-            </ThemedText>
-            {props.endIcon ? <Icon name={props.endIcon} style={styles.cardIcon} size={Spacing.xl} /> : null}
-          </View>
-          {props.subtext ? <ThemedText style={styles.cardSubtext}>{props.subtext}</ThemedText> : null}
-        </View>
-      </View>
+      {cardContent}
     </PressableOpacity>
   )
 }

--- a/app/src/bcsc-theme/components/__snapshots__/CardButton.test.tsx.snap
+++ b/app/src/bcsc-theme/components/__snapshots__/CardButton.test.tsx.snap
@@ -36,7 +36,9 @@ exports[`CardButton Component renders correctly when disabled 1`] = `
   style={
     {
       "backgroundColor": "#003366",
+      "borderColor": "transparent",
       "borderRadius": 4,
+      "borderWidth": 2,
       "opacity": 0.6,
       "padding": 16,
     }
@@ -148,7 +150,9 @@ exports[`CardButton Component renders correctly with subtext and end icon 1`] = 
   style={
     {
       "backgroundColor": "#003366",
+      "borderColor": "transparent",
       "borderRadius": 4,
+      "borderWidth": 2,
       "opacity": 1,
       "padding": 16,
     }
@@ -283,7 +287,9 @@ exports[`CardButton Component renders correctly with title only 1`] = `
   style={
     {
       "backgroundColor": "#003366",
+      "borderColor": "transparent",
       "borderRadius": 4,
+      "borderWidth": 2,
       "opacity": 1,
       "padding": 16,
     }

--- a/app/src/bcsc-theme/features/auth/ChangeSecurityContent.test.tsx
+++ b/app/src/bcsc-theme/features/auth/ChangeSecurityContent.test.tsx
@@ -60,13 +60,11 @@ const mockSetAccountSecurityMethod = jest.mocked(setAccountSecurityMethod)
 describe('ChangeSecurityContent', () => {
   let mockNavigation = useNavigation()
   let onDeviceAuthSuccess = mockNavigation['goBack']
-  let onLearnMorePressed = mockNavigation['navigate']
   let onPINPress = mockNavigation['navigate']
 
   beforeEach(() => {
     mockNavigation = useNavigation()
     onDeviceAuthSuccess = mockNavigation.goBack
-    onLearnMorePressed = mockNavigation.navigate
     onPINPress = mockNavigation.navigate
     jest.clearAllMocks()
     jest.useFakeTimers()
@@ -88,17 +86,13 @@ describe('ChangeSecurityContent', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <ChangeSecurityContent
-              onDeviceAuthSuccess={onDeviceAuthSuccess}
-              onLearnMorePress={onLearnMorePressed}
-              onPINPress={onPINPress}
-            />
+            <ChangeSecurityContent onDeviceAuthSuccess={onDeviceAuthSuccess} onPINPress={onPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
 
       await waitFor(() => {
-        expect(tree.getByText('BCSC.Onboarding.SecureAppHeader')).toBeTruthy()
+        expect(tree.getByText('BCSC.Onboarding.SecureAppOnboardingHeader')).toBeTruthy()
       })
 
       // Should show current method indicator
@@ -110,43 +104,36 @@ describe('ChangeSecurityContent', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <ChangeSecurityContent
-              onDeviceAuthSuccess={onDeviceAuthSuccess}
-              onLearnMorePress={onLearnMorePressed}
-              onPINPress={onPINPress}
-            />
+            <ChangeSecurityContent onDeviceAuthSuccess={onDeviceAuthSuccess} onPINPress={onPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
 
       await waitFor(() => {
-        expect(tree.getByText('BCSC.Onboarding.SecureAppHeader')).toBeTruthy()
+        expect(tree.getByText('BCSC.Onboarding.SecureAppOnboardingHeader')).toBeTruthy()
       })
 
-      // Should show both options
+      // Device auth is the actionable option; PIN is shown as the current method.
       expect(tree.getByText('BCSC.Onboarding.SecureAppDeviceAuthTitle')).toBeTruthy()
-      expect(tree.getByText('BCSC.Onboarding.SecureAppPINTitle')).toBeTruthy()
+      expect(tree.getByTestId(testIdWithKey('ChoosePINButton'))).toBeTruthy()
     })
 
-    it('disables PIN option when current method is PIN', async () => {
+    it('marks PIN as the current method when current method is PIN', async () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <ChangeSecurityContent
-              onDeviceAuthSuccess={onDeviceAuthSuccess}
-              onLearnMorePress={onLearnMorePressed}
-              onPINPress={onPINPress}
-            />
+            <ChangeSecurityContent onDeviceAuthSuccess={onDeviceAuthSuccess} onPINPress={onPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
 
       await waitFor(() => {
-        expect(tree.getByText('BCSC.Onboarding.SecureAppHeader')).toBeTruthy()
+        expect(tree.getByText('BCSC.Onboarding.SecureAppOnboardingHeader')).toBeTruthy()
       })
 
-      // The PIN option should show "Currently active"
-      expect(tree.getByText('BCSC.Settings.AppSecurity.CurrentlySelected')).toBeTruthy()
+      // The PIN card shows the current-method label with the PIN name as its subtext.
+      expect(tree.getByText('BCSC.Settings.AppSecurity.CurrentMethod')).toBeTruthy()
+      expect(tree.getByText('BCSC.Settings.AppSecurity.PIN')).toBeTruthy()
     })
   })
 
@@ -161,17 +148,13 @@ describe('ChangeSecurityContent', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <ChangeSecurityContent
-              onDeviceAuthSuccess={onDeviceAuthSuccess}
-              onLearnMorePress={onLearnMorePressed}
-              onPINPress={onPINPress}
-            />
+            <ChangeSecurityContent onDeviceAuthSuccess={onDeviceAuthSuccess} onPINPress={onPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
 
       await waitFor(() => {
-        expect(tree.getByText('BCSC.Onboarding.SecureAppHeader')).toBeTruthy()
+        expect(tree.getByText('BCSC.Onboarding.SecureAppOnboardingHeader')).toBeTruthy()
       })
 
       expect(tree.getByText('BCSC.Settings.AppSecurity.CurrentMethod')).toBeTruthy()
@@ -182,11 +165,7 @@ describe('ChangeSecurityContent', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <ChangeSecurityContent
-              onDeviceAuthSuccess={onDeviceAuthSuccess}
-              onLearnMorePress={onLearnMorePressed}
-              onPINPress={onPINPress}
-            />
+            <ChangeSecurityContent onDeviceAuthSuccess={onDeviceAuthSuccess} onPINPress={onPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -213,17 +192,13 @@ describe('ChangeSecurityContent', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <ChangeSecurityContent
-              onDeviceAuthSuccess={onDeviceAuthSuccess}
-              onLearnMorePress={onLearnMorePressed}
-              onPINPress={onPINPress}
-            />
+            <ChangeSecurityContent onDeviceAuthSuccess={onDeviceAuthSuccess} onPINPress={onPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
 
       await waitFor(() => {
-        expect(tree.getByText('BCSC.Onboarding.SecureAppHeader')).toBeTruthy()
+        expect(tree.getByText('BCSC.Onboarding.SecureAppOnboardingHeader')).toBeTruthy()
       })
 
       expect(tree.getByText('BCSC.Settings.AppSecurity.DeviceAuthNotSetup')).toBeTruthy()
@@ -240,11 +215,7 @@ describe('ChangeSecurityContent', () => {
       render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <ChangeSecurityContent
-              onDeviceAuthSuccess={onDeviceAuthSuccess}
-              onLearnMorePress={onLearnMorePressed}
-              onPINPress={onPINPress}
-            />
+            <ChangeSecurityContent onDeviceAuthSuccess={onDeviceAuthSuccess} onPINPress={onPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -275,11 +246,7 @@ describe('ChangeSecurityContent', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <ChangeSecurityContent
-              onDeviceAuthSuccess={onDeviceAuthSuccess}
-              onLearnMorePress={onLearnMorePressed}
-              onPINPress={onPINPress}
-            />
+            <ChangeSecurityContent onDeviceAuthSuccess={onDeviceAuthSuccess} onPINPress={onPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -314,11 +281,7 @@ describe('ChangeSecurityContent', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <ChangeSecurityContent
-              onDeviceAuthSuccess={onDeviceAuthSuccess}
-              onLearnMorePress={onLearnMorePressed}
-              onPINPress={onPINPress}
-            />
+            <ChangeSecurityContent onDeviceAuthSuccess={onDeviceAuthSuccess} onPINPress={onPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -348,11 +311,7 @@ describe('ChangeSecurityContent', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <ChangeSecurityContent
-              onDeviceAuthSuccess={onDeviceAuthSuccess}
-              onLearnMorePress={onLearnMorePressed}
-              onPINPress={onPINPress}
-            />
+            <ChangeSecurityContent onDeviceAuthSuccess={onDeviceAuthSuccess} onPINPress={onPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -370,37 +329,6 @@ describe('ChangeSecurityContent', () => {
           'BCSC.Settings.AppSecurity.SetupFailedMessage'
         )
       })
-    })
-  })
-
-  describe('Learn More', () => {
-    beforeEach(() => {
-      mockCanPerformDeviceAuthentication.mockResolvedValue(true)
-      mockGetAvailableBiometricType.mockResolvedValue(BiometricType.FaceID)
-      mockGetAccountSecurityMethod.mockResolvedValue(AccountSecurityMethod.PinWithDeviceAuth)
-    })
-
-    it('navigates to WebView when Learn More is pressed', async () => {
-      const tree = render(
-        <BasicAppContext>
-          <BCSCLoadingProvider>
-            <ChangeSecurityContent
-              onDeviceAuthSuccess={onDeviceAuthSuccess}
-              onLearnMorePress={onLearnMorePressed}
-              onPINPress={onPINPress}
-            />
-          </BCSCLoadingProvider>
-        </BasicAppContext>
-      )
-
-      await waitFor(() => {
-        expect(tree.getByText('BCSC.Onboarding.LearnMore')).toBeTruthy()
-      })
-
-      const learnMoreButton = tree.getByTestId(testIdWithKey('LearnMoreButton'))
-      fireEvent.press(learnMoreButton)
-
-      expect(onLearnMorePressed).toHaveBeenCalled()
     })
   })
 })

--- a/app/src/bcsc-theme/features/auth/ChangeSecurityContent.tsx
+++ b/app/src/bcsc-theme/features/auth/ChangeSecurityContent.tsx
@@ -16,7 +16,6 @@ import {
 export interface ChangeSecurityContentProps {
   onDeviceAuthSuccess: () => void
   onPINPress: () => void
-  onLearnMorePress: () => void
 }
 
 /**
@@ -24,11 +23,7 @@ export interface ChangeSecurityContentProps {
  * Allows users to toggle between PIN and biometric/device authentication.
  * Uses the shared SecurityMethodSelector component.
  */
-export const ChangeSecurityContent = ({
-  onDeviceAuthSuccess,
-  onPINPress,
-  onLearnMorePress,
-}: ChangeSecurityContentProps) => {
+export const ChangeSecurityContent = ({ onDeviceAuthSuccess, onPINPress }: ChangeSecurityContentProps) => {
   const { t } = useTranslation()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const { emitAlert } = useErrorAlert()
@@ -78,7 +73,6 @@ export const ChangeSecurityContent = ({
     <SecurityMethodSelector
       onDeviceAuthPress={handleDeviceAuthPress}
       onPINPress={onPINPress}
-      onLearnMorePress={onLearnMorePress}
       currentMethod={currentMethod}
       deviceAuthPrompt={t('BCSC.Settings.AppSecurity.AuthenticateToSwitch')}
     />

--- a/app/src/bcsc-theme/features/auth/MainChangeSecurityScreen.tsx
+++ b/app/src/bcsc-theme/features/auth/MainChangeSecurityScreen.tsx
@@ -1,8 +1,6 @@
 import { BCSCMainStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
-import { SECURE_APP_LEARN_MORE_URL } from '@/constants'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useCallback } from 'react'
-import { useTranslation } from 'react-i18next'
 import { ChangeSecurityContent } from './ChangeSecurityContent'
 
 export interface MainChangeSecurityScreenProps {
@@ -14,8 +12,6 @@ export interface MainChangeSecurityScreenProps {
  * Wraps ChangeSecurityContent with Main stack-specific navigation callbacks.
  */
 export const MainChangeSecurityScreen = ({ navigation }: MainChangeSecurityScreenProps) => {
-  const { t } = useTranslation()
-
   const handleDeviceAuthSuccess = useCallback(() => {
     navigation.goBack()
   }, [navigation])
@@ -24,18 +20,5 @@ export const MainChangeSecurityScreen = ({ navigation }: MainChangeSecurityScree
     navigation.navigate(BCSCScreens.MainChangePIN)
   }, [navigation])
 
-  const handleLearnMorePress = useCallback(() => {
-    navigation.navigate(BCSCScreens.MainWebView, {
-      title: t('BCSC.Onboarding.PrivacyPolicyHeaderSecuringApp'),
-      url: SECURE_APP_LEARN_MORE_URL,
-    })
-  }, [navigation, t])
-
-  return (
-    <ChangeSecurityContent
-      onDeviceAuthSuccess={handleDeviceAuthSuccess}
-      onPINPress={handlePINPress}
-      onLearnMorePress={handleLearnMorePress}
-    />
-  )
+  return <ChangeSecurityContent onDeviceAuthSuccess={handleDeviceAuthSuccess} onPINPress={handlePINPress} />
 }

--- a/app/src/bcsc-theme/features/auth/VerifyChangeSecurityScreen.tsx
+++ b/app/src/bcsc-theme/features/auth/VerifyChangeSecurityScreen.tsx
@@ -1,8 +1,6 @@
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
-import { SECURE_APP_LEARN_MORE_URL } from '@/constants'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useCallback } from 'react'
-import { useTranslation } from 'react-i18next'
 import { ChangeSecurityContent } from './ChangeSecurityContent'
 
 export interface VerifyChangeSecurityScreenProps {
@@ -14,8 +12,6 @@ export interface VerifyChangeSecurityScreenProps {
  * Wraps ChangeSecurityContent with Verify stack-specific navigation callbacks.
  */
 export const VerifyChangeSecurityScreen = ({ navigation }: VerifyChangeSecurityScreenProps) => {
-  const { t } = useTranslation()
-
   const handleDeviceAuthSuccess = useCallback(() => {
     navigation.goBack()
   }, [navigation])
@@ -24,18 +20,5 @@ export const VerifyChangeSecurityScreen = ({ navigation }: VerifyChangeSecurityS
     navigation.navigate(BCSCScreens.VerifyChangePIN)
   }, [navigation])
 
-  const handleLearnMorePress = useCallback(() => {
-    navigation.navigate(BCSCScreens.VerifyWebView, {
-      title: t('BCSC.Onboarding.PrivacyPolicyHeaderSecuringApp'),
-      url: SECURE_APP_LEARN_MORE_URL,
-    })
-  }, [navigation, t])
-
-  return (
-    <ChangeSecurityContent
-      onDeviceAuthSuccess={handleDeviceAuthSuccess}
-      onPINPress={handlePINPress}
-      onLearnMorePress={handleLearnMorePress}
-    />
-  )
+  return <ChangeSecurityContent onDeviceAuthSuccess={handleDeviceAuthSuccess} onPINPress={handlePINPress} />
 }

--- a/app/src/bcsc-theme/features/auth/__snapshots__/ChangeSecurityContent.test.tsx.snap
+++ b/app/src/bcsc-theme/features/auth/__snapshots__/ChangeSecurityContent.test.tsx.snap
@@ -55,12 +55,12 @@ exports[`ChangeSecurityContent when current method is Device Auth shows Device A
                   "fontWeight": "bold",
                 },
                 {
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
               ]
             }
           >
-            BCSC.Onboarding.SecureAppHeader
+            BCSC.Onboarding.SecureAppOnboardingHeader
           </Text>
           <Text
             maxFontSizeMultiplier={2}
@@ -76,142 +76,29 @@ exports[`ChangeSecurityContent when current method is Device Auth shows Device A
               ]
             }
           >
-            BCSC.Onboarding.SecureAppContent
+            BCSC.Onboarding.SecureAppOnboardingContent
           </Text>
           <View
-            style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#FFFFFF",
-                "borderRadius": 8,
-                "flexDirection": "row",
-                "gap": 8,
-                "padding": 16,
-              }
-            }
-          >
-            <Text
-              allowFontScaling={false}
-              selectable={false}
-              style={
-                [
-                  {
-                    "color": "#003366",
-                    "fontSize": 24,
-                  },
-                  undefined,
-                  {
-                    "fontFamily": "Material Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  {},
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                {
-                  "flex": 1,
-                }
-              }
-            >
-              <Text
-                maxFontSizeMultiplier={2}
-                style={
-                  [
-                    {
-                      "color": "#313132",
-                      "fontFamily": "BCSans-Regular",
-                      "fontSize": 14,
-                      "fontWeight": "normal",
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                BCSC.Settings.AppSecurity.CurrentMethod
-              </Text>
-              <Text
-                maxFontSizeMultiplier={2}
-                style={
-                  [
-                    {
-                      "color": "#313132",
-                      "fontFamily": "BCSans-Regular",
-                      "fontSize": 18,
-                      "fontWeight": "bold",
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                Face id
-              </Text>
-            </View>
-            <Text
-              allowFontScaling={false}
-              selectable={false}
-              style={
-                [
-                  {
-                    "color": "#2E8540",
-                    "fontSize": 24,
-                  },
-                  undefined,
-                  {
-                    "fontFamily": "Material Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  {},
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-          <View
-            accessibilityLabel="BCSC.Onboarding.SecureAppDeviceAuthTitle"
-            accessibilityRole="button"
+            accessibilityLabel="BCSC.Settings.AppSecurity.CurrentMethod. Face id"
             accessibilityState={
               {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": true,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
+                "selected": true,
               }
             }
             accessible={true}
-            collapsable={false}
-            focusable={true}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
-              {
-                "backgroundColor": "#003366",
-                "borderRadius": 4,
-                "opacity": 0.6,
-                "padding": 16,
-              }
+              [
+                {
+                  "backgroundColor": "#003366",
+                  "borderColor": "transparent",
+                  "borderRadius": 4,
+                  "borderWidth": 2,
+                  "padding": 16,
+                },
+                {
+                  "borderColor": "#003366",
+                },
+              ]
             }
             testID="com.ariesbifold:id/ChooseDeviceAuthButton"
           >
@@ -224,6 +111,29 @@ exports[`ChangeSecurityContent when current method is Device Auth shows Device A
                 }
               }
             >
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": undefined,
+                      "fontSize": 40,
+                    },
+                    {
+                      "color": "#313132",
+                    },
+                    {
+                      "fontFamily": "Material Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                
+              </Text>
               <View
                 style={
                   {
@@ -248,17 +158,17 @@ exports[`ChangeSecurityContent when current method is Device Auth shows Device A
                         {
                           "color": "#313132",
                           "fontFamily": "BCSans-Regular",
-                          "fontSize": 21,
+                          "fontSize": 18,
                           "fontWeight": "bold",
                         },
                         {
                           "color": "#313132",
-                          "fontSize": 21,
+                          "fontSize": 16,
                         },
                       ]
                     }
                   >
-                    BCSC.Onboarding.SecureAppDeviceAuthTitle
+                    BCSC.Settings.AppSecurity.CurrentMethod
                   </Text>
                 </View>
                 <Text
@@ -277,122 +187,34 @@ exports[`ChangeSecurityContent when current method is Device Auth shows Device A
                     ]
                   }
                 >
-                  BCSC.Settings.AppSecurity.CurrentlySelected
+                  Face id
                 </Text>
               </View>
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": "#003366",
+                      "fontSize": 32,
+                    },
+                    undefined,
+                    {
+                      "fontFamily": "Material Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                
+              </Text>
             </View>
           </View>
           <View
             accessibilityLabel="BCSC.Onboarding.SecureAppPINTitle"
-            accessibilityRole="button"
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": false,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              {
-                "backgroundColor": "#003366",
-                "borderRadius": 4,
-                "opacity": 1,
-                "padding": 16,
-              }
-            }
-            testID="com.ariesbifold:id/ChoosePINButton"
-          >
-            <View
-              style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "gap": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "flex": 1,
-                    "gap": 4,
-                  }
-                }
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "justifyContent": "space-between",
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 21,
-                          "fontWeight": "bold",
-                        },
-                        {
-                          "color": "#313132",
-                          "fontSize": 21,
-                        },
-                      ]
-                    }
-                  >
-                    BCSC.Onboarding.SecureAppPINTitle
-                  </Text>
-                </View>
-                <Text
-                  maxFontSizeMultiplier={2}
-                  style={
-                    [
-                      {
-                        "color": "#313132",
-                        "fontFamily": "BCSans-Regular",
-                        "fontSize": 18,
-                        "fontWeight": "normal",
-                      },
-                      {
-                        "fontSize": 16,
-                      },
-                    ]
-                  }
-                >
-                  BCSC.Onboarding.SecureAppPINSubtext
-                </Text>
-              </View>
-            </View>
-          </View>
-          <View
-            accessibilityLabel="BCSC.Onboarding.LearnMore"
             accessibilityRole="button"
             accessibilityState={
               {
@@ -426,12 +248,14 @@ exports[`ChangeSecurityContent when current method is Device Auth shows Device A
             style={
               {
                 "backgroundColor": "#003366",
+                "borderColor": "transparent",
                 "borderRadius": 4,
+                "borderWidth": 2,
                 "opacity": 1,
                 "padding": 16,
               }
             }
-            testID="com.ariesbifold:id/LearnMoreButton"
+            testID="com.ariesbifold:id/ChoosePINButton"
           >
             <View
               style={
@@ -442,6 +266,29 @@ exports[`ChangeSecurityContent when current method is Device Auth shows Device A
                 }
               }
             >
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": undefined,
+                      "fontSize": 40,
+                    },
+                    {
+                      "color": "#313132",
+                    },
+                    {
+                      "fontFamily": "Material Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                
+              </Text>
               <View
                 style={
                   {
@@ -466,42 +313,37 @@ exports[`ChangeSecurityContent when current method is Device Auth shows Device A
                         {
                           "color": "#313132",
                           "fontFamily": "BCSans-Regular",
-                          "fontSize": 21,
+                          "fontSize": 18,
                           "fontWeight": "bold",
                         },
                         {
                           "color": "#313132",
-                          "fontSize": 21,
+                          "fontSize": 16,
                         },
                       ]
                     }
                   >
-                    BCSC.Onboarding.LearnMore
-                  </Text>
-                  <Text
-                    allowFontScaling={false}
-                    selectable={false}
-                    style={
-                      [
-                        {
-                          "color": undefined,
-                          "fontSize": 32,
-                        },
-                        {
-                          "color": "#313132",
-                        },
-                        {
-                          "fontFamily": "Material Icons",
-                          "fontStyle": "normal",
-                          "fontWeight": "normal",
-                        },
-                        {},
-                      ]
-                    }
-                  >
-                    
+                    BCSC.Onboarding.SecureAppPINTitle
                   </Text>
                 </View>
+                <Text
+                  maxFontSizeMultiplier={2}
+                  style={
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      {
+                        "fontSize": 16,
+                      },
+                    ]
+                  }
+                >
+                  BCSC.Onboarding.SecureAppPINSubtext
+                </Text>
               </View>
             </View>
           </View>
@@ -852,12 +694,12 @@ exports[`ChangeSecurityContent when current method is PIN and device auth is ava
                   "fontWeight": "bold",
                 },
                 {
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
               ]
             }
           >
-            BCSC.Onboarding.SecureAppHeader
+            BCSC.Onboarding.SecureAppOnboardingHeader
           </Text>
           <Text
             maxFontSizeMultiplier={2}
@@ -873,323 +715,10 @@ exports[`ChangeSecurityContent when current method is PIN and device auth is ava
               ]
             }
           >
-            BCSC.Onboarding.SecureAppContent
+            BCSC.Onboarding.SecureAppOnboardingContent
           </Text>
           <View
-            style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#FFFFFF",
-                "borderRadius": 8,
-                "flexDirection": "row",
-                "gap": 8,
-                "padding": 16,
-              }
-            }
-          >
-            <Text
-              allowFontScaling={false}
-              selectable={false}
-              style={
-                [
-                  {
-                    "color": "#003366",
-                    "fontSize": 24,
-                  },
-                  undefined,
-                  {
-                    "fontFamily": "Material Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  {},
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                {
-                  "flex": 1,
-                }
-              }
-            >
-              <Text
-                maxFontSizeMultiplier={2}
-                style={
-                  [
-                    {
-                      "color": "#313132",
-                      "fontFamily": "BCSans-Regular",
-                      "fontSize": 14,
-                      "fontWeight": "normal",
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                BCSC.Settings.AppSecurity.CurrentMethod
-              </Text>
-              <Text
-                maxFontSizeMultiplier={2}
-                style={
-                  [
-                    {
-                      "color": "#313132",
-                      "fontFamily": "BCSans-Regular",
-                      "fontSize": 18,
-                      "fontWeight": "bold",
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                BCSC.Settings.AppSecurity.PIN
-              </Text>
-            </View>
-            <Text
-              allowFontScaling={false}
-              selectable={false}
-              style={
-                [
-                  {
-                    "color": "#2E8540",
-                    "fontSize": 24,
-                  },
-                  undefined,
-                  {
-                    "fontFamily": "Material Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  {},
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-          <View
             accessibilityLabel="BCSC.Onboarding.SecureAppDeviceAuthTitle"
-            accessibilityRole="button"
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": false,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              {
-                "backgroundColor": "#003366",
-                "borderRadius": 4,
-                "opacity": 1,
-                "padding": 16,
-              }
-            }
-            testID="com.ariesbifold:id/ChooseDeviceAuthButton"
-          >
-            <View
-              style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "gap": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "flex": 1,
-                    "gap": 4,
-                  }
-                }
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "justifyContent": "space-between",
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 21,
-                          "fontWeight": "bold",
-                        },
-                        {
-                          "color": "#313132",
-                          "fontSize": 21,
-                        },
-                      ]
-                    }
-                  >
-                    BCSC.Onboarding.SecureAppDeviceAuthTitle
-                  </Text>
-                </View>
-                <Text
-                  maxFontSizeMultiplier={2}
-                  style={
-                    [
-                      {
-                        "color": "#313132",
-                        "fontFamily": "BCSans-Regular",
-                        "fontSize": 18,
-                        "fontWeight": "normal",
-                      },
-                      {
-                        "fontSize": 16,
-                      },
-                    ]
-                  }
-                >
-                  BCSC.Onboarding.SecureAppDeviceAuthSubtext
-                </Text>
-              </View>
-            </View>
-          </View>
-          <View
-            accessibilityLabel="BCSC.Onboarding.SecureAppPINTitle"
-            accessibilityRole="button"
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": true,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              {
-                "backgroundColor": "#003366",
-                "borderRadius": 4,
-                "opacity": 0.6,
-                "padding": 16,
-              }
-            }
-            testID="com.ariesbifold:id/ChoosePINButton"
-          >
-            <View
-              style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "gap": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "flex": 1,
-                    "gap": 4,
-                  }
-                }
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "justifyContent": "space-between",
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 21,
-                          "fontWeight": "bold",
-                        },
-                        {
-                          "color": "#313132",
-                          "fontSize": 21,
-                        },
-                      ]
-                    }
-                  >
-                    BCSC.Onboarding.SecureAppPINTitle
-                  </Text>
-                </View>
-                <Text
-                  maxFontSizeMultiplier={2}
-                  style={
-                    [
-                      {
-                        "color": "#313132",
-                        "fontFamily": "BCSans-Regular",
-                        "fontSize": 18,
-                        "fontWeight": "normal",
-                      },
-                      {
-                        "fontSize": 16,
-                      },
-                    ]
-                  }
-                >
-                  BCSC.Settings.AppSecurity.CurrentlySelected
-                </Text>
-              </View>
-            </View>
-          </View>
-          <View
-            accessibilityLabel="BCSC.Onboarding.LearnMore"
             accessibilityRole="button"
             accessibilityState={
               {
@@ -1223,12 +752,14 @@ exports[`ChangeSecurityContent when current method is PIN and device auth is ava
             style={
               {
                 "backgroundColor": "#003366",
+                "borderColor": "transparent",
                 "borderRadius": 4,
+                "borderWidth": 2,
                 "opacity": 1,
                 "padding": 16,
               }
             }
-            testID="com.ariesbifold:id/LearnMoreButton"
+            testID="com.ariesbifold:id/ChooseDeviceAuthButton"
           >
             <View
               style={
@@ -1239,6 +770,29 @@ exports[`ChangeSecurityContent when current method is PIN and device auth is ava
                 }
               }
             >
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": undefined,
+                      "fontSize": 40,
+                    },
+                    {
+                      "color": "#313132",
+                    },
+                    {
+                      "fontFamily": "Material Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                
+              </Text>
               <View
                 style={
                   {
@@ -1263,43 +817,173 @@ exports[`ChangeSecurityContent when current method is PIN and device auth is ava
                         {
                           "color": "#313132",
                           "fontFamily": "BCSans-Regular",
-                          "fontSize": 21,
+                          "fontSize": 18,
                           "fontWeight": "bold",
                         },
                         {
                           "color": "#313132",
-                          "fontSize": 21,
+                          "fontSize": 16,
                         },
                       ]
                     }
                   >
-                    BCSC.Onboarding.LearnMore
+                    BCSC.Onboarding.SecureAppDeviceAuthTitle
                   </Text>
+                </View>
+                <Text
+                  maxFontSizeMultiplier={2}
+                  style={
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      {
+                        "fontSize": 16,
+                      },
+                    ]
+                  }
+                >
+                  BCSC.Onboarding.SecureAppDeviceAuthSubtext
+                </Text>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityLabel="BCSC.Settings.AppSecurity.CurrentMethod. BCSC.Settings.AppSecurity.PIN"
+            accessibilityState={
+              {
+                "selected": true,
+              }
+            }
+            accessible={true}
+            style={
+              [
+                {
+                  "backgroundColor": "#003366",
+                  "borderColor": "transparent",
+                  "borderRadius": 4,
+                  "borderWidth": 2,
+                  "padding": 16,
+                },
+                {
+                  "borderColor": "#003366",
+                },
+              ]
+            }
+            testID="com.ariesbifold:id/ChoosePINButton"
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 16,
+                }
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": undefined,
+                      "fontSize": 40,
+                    },
+                    {
+                      "color": "#313132",
+                    },
+                    {
+                      "fontFamily": "Material Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                
+              </Text>
+              <View
+                style={
+                  {
+                    "flex": 1,
+                    "gap": 4,
+                  }
+                }
+              >
+                <View
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "justifyContent": "space-between",
+                    }
+                  }
+                >
                   <Text
-                    allowFontScaling={false}
-                    selectable={false}
+                    maxFontSizeMultiplier={2}
                     style={
                       [
                         {
-                          "color": undefined,
-                          "fontSize": 32,
+                          "color": "#313132",
+                          "fontFamily": "BCSans-Regular",
+                          "fontSize": 18,
+                          "fontWeight": "bold",
                         },
                         {
                           "color": "#313132",
+                          "fontSize": 16,
                         },
-                        {
-                          "fontFamily": "Material Icons",
-                          "fontStyle": "normal",
-                          "fontWeight": "normal",
-                        },
-                        {},
                       ]
                     }
                   >
-                    
+                    BCSC.Settings.AppSecurity.CurrentMethod
                   </Text>
                 </View>
+                <Text
+                  maxFontSizeMultiplier={2}
+                  style={
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      {
+                        "fontSize": 16,
+                      },
+                    ]
+                  }
+                >
+                  BCSC.Settings.AppSecurity.PIN
+                </Text>
               </View>
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": "#003366",
+                      "fontSize": 32,
+                    },
+                    undefined,
+                    {
+                      "fontFamily": "Material Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                
+              </Text>
             </View>
           </View>
         </View>
@@ -1649,108 +1333,13 @@ exports[`ChangeSecurityContent when device auth is NOT available shows message t
                   "fontWeight": "bold",
                 },
                 {
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
               ]
             }
           >
-            BCSC.Onboarding.SecureAppHeader
+            BCSC.Onboarding.SecureAppOnboardingHeader
           </Text>
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#FFFFFF",
-                "borderRadius": 8,
-                "flexDirection": "row",
-                "gap": 8,
-                "padding": 16,
-              }
-            }
-          >
-            <Text
-              allowFontScaling={false}
-              selectable={false}
-              style={
-                [
-                  {
-                    "color": "#003366",
-                    "fontSize": 24,
-                  },
-                  undefined,
-                  {
-                    "fontFamily": "Material Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  {},
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                {
-                  "flex": 1,
-                }
-              }
-            >
-              <Text
-                maxFontSizeMultiplier={2}
-                style={
-                  [
-                    {
-                      "color": "#313132",
-                      "fontFamily": "BCSans-Regular",
-                      "fontSize": 14,
-                      "fontWeight": "normal",
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                BCSC.Settings.AppSecurity.CurrentMethod
-              </Text>
-              <Text
-                maxFontSizeMultiplier={2}
-                style={
-                  [
-                    {
-                      "color": "#313132",
-                      "fontFamily": "BCSans-Regular",
-                      "fontSize": 18,
-                      "fontWeight": "bold",
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                BCSC.Settings.AppSecurity.PIN
-              </Text>
-            </View>
-            <Text
-              allowFontScaling={false}
-              selectable={false}
-              style={
-                [
-                  {
-                    "color": "#2E8540",
-                    "fontSize": 24,
-                  },
-                  undefined,
-                  {
-                    "fontFamily": "Material Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  {},
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
           <Text
             maxFontSizeMultiplier={2}
             style={

--- a/app/src/bcsc-theme/features/auth/components/SecurityMethodSelector.test.tsx
+++ b/app/src/bcsc-theme/features/auth/components/SecurityMethodSelector.test.tsx
@@ -36,7 +36,6 @@ const mockPerformDeviceAuthentication = jest.mocked(performDeviceAuthentication)
 describe('SecurityMethodSelector', () => {
   const mockOnDeviceAuthPress = jest.fn()
   const mockOnPINPress = jest.fn()
-  const mockOnLearnMorePress = jest.fn()
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -57,11 +56,7 @@ describe('SecurityMethodSelector', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <SecurityMethodSelector
-              onDeviceAuthPress={mockOnDeviceAuthPress}
-              onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
-            />
+            <SecurityMethodSelector onDeviceAuthPress={mockOnDeviceAuthPress} onPINPress={mockOnPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -80,11 +75,7 @@ describe('SecurityMethodSelector', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <SecurityMethodSelector
-              onDeviceAuthPress={mockOnDeviceAuthPress}
-              onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
-            />
+            <SecurityMethodSelector onDeviceAuthPress={mockOnDeviceAuthPress} onPINPress={mockOnPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -98,11 +89,7 @@ describe('SecurityMethodSelector', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <SecurityMethodSelector
-              onDeviceAuthPress={mockOnDeviceAuthPress}
-              onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
-            />
+            <SecurityMethodSelector onDeviceAuthPress={mockOnDeviceAuthPress} onPINPress={mockOnPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -123,11 +110,7 @@ describe('SecurityMethodSelector', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <SecurityMethodSelector
-              onDeviceAuthPress={mockOnDeviceAuthPress}
-              onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
-            />
+            <SecurityMethodSelector onDeviceAuthPress={mockOnDeviceAuthPress} onPINPress={mockOnPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -150,11 +133,7 @@ describe('SecurityMethodSelector', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <SecurityMethodSelector
-              onDeviceAuthPress={mockOnDeviceAuthPress}
-              onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
-            />
+            <SecurityMethodSelector onDeviceAuthPress={mockOnDeviceAuthPress} onPINPress={mockOnPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -170,31 +149,6 @@ describe('SecurityMethodSelector', () => {
         expect(mockOnDeviceAuthPress).toHaveBeenCalled()
       })
     })
-
-    it('calls onLearnMorePress when learn more option is pressed', async () => {
-      // Learn More is only shown in the settings context (with currentMethod) when device auth is available
-      const tree = render(
-        <BasicAppContext>
-          <BCSCLoadingProvider>
-            <SecurityMethodSelector
-              onDeviceAuthPress={mockOnDeviceAuthPress}
-              onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
-              currentMethod={AccountSecurityMethod.PinWithDeviceAuth}
-            />
-          </BCSCLoadingProvider>
-        </BasicAppContext>
-      )
-
-      await waitFor(() => {
-        expect(tree.getByTestId(testIdWithKey('LearnMoreButton'))).toBeTruthy()
-      })
-
-      const learnMoreButton = tree.getByTestId(testIdWithKey('LearnMoreButton'))
-      fireEvent.press(learnMoreButton)
-
-      expect(mockOnLearnMorePress).toHaveBeenCalled()
-    })
   })
 
   describe('when device auth is NOT available', () => {
@@ -207,11 +161,7 @@ describe('SecurityMethodSelector', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <SecurityMethodSelector
-              onDeviceAuthPress={mockOnDeviceAuthPress}
-              onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
-            />
+            <SecurityMethodSelector onDeviceAuthPress={mockOnDeviceAuthPress} onPINPress={mockOnPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -230,11 +180,7 @@ describe('SecurityMethodSelector', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <SecurityMethodSelector
-              onDeviceAuthPress={mockOnDeviceAuthPress}
-              onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
-            />
+            <SecurityMethodSelector onDeviceAuthPress={mockOnDeviceAuthPress} onPINPress={mockOnPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -250,11 +196,7 @@ describe('SecurityMethodSelector', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <SecurityMethodSelector
-              onDeviceAuthPress={mockOnDeviceAuthPress}
-              onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
-            />
+            <SecurityMethodSelector onDeviceAuthPress={mockOnDeviceAuthPress} onPINPress={mockOnPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -283,7 +225,6 @@ describe('SecurityMethodSelector', () => {
             <SecurityMethodSelector
               onDeviceAuthPress={mockOnDeviceAuthPress}
               onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
               currentMethod={AccountSecurityMethod.PinWithDeviceAuth}
             />
           </BCSCLoadingProvider>
@@ -295,14 +236,13 @@ describe('SecurityMethodSelector', () => {
       })
     })
 
-    it('disables current method option (PIN)', async () => {
+    it('marks the PIN card as the current method', async () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
             <SecurityMethodSelector
               onDeviceAuthPress={mockOnDeviceAuthPress}
               onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
               currentMethod={AccountSecurityMethod.PinWithDeviceAuth}
             />
           </BCSCLoadingProvider>
@@ -310,18 +250,31 @@ describe('SecurityMethodSelector', () => {
       )
 
       await waitFor(() => {
-        expect(tree.getByText('BCSC.Settings.AppSecurity.CurrentlySelected')).toBeTruthy()
+        expect(tree.getByText('BCSC.Settings.AppSecurity.CurrentMethod')).toBeTruthy()
       })
+
+      // The PIN card shows the current-method label with the PIN name as its subtext, while device
+      // auth becomes the actionable option.
+      expect(tree.getByText('BCSC.Settings.AppSecurity.PIN')).toBeTruthy()
+      expect(tree.getByText('BCSC.Onboarding.SecureAppDeviceAuthTitle')).toBeTruthy()
+
+      // Accessibility: the current-method card must announce the method name (its subtext), be
+      // marked selected (not disabled), and be a non-interactive status indicator.
+      const pinCard = tree.getByTestId(testIdWithKey('ChoosePINButton'))
+      expect(pinCard.props.accessibilityLabel).toContain('BCSC.Settings.AppSecurity.PIN')
+      expect(pinCard.props.accessibilityState).toMatchObject({ selected: true })
+      expect(pinCard.props.accessibilityState.disabled).toBeFalsy()
+      expect(pinCard.props.accessibilityRole).toBeUndefined()
+      expect(pinCard.props.onPress).toBeUndefined()
     })
 
-    it('disables current method option (Device Auth)', async () => {
+    it('marks the device auth card as the current method', async () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
             <SecurityMethodSelector
               onDeviceAuthPress={mockOnDeviceAuthPress}
               onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
               currentMethod={AccountSecurityMethod.DeviceAuth}
             />
           </BCSCLoadingProvider>
@@ -329,8 +282,18 @@ describe('SecurityMethodSelector', () => {
       )
 
       await waitFor(() => {
-        expect(tree.getByText('BCSC.Settings.AppSecurity.CurrentlySelected')).toBeTruthy()
+        expect(tree.getByText('BCSC.Settings.AppSecurity.CurrentMethod')).toBeTruthy()
       })
+
+      // Device auth shows the current-method label; creating a PIN becomes the actionable option.
+      expect(tree.getByText('BCSC.Onboarding.SecureAppPINTitle')).toBeTruthy()
+
+      // Accessibility: the biometric name (subtext) is part of the current-method card's label and
+      // the card is marked selected rather than disabled.
+      const deviceAuthCard = tree.getByTestId(testIdWithKey('ChooseDeviceAuthButton'))
+      expect(deviceAuthCard.props.accessibilityLabel).toMatch(/Face/)
+      expect(deviceAuthCard.props.accessibilityState).toMatchObject({ selected: true })
+      expect(deviceAuthCard.props.accessibilityState.disabled).toBeFalsy()
 
       expect(tree).toMatchSnapshot()
     })
@@ -345,7 +308,6 @@ describe('SecurityMethodSelector', () => {
             <SecurityMethodSelector
               onDeviceAuthPress={mockOnDeviceAuthPress}
               onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
               currentMethod={AccountSecurityMethod.PinWithDeviceAuth}
               deviceAuthPrompt={customPrompt}
             />
@@ -379,7 +341,6 @@ describe('SecurityMethodSelector', () => {
             <SecurityMethodSelector
               onDeviceAuthPress={mockOnDeviceAuthPress}
               onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
               currentMethod={AccountSecurityMethod.PinNoDeviceAuth}
             />
           </BCSCLoadingProvider>
@@ -400,11 +361,7 @@ describe('SecurityMethodSelector', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <SecurityMethodSelector
-              onDeviceAuthPress={mockOnDeviceAuthPress}
-              onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
-            />
+            <SecurityMethodSelector onDeviceAuthPress={mockOnDeviceAuthPress} onPINPress={mockOnPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -423,11 +380,7 @@ describe('SecurityMethodSelector', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <SecurityMethodSelector
-              onDeviceAuthPress={mockOnDeviceAuthPress}
-              onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
-            />
+            <SecurityMethodSelector onDeviceAuthPress={mockOnDeviceAuthPress} onPINPress={mockOnPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -455,11 +408,7 @@ describe('SecurityMethodSelector', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <SecurityMethodSelector
-              onDeviceAuthPress={mockOnDeviceAuthPress}
-              onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
-            />
+            <SecurityMethodSelector onDeviceAuthPress={mockOnDeviceAuthPress} onPINPress={mockOnPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -488,11 +437,7 @@ describe('SecurityMethodSelector', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <SecurityMethodSelector
-              onDeviceAuthPress={mockOnDeviceAuthPress}
-              onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
-            />
+            <SecurityMethodSelector onDeviceAuthPress={mockOnDeviceAuthPress} onPINPress={mockOnPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )
@@ -518,11 +463,7 @@ describe('SecurityMethodSelector', () => {
       const tree = render(
         <BasicAppContext>
           <BCSCLoadingProvider>
-            <SecurityMethodSelector
-              onDeviceAuthPress={mockOnDeviceAuthPress}
-              onPINPress={mockOnPINPress}
-              onLearnMorePress={mockOnLearnMorePress}
-            />
+            <SecurityMethodSelector onDeviceAuthPress={mockOnDeviceAuthPress} onPINPress={mockOnPINPress} />
           </BCSCLoadingProvider>
         </BasicAppContext>
       )

--- a/app/src/bcsc-theme/features/auth/components/SecurityMethodSelector.tsx
+++ b/app/src/bcsc-theme/features/auth/components/SecurityMethodSelector.tsx
@@ -15,7 +15,7 @@ import { TFunction } from 'i18next'
 import { upperFirst } from 'lodash'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ActivityIndicator, Platform, StyleSheet, View } from 'react-native'
+import { ActivityIndicator, Platform, StyleSheet } from 'react-native'
 import {
   AccountSecurityMethod,
   BiometricType,
@@ -23,7 +23,6 @@ import {
   getAvailableBiometricType,
   performDeviceAuthentication,
 } from 'react-native-bcsc-core'
-import Icon from 'react-native-vector-icons/MaterialIcons'
 
 interface SecurityMethodSelectorProps {
   /**
@@ -38,13 +37,8 @@ interface SecurityMethodSelectorProps {
    */
   onPINPress: () => void
   /**
-   * Called when user presses Learn More.
-   * The parent should navigate to the appropriate WebView.
-   */
-  onLearnMorePress: () => void
-  /**
    * Current security method (for settings context).
-   * If provided, shows current method indicator and disables the current option.
+   * If provided, the matching option's card is shown as selected (the current method).
    * If undefined, assumes onboarding context (no current method).
    */
   currentMethod?: AccountSecurityMethod | null
@@ -59,6 +53,7 @@ interface SecurityCopy {
   content: string
   deviceAuthTitle: string
   deviceAuthSubtext: string
+  pinTitle: string
   pinSubtext: string
 }
 
@@ -71,8 +66,14 @@ const getSecurityCopy = (
   {
     isSettingsContext,
     isCurrentMethodDeviceAuth,
+    isCurrentMethodPin,
     deviceAuthMethodName,
-  }: { isSettingsContext: boolean; isCurrentMethodDeviceAuth: boolean; deviceAuthMethodName: string }
+  }: {
+    isSettingsContext: boolean
+    isCurrentMethodDeviceAuth: boolean
+    isCurrentMethodPin: boolean
+    deviceAuthMethodName: string
+  }
 ): SecurityCopy => {
   if (!isSettingsContext) {
     return {
@@ -80,20 +81,28 @@ const getSecurityCopy = (
       content: t('BCSC.Onboarding.SecureAppOnboardingContent'),
       deviceAuthTitle: t('BCSC.Onboarding.SecureAppOnboardingDeviceAuthTitle'),
       deviceAuthSubtext: t('BCSC.Onboarding.SecureAppOnboardingDeviceAuthSubtext'),
+      pinTitle: t('BCSC.Onboarding.SecureAppPINTitle'),
       pinSubtext: t('BCSC.Onboarding.SecureAppPINSubtext'),
     }
   }
 
+  // Settings uses the same intro copy as onboarding, but each option's card doubles as the current
+  // method indicator: whichever method is active shows the CurrentMethod label with the method name
+  // as its subtext, while the other keeps its actionable copy.
   const platformName = Platform.OS === 'ios' ? 'iPhone or iPad' : 'Android device'
-  const currentlySelected = t('BCSC.Settings.AppSecurity.CurrentlySelected')
+  const currentMethodLabel = t('BCSC.Settings.AppSecurity.CurrentMethod')
+  const deviceAuthName = deviceAuthMethodName || t('BCSC.Settings.AppSecurity.DeviceAuth')
   return {
-    header: t('BCSC.Onboarding.SecureAppHeader'),
-    content: t('BCSC.Onboarding.SecureAppContent'),
-    deviceAuthTitle: t('BCSC.Onboarding.SecureAppDeviceAuthTitle', { deviceAuthMethodName }),
+    header: t('BCSC.Onboarding.SecureAppOnboardingHeader'),
+    content: t('BCSC.Onboarding.SecureAppOnboardingContent'),
+    deviceAuthTitle: isCurrentMethodDeviceAuth
+      ? currentMethodLabel
+      : t('BCSC.Onboarding.SecureAppDeviceAuthTitle', { deviceAuthMethodName }),
     deviceAuthSubtext: isCurrentMethodDeviceAuth
-      ? currentlySelected
+      ? deviceAuthName
       : t('BCSC.Onboarding.SecureAppDeviceAuthSubtext', { platform: platformName }),
-    pinSubtext: isCurrentMethodDeviceAuth ? t('BCSC.Onboarding.SecureAppPINSubtext') : currentlySelected,
+    pinTitle: isCurrentMethodPin ? currentMethodLabel : t('BCSC.Onboarding.SecureAppPINTitle'),
+    pinSubtext: isCurrentMethodPin ? t('BCSC.Settings.AppSecurity.PIN') : t('BCSC.Onboarding.SecureAppPINSubtext'),
   }
 }
 
@@ -105,7 +114,6 @@ const getSecurityCopy = (
 export const SecurityMethodSelector: React.FC<SecurityMethodSelectorProps> = ({
   onDeviceAuthPress,
   onPINPress,
-  onLearnMorePress,
   currentMethod,
   deviceAuthPrompt,
 }: SecurityMethodSelectorProps) => {
@@ -120,22 +128,13 @@ export const SecurityMethodSelector: React.FC<SecurityMethodSelectorProps> = ({
 
   const isSettingsContext = currentMethod !== undefined
   const isCurrentMethodDeviceAuth = currentMethod === AccountSecurityMethod.DeviceAuth
+  const isCurrentMethodPin =
+    currentMethod === AccountSecurityMethod.PinNoDeviceAuth || currentMethod === AccountSecurityMethod.PinWithDeviceAuth
 
   const styles = StyleSheet.create({
     scrollContainer: {
       gap: Spacing.lg,
       padding: Spacing.lg,
-    },
-    currentMethodContainer: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      backgroundColor: ColorPalette.brand.secondaryBackground,
-      padding: Spacing.md,
-      borderRadius: Spacing.sm,
-      gap: Spacing.sm,
-    },
-    currentMethodText: {
-      flex: 1,
     },
   })
 
@@ -188,24 +187,17 @@ export const SecurityMethodSelector: React.FC<SecurityMethodSelectorProps> = ({
     }
   }
 
-  // Pre-compute conditional values
-  const currentMethodIcon = isCurrentMethodDeviceAuth ? 'fingerprint' : 'lock'
-  const currentMethodLabel = isCurrentMethodDeviceAuth
-    ? deviceAuthMethodName || t('BCSC.Settings.AppSecurity.DeviceAuth')
-    : t('BCSC.Settings.AppSecurity.PIN')
-  const copy = getSecurityCopy(t, { isSettingsContext, isCurrentMethodDeviceAuth, deviceAuthMethodName })
+  const copy = getSecurityCopy(t, {
+    isSettingsContext,
+    isCurrentMethodDeviceAuth,
+    isCurrentMethodPin,
+    deviceAuthMethodName,
+  })
 
-  // Current method indicator (only shown in settings context)
-  const currentMethodIndicator = isSettingsContext ? (
-    <View style={styles.currentMethodContainer}>
-      <Icon name={currentMethodIcon} size={24} color={ColorPalette.brand.primary} />
-      <View style={styles.currentMethodText}>
-        <ThemedText variant="labelSubtitle">{t('BCSC.Settings.AppSecurity.CurrentMethod')}</ThemedText>
-        <ThemedText variant="bold">{currentMethodLabel}</ThemedText>
-      </View>
-      <Icon name="check-circle" size={24} color={ColorPalette.semantic.success} />
-    </View>
-  ) : null
+  // In settings, the active method's card is shown as selected (highlighted + check) rather than a
+  // separate indicator row. In onboarding there is no current method, so neither card is selected.
+  const deviceAuthSelected = isSettingsContext && isCurrentMethodDeviceAuth
+  const pinSelected = isSettingsContext && isCurrentMethodPin
 
   // Controls for when device auth is NOT available
   const controlsForNoDeviceAuth = (
@@ -232,43 +224,30 @@ export const SecurityMethodSelector: React.FC<SecurityMethodSelectorProps> = ({
   if (isDeviceAuthAvailable) {
     return (
       <ScreenWrapper padded={false} scrollViewContainerStyle={styles.scrollContainer}>
-        <ThemedText variant="headingThree" style={{ textAlign: 'center' }}>
+        <ThemedText variant="headingThree" style={{ textAlign: isSettingsContext ? 'left' : 'center' }}>
           {copy.header}
         </ThemedText>
         <ThemedText>{copy.content}</ThemedText>
 
-        {/* Show current method indicator (settings only) */}
-        {currentMethodIndicator}
-
-        {/* Device Auth Option */}
+        {/* Device Auth Option (selected when it is the current method in settings) */}
         <CardButton
           title={copy.deviceAuthTitle}
           testID={testIdWithKey('ChooseDeviceAuthButton')}
           subtext={copy.deviceAuthSubtext}
-          startIcon={isSettingsContext ? undefined : 'fingerprint'}
+          startIcon="fingerprint"
           onPress={handleDeviceAuthentication}
-          disabled={isSettingsContext && isCurrentMethodDeviceAuth}
+          selected={deviceAuthSelected}
         />
 
-        {/* PIN Option */}
+        {/* PIN Option (selected when it is the current method in settings) */}
         <CardButton
-          title={t('BCSC.Onboarding.SecureAppPINTitle')}
+          title={copy.pinTitle}
           testID={testIdWithKey('ChoosePINButton')}
           subtext={copy.pinSubtext}
-          startIcon={isSettingsContext ? undefined : 'password'}
+          startIcon="password"
           onPress={onPINPress}
-          disabled={isSettingsContext && !isCurrentMethodDeviceAuth}
+          selected={pinSelected}
         />
-
-        {/* Learn More (settings only — onboarding wireframe omits it) */}
-        {isSettingsContext ? (
-          <CardButton
-            title={t('BCSC.Onboarding.LearnMore')}
-            testID={testIdWithKey('LearnMoreButton')}
-            endIcon="open-in-new"
-            onPress={onLearnMorePress}
-          />
-        ) : null}
       </ScreenWrapper>
     )
   }
@@ -276,12 +255,9 @@ export const SecurityMethodSelector: React.FC<SecurityMethodSelectorProps> = ({
   // When device auth is NOT available
   return (
     <ScreenWrapper padded={false} scrollViewContainerStyle={styles.scrollContainer} controls={controlsForNoDeviceAuth}>
-      <ThemedText variant="headingThree" style={{ textAlign: 'center' }}>
+      <ThemedText variant="headingThree" style={{ textAlign: isSettingsContext ? 'left' : 'center' }}>
         {copy.header}
       </ThemedText>
-
-      {/* Show current method indicator (settings only) */}
-      {currentMethodIndicator}
 
       {isSettingsContext ? (
         <ThemedText>{t('BCSC.Settings.AppSecurity.DeviceAuthNotSetup')}</ThemedText>

--- a/app/src/bcsc-theme/features/auth/components/__snapshots__/SecurityMethodSelector.test.tsx.snap
+++ b/app/src/bcsc-theme/features/auth/components/__snapshots__/SecurityMethodSelector.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SecurityMethodSelector in settings context (with currentMethod) disables current method option (Device Auth) 1`] = `
+exports[`SecurityMethodSelector in settings context (with currentMethod) marks the device auth card as the current method 1`] = `
 [
   <View
     importantForAccessibility="yes"
@@ -55,12 +55,12 @@ exports[`SecurityMethodSelector in settings context (with currentMethod) disable
                   "fontWeight": "bold",
                 },
                 {
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
               ]
             }
           >
-            BCSC.Onboarding.SecureAppHeader
+            BCSC.Onboarding.SecureAppOnboardingHeader
           </Text>
           <Text
             maxFontSizeMultiplier={2}
@@ -76,142 +76,29 @@ exports[`SecurityMethodSelector in settings context (with currentMethod) disable
               ]
             }
           >
-            BCSC.Onboarding.SecureAppContent
+            BCSC.Onboarding.SecureAppOnboardingContent
           </Text>
           <View
-            style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#FFFFFF",
-                "borderRadius": 8,
-                "flexDirection": "row",
-                "gap": 8,
-                "padding": 16,
-              }
-            }
-          >
-            <Text
-              allowFontScaling={false}
-              selectable={false}
-              style={
-                [
-                  {
-                    "color": "#003366",
-                    "fontSize": 24,
-                  },
-                  undefined,
-                  {
-                    "fontFamily": "Material Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  {},
-                ]
-              }
-            >
-              
-            </Text>
-            <View
-              style={
-                {
-                  "flex": 1,
-                }
-              }
-            >
-              <Text
-                maxFontSizeMultiplier={2}
-                style={
-                  [
-                    {
-                      "color": "#313132",
-                      "fontFamily": "BCSans-Regular",
-                      "fontSize": 14,
-                      "fontWeight": "normal",
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                BCSC.Settings.AppSecurity.CurrentMethod
-              </Text>
-              <Text
-                maxFontSizeMultiplier={2}
-                style={
-                  [
-                    {
-                      "color": "#313132",
-                      "fontFamily": "BCSans-Regular",
-                      "fontSize": 18,
-                      "fontWeight": "bold",
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                Face id
-              </Text>
-            </View>
-            <Text
-              allowFontScaling={false}
-              selectable={false}
-              style={
-                [
-                  {
-                    "color": "#2E8540",
-                    "fontSize": 24,
-                  },
-                  undefined,
-                  {
-                    "fontFamily": "Material Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  {},
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-          <View
-            accessibilityLabel="BCSC.Onboarding.SecureAppDeviceAuthTitle"
-            accessibilityRole="button"
+            accessibilityLabel="BCSC.Settings.AppSecurity.CurrentMethod. Face id"
             accessibilityState={
               {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": true,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
+                "selected": true,
               }
             }
             accessible={true}
-            collapsable={false}
-            focusable={true}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
-              {
-                "backgroundColor": "#003366",
-                "borderRadius": 4,
-                "opacity": 0.6,
-                "padding": 16,
-              }
+              [
+                {
+                  "backgroundColor": "#003366",
+                  "borderColor": "transparent",
+                  "borderRadius": 4,
+                  "borderWidth": 2,
+                  "padding": 16,
+                },
+                {
+                  "borderColor": "#003366",
+                },
+              ]
             }
             testID="com.ariesbifold:id/ChooseDeviceAuthButton"
           >
@@ -224,6 +111,29 @@ exports[`SecurityMethodSelector in settings context (with currentMethod) disable
                 }
               }
             >
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": undefined,
+                      "fontSize": 40,
+                    },
+                    {
+                      "color": "#313132",
+                    },
+                    {
+                      "fontFamily": "Material Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                
+              </Text>
               <View
                 style={
                   {
@@ -248,17 +158,17 @@ exports[`SecurityMethodSelector in settings context (with currentMethod) disable
                         {
                           "color": "#313132",
                           "fontFamily": "BCSans-Regular",
-                          "fontSize": 21,
+                          "fontSize": 18,
                           "fontWeight": "bold",
                         },
                         {
                           "color": "#313132",
-                          "fontSize": 21,
+                          "fontSize": 16,
                         },
                       ]
                     }
                   >
-                    BCSC.Onboarding.SecureAppDeviceAuthTitle
+                    BCSC.Settings.AppSecurity.CurrentMethod
                   </Text>
                 </View>
                 <Text
@@ -277,122 +187,34 @@ exports[`SecurityMethodSelector in settings context (with currentMethod) disable
                     ]
                   }
                 >
-                  BCSC.Settings.AppSecurity.CurrentlySelected
+                  Face id
                 </Text>
               </View>
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": "#003366",
+                      "fontSize": 32,
+                    },
+                    undefined,
+                    {
+                      "fontFamily": "Material Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                
+              </Text>
             </View>
           </View>
           <View
             accessibilityLabel="BCSC.Onboarding.SecureAppPINTitle"
-            accessibilityRole="button"
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": false,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              {
-                "backgroundColor": "#003366",
-                "borderRadius": 4,
-                "opacity": 1,
-                "padding": 16,
-              }
-            }
-            testID="com.ariesbifold:id/ChoosePINButton"
-          >
-            <View
-              style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "gap": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "flex": 1,
-                    "gap": 4,
-                  }
-                }
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "justifyContent": "space-between",
-                    }
-                  }
-                >
-                  <Text
-                    maxFontSizeMultiplier={2}
-                    style={
-                      [
-                        {
-                          "color": "#313132",
-                          "fontFamily": "BCSans-Regular",
-                          "fontSize": 21,
-                          "fontWeight": "bold",
-                        },
-                        {
-                          "color": "#313132",
-                          "fontSize": 21,
-                        },
-                      ]
-                    }
-                  >
-                    BCSC.Onboarding.SecureAppPINTitle
-                  </Text>
-                </View>
-                <Text
-                  maxFontSizeMultiplier={2}
-                  style={
-                    [
-                      {
-                        "color": "#313132",
-                        "fontFamily": "BCSans-Regular",
-                        "fontSize": 18,
-                        "fontWeight": "normal",
-                      },
-                      {
-                        "fontSize": 16,
-                      },
-                    ]
-                  }
-                >
-                  BCSC.Onboarding.SecureAppPINSubtext
-                </Text>
-              </View>
-            </View>
-          </View>
-          <View
-            accessibilityLabel="BCSC.Onboarding.LearnMore"
             accessibilityRole="button"
             accessibilityState={
               {
@@ -426,12 +248,14 @@ exports[`SecurityMethodSelector in settings context (with currentMethod) disable
             style={
               {
                 "backgroundColor": "#003366",
+                "borderColor": "transparent",
                 "borderRadius": 4,
+                "borderWidth": 2,
                 "opacity": 1,
                 "padding": 16,
               }
             }
-            testID="com.ariesbifold:id/LearnMoreButton"
+            testID="com.ariesbifold:id/ChoosePINButton"
           >
             <View
               style={
@@ -442,6 +266,29 @@ exports[`SecurityMethodSelector in settings context (with currentMethod) disable
                 }
               }
             >
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": undefined,
+                      "fontSize": 40,
+                    },
+                    {
+                      "color": "#313132",
+                    },
+                    {
+                      "fontFamily": "Material Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                
+              </Text>
               <View
                 style={
                   {
@@ -466,42 +313,37 @@ exports[`SecurityMethodSelector in settings context (with currentMethod) disable
                         {
                           "color": "#313132",
                           "fontFamily": "BCSans-Regular",
-                          "fontSize": 21,
+                          "fontSize": 18,
                           "fontWeight": "bold",
                         },
                         {
                           "color": "#313132",
-                          "fontSize": 21,
+                          "fontSize": 16,
                         },
                       ]
                     }
                   >
-                    BCSC.Onboarding.LearnMore
-                  </Text>
-                  <Text
-                    allowFontScaling={false}
-                    selectable={false}
-                    style={
-                      [
-                        {
-                          "color": undefined,
-                          "fontSize": 32,
-                        },
-                        {
-                          "color": "#313132",
-                        },
-                        {
-                          "fontFamily": "Material Icons",
-                          "fontStyle": "normal",
-                          "fontWeight": "normal",
-                        },
-                        {},
-                      ]
-                    }
-                  >
-                    
+                    BCSC.Onboarding.SecureAppPINTitle
                   </Text>
                 </View>
+                <Text
+                  maxFontSizeMultiplier={2}
+                  style={
+                    [
+                      {
+                        "color": "#313132",
+                        "fontFamily": "BCSans-Regular",
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      {
+                        "fontSize": 16,
+                      },
+                    ]
+                  }
+                >
+                  BCSC.Onboarding.SecureAppPINSubtext
+                </Text>
               </View>
             </View>
           </View>
@@ -1404,7 +1246,7 @@ exports[`SecurityMethodSelector when device auth is available renders both devic
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": false,
+                "disabled": undefined,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -1432,7 +1274,9 @@ exports[`SecurityMethodSelector when device auth is available renders both devic
             style={
               {
                 "backgroundColor": "#003366",
+                "borderColor": "transparent",
                 "borderRadius": 4,
+                "borderWidth": 2,
                 "opacity": 1,
                 "padding": 16,
               }
@@ -1536,7 +1380,7 @@ exports[`SecurityMethodSelector when device auth is available renders both devic
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": false,
+                "disabled": undefined,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -1564,7 +1408,9 @@ exports[`SecurityMethodSelector when device auth is available renders both devic
             style={
               {
                 "backgroundColor": "#003366",
+                "borderColor": "transparent",
                 "borderRadius": 4,
+                "borderWidth": 2,
                 "opacity": 1,
                 "padding": 16,
               }

--- a/app/src/bcsc-theme/features/modal/__snapshots__/ServiceOutage.test.tsx.snap
+++ b/app/src/bcsc-theme/features/modal/__snapshots__/ServiceOutage.test.tsx.snap
@@ -122,7 +122,9 @@ exports[`ServiceOutage should match snapshot 1`] = `
           style={
             {
               "backgroundColor": "#003366",
+              "borderColor": "transparent",
               "borderRadius": 4,
+              "borderWidth": 2,
               "opacity": 1,
               "padding": 16,
             }

--- a/app/src/bcsc-theme/features/onboarding/SecureAppScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/SecureAppScreen.tsx
@@ -3,7 +3,7 @@ import { useBCSCApiClient } from '@/bcsc-theme/hooks/useBCSCApiClient'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCSCOnboardingStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { toAppError } from '@/bcsc-theme/utils/native-error-map'
-import { SECURE_APP_LEARN_MORE_URL, TEMPORARY_ACCOUNT_CLIENT_ID } from '@/constants'
+import { TEMPORARY_ACCOUNT_CLIENT_ID } from '@/constants'
 import { ErrorRegistry } from '@/errors/errorRegistry'
 import { TOKENS, useServices } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -54,18 +54,10 @@ export const SecureAppScreen = ({ navigation }: SecureAppScreenProps): React.Rea
     navigation.navigate(BCSCScreens.OnboardingCreatePIN)
   }, [navigation])
 
-  const handleLearnMorePress = useCallback(() => {
-    navigation.navigate(BCSCScreens.OnboardingWebView, {
-      title: t('BCSC.Onboarding.PrivacyPolicyHeaderSecuringApp'),
-      url: SECURE_APP_LEARN_MORE_URL,
-    })
-  }, [navigation, t])
-
   return (
     <SecurityMethodSelector
       onDeviceAuthPress={handleDeviceAuthPress}
       onPINPress={handlePINPress}
-      onLearnMorePress={handleLearnMorePress}
       deviceAuthPrompt={t('BCSC.Security.AuthenticateToSecure')}
     />
   )

--- a/app/src/bcsc-theme/features/onboarding/__snapshots__/OnboardingPrivacyPolicyScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/onboarding/__snapshots__/OnboardingPrivacyPolicyScreen.test.tsx.snap
@@ -164,7 +164,9 @@ exports[`OnboardingPrivacyPolicy renders correctly 1`] = `
         style={
           {
             "backgroundColor": "#003366",
+            "borderColor": "transparent",
             "borderRadius": 4,
+            "borderWidth": 2,
             "opacity": 1,
             "padding": 16,
           }

--- a/app/src/bcsc-theme/features/onboarding/__snapshots__/SecureAppScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/onboarding/__snapshots__/SecureAppScreen.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`SecureApp renders correctly when device auth IS available 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": false,
+                "disabled": undefined,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -113,7 +113,9 @@ exports[`SecureApp renders correctly when device auth IS available 1`] = `
             style={
               {
                 "backgroundColor": "#003366",
+                "borderColor": "transparent",
                 "borderRadius": 4,
+                "borderWidth": 2,
                 "opacity": 1,
                 "padding": 16,
               }
@@ -217,7 +219,7 @@ exports[`SecureApp renders correctly when device auth IS available 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": false,
+                "disabled": undefined,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -245,7 +247,9 @@ exports[`SecureApp renders correctly when device auth IS available 1`] = `
             style={
               {
                 "backgroundColor": "#003366",
+                "borderColor": "transparent",
                 "borderRadius": 4,
+                "borderWidth": 2,
                 "opacity": 1,
                 "padding": 16,
               }

--- a/app/src/bcsc-theme/features/settings/__snapshots__/AuthPrivacyPolicyScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/settings/__snapshots__/AuthPrivacyPolicyScreen.test.tsx.snap
@@ -164,7 +164,9 @@ exports[`AuthPrivacyPolicyScreen renders correctly 1`] = `
         style={
           {
             "backgroundColor": "#003366",
+            "borderColor": "transparent",
             "borderRadius": 4,
+            "borderWidth": 2,
             "opacity": 1,
             "padding": 16,
           }

--- a/app/src/bcsc-theme/features/settings/__snapshots__/MainPrivacyPolicyScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/settings/__snapshots__/MainPrivacyPolicyScreen.test.tsx.snap
@@ -164,7 +164,9 @@ exports[`MainPrivacyPolicyScreen renders correctly 1`] = `
         style={
           {
             "backgroundColor": "#003366",
+            "borderColor": "transparent",
             "borderRadius": 4,
+            "borderWidth": 2,
             "opacity": 1,
             "padding": 16,
           }

--- a/app/src/bcsc-theme/features/settings/__snapshots__/OnboardingPrivacyInformationScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/settings/__snapshots__/OnboardingPrivacyInformationScreen.test.tsx.snap
@@ -164,7 +164,9 @@ exports[`OnboardingPrivacyInformationScreen renders correctly 1`] = `
         style={
           {
             "backgroundColor": "#003366",
+            "borderColor": "transparent",
             "borderRadius": 4,
+            "borderWidth": 2,
             "opacity": 1,
             "padding": 16,
           }

--- a/app/src/bcsc-theme/features/settings/__snapshots__/VerifyPrivacyPolicyScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/settings/__snapshots__/VerifyPrivacyPolicyScreen.test.tsx.snap
@@ -164,7 +164,9 @@ exports[`VerifyPrivacyPolicyScreen renders correctly 1`] = `
         style={
           {
             "backgroundColor": "#003366",
+            "borderColor": "transparent",
             "borderRadius": 4,
+            "borderWidth": 2,
             "opacity": 1,
             "padding": 16,
           }

--- a/packages/bcsc-core/ios/ClientMetadataModel.swift
+++ b/packages/bcsc-core/ios/ClientMetadataModel.swift
@@ -132,21 +132,39 @@ class MetadataClients: NSObject, NSSecureCoding {
       "clientRefId": clientId ?? "",
       "bookmarked": bookmarked ?? false,
     ]
-    if let clientName = clientName { dict["clientName"] = clientName }
-    if let dateAdded = dateAdded { dict["dateAdded"] = dateAdded.timeIntervalSince1970 }
-    if let lastUsed = lastUsed { dict["lastUsed"] = lastUsed.timeIntervalSince1970 }
-    if let clientUri = clientUri { dict["clientUri"] = clientUri }
-    if let initiateLoginUri = initiateLoginUri { dict["initiateLoginUri"] = initiateLoginUri }
-    if let clientDescription = clientDescription { dict["clientDescription"] = clientDescription }
-    if let policyUri = policyUri { dict["policyUri"] = policyUri }
+    if let clientName = clientName {
+      dict["clientName"] = clientName
+    }
+    if let dateAdded = dateAdded {
+      dict["dateAdded"] = dateAdded.timeIntervalSince1970
+    }
+    if let lastUsed = lastUsed {
+      dict["lastUsed"] = lastUsed.timeIntervalSince1970
+    }
+    if let clientUri = clientUri {
+      dict["clientUri"] = clientUri
+    }
+    if let initiateLoginUri = initiateLoginUri {
+      dict["initiateLoginUri"] = initiateLoginUri
+    }
+    if let clientDescription = clientDescription {
+      dict["clientDescription"] = clientDescription
+    }
+    if let policyUri = policyUri {
+      dict["policyUri"] = policyUri
+    }
     if let serviceListingSortOrder = serviceListingSortOrder {
       dict["serviceListingSortOrder"] = serviceListingSortOrder
     }
-    if let claimsDescription = claimsDescription { dict["claimsDescription"] = claimsDescription }
+    if let claimsDescription = claimsDescription {
+      dict["claimsDescription"] = claimsDescription
+    }
     if let suppressConfirmationInfo = suppressConfirmationInfo {
       dict["suppressConfirmationInfo"] = suppressConfirmationInfo
     }
-    if let suppressBookmarkPrompt = suppressBookmarkPrompt { dict["suppressBookmarkPrompt"] = suppressBookmarkPrompt }
+    if let suppressBookmarkPrompt = suppressBookmarkPrompt {
+      dict["suppressBookmarkPrompt"] = suppressBookmarkPrompt
+    }
     return dict
   }
 

--- a/packages/bcsc-core/ios/DocumentsDataModel.swift
+++ b/packages/bcsc-core/ios/DocumentsDataModel.swift
@@ -229,20 +229,36 @@ class EvidenceType: NSObject, NSSecureCoding {
   /// Convert to dictionary for JS
   func toDictionary() -> [String: Any] {
     var dict = [String: Any]()
-    if let evidenceType = evidenceType { dict["evidence_type"] = evidenceType }
-    if let hasPhoto = hasPhoto { dict["has_photo"] = hasPhoto }
-    if let group = group { dict["group"] = group }
-    if let sortOrder = sortOrder { dict["sort_order"] = sortOrder }
-    if let groupSortOrder = groupSortOrder { dict["group_sort_order"] = groupSortOrder }
-    if let collectionOrder = collectionOrder { dict["collection_order"] = collectionOrder }
+    if let evidenceType = evidenceType {
+      dict["evidence_type"] = evidenceType
+    }
+    if let hasPhoto = hasPhoto {
+      dict["has_photo"] = hasPhoto
+    }
+    if let group = group {
+      dict["group"] = group
+    }
+    if let sortOrder = sortOrder {
+      dict["sort_order"] = sortOrder
+    }
+    if let groupSortOrder = groupSortOrder {
+      dict["group_sort_order"] = groupSortOrder
+    }
+    if let collectionOrder = collectionOrder {
+      dict["collection_order"] = collectionOrder
+    }
     if let documentReferenceInputMask = documentReferenceInputMask {
       dict["document_reference_input_mask"] = documentReferenceInputMask
     }
-    if let documentReferenceLabel = documentReferenceLabel { dict["document_reference_label"] = documentReferenceLabel }
+    if let documentReferenceLabel = documentReferenceLabel {
+      dict["document_reference_label"] = documentReferenceLabel
+    }
     if let documentReferenceSample = documentReferenceSample {
       dict["document_reference_sample"] = documentReferenceSample
     }
-    if let evidenceTypeLabel = evidenceTypeLabel { dict["evidence_type_label"] = evidenceTypeLabel }
+    if let evidenceTypeLabel = evidenceTypeLabel {
+      dict["evidence_type_label"] = evidenceTypeLabel
+    }
     dict["image_sides"] = imageSides.map { side -> [String: String] in
       [
         "image_side_name": side.imageSideName,


### PR DESCRIPTION
# Summary of Changes

Redesigns the **App Security** settings screen to the new spec: left-aligned "How to secure this app" heading with updated intro copy, leading icons on both options, and the current security method now shown as a highlighted card (accent border + check) instead of a separate indicator row. Adds a reusable `selected` state to the shared `CardButton` and removes the "Learn more" card (and its now-unused `onLearnMorePress` plumbing) from this screen.

A selected card is rendered as a non-interactive status element rather than a disabled button, so screen readers announce the current method's name (e.g. "Current security method, PIN") with a "selected" state instead of just "Current security method, dimmed".

# Testing Instructions

1. Settings → **App Security**. Confirm the new heading/copy, both options show leading icons, and the current method appears as a highlighted card with a checkmark while the other is a tappable option.
2. Switch method (PIN ↔ Face ID / Touch ID) and confirm the highlighted card follows the active method, and there is no "Learn more" card.
3. With VoiceOver/TalkBack, focus the current-method card: it should announce the method name and "selected" (not "disabled") and not act as a button.
4. Confirm the onboarding "secure this app" screen is unchanged.
5. `cd app && yarn test`.

# Acceptance Criteria

- App Security screen matches the new design spec (heading, copy, icons, highlighted current-method card).
- Current method is a non-interactive, highlighted card with a check; the alternative method is tappable.
- Screen readers announce the current method's name and a selected state, not a disabled button.
- No "Learn more" card on the App Security screen; onboarding flow unchanged.
- Unit tests and snapshots pass.

# Screenshots, videos, or gifs

<img width="350" height="756" alt="image" src="https://github.com/user-attachments/assets/c3df65ac-eabc-4aba-8eb6-ac03c686fe79" />

# Related Issues

N/A
