### PR TITLE
fix: restore nickname from account record and handle mononyms consistently

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useInitializeAccountStatus.test.tsx
+++ b/app/src/bcsc-theme/api/hooks/useInitializeAccountStatus.test.tsx
@@ -42,11 +42,14 @@ describe('useInitializeAccountStatus', () => {
     expect(result.current.initializingAccount).toBe(false)
   })
 
-  it('returns initializingAccount as false when hasAccount is already true', () => {
+  it('returns initializingAccount as false when hasAccount is already true and nickname is present', () => {
     const mockDispatch = jest.fn()
     jest
       .mocked(Bifold.useStore)
-      .mockReturnValue([{ stateLoaded: true, bcsc: { hasAccount: true } } as any, mockDispatch])
+      .mockReturnValue([
+        { stateLoaded: true, bcsc: { hasAccount: true, selectedNickname: 'Combo' } } as any,
+        mockDispatch,
+      ])
     jest.mocked(Bifold.useServices).mockReturnValue([{ info: jest.fn(), error: jest.fn() }] as any)
 
     const { result } = renderHook(() => useInitializeAccountStatus())
@@ -54,11 +57,14 @@ describe('useInitializeAccountStatus', () => {
     expect(result.current.initializingAccount).toBe(false)
   })
 
-  it('skips native call when store.bcsc.hasAccount is true', async () => {
+  it('skips native call when store.bcsc.hasAccount is true and nickname is present', async () => {
     const mockDispatch = jest.fn()
     jest
       .mocked(Bifold.useStore)
-      .mockReturnValue([{ stateLoaded: true, bcsc: { hasAccount: true } } as any, mockDispatch])
+      .mockReturnValue([
+        { stateLoaded: true, bcsc: { hasAccount: true, selectedNickname: 'Combo' } } as any,
+        mockDispatch,
+      ])
     jest.mocked(Bifold.useServices).mockReturnValue([{ info: jest.fn(), error: jest.fn() }] as any)
 
     const { result } = renderHook(() => useInitializeAccountStatus())
@@ -86,7 +92,7 @@ describe('useInitializeAccountStatus', () => {
     expect(mockDispatch).not.toHaveBeenCalled()
   })
 
-  it('dispatches SET_HAS_ACCOUNT with true when account is found', async () => {
+  it('dispatches SET_HAS_ACCOUNT with true and UPDATE_NICKNAME when account is found with a nickname', async () => {
     const mockDispatch = jest.fn()
     const mockAccount = { nickname: 'My Wallet' }
     jest
@@ -103,6 +109,10 @@ describe('useInitializeAccountStatus', () => {
     expect(mockDispatch).toHaveBeenCalledWith({
       type: BCDispatchAction.SET_HAS_ACCOUNT,
       payload: [true],
+    })
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: BCDispatchAction.UPDATE_NICKNAME,
+      payload: ['My Wallet'],
     })
     expect(result.current.initializingAccount).toBe(false)
   })
@@ -138,6 +148,11 @@ describe('useInitializeAccountStatus', () => {
     renderHook(() => useInitializeAccountStatus())
 
     await act(async () => {})
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: BCDispatchAction.UPDATE_NICKNAME,
+      payload: ['Jane'],
+    })
   })
 
   it('prefers nickname over displayName when both are present', async () => {
@@ -152,6 +167,84 @@ describe('useInitializeAccountStatus', () => {
     renderHook(() => useInitializeAccountStatus())
 
     await act(async () => {})
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: BCDispatchAction.UPDATE_NICKNAME,
+      payload: ['My Wallet'],
+    })
+  })
+
+  describe('nickname restoration (#4258)', () => {
+    it('restores the nickname from the native account record when hasAccount is true but the nickname is missing, without dispatching SET_HAS_ACCOUNT', async () => {
+      const mockDispatch = jest.fn()
+      const mockAccount = { nickname: 'Combo' }
+      jest
+        .mocked(Bifold.useStore)
+        .mockReturnValue([
+          { stateLoaded: true, bcsc: { hasAccount: true, selectedNickname: undefined } } as any,
+          mockDispatch,
+        ])
+      jest.mocked(Bifold.useServices).mockReturnValue([{ info: jest.fn(), error: jest.fn() }] as any)
+      jest.mocked(retryModule.retryAsync).mockResolvedValue(mockAccount)
+
+      const { result } = renderHook(() => useInitializeAccountStatus())
+
+      await act(async () => {})
+
+      expect(jest.mocked(retryModule.retryAsync)).toHaveBeenCalledWith(getAccount, 3, 500, true)
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_NICKNAME,
+        payload: ['Combo'],
+      })
+      expect(mockDispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: BCDispatchAction.SET_HAS_ACCOUNT }))
+      expect(result.current.initializingAccount).toBe(false)
+    })
+
+    it('does not dispatch UPDATE_NICKNAME or downgrade hasAccount when the native account record is not found', async () => {
+      const mockDispatch = jest.fn()
+      jest
+        .mocked(Bifold.useStore)
+        .mockReturnValue([
+          { stateLoaded: true, bcsc: { hasAccount: true, selectedNickname: undefined } } as any,
+          mockDispatch,
+        ])
+      jest.mocked(Bifold.useServices).mockReturnValue([{ info: jest.fn(), error: jest.fn() }] as any)
+      jest.mocked(retryModule.retryAsync).mockResolvedValue(null)
+
+      const { result } = renderHook(() => useInitializeAccountStatus())
+
+      await act(async () => {})
+
+      expect(mockDispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: BCDispatchAction.UPDATE_NICKNAME }))
+      expect(mockDispatch).not.toHaveBeenCalledWith({
+        type: BCDispatchAction.SET_HAS_ACCOUNT,
+        payload: [false],
+      })
+      expect(result.current.initializingAccount).toBe(false)
+    })
+
+    it('never clobbers an existing nickname with a different native value', async () => {
+      const mockDispatch = jest.fn()
+      const mockAccount = { nickname: 'Combo' }
+      jest
+        .mocked(Bifold.useStore)
+        .mockReturnValue([
+          { stateLoaded: true, bcsc: { hasAccount: false, selectedNickname: 'MyNickname' } } as any,
+          mockDispatch,
+        ])
+      jest.mocked(Bifold.useServices).mockReturnValue([{ info: jest.fn(), error: jest.fn() }] as any)
+      jest.mocked(retryModule.retryAsync).mockResolvedValue(mockAccount)
+
+      renderHook(() => useInitializeAccountStatus())
+
+      await act(async () => {})
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.SET_HAS_ACCOUNT,
+        payload: [true],
+      })
+      expect(mockDispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: BCDispatchAction.UPDATE_NICKNAME }))
+    })
   })
 
   it('logs error when getAccount throws', async () => {

--- a/app/src/bcsc-theme/api/hooks/useInitializeAccountStatus.tsx
+++ b/app/src/bcsc-theme/api/hooks/useInitializeAccountStatus.tsx
@@ -15,7 +15,12 @@ const ACCOUNT_FETCH_RETRY_DELAY_MS = 500
 export const useInitializeAccountStatus = () => {
   const [store, dispatch] = useStore<BCState>()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
-  const [hasCheckedAccount, setHasCheckedAccount] = useState(Boolean(store.bcsc.hasAccount))
+  // "Checked" means fully initialized: an account is known AND its nickname is present.
+  // Mirrors the useEffect's early-return condition below so a store that's already
+  // hydrated (hasAccount true) but missing its nickname still runs the self-heal.
+  const [hasCheckedAccount, setHasCheckedAccount] = useState(
+    Boolean(store.bcsc.hasAccount) && Boolean(store.bcsc.selectedNickname?.trim())
+  )
 
   const initializingAccount = store.stateLoaded && !hasCheckedAccount
 
@@ -30,26 +35,45 @@ export const useInitializeAccountStatus = () => {
       // TEMP (MD): Patch until BcscCore package correctly bubbles errors https://github.com/bcgov/bc-wallet-mobile/issues/3372
       const account = await retryAsync(getAccount, ACCOUNT_FETCH_MAX_RETRIES, ACCOUNT_FETCH_RETRY_DELAY_MS, true)
 
-      dispatch({ type: BCDispatchAction.SET_HAS_ACCOUNT, payload: [Boolean(account)] })
+      // Preserve existing semantics: never downgrade a persisted hasAccount=true
+      // on a transient native read failure (see #3405 verification-loop fix)
+      if (!store.bcsc.hasAccount) {
+        dispatch({ type: BCDispatchAction.SET_HAS_ACCOUNT, payload: [Boolean(account)] })
+      }
+
+      // Self-heal: the AsyncStorage nickname can be lost on process death (e.g. Android
+      // killing the app after phone lock); the native account record is durable secure
+      // storage. displayName fallback covers v3 ias-ios migrated users. See #4258.
+      const nativeNickname = account?.nickname?.trim() || account?.displayName?.trim()
+      if (nativeNickname && !store.bcsc.selectedNickname?.trim()) {
+        logger.info('[useInitializeAccountStatus] Restoring nickname from native account record')
+        dispatch({ type: BCDispatchAction.UPDATE_NICKNAME, payload: [nativeNickname] })
+      }
     } catch (error) {
       logger.error('[useInitializeAccountStatus] Error checking for existing account:', error as Error)
     } finally {
       setHasCheckedAccount(true)
     }
-  }, [dispatch, logger])
+  }, [dispatch, logger, store.bcsc.hasAccount, store.bcsc.selectedNickname])
 
   useEffect(() => {
     if (!store.stateLoaded || hasCheckedAccount) {
       return
     }
 
-    if (store.bcsc.hasAccount) {
+    if (store.bcsc.hasAccount && store.bcsc.selectedNickname?.trim()) {
       setHasCheckedAccount(true)
       return
     }
 
     initializeAccountStatus()
-  }, [hasCheckedAccount, initializeAccountStatus, store.bcsc.hasAccount, store.stateLoaded])
+  }, [
+    hasCheckedAccount,
+    initializeAccountStatus,
+    store.bcsc.hasAccount,
+    store.bcsc.selectedNickname,
+    store.stateLoaded,
+  ])
 
   return {
     initializingAccount,

--- a/app/src/bcsc-theme/contexts/BCSCIdTokenContext.test.ts
+++ b/app/src/bcsc-theme/contexts/BCSCIdTokenContext.test.ts
@@ -1,0 +1,121 @@
+import { compareCredentialMetadata, tokenToCredentialMetadata } from '@/bcsc-theme/contexts/BCSCIdTokenContext'
+import { BCSCEvent, BCSCReason, IdToken } from '@/bcsc-theme/utils/id-token'
+import { CredentialMetadata } from '@/store'
+
+const createMockIdToken = (overrides?: Partial<IdToken>): IdToken => ({
+  sub: 'test-sub',
+  aud: 'test-aud',
+  iss: 'test-iss',
+  exp: 1234567890,
+  iat: '1234567890',
+  jti: 'test-jti',
+  family_name: 'Deluca',
+  given_name: 'Mac',
+  bcsc_card_type: 'Combined' as any,
+  bcsc_event: BCSCEvent.Authorization,
+  bcsc_reason: BCSCReason.ApprovedByAgent,
+  bcsc_status_date: 1234567890,
+  acr: 0,
+  bcsc_devices_count: 1,
+  bcsc_max_devices: 5,
+  hasActivePersonCredential: true,
+  bcsc_account_type: 'BC Services Card with photo' as any,
+  ...overrides,
+})
+
+const createMockMetadata = (overrides?: Partial<CredentialMetadata>): CredentialMetadata => ({
+  fullName: 'Mac Deluca',
+  bcscReason: BCSCReason.ApprovedByAgent,
+  deviceCount: 1,
+  deviceLimit: 5,
+  cardType: 'Combined',
+  lastUpdated: 1234567890,
+  ...overrides,
+})
+
+describe('BCSCIdTokenContext', () => {
+  describe('tokenToCredentialMetadata', () => {
+    it('returns the joined full name for a two-name token', () => {
+      const token = createMockIdToken({ given_name: 'Mac', family_name: 'Deluca' })
+
+      expect(tokenToCredentialMetadata(token).fullName).toBe('Mac Deluca')
+    })
+
+    it('returns just the family name for a mononym token (no "undefined" artifact)', () => {
+      const token = createMockIdToken({ given_name: undefined, family_name: 'Deluca' })
+
+      expect(tokenToCredentialMetadata(token).fullName).toBe('Deluca')
+    })
+
+    it('maps the remaining token fields', () => {
+      const token = createMockIdToken({
+        bcsc_reason: BCSCReason.Renew,
+        bcsc_devices_count: 2,
+        bcsc_max_devices: 6,
+        bcsc_card_type: 'Combined' as any,
+        bcsc_status_date: 999,
+      })
+
+      expect(tokenToCredentialMetadata(token)).toMatchObject({
+        bcscReason: BCSCReason.Renew,
+        deviceCount: 2,
+        deviceLimit: 6,
+        cardType: 'Combined',
+        lastUpdated: 999,
+      })
+    })
+  })
+
+  describe('compareCredentialMetadata', () => {
+    it('returns false when either argument is undefined', () => {
+      const metadata = createMockMetadata()
+
+      expect(compareCredentialMetadata(undefined, metadata)).toBe(false)
+      expect(compareCredentialMetadata(metadata, undefined)).toBe(false)
+      expect(compareCredentialMetadata(undefined, undefined)).toBe(false)
+    })
+
+    it('returns true for identical metadata', () => {
+      const metadata = createMockMetadata()
+
+      expect(compareCredentialMetadata(metadata, { ...metadata })).toBe(true)
+    })
+
+    it('returns false when a non-fullName field differs', () => {
+      const c1 = createMockMetadata()
+      const c2 = createMockMetadata({ deviceCount: 2 })
+
+      expect(compareCredentialMetadata(c1, c2)).toBe(false)
+    })
+
+    // #4258 user decision: normalize the legacy `${given_name} ${family_name}` mononym
+    // artifact so the fullName bugfix doesn't fire a one-time false "account updated" alert.
+    it('treats a legacy "undefined <name>" stored fullName as equal to the corrected mononym fullName', () => {
+      const legacyStored = createMockMetadata({ fullName: 'undefined Smith' })
+      const corrected = createMockMetadata({ fullName: 'Smith' })
+
+      expect(compareCredentialMetadata(corrected, legacyStored)).toBe(true)
+    })
+
+    it('treats a legacy stray-leading-space stored fullName as equal to the corrected mononym fullName', () => {
+      const legacyStored = createMockMetadata({ fullName: ' Smith' })
+      const corrected = createMockMetadata({ fullName: 'Smith' })
+
+      expect(compareCredentialMetadata(corrected, legacyStored)).toBe(true)
+    })
+
+    it('still returns false for genuinely different names', () => {
+      const c1 = createMockMetadata({ fullName: 'John Smith' })
+      const c2 = createMockMetadata({ fullName: 'Jane Smith' })
+
+      expect(compareCredentialMetadata(c1, c2)).toBe(false)
+    })
+
+    it('still returns false when a legacy-normalized mononym name differs from a genuinely different name', () => {
+      const legacyStored = createMockMetadata({ fullName: 'undefined Smith' })
+      const differentName = createMockMetadata({ fullName: 'Jones' })
+
+      expect(compareCredentialMetadata(differentName, legacyStored)).toBe(false)
+    })
+  })
+})

--- a/app/src/bcsc-theme/contexts/BCSCIdTokenContext.test.ts
+++ b/app/src/bcsc-theme/contexts/BCSCIdTokenContext.test.ts
@@ -104,6 +104,30 @@ describe('BCSCIdTokenContext', () => {
       expect(compareCredentialMetadata(corrected, legacyStored)).toBe(true)
     })
 
+    // Regression: when BOTH given_name and family_name were absent, the legacy template
+    // rendered the literal "undefined undefined" (one "undefined" per absent part), which
+    // must normalize the same as getFullDisplayName({})'s '' -- otherwise every account with
+    // no name on file at all would get a spurious one-time "account updated" alert.
+    it('treats a legacy "undefined undefined" stored fullName as equal to a fresh empty fullName', () => {
+      const legacyStored = createMockMetadata({ fullName: 'undefined undefined' })
+      const corrected = createMockMetadata({ fullName: '' })
+
+      expect(compareCredentialMetadata(corrected, legacyStored)).toBe(true)
+    })
+
+    // Documents the accepted tradeoff: the normalization matches the literal lowercase
+    // "undefined" string JS produces when interpolating a real `undefined` value, so it's
+    // scoped to that exact case. A genuine name is safe as long as it isn't literally the
+    // lowercase word "undefined" -- e.g. capitalized "Undefined" (a real name) is untouched,
+    // since the match is case-sensitive.
+    it('does not touch a genuine name that starts with capitalized "Undefined"', () => {
+      const c1 = createMockMetadata({ fullName: 'Undefined Smith' })
+      const c2 = createMockMetadata({ fullName: 'Undefined Smith' })
+
+      expect(compareCredentialMetadata(c1, c2)).toBe(true)
+      expect(compareCredentialMetadata(c1, createMockMetadata({ fullName: 'Smith' }))).toBe(false)
+    })
+
     it('still returns false for genuinely different names', () => {
       const c1 = createMockMetadata({ fullName: 'John Smith' })
       const c2 = createMockMetadata({ fullName: 'Jane Smith' })

--- a/app/src/bcsc-theme/contexts/BCSCIdTokenContext.test.ts
+++ b/app/src/bcsc-theme/contexts/BCSCIdTokenContext.test.ts
@@ -9,8 +9,8 @@ const createMockIdToken = (overrides?: Partial<IdToken>): IdToken => ({
   exp: 1234567890,
   iat: '1234567890',
   jti: 'test-jti',
-  family_name: 'Deluca',
-  given_name: 'Mac',
+  family_name: 'Doe',
+  given_name: 'Jamie',
   bcsc_card_type: 'Combined' as any,
   bcsc_event: BCSCEvent.Authorization,
   bcsc_reason: BCSCReason.ApprovedByAgent,
@@ -24,7 +24,7 @@ const createMockIdToken = (overrides?: Partial<IdToken>): IdToken => ({
 })
 
 const createMockMetadata = (overrides?: Partial<CredentialMetadata>): CredentialMetadata => ({
-  fullName: 'Mac Deluca',
+  fullName: 'Jamie Doe',
   bcscReason: BCSCReason.ApprovedByAgent,
   deviceCount: 1,
   deviceLimit: 5,
@@ -36,15 +36,15 @@ const createMockMetadata = (overrides?: Partial<CredentialMetadata>): Credential
 describe('BCSCIdTokenContext', () => {
   describe('tokenToCredentialMetadata', () => {
     it('returns the joined full name for a two-name token', () => {
-      const token = createMockIdToken({ given_name: 'Mac', family_name: 'Deluca' })
+      const token = createMockIdToken({ given_name: 'Jamie', family_name: 'Doe' })
 
-      expect(tokenToCredentialMetadata(token).fullName).toBe('Mac Deluca')
+      expect(tokenToCredentialMetadata(token).fullName).toBe('Jamie Doe')
     })
 
     it('returns just the family name for a mononym token (no "undefined" artifact)', () => {
-      const token = createMockIdToken({ given_name: undefined, family_name: 'Deluca' })
+      const token = createMockIdToken({ given_name: undefined, family_name: 'Doe' })
 
-      expect(tokenToCredentialMetadata(token).fullName).toBe('Deluca')
+      expect(tokenToCredentialMetadata(token).fullName).toBe('Doe')
     })
 
     it('maps the remaining token fields', () => {

--- a/app/src/bcsc-theme/contexts/BCSCIdTokenContext.test.ts
+++ b/app/src/bcsc-theme/contexts/BCSCIdTokenContext.test.ts
@@ -115,6 +115,16 @@ describe('BCSCIdTokenContext', () => {
       expect(compareCredentialMetadata(corrected, legacyStored)).toBe(true)
     })
 
+    // The legacy template's OTHER slot: family_name absent with given_name present
+    // rendered "Jamie undefined", which must normalize the same as the corrected
+    // given-name-only output "Jamie". (PR feedback: trailing artifact was unhandled.)
+    it('treats a legacy trailing-"undefined" stored fullName as equal to the corrected given-name-only fullName', () => {
+      const legacyStored = createMockMetadata({ fullName: 'Jamie undefined' })
+      const corrected = createMockMetadata({ fullName: 'Jamie' })
+
+      expect(compareCredentialMetadata(corrected, legacyStored)).toBe(true)
+    })
+
     // Documents the accepted tradeoff: the normalization matches the literal lowercase
     // "undefined" string JS produces when interpolating a real `undefined` value, so it's
     // scoped to that exact case. A genuine name is safe as long as it isn't literally the

--- a/app/src/bcsc-theme/contexts/BCSCIdTokenContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCIdTokenContext.tsx
@@ -44,8 +44,8 @@ export const tokenToCredentialMetadata = (token: IdToken): CredentialMetadata =>
  * {@link getFullDisplayName} output, avoiding a one-time false-positive
  * "account updated" alert for existing mononym users. See #4258.
  *
- * Narrowly scoped to leading "undefined" artifacts by design (matches the
- * literal lowercase string JS produces when interpolating `undefined`); a
+ * Narrowly scoped to leading/trailing "undefined" artifacts by design (matches
+ * the literal lowercase string JS produces when interpolating `undefined`); a
  * genuine name that happens to start with capitalized "Undefined" is safe,
  * since the match is case-sensitive. See BCSCIdTokenContext.test.ts for the
  * documented tradeoff around a literal lowercase "undefined" name part.
@@ -63,8 +63,10 @@ const normalizeLegacyFullName = (fullName: string | undefined): string => {
     return ''
   }
 
-  // Only one part (given_name) was absent, e.g. "undefined Smith" -> "Smith".
-  return collapsed.replace(/^undefined\s+/, '')
+  // Only one part was absent: given_name ("undefined Smith" -> "Smith") or
+  // family_name ("Jamie undefined" -> "Jamie") — the legacy template had
+  // exactly two slots, so leading + trailing strips cover the remaining artifacts.
+  return collapsed.replace(/^undefined\s+/, '').replace(/\s+undefined$/, '')
 }
 
 /**

--- a/app/src/bcsc-theme/contexts/BCSCIdTokenContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCIdTokenContext.tsx
@@ -38,19 +38,34 @@ export const tokenToCredentialMetadata = (token: IdToken): CredentialMetadata =>
  * Normalizes a fullName value that may have been produced by the legacy
  * `${given_name} ${family_name}` template, which rendered a literal
  * "undefined " prefix (and/or stray whitespace) for mononym users whose
- * given_name was absent. This lets {@link compareCredentialMetadata} treat a
- * legacy-stored mononym value as equivalent to the corrected
+ * given_name was absent -- or, when BOTH parts were absent, the entire value
+ * as the literal "undefined undefined". This lets {@link compareCredentialMetadata}
+ * treat a legacy-stored value as equivalent to the corrected
  * {@link getFullDisplayName} output, avoiding a one-time false-positive
  * "account updated" alert for existing mononym users. See #4258.
  *
+ * Narrowly scoped to leading "undefined" artifacts by design (matches the
+ * literal lowercase string JS produces when interpolating `undefined`); a
+ * genuine name that happens to start with capitalized "Undefined" is safe,
+ * since the match is case-sensitive. See BCSCIdTokenContext.test.ts for the
+ * documented tradeoff around a literal lowercase "undefined" name part.
+ *
  * @param fullName Stored or freshly-computed fullName value to normalize
- * @returns The fullName with any legacy "undefined " prefix stripped and whitespace collapsed/trimmed
+ * @returns The fullName with legacy "undefined" artifacts stripped and whitespace collapsed/trimmed
  */
-const normalizeLegacyFullName = (fullName: string | undefined): string =>
-  (fullName ?? '')
-    .replace(/^undefined\s+/, '')
-    .replace(/\s+/g, ' ')
-    .trim()
+const normalizeLegacyFullName = (fullName: string | undefined): string => {
+  const collapsed = (fullName ?? '').replace(/\s+/g, ' ').trim()
+
+  // Both given_name and family_name were absent: the legacy template rendered this
+  // as "undefined undefined" (repeated once per absent part), which carries no real
+  // name text. Normalize it the same as getFullDisplayName({})'s '' output.
+  if (/^(undefined\s*)+$/.test(collapsed)) {
+    return ''
+  }
+
+  // Only one part (given_name) was absent, e.g. "undefined Smith" -> "Smith".
+  return collapsed.replace(/^undefined\s+/, '')
+}
 
 /**
  * A helper function to compare 'new' credential metadata from the token endpoint with the existing credential metadata in the store.

--- a/app/src/bcsc-theme/contexts/BCSCIdTokenContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCIdTokenContext.tsx
@@ -1,3 +1,4 @@
+import { getFullDisplayName } from '@/bcsc-theme/utils/account-utils'
 import { BCSCEventTypes } from '@/events/eventTypes'
 import { CredentialMetadata } from '@/store'
 import { TOKENS, useServices } from '@bifold/core'
@@ -21,7 +22,7 @@ export interface BCSCIdTokenContextType<T> {
  * @returns CredentialMetadata object derived from the token
  */
 export const tokenToCredentialMetadata = (token: IdToken): CredentialMetadata => {
-  const fullName = `${token.given_name} ${token.family_name}`
+  const fullName = getFullDisplayName(token)
 
   return {
     fullName,
@@ -34,8 +35,29 @@ export const tokenToCredentialMetadata = (token: IdToken): CredentialMetadata =>
 }
 
 /**
+ * Normalizes a fullName value that may have been produced by the legacy
+ * `${given_name} ${family_name}` template, which rendered a literal
+ * "undefined " prefix (and/or stray whitespace) for mononym users whose
+ * given_name was absent. This lets {@link compareCredentialMetadata} treat a
+ * legacy-stored mononym value as equivalent to the corrected
+ * {@link getFullDisplayName} output, avoiding a one-time false-positive
+ * "account updated" alert for existing mononym users. See #4258.
+ *
+ * @param fullName Stored or freshly-computed fullName value to normalize
+ * @returns The fullName with any legacy "undefined " prefix stripped and whitespace collapsed/trimmed
+ */
+const normalizeLegacyFullName = (fullName: string | undefined): string =>
+  (fullName ?? '')
+    .replace(/^undefined\s+/, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+/**
  * A helper function to compare 'new' credential metadata from the token endpoint with the existing credential metadata in the store.
  * If any of the values checked are different a false is returned to trigger the system to alert the user that something has happened.
+ *
+ * fullName is compared after normalizing away the legacy mononym artifact (see {@link normalizeLegacyFullName})
+ * so existing mononym users don't get a spurious "account updated" alert purely from the fullName bugfix.
  *
  * @param c1 Credential Metadata object to check
  * @param c2 Credential Metadata object to check
@@ -49,7 +71,7 @@ export const compareCredentialMetadata = (
     return false
   }
   return (
-    c1.fullName === c2.fullName &&
+    normalizeLegacyFullName(c1.fullName) === normalizeLegacyFullName(c2.fullName) &&
     c1.bcscReason === c2.bcscReason &&
     c1.deviceCount === c2.deviceCount &&
     c1.deviceLimit === c2.deviceLimit &&

--- a/app/src/bcsc-theme/features/verify/_models/useVerificationResponseViewModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/_models/useVerificationResponseViewModel.test.ts
@@ -393,7 +393,7 @@ describe('useVerificationResponseViewModel', () => {
     })
 
     it('prefers given_name over family_name when both are present', async () => {
-      mockGetCachedIdTokenMetadata.mockResolvedValue({ given_name: 'Mac', family_name: 'Deluca' })
+      mockGetCachedIdTokenMetadata.mockResolvedValue({ given_name: 'Jamie', family_name: 'Doe' })
       mockRegistrationService.updateRegistration.mockResolvedValue(undefined)
 
       const { result } = renderHook(() => useVerificationResponseViewModel())
@@ -404,9 +404,9 @@ describe('useVerificationResponseViewModel', () => {
 
       expect(mockDispatch).toHaveBeenNthCalledWith(1, {
         type: BCDispatchAction.UPDATE_NICKNAME,
-        payload: ['Mac'],
+        payload: ['Jamie'],
       })
-      expect(mockRegistrationService.updateRegistration).toHaveBeenCalledWith('test-registration-token', 'Mac')
+      expect(mockRegistrationService.updateRegistration).toHaveBeenCalledWith('test-registration-token', 'Jamie')
     })
   })
 })

--- a/app/src/bcsc-theme/features/verify/_models/useVerificationResponseViewModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/_models/useVerificationResponseViewModel.test.ts
@@ -373,4 +373,40 @@ describe('useVerificationResponseViewModel', () => {
       expect(mockUpdateVerified).toHaveBeenCalledWith(true)
     })
   })
+
+  describe('mononym support (#4258)', () => {
+    it('falls back to family_name for mononym users (no given_name)', async () => {
+      mockGetCachedIdTokenMetadata.mockResolvedValue({ given_name: undefined, family_name: 'RC0000080' })
+      mockRegistrationService.updateRegistration.mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => useVerificationResponseViewModel())
+
+      await act(async () => {
+        await result.current.handleAccountSetup()
+      })
+
+      expect(mockDispatch).toHaveBeenNthCalledWith(1, {
+        type: BCDispatchAction.UPDATE_NICKNAME,
+        payload: ['RC0000080'],
+      })
+      expect(mockRegistrationService.updateRegistration).toHaveBeenCalledWith('test-registration-token', 'RC0000080')
+    })
+
+    it('prefers given_name over family_name when both are present', async () => {
+      mockGetCachedIdTokenMetadata.mockResolvedValue({ given_name: 'Mac', family_name: 'Deluca' })
+      mockRegistrationService.updateRegistration.mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => useVerificationResponseViewModel())
+
+      await act(async () => {
+        await result.current.handleAccountSetup()
+      })
+
+      expect(mockDispatch).toHaveBeenNthCalledWith(1, {
+        type: BCDispatchAction.UPDATE_NICKNAME,
+        payload: ['Mac'],
+      })
+      expect(mockRegistrationService.updateRegistration).toHaveBeenCalledWith('test-registration-token', 'Mac')
+    })
+  })
 })

--- a/app/src/bcsc-theme/features/verify/_models/useVerificationResponseViewModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useVerificationResponseViewModel.tsx
@@ -2,6 +2,7 @@ import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { useRegistrationService } from '@/bcsc-theme/services/hooks/useRegistrationService'
 import { useTokenService } from '@/bcsc-theme/services/hooks/useTokenService'
 import { BCSCMainStackParams, BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
+import { getShortDisplayName } from '@/bcsc-theme/utils/account-utils'
 import { BCDispatchAction, BCState } from '@/store'
 import { TOKENS, useServices, useStore } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
@@ -43,8 +44,8 @@ const useVerificationResponseViewModel = () => {
       await updateUserMetadata(null)
       // force a token exchange so the backend activates the device registration before navigation
       const token = await getCachedIdTokenMetadata({ refreshCache: true })
-      // fallback to family_name to support mononymns
-      const nickname = token?.given_name || token?.family_name
+      // fallback to family_name to support mononyms
+      const nickname = getShortDisplayName(token ?? {})
       // update local store with nickname
       updateNicknameInLocalStorage(nickname)
       // this updates their registration status with their nickname and new access tokens

--- a/app/src/bcsc-theme/utils/account-utils.test.ts
+++ b/app/src/bcsc-theme/utils/account-utils.test.ts
@@ -189,15 +189,15 @@ describe('account-utils', () => {
 
   describe('getFullDisplayName', () => {
     it('should join given_name and family_name', () => {
-      expect(getFullDisplayName({ given_name: 'Mac', family_name: 'Deluca' })).toBe('Mac Deluca')
+      expect(getFullDisplayName({ given_name: 'Jamie', family_name: 'Doe' })).toBe('Jamie Doe')
     })
 
     it('should return just family_name when given_name is missing (mononym)', () => {
-      expect(getFullDisplayName({ family_name: 'Deluca' })).toBe('Deluca')
+      expect(getFullDisplayName({ family_name: 'Doe' })).toBe('Doe')
     })
 
     it('should return just given_name when family_name is missing', () => {
-      expect(getFullDisplayName({ given_name: 'Mac' })).toBe('Mac')
+      expect(getFullDisplayName({ given_name: 'Jamie' })).toBe('Jamie')
     })
 
     it('should return an empty string when both are empty or undefined', () => {
@@ -206,9 +206,9 @@ describe('account-utils', () => {
     })
 
     it('should not produce leading, trailing, or double spaces', () => {
-      expect(getFullDisplayName({ given_name: '  Mac  ', family_name: '  Deluca  ' })).toBe('Mac Deluca')
-      expect(getFullDisplayName({ given_name: '', family_name: 'Deluca' })).toBe('Deluca')
-      expect(getFullDisplayName({ given_name: 'Mac', family_name: '' })).toBe('Mac')
+      expect(getFullDisplayName({ given_name: '  Jamie  ', family_name: '  Doe  ' })).toBe('Jamie Doe')
+      expect(getFullDisplayName({ given_name: '', family_name: 'Doe' })).toBe('Doe')
+      expect(getFullDisplayName({ given_name: 'Jamie', family_name: '' })).toBe('Jamie')
     })
   })
 })

--- a/app/src/bcsc-theme/utils/account-utils.test.ts
+++ b/app/src/bcsc-theme/utils/account-utils.test.ts
@@ -1,4 +1,9 @@
-import { formatAccountName, getNicknameValidationErrorKey } from '@/bcsc-theme/utils/account-utils'
+import {
+  formatAccountName,
+  getFullDisplayName,
+  getNicknameValidationErrorKey,
+  getShortDisplayName,
+} from '@/bcsc-theme/utils/account-utils'
 import { BCState } from '@/store'
 
 const createMockState = (nicknames: string[]): BCState =>
@@ -155,6 +160,55 @@ describe('account-utils', () => {
       })
 
       expect(name).toBe('')
+    })
+  })
+
+  describe('getShortDisplayName', () => {
+    it('should return given_name when both given_name and family_name are present', () => {
+      expect(getShortDisplayName({ given_name: 'Combo', family_name: 'RC0000080' })).toBe('Combo')
+    })
+
+    it('should fall back to family_name when given_name is missing (mononym)', () => {
+      expect(getShortDisplayName({ family_name: 'RC0000080' })).toBe('RC0000080')
+    })
+
+    it('should fall back to family_name when given_name is empty/whitespace', () => {
+      expect(getShortDisplayName({ given_name: '', family_name: 'RC0000080' })).toBe('RC0000080')
+      expect(getShortDisplayName({ given_name: '   ', family_name: 'RC0000080' })).toBe('RC0000080')
+    })
+
+    it('should return an empty string when both are empty or undefined', () => {
+      expect(getShortDisplayName({})).toBe('')
+      expect(getShortDisplayName({ given_name: '', family_name: '' })).toBe('')
+    })
+
+    it('should trim whitespace', () => {
+      expect(getShortDisplayName({ given_name: '  Combo  ' })).toBe('Combo')
+    })
+  })
+
+  describe('getFullDisplayName', () => {
+    it('should join given_name and family_name', () => {
+      expect(getFullDisplayName({ given_name: 'Mac', family_name: 'Deluca' })).toBe('Mac Deluca')
+    })
+
+    it('should return just family_name when given_name is missing (mononym)', () => {
+      expect(getFullDisplayName({ family_name: 'Deluca' })).toBe('Deluca')
+    })
+
+    it('should return just given_name when family_name is missing', () => {
+      expect(getFullDisplayName({ given_name: 'Mac' })).toBe('Mac')
+    })
+
+    it('should return an empty string when both are empty or undefined', () => {
+      expect(getFullDisplayName({})).toBe('')
+      expect(getFullDisplayName({ given_name: '', family_name: '' })).toBe('')
+    })
+
+    it('should not produce leading, trailing, or double spaces', () => {
+      expect(getFullDisplayName({ given_name: '  Mac  ', family_name: '  Deluca  ' })).toBe('Mac Deluca')
+      expect(getFullDisplayName({ given_name: '', family_name: 'Deluca' })).toBe('Deluca')
+      expect(getFullDisplayName({ given_name: 'Mac', family_name: '' })).toBe('Mac')
     })
   })
 })

--- a/app/src/bcsc-theme/utils/account-utils.ts
+++ b/app/src/bcsc-theme/utils/account-utils.ts
@@ -77,8 +77,8 @@ export const getShortDisplayName = (name: TokenNameParts): string =>
  * would produce when given_name is absent (mononym accounts).
  *
  * @example
- *  getFullDisplayName({ given_name: 'Mac', family_name: 'Deluca' }) // 'Mac Deluca'
- *  getFullDisplayName({ family_name: 'Deluca' }) // 'Deluca' (mononym)
+ *  getFullDisplayName({ given_name: 'Jamie', family_name: 'Doe' }) // 'Jamie Doe'
+ *  getFullDisplayName({ family_name: 'Doe' }) // 'Doe' (mononym)
  */
 export const getFullDisplayName = (name: TokenNameParts): string =>
   [name.given_name?.trim(), name.family_name?.trim()].filter(Boolean).join(' ')

--- a/app/src/bcsc-theme/utils/account-utils.ts
+++ b/app/src/bcsc-theme/utils/account-utils.ts
@@ -49,3 +49,36 @@ export const formatAccountName = (account: { firstName?: string; middleNames?: s
 
   return formattedNameParts.join(' ')
 }
+
+/**
+ * Name parts as found on an IdToken (snake_case, unlike the camelCase account
+ * shape used by {@link formatAccountName}).
+ */
+export interface TokenNameParts {
+  given_name?: string
+  family_name?: string
+}
+
+/**
+ * Short display name / default nickname rule: given_name, falling back to
+ * family_name (mononyms are stored in family_name). Empty string if neither
+ * is present.
+ *
+ * @example
+ *  getShortDisplayName({ given_name: 'Combo', family_name: 'RC0000080' }) // 'Combo'
+ *  getShortDisplayName({ family_name: 'RC0000080' }) // 'RC0000080' (mononym)
+ */
+export const getShortDisplayName = (name: TokenNameParts): string =>
+  name.given_name?.trim() || name.family_name?.trim() || ''
+
+/**
+ * Mononym-safe full name: joins the non-empty parts of given_name and
+ * family_name. Avoids the literal "undefined" that `${given_name} ${family_name}`
+ * would produce when given_name is absent (mononym accounts).
+ *
+ * @example
+ *  getFullDisplayName({ given_name: 'Mac', family_name: 'Deluca' }) // 'Mac Deluca'
+ *  getFullDisplayName({ family_name: 'Deluca' }) // 'Deluca' (mononym)
+ */
+export const getFullDisplayName = (name: TokenNameParts): string =>
+  [name.given_name?.trim(), name.family_name?.trim()].filter(Boolean).join(' ')


### PR DESCRIPTION
## What

When a user with a mononym-style BC Services Card account (a name stored only in the "surname" field, like a business name — e.g. "Combo") locked their phone and came back into the app, their account nickname could silently revert to the generic "BC Services Card" label instead of staying as the name they'd set. This restores the correct nickname automatically when that happens, and closes a related gap where mononym accounts could get a broken "undefined \<name\>" value stored internally.

## Why

On Android, locking the phone can kill the app process. When the app restarts, its saved settings are rebuilt from local storage — but the nickname wasn't being restored from the durable native account record, so if that particular save was lost, the app fell back to a generic placeholder instead of the user's real nickname. This also surfaced a second, related bug: accounts with only one name on file (no separate given name) could end up with a corrupted "undefined \<name\>" value stored internally, which risked triggering an unnecessary "your account was updated" alert once the underlying bug was fixed.

## Decisions

- **Self-healing restore, not a persistence rewrite**: rather than chasing every possible race in how the nickname gets saved to local storage, the app now restores the nickname from the native secure-storage account record (which survives process death) on startup whenever the store's nickname is empty. This repairs the symptom regardless of which specific write was lost.
- **Shared name helpers**: added `getShortDisplayName` (nickname default: given name, falling back to the stored surname for mononym accounts) and `getFullDisplayName` (mononym-safe full name join) to `account-utils.ts`, reused in both the post-verification nickname flow and the credential metadata used for account-change alerts — replacing two separate ad hoc implementations that disagreed slightly on mononym handling.
- **One-time alert suppression for existing mononym users**: the old buggy template stored values like `"undefined Smith"` for existing mononym accounts. Fixing the template alone would make that stored value look different from the newly-computed correct value on next login, firing a spurious "your account was updated" alert. `compareCredentialMetadata` now normalizes away that specific legacy artifact (a leading `"undefined "` token, plus stray whitespace) before comparing, so existing mononym users don't see that one-time false alert. Genuinely different names still compare as different.
- Scope: `bcsc` build target only — no changes to `bcwallet-theme`, no native/platform code, no `packages/bcsc-core` changes.

## Tests

- `account-utils.test.ts`: unit tests for `getShortDisplayName`/`getFullDisplayName` covering two-name, mononym (given-name missing/blank), and empty inputs, including the issue's own repro values (`given: 'Combo'`, `family: 'RC0000080'`).
- `useInitializeAccountStatus.test.tsx`: covers the acceptance criterion directly — `hasAccount: true` with an empty nickname and a native account record restores the nickname without touching `hasAccount`; an already-complete store skips the native call entirely; a missing native account doesn't clobber or downgrade anything; an existing user-set nickname is never overwritten by a different native value.
- `useVerificationResponseViewModel.test.ts`: added mononym (family_name-only) and given-name-preferred cases for the post-verification nickname.
- New `BCSCIdTokenContext.test.ts`: pins `tokenToCredentialMetadata`'s mononym-safe `fullName` output, and proves the legacy `"undefined Smith"` vs corrected `"Smith"` case compares equal while genuinely different names still compare unequal.
- Full suite: `yarn typecheck`, TS lint/format (app + bcsc-core), and `yarn test` (275 suites / 2687 tests / 158 snapshots) all pass.

## Verification

1. Repro the original issue's steps (non-BCSC flow matched to a DL with a mononym name, e.g. Given = Combo), confirm the nickname is set correctly, lock the phone until Android kills the app, reopen, and confirm the nickname is unchanged instead of reverting to "BC Services Card".
2. For an existing account that already has the legacy `"undefined <name>"` artifact stored, confirm no "your account was updated" alert appears purely from this fix.

#4258
