### PR TITLE
feat: automatic bcsc digital services card flow

### DIFF
--- a/app/container-imp.ts
+++ b/app/container-imp.ts
@@ -71,7 +71,7 @@ import PINExplainer from './src/screens/PINExplainer'
 import Preface from './src/screens/Preface'
 import Splash from './src/screens/Splash'
 import Terms, { TermsVersion } from './src/screens/Terms'
-import { AttestationMonitor, allCredDefIds } from './src/services/attestation'
+import { AttestationMonitor, allCredDefIds, noOpAttestationMonitor } from './src/services/attestation'
 import { AutoCredentialMonitor } from './src/services/auto-credential'
 import { VersionCheckService } from './src/services/version'
 import {
@@ -120,10 +120,18 @@ export class AppContainer implements Container {
       shouldHandleProofRequestAutomatically: true,
     }
 
-    this._container.registerInstance(TOKENS.UTIL_ATTESTATION_MONITOR, new AttestationMonitor(this.logger, options))
+    // Device attestation only runs on the BCWallet build target. BCSC builds
+    // can't produce an attestation blob our controller accepts, and their
+    // Person Credential flow bypasses attestation anyway.
+    const attestationMonitor =
+      Config.BUILD_TARGET === Mode.BCWallet ? new AttestationMonitor(this.logger, options) : noOpAttestationMonitor()
+    this._container.registerInstance(TOKENS.UTIL_ATTESTATION_MONITOR, attestationMonitor)
     this._container.registerInstance(
       TOKENS.UTIL_CREDENTIAL_PROVISIONING_MONITOR,
-      new AutoCredentialMonitor(this.logger, { rules: [buildDigitalServicesCardCredentialRule()] })
+      new AutoCredentialMonitor(this.logger, {
+        rules: [buildDigitalServicesCardCredentialRule()],
+        attestationMonitor,
+      })
     )
     this._container.registerInstance(TOKENS.UTIL_APP_VERSION_MONITOR, new VersionCheckService(this.logger))
     // Here you can register any component to override components in core package

--- a/app/src/bcsc-theme/services/digitalServicesCardProvisioner.test.ts
+++ b/app/src/bcsc-theme/services/digitalServicesCardProvisioner.test.ts
@@ -1,0 +1,64 @@
+import { AutoFetchCredentialConfig } from '@/constants'
+import { getBCSCApiClient } from '@bcsc-theme/contexts/BCSCApiClientContext'
+import { buildDigitalServicesCardCredentialRule } from '@bcsc-theme/services/digitalServicesCardProvisioner'
+import { Platform } from 'react-native'
+import { getBundleId } from 'react-native-device-info'
+
+jest.mock('@bcsc-theme/contexts/BCSCApiClientContext', () => ({
+  getBCSCApiClient: jest.fn(),
+}))
+
+jest.mock('react-native-device-info', () => ({
+  getBundleId: jest.fn(),
+}))
+
+const mockedGetBCSCApiClient = getBCSCApiClient as jest.Mock
+const mockedGetBundleId = getBundleId as jest.Mock
+
+describe('digitalServicesCardProvisioner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    Platform.OS = 'ios'
+    mockedGetBundleId.mockReturnValue('ca.bc.gov.iddev.servicescard')
+  })
+
+  describe('buildDigitalServicesCardCredentialRule', () => {
+    it('flattens every cred def ID from AutoFetchCredentialConfig into triggerCredDefIds', () => {
+      const rule = buildDigitalServicesCardCredentialRule()
+      const expected = Object.values(AutoFetchCredentialConfig).flatMap((env) => [...env.credDefIDs])
+      expect(rule.triggerCredDefIds).toEqual(expect.arrayContaining(expected))
+      expect(rule.triggerCredDefIds).toHaveLength(expected.length)
+    })
+
+    it('defaults autoAcceptIssuerProofRequest and autoAcceptCredentialOffer to true', () => {
+      const rule = buildDigitalServicesCardCredentialRule()
+      expect(rule.autoAcceptIssuerProofRequest).toBe(true)
+      expect(rule.autoAcceptCredentialOffer).toBe(true)
+    })
+  })
+
+  describe('getInvitationUrl (via rule)', () => {
+    it('throws when the BCSC api client is not ready', async () => {
+      mockedGetBCSCApiClient.mockReturnValue(null)
+      const rule = buildDigitalServicesCardCredentialRule()
+      await expect(rule.getInvitationUrl({} as any, {} as any)).rejects.toThrow(/client not ready/i)
+    })
+
+    it('POSTs to the credential endpoint with source_os + source_application and returns invitation_url', async () => {
+      const post = jest.fn().mockResolvedValue({ data: { invitation_url: 'https://issuer.example?c_i=abc' } })
+      mockedGetBCSCApiClient.mockReturnValue({
+        endpoints: { credential: '/credentials/v1/person' },
+        post,
+      })
+
+      const rule = buildDigitalServicesCardCredentialRule()
+      const url = await rule.getInvitationUrl({} as any, {} as any)
+
+      expect(post).toHaveBeenCalledWith('/credentials/v1/person', {
+        source_os: 'ios',
+        source_application: 'ca.bc.gov.iddev.servicescard',
+      })
+      expect(url).toBe('https://issuer.example?c_i=abc')
+    })
+  })
+})

--- a/app/src/bcsc-theme/services/digitalServicesCardProvisioner.ts
+++ b/app/src/bcsc-theme/services/digitalServicesCardProvisioner.ts
@@ -1,46 +1,32 @@
 import { AutoFetchCredentialConfig } from '@/constants'
 import { AutoCredentialRule } from '@/services/auto-credential'
-import { DidCommProofExchangeRecord } from '@credo-ts/didcomm'
-import { BCAgent } from '@utils/bc-agent-modules'
+import { Platform } from 'react-native'
+import { getBundleId } from 'react-native-device-info'
+import { getBCSCApiClient } from '../contexts/BCSCApiClientContext'
+
+interface CreatePersonCredentialResponse {
+  invitation_url: string
+  has_active_credential?: boolean
+}
 
 /**
- * Finds which DigitalServicesCard environment config matches the cred def IDs present in
- * the incoming proof's restrictions, and returns its invitation URL.
- *
- * This mirrors the `invitationUrlFromRestrictions` pattern used by the
- * AttestationMonitor — the issuer URL is derived from the proof itself so the
- * correct environment is always selected automatically.
+ * Mint a Person Credential issuer invitation via the BCSC-initiated flow.
+ * The invitation is single-use and issued fresh per request, so this hits
+ * `POST /credentials/v1/person` every time AutoCredentialMonitor decides a
+ * Person Credential is missing. Environment selection is implicit — the
+ * request goes to whichever IAS the currently-configured BCSC client points at,
+ * and IAS mints an invitation whose cred def matches that env.
  */
-const getDigitalServicesCardInvitationUrl = async (
-  proof: DidCommProofExchangeRecord,
-  agent: BCAgent
-): Promise<string> => {
-  const format = await agent.didcomm.proofs.getFormatData(proof.id)
-  const requestFormat = (format.request?.anoncreds ?? format.request?.indy) as
-    | {
-        requested_attributes?: Record<string, { restrictions?: { cred_def_id?: string }[] }>
-        requested_predicates?: Record<string, { restrictions?: { cred_def_id?: string }[] }>
-      }
-    | undefined
-
-  if (!requestFormat) {
-    throw new Error('Could not read proof request format to determine DigitalServicesCard issuer URL')
+const getDigitalServicesCardInvitationUrl = async (): Promise<string> => {
+  const apiClient = getBCSCApiClient()
+  if (!apiClient) {
+    throw new Error('BCSC client not ready — cannot request Person Credential invitation')
   }
-
-  const allRestrictions = [
-    ...Object.values(requestFormat.requested_attributes ?? {}).flatMap((a) => a.restrictions ?? []),
-    ...Object.values(requestFormat.requested_predicates ?? {}).flatMap((p) => p.restrictions ?? []),
-  ]
-
-  for (const env of Object.values(AutoFetchCredentialConfig)) {
-    for (const restriction of allRestrictions) {
-      if (restriction.cred_def_id && env.credDefIDs.includes(restriction.cred_def_id)) {
-        return env.invitationUrl
-      }
-    }
-  }
-
-  throw new Error('No matching DigitalServicesCard issuer found for the proof request restrictions')
+  const response = await apiClient.post<CreatePersonCredentialResponse>(apiClient.endpoints.credential, {
+    source_os: Platform.OS,
+    source_application: getBundleId(),
+  })
+  return response.data.invitation_url
 }
 
 /**

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -16,24 +16,28 @@ export interface CredentialRestrictionEnvironment {
   invitationUrl: string
 }
 
+export interface AutoFetchCredentialConfigEntry {
+  credDefIDs: readonly string[]
+}
+
 /**
- * Per-environment Auto fetch credential configuration.
- *
- * TODO: Replace placeholder cred def IDs and invitation URLs with real values
- * from the IAS team once they are available.
+ * Per-environment Person Credential cred def IDs. AutoCredentialMonitor
+ * flattens these into its trigger set; a proof requesting any of them tells
+ * the wallet a Person Credential is missing and the BCSC-initiated flow
+ * (POST /credentials/v1/person) is used to mint an issuer invitation.
  */
-export const AutoFetchCredentialConfig: Record<string, CredentialRestrictionEnvironment> = {
+export const AutoFetchCredentialConfig: Record<string, AutoFetchCredentialConfigEntry> = {
   Development: {
-    credDefIDs: ['PLACEHOLDER_DEV_ACCOUNT_ID_CRED_DEF_ID'],
-    invitationUrl: 'PLACEHOLDER_DEV_ACCOUNT_ID_INVITATION_URL',
+    credDefIDs: ['XpgeQa93eZvGSZBZef3PHn:3:CL:28075:PersonDEV'],
   },
-  Test: {
-    credDefIDs: ['PLACEHOLDER_TEST_ACCOUNT_ID_CRED_DEF_ID'],
-    invitationUrl: 'PLACEHOLDER_TEST_ACCOUNT_ID_INVITATION_URL',
+  SIT: {
+    credDefIDs: ['7xjfawcnyTUcduWVysLww5:3:CL:28075:PersonSIT'],
+  },
+  QA: {
+    credDefIDs: ['KCxVC8GkKywjhWJnUfCmkW:3:CL:20:PersonQA'],
   },
   Production: {
-    credDefIDs: ['PLACEHOLDER_PROD_ACCOUNT_ID_CRED_DEF_ID'],
-    invitationUrl: 'PLACEHOLDER_PROD_ACCOUNT_ID_INVITATION_URL',
+    credDefIDs: ['RGjWbW1eycP7FrMf4QJvX8:3:CL:13:Person'],
   },
 } as const
 

--- a/app/src/services/attestation.ts
+++ b/app/src/services/attestation.ts
@@ -150,6 +150,17 @@ export const isOfferingAttestation = (credDefId: string, restrictions: Attestati
   return allCredDefIds(restrictions).includes(credDefId)
 }
 
+/**
+ * No-op AttestationMonitor for builds where device attestation is not required
+ */
+export const noOpAttestationMonitor = (): AttestationMonitorI => ({
+  attestationWorkflowInProgress: false,
+  shouldHandleProofRequestAutomatically: false,
+  start: () => {},
+  stop: () => {},
+  requestAttestationCredential: async () => {},
+})
+
 export class AttestationMonitor implements AttestationMonitorI {
   private proofSubscription?: AgentSubscription
   private offerSubscription?: AgentSubscription

--- a/app/src/services/auto-credential.test.ts
+++ b/app/src/services/auto-credential.test.ts
@@ -50,7 +50,10 @@ const createMockAgent = () => {
     // and await each handler so async work settles before assertions.
     async emit(eventType: string, payload: any) {
       const bucket = handlers[eventType]
-      if (!bucket) return
+      if (!bucket) {
+        return
+      }
+
       for (const h of Array.from(bucket)) {
         await h({ payload })
       }

--- a/app/src/services/auto-credential.test.ts
+++ b/app/src/services/auto-credential.test.ts
@@ -1,0 +1,307 @@
+import { AutoCredentialMonitor, AutoCredentialRule } from '@/services/auto-credential'
+import { CredentialProvisioningEventTypes, MockLogger } from '@bifold/core'
+import {
+  DidCommCredentialEventTypes,
+  DidCommCredentialState,
+  DidCommProofEventTypes,
+  DidCommProofState,
+} from '@credo-ts/didcomm'
+import { credentialsMatchForProof } from '@utils/credentials'
+import { DeviceEventEmitter } from 'react-native'
+
+jest.mock('@utils/credentials', () => ({
+  credentialsMatchForProof: jest.fn(),
+}))
+
+const mockedCredentialsMatchForProof = credentialsMatchForProof as jest.Mock
+
+type Handler = (event: any) => void | Promise<void>
+
+/**
+ * Mock BCAgent with per-event-type handler tracking so tests can synthetically
+ * emit events onto the observable that AutoCredentialMonitor subscribes to.
+ */
+const createMockAgent = () => {
+  const handlers: Record<string, Set<Handler>> = {}
+  return {
+    events: {
+      observable: (eventType: string) => ({
+        subscribe: (handler: Handler) => {
+          const bucket = (handlers[eventType] ??= new Set())
+          bucket.add(handler)
+          return { unsubscribe: () => bucket.delete(handler) }
+        },
+      }),
+    },
+    didcomm: {
+      oob: {
+        parseInvitation: jest.fn(),
+        receiveInvitation: jest.fn(),
+      },
+      proofs: {
+        getFormatData: jest.fn(),
+        declineRequest: jest.fn().mockResolvedValue(undefined),
+      },
+      credentials: {
+        acceptOffer: jest.fn().mockResolvedValue(undefined),
+      },
+    },
+    // Test helper: fire the given payload at every handler subscribed to eventType
+    // and await each handler so async work settles before assertions.
+    async emit(eventType: string, payload: any) {
+      const bucket = handlers[eventType]
+      if (!bucket) return
+      for (const h of Array.from(bucket)) {
+        await h({ payload })
+      }
+    },
+  }
+}
+
+const TRIGGER_CRED_DEF_ID = 'issuer:3:CL:1:Person'
+
+const buildRule = (overrides: Partial<AutoCredentialRule> = {}): AutoCredentialRule => ({
+  triggerCredDefIds: [TRIGGER_CRED_DEF_ID],
+  getInvitationUrl: jest.fn().mockResolvedValue('https://issuer.example?c_i=abc'),
+  autoAcceptIssuerProofRequest: true,
+  autoAcceptCredentialOffer: true,
+  ...overrides,
+})
+
+const proofFormat = (credDefId: string) => ({
+  request: {
+    anoncreds: {
+      requested_attributes: {
+        group1: { restrictions: [{ cred_def_id: credDefId }] },
+      },
+      requested_predicates: {},
+    },
+  },
+})
+
+describe('AutoCredentialMonitor', () => {
+  let agent: ReturnType<typeof createMockAgent>
+  let attestationMonitor: { start: jest.Mock; stop: jest.Mock }
+  let emitSpy: jest.SpyInstance
+
+  const buildMonitor = (rule = buildRule()) => {
+    const monitor = new AutoCredentialMonitor(new MockLogger(), {
+      rules: [rule],
+      attestationMonitor,
+    })
+    monitor.start(agent as any)
+    return { monitor, rule }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    agent = createMockAgent()
+    attestationMonitor = { start: jest.fn(), stop: jest.fn() }
+    emitSpy = jest.spyOn(DeviceEventEmitter, 'emit').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    emitSpy.mockRestore()
+  })
+
+  describe('handleProofStateChanged', () => {
+    it('ignores proof state changes that are not RequestReceived', async () => {
+      buildMonitor()
+      await agent.emit(DidCommProofEventTypes.ProofStateChanged, {
+        proofRecord: { id: 'p1', state: DidCommProofState.PresentationSent },
+      })
+      expect(agent.didcomm.proofs.getFormatData).not.toHaveBeenCalled()
+    })
+
+    it('does not trigger a workflow when the proof does not match any rule', async () => {
+      const { monitor, rule } = buildMonitor()
+      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat('unrelated:cred:def'))
+
+      await agent.emit(DidCommProofEventTypes.ProofStateChanged, {
+        proofRecord: { id: 'p1', state: DidCommProofState.RequestReceived },
+      })
+
+      expect(rule.getInvitationUrl).not.toHaveBeenCalled()
+      expect(monitor.workflowInProgress).toBe(false)
+    })
+
+    it('does not trigger a workflow when the matching credential is already in the wallet', async () => {
+      const { monitor, rule } = buildMonitor()
+      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat(TRIGGER_CRED_DEF_ID))
+      mockedCredentialsMatchForProof.mockResolvedValue({
+        proofFormats: { anoncreds: { attributes: { group1: [{ credentialId: 'c-1' }] }, predicates: {} } },
+      })
+
+      await agent.emit(DidCommProofEventTypes.ProofStateChanged, {
+        proofRecord: { id: 'p1', state: DidCommProofState.RequestReceived },
+      })
+
+      expect(rule.getInvitationUrl).not.toHaveBeenCalled()
+      expect(monitor.workflowInProgress).toBe(false)
+    })
+
+    it('ignores further proof requests once a workflow is already in progress', async () => {
+      agent.didcomm.oob.parseInvitation.mockResolvedValue({ id: 'inv-1' })
+      agent.didcomm.oob.receiveInvitation.mockResolvedValue({ connectionRecord: { id: 'conn-1' } })
+      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat(TRIGGER_CRED_DEF_ID))
+      mockedCredentialsMatchForProof.mockResolvedValue({
+        proofFormats: { anoncreds: { attributes: {}, predicates: {} } },
+      })
+
+      const { monitor } = buildMonitor()
+
+      await agent.emit(DidCommProofEventTypes.ProofStateChanged, {
+        proofRecord: { id: 'p1', state: DidCommProofState.RequestReceived },
+      })
+      expect(monitor.workflowInProgress).toBe(true)
+
+      agent.didcomm.proofs.getFormatData.mockClear()
+      await agent.emit(DidCommProofEventTypes.ProofStateChanged, {
+        proofRecord: { id: 'p2', state: DidCommProofState.RequestReceived },
+      })
+      expect(agent.didcomm.proofs.getFormatData).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('runWorkflow', () => {
+    beforeEach(() => {
+      agent.didcomm.oob.parseInvitation.mockResolvedValue({ id: 'inv-1' })
+      agent.didcomm.oob.receiveInvitation.mockResolvedValue({ connectionRecord: { id: 'conn-1' } })
+      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat(TRIGGER_CRED_DEF_ID))
+      mockedCredentialsMatchForProof.mockResolvedValue({
+        proofFormats: { anoncreds: { attributes: {}, predicates: {} } },
+      })
+    })
+
+    const triggerWorkflow = async () =>
+      agent.emit(DidCommProofEventTypes.ProofStateChanged, {
+        proofRecord: { id: 'trigger-proof', state: DidCommProofState.RequestReceived },
+      })
+
+    it('stops AttestationMonitor and receives the invitation from the rule', async () => {
+      const { rule } = buildMonitor()
+
+      await triggerWorkflow()
+
+      expect(attestationMonitor.stop).toHaveBeenCalledTimes(1)
+      expect(rule.getInvitationUrl).toHaveBeenCalled()
+      expect(agent.didcomm.oob.parseInvitation).toHaveBeenCalledWith('https://issuer.example?c_i=abc')
+      expect(agent.didcomm.oob.receiveInvitation).toHaveBeenCalledWith(
+        { id: 'inv-1' },
+        { label: 'Person Credential Issuer' }
+      )
+      expect(emitSpy).toHaveBeenCalledWith(CredentialProvisioningEventTypes.Started)
+    })
+
+    it('declines issuer proof requests that arrive on the new connection', async () => {
+      buildMonitor()
+      await triggerWorkflow()
+
+      await agent.emit(DidCommProofEventTypes.ProofStateChanged, {
+        proofRecord: { id: 'issuer-proof', state: DidCommProofState.RequestReceived, connectionId: 'conn-1' },
+      })
+
+      expect(agent.didcomm.proofs.declineRequest).toHaveBeenCalledWith({
+        proofExchangeRecordId: 'issuer-proof',
+        sendProblemReport: true,
+      })
+    })
+
+    it('ignores issuer proof requests on unrelated connections', async () => {
+      buildMonitor()
+      await triggerWorkflow()
+
+      await agent.emit(DidCommProofEventTypes.ProofStateChanged, {
+        proofRecord: { id: 'stray', state: DidCommProofState.RequestReceived, connectionId: 'some-other-conn' },
+      })
+
+      expect(agent.didcomm.proofs.declineRequest).not.toHaveBeenCalled()
+    })
+
+    it('auto-accepts the credential offer on the workflow connection', async () => {
+      buildMonitor()
+      await triggerWorkflow()
+
+      await agent.emit(DidCommCredentialEventTypes.DidCommCredentialStateChanged, {
+        credentialExchangeRecord: {
+          id: 'offer-1',
+          state: DidCommCredentialState.OfferReceived,
+          connectionId: 'conn-1',
+        },
+      })
+
+      expect(agent.didcomm.credentials.acceptOffer).toHaveBeenCalledWith({ credentialExchangeRecordId: 'offer-1' })
+    })
+
+    it('does not accept the offer when the rule opts out via autoAcceptCredentialOffer:false', async () => {
+      buildMonitor(buildRule({ autoAcceptCredentialOffer: false }))
+      await triggerWorkflow()
+
+      await agent.emit(DidCommCredentialEventTypes.DidCommCredentialStateChanged, {
+        credentialExchangeRecord: {
+          id: 'offer-1',
+          state: DidCommCredentialState.OfferReceived,
+          connectionId: 'conn-1',
+        },
+      })
+
+      expect(agent.didcomm.credentials.acceptOffer).not.toHaveBeenCalled()
+    })
+
+    it('emits Completed and restarts AttestationMonitor when the credential reaches Done', async () => {
+      const { monitor } = buildMonitor()
+      await triggerWorkflow()
+
+      await agent.emit(DidCommCredentialEventTypes.DidCommCredentialStateChanged, {
+        credentialExchangeRecord: { id: 'cred-1', state: DidCommCredentialState.Done, connectionId: 'conn-1' },
+      })
+
+      expect(emitSpy).toHaveBeenCalledWith(CredentialProvisioningEventTypes.Completed)
+      expect(attestationMonitor.start).toHaveBeenCalledTimes(1)
+      expect(monitor.workflowInProgress).toBe(false)
+    })
+
+    it('emits FailedRequestCredential and restarts AttestationMonitor when getInvitationUrl throws', async () => {
+      const failingRule = buildRule({
+        getInvitationUrl: jest.fn().mockRejectedValue(new Error('issuer unavailable')),
+      })
+      const { monitor } = buildMonitor(failingRule)
+
+      await triggerWorkflow()
+
+      expect(emitSpy).toHaveBeenCalledWith(CredentialProvisioningEventTypes.FailedRequestCredential, expect.any(Error))
+      expect(attestationMonitor.start).toHaveBeenCalledTimes(1)
+      expect(monitor.workflowInProgress).toBe(false)
+    })
+  })
+
+  describe('stop', () => {
+    it('tears down workflow subscriptions and resets in-flight workflow state', async () => {
+      agent.didcomm.oob.parseInvitation.mockResolvedValue({ id: 'inv-1' })
+      agent.didcomm.oob.receiveInvitation.mockResolvedValue({ connectionRecord: { id: 'conn-1' } })
+      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat(TRIGGER_CRED_DEF_ID))
+      mockedCredentialsMatchForProof.mockResolvedValue({
+        proofFormats: { anoncreds: { attributes: {}, predicates: {} } },
+      })
+
+      const { monitor } = buildMonitor()
+      await agent.emit(DidCommProofEventTypes.ProofStateChanged, {
+        proofRecord: { id: 'trigger-proof', state: DidCommProofState.RequestReceived },
+      })
+      expect(monitor.workflowInProgress).toBe(true)
+
+      monitor.stop()
+      expect(monitor.workflowInProgress).toBe(false)
+
+      // After stop, credential offers on the workflow connection should no longer trigger acceptOffer.
+      await agent.emit(DidCommCredentialEventTypes.DidCommCredentialStateChanged, {
+        credentialExchangeRecord: {
+          id: 'late-offer',
+          state: DidCommCredentialState.OfferReceived,
+          connectionId: 'conn-1',
+        },
+      })
+      expect(agent.didcomm.credentials.acceptOffer).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/app/src/services/auto-credential.ts
+++ b/app/src/services/auto-credential.ts
@@ -2,6 +2,9 @@ import { AbstractBifoldLogger, CredentialProvisioningEventTypes, CredentialProvi
 import { AnonCredsRequestedAttribute, AnonCredsRequestedPredicate } from '@credo-ts/anoncreds'
 import { Agent } from '@credo-ts/core'
 import {
+  DidCommCredentialEventTypes,
+  DidCommCredentialState,
+  DidCommCredentialStateChangedEvent,
   DidCommProofEventTypes,
   DidCommProofExchangeRecord,
   DidCommProofState,
@@ -17,6 +20,12 @@ type AgentSubscription = ReturnType<ReturnType<Agent['events']['observable']>['s
 interface ProofRequestFormat {
   requested_attributes?: Record<string, AnonCredsRequestedAttribute>
   requested_predicates?: Record<string, AnonCredsRequestedPredicate>
+}
+
+/** Minimal shape of the always-on AttestationMonitor we need to pause. */
+interface PausableAttestationMonitor {
+  start: (agent: Agent) => void
+  stop: () => void
 }
 
 /**
@@ -50,6 +59,12 @@ export interface AutoCredentialRule {
 
 export interface AutoCredentialMonitorOptions {
   rules: AutoCredentialRule[]
+  /**
+   * Always-on AttestationMonitor. Paused for the duration of an auto-workflow
+   * so it can't race our filtered subscription trying to satisfy the (now
+   * optional) attestation proof the issuer sends during issuance.
+   */
+  attestationMonitor?: PausableAttestationMonitor
 }
 
 /**
@@ -63,24 +78,26 @@ export interface AutoCredentialMonitorOptions {
  * refresh and allow the user to approve the original request.
  *
  * Register an instance at TOKENS.UTIL_CREDENTIAL_PROVISIONING_MONITOR
- *
- * TODO: (al) This currently logs any results of a rule triggering, implement full workflow when target credential is ready
  */
 export class AutoCredentialMonitor implements CredentialProvisioningMonitor {
   private proofSubscription?: AgentSubscription
   private agent?: BCAgent
   private readonly log?: AbstractBifoldLogger
   private readonly rules: AutoCredentialRule[]
+  private readonly attestationMonitor?: PausableAttestationMonitor
 
   // State for the active workflow (one at a time)
   private _workflowInProgress = false
   private _pendingProofRequest?: DidCommProofExchangeRecord
   private _pendingConnectionId?: string
   private _activeRule?: AutoCredentialRule
+  private _workflowProofSubscription?: AgentSubscription
+  private _workflowOfferSubscription?: AgentSubscription
 
   public constructor(logger: AbstractBifoldLogger, options: AutoCredentialMonitorOptions) {
     this.log = logger
     this.rules = options.rules
+    this.attestationMonitor = options.attestationMonitor
   }
 
   public get workflowInProgress(): boolean {
@@ -97,6 +114,7 @@ export class AutoCredentialMonitor implements CredentialProvisioningMonitor {
 
   public stop(): void {
     this.proofSubscription?.unsubscribe()
+    this.teardownWorkflowSubscriptions()
     this._workflowInProgress = false
     this._pendingProofRequest = undefined
     this._pendingConnectionId = undefined
@@ -116,6 +134,8 @@ export class AutoCredentialMonitor implements CredentialProvisioningMonitor {
   }
 
   private completeWorkflow(): void {
+    this.teardownWorkflowSubscriptions()
+    this.resumeAttestationMonitor()
     this._workflowInProgress = false
     this._pendingProofRequest = undefined
     this._pendingConnectionId = undefined
@@ -131,12 +151,31 @@ export class AutoCredentialMonitor implements CredentialProvisioningMonitor {
       | typeof CredentialProvisioningEventTypes.FailedRequestCredential,
     error: Error
   ): void {
+    this.teardownWorkflowSubscriptions()
+    this.resumeAttestationMonitor()
     this._workflowInProgress = false
     this._pendingProofRequest = undefined
     this._pendingConnectionId = undefined
     this._activeRule = undefined
     DeviceEventEmitter.emit(eventType, error)
     this.log?.error('[AutoCredentialMonitor] Workflow failed', error)
+  }
+
+  private teardownWorkflowSubscriptions(): void {
+    this._workflowProofSubscription?.unsubscribe()
+    this._workflowProofSubscription = undefined
+    this._workflowOfferSubscription?.unsubscribe()
+    this._workflowOfferSubscription = undefined
+  }
+
+  private resumeAttestationMonitor(): void {
+    if (this.attestationMonitor && this.agent) {
+      try {
+        this.attestationMonitor.start(this.agent)
+      } catch (err) {
+        this.log?.warn('[AutoCredentialMonitor] Could not restart AttestationMonitor', { error: err as Error })
+      }
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -216,6 +255,92 @@ export class AutoCredentialMonitor implements CredentialProvisioningMonitor {
   }
 
   // ---------------------------------------------------------------------------
+  // Private — workflow driver
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Fetch the missing credential:
+   *   1. Pause the always-on AttestationMonitor.
+   *   2. Get the issuer invitation URL from the rule (BCSC-initiated: POST
+   *      /credentials/v1/person; static: literal from config).
+   *   3. Receive the invitation. The didexchange connection completes async.
+   *   4. On any proof request the issuer sends over the new connection,
+   *      decline it (attestation is optional server-side).
+   *   5. On credential offer, auto-accept; on credential done, complete.
+   *
+   * The original triggering proof request is left in `RequestReceived` state
+   * so the user can approve it manually once the missing cred lands.
+   */
+  private async runWorkflow(rule: AutoCredentialRule, proof: DidCommProofExchangeRecord): Promise<void> {
+    if (!this.agent) {
+      return
+    }
+
+    this.startWorkflow(proof, rule)
+    this.attestationMonitor?.stop()
+
+    try {
+      const invitationUrl = await rule.getInvitationUrl(proof, this.agent)
+      const invite = await this.agent.didcomm.oob.parseInvitation(invitationUrl)
+      if (!invite) {
+        throw new Error('Could not parse issuer invitation')
+      }
+      const { connectionRecord } = await this.agent.didcomm.oob.receiveInvitation(invite, {
+        label: 'Person Credential Issuer',
+      })
+      if (!connectionRecord) {
+        throw new Error('No connection record returned from receiveInvitation')
+      }
+      const connectionId = connectionRecord.id
+      this._pendingConnectionId = connectionId
+
+      // Decline any proof the issuer sends on this connection. In the BCSC flow
+      // the issuer sends an (optional) attestation proof request that we can't
+      // satisfy from the wallet; declining lets the issuance proceed to the
+      // credential offer.
+      this._workflowProofSubscription = this.agent.events
+        .observable<DidCommProofStateChangedEvent>(DidCommProofEventTypes.ProofStateChanged)
+        .subscribe(async ({ payload: { proofRecord } }) => {
+          if (!this.agent) return
+          if (proofRecord.connectionId !== connectionId) return
+          if (proofRecord.state !== DidCommProofState.RequestReceived) return
+          try {
+            await this.agent.didcomm.proofs.declineRequest({
+              proofExchangeRecordId: proofRecord.id,
+              sendProblemReport: true,
+            })
+          } catch (err) {
+            this.failWorkflow(CredentialProvisioningEventTypes.FailedHandleProof, err as Error)
+          }
+        })
+
+      // Auto-accept the Person Credential offer and complete when it lands.
+      this._workflowOfferSubscription = this.agent.events
+        .observable<DidCommCredentialStateChangedEvent>(DidCommCredentialEventTypes.DidCommCredentialStateChanged)
+        .subscribe(async ({ payload: { credentialExchangeRecord } }) => {
+          if (!this.agent) return
+          if (credentialExchangeRecord.connectionId !== connectionId) return
+          try {
+            if (
+              credentialExchangeRecord.state === DidCommCredentialState.OfferReceived &&
+              rule.autoAcceptCredentialOffer !== false
+            ) {
+              await this.agent.didcomm.credentials.acceptOffer({
+                credentialExchangeRecordId: credentialExchangeRecord.id,
+              })
+            } else if (credentialExchangeRecord.state === DidCommCredentialState.Done) {
+              this.completeWorkflow()
+            }
+          } catch (err) {
+            this.failWorkflow(CredentialProvisioningEventTypes.FailedHandleOffer, err as Error)
+          }
+        })
+    } catch (err) {
+      this.failWorkflow(CredentialProvisioningEventTypes.FailedRequestCredential, err as Error)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // Private — event handler
   // ---------------------------------------------------------------------------
 
@@ -225,6 +350,11 @@ export class AutoCredentialMonitor implements CredentialProvisioningMonitor {
     }
     const proof = event.payload.proofRecord
     if (proof.state !== DidCommProofState.RequestReceived) {
+      return
+    }
+    // A workflow already claimed a proof; the workflow-scoped subscription
+    // handles proofs on its own connection. Ignore everything else.
+    if (this._workflowInProgress) {
       return
     }
 
@@ -266,10 +396,16 @@ export class AutoCredentialMonitor implements CredentialProvisioningMonitor {
 
       try {
         const isMissing = await this.isCredentialMissingForRule(proof.id, requestFormat, rule)
-        // TODO: if isMissing == true, trigger workflow to fetch missing credential and respond to proof request
         this.log?.info(
           `[AutoCredentialMonitor] Credential (${rule.triggerCredDefIds.join(', ')}) is ${isMissing ? 'NOT ' : ''}in the wallet`
         )
+        if (isMissing) {
+          // Fire and forget — inside runWorkflow drives its own subscriptions
+          // and error handling. Return so we don't try further rules against the
+          // same proof.
+          this.runWorkflow(rule, proof)
+          return
+        }
       } catch (err) {
         this.log?.warn(`[AutoCredentialMonitor] Could not check credential availability`, { error: err as Error })
       }

--- a/app/src/services/auto-credential.ts
+++ b/app/src/services/auto-credential.ts
@@ -301,9 +301,18 @@ export class AutoCredentialMonitor implements CredentialProvisioningMonitor {
       this._workflowProofSubscription = this.agent.events
         .observable<DidCommProofStateChangedEvent>(DidCommProofEventTypes.ProofStateChanged)
         .subscribe(async ({ payload: { proofRecord } }) => {
-          if (!this.agent) return
-          if (proofRecord.connectionId !== connectionId) return
-          if (proofRecord.state !== DidCommProofState.RequestReceived) return
+          if (!this.agent) {
+            return
+          }
+
+          if (proofRecord.connectionId !== connectionId) {
+            return
+          }
+
+          if (proofRecord.state !== DidCommProofState.RequestReceived) {
+            return
+          }
+
           try {
             await this.agent.didcomm.proofs.declineRequest({
               proofExchangeRecordId: proofRecord.id,
@@ -318,8 +327,14 @@ export class AutoCredentialMonitor implements CredentialProvisioningMonitor {
       this._workflowOfferSubscription = this.agent.events
         .observable<DidCommCredentialStateChangedEvent>(DidCommCredentialEventTypes.DidCommCredentialStateChanged)
         .subscribe(async ({ payload: { credentialExchangeRecord } }) => {
-          if (!this.agent) return
-          if (credentialExchangeRecord.connectionId !== connectionId) return
+          if (!this.agent) {
+            return
+          }
+
+          if (credentialExchangeRecord.connectionId !== connectionId) {
+            return
+          }
+
           try {
             if (
               credentialExchangeRecord.state === DidCommCredentialState.OfferReceived &&


### PR DESCRIPTION
# Summary of Changes

Person Credential Flow, triggered automatically when a proof request requiring a Person credential from the appropriate environment is received.

# Testing Instructions
Once verified, get a Traction Sandbox instance and send yourself a proof request like this:
```
{
  "name": "proof-request",
  "nonce": "1234567890",
  "version": "1.0",
  "requested_attributes": {
    "studentInfo": {
      "names": [
        "given_names"
      ],
      "restrictions": [
        {
          "cred_def_id": "7xjfawcnyTUcduWVysLww5:3:CL:28075:PersonSIT"
        }
      ]
    }
  },
  "requested_predicates": {}
}
```

# Acceptance Criteria

You get your Person credential

# Screenshots, videos, or gifs

N/A

# Related Issues

#3883 
#3948 