### PR TITLE
fix: persist last-known-good JWK and retry JWKS fetch

### DIFF
--- a/app/src/bcsc-theme/api/client.test.ts
+++ b/app/src/bcsc-theme/api/client.test.ts
@@ -1,4 +1,5 @@
 import BCSCApiClient from '@/bcsc-theme/api/client'
+import { loadPersistedJwk, persistJwk } from '@/bcsc-theme/api/jwk-cache'
 import { AppError } from '@/errors/appError'
 import { ErrorCategory } from '@/errors/errorRegistry'
 import { AppEventCode } from '@/events/appEventCode'
@@ -13,6 +14,8 @@ import { getAccount, getRefreshTokenRequestBody, getToken, TokenType } from 'rea
 jest.mock('jwt-decode', () => ({
   jwtDecode: jest.fn(),
 }))
+
+jest.mock('@/bcsc-theme/api/jwk-cache')
 
 describe('BCSC Client', () => {
   beforeAll(() => {
@@ -713,11 +716,18 @@ describe('BCSC Client', () => {
   })
 
   describe('fetchJwk', () => {
+    const mockJwk = { kty: 'RSA', kid: 'key-1' }
+
+    beforeEach(() => {
+      // Default: nothing persisted, persistence always "succeeds" — individual tests override.
+      jest.mocked(persistJwk).mockReset().mockResolvedValue(undefined)
+      jest.mocked(loadPersistedJwk).mockReset().mockResolvedValue(null)
+    })
+
     it('should return the first JWK from the JWKS endpoint', async () => {
       const mockLogger = { info: jest.fn(), error: jest.fn() }
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
-      const mockJwk = { kty: 'RSA', kid: 'key-1' }
       jest.spyOn(client, 'get').mockResolvedValue({
         data: { keys: [mockJwk, { kty: 'RSA', kid: 'key-2' }] },
       } as any)
@@ -728,7 +738,7 @@ describe('BCSC Client', () => {
     })
 
     it('should return null when JWKS endpoint returns empty keys array', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       jest.spyOn(client, 'get').mockResolvedValue({
@@ -744,6 +754,8 @@ describe('BCSC Client', () => {
       const mockLogger = { info: jest.fn(), error: jest.fn() }
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
+      // A plain Error (not AxiosError/AppError) is not retryable, so this exercises the
+      // single-attempt-then-fail path without needing fake timers.
       jest.spyOn(client, 'get').mockRejectedValue(new Error('Network error'))
 
       const result = await client.fetchJwk()
@@ -753,7 +765,7 @@ describe('BCSC Client', () => {
     })
 
     it('should return null when keys property is undefined', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       jest.spyOn(client, 'get').mockResolvedValue({
@@ -769,7 +781,6 @@ describe('BCSC Client', () => {
       const mockLogger = { info: jest.fn(), error: jest.fn() }
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
-      const mockJwk = { kty: 'RSA', kid: 'key-1' }
       const getSpy = jest.spyOn(client, 'get').mockResolvedValue({
         data: { keys: [mockJwk] },
       } as any)
@@ -798,6 +809,123 @@ describe('BCSC Client', () => {
       await client.fetchJwk()
 
       expect(getSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('should request the JWKS endpoint with skipOnErrorHandler set', async () => {
+      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const client = new BCSCApiClient('https://example.com', mockLogger as any)
+
+      const getSpy = jest.spyOn(client, 'get').mockResolvedValue({
+        data: { keys: [mockJwk] },
+      } as any)
+
+      await client.fetchJwk()
+
+      expect(getSpy).toHaveBeenCalledWith(
+        client.endpoints.jwksURI,
+        expect.objectContaining({ skipBearerAuth: true, skipOnErrorHandler: true })
+      )
+    })
+
+    describe('retry and persisted fallback', () => {
+      beforeEach(() => {
+        jest.useFakeTimers()
+      })
+
+      afterEach(() => {
+        jest.useRealTimers()
+      })
+
+      it('retries a transient network error up to the max attempts, then returns the persisted key', async () => {
+        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const client = new BCSCApiClient('https://example.com', mockLogger as any)
+        const networkError = new AxiosError('Network Error', 'ERR_NETWORK')
+        const getSpy = jest.spyOn(client, 'get').mockRejectedValue(networkError)
+        jest.mocked(loadPersistedJwk).mockResolvedValueOnce(mockJwk as any)
+
+        const resultPromise = client.fetchJwk()
+        // Two backoff delays between three attempts: 500ms, then 1000ms
+        await jest.advanceTimersByTimeAsync(500)
+        await jest.advanceTimersByTimeAsync(1000)
+        const result = await resultPromise
+
+        expect(getSpy).toHaveBeenCalledTimes(3)
+        expect(result).toEqual(mockJwk)
+      })
+
+      it('succeeds on a retry, caching and persisting the fresh key', async () => {
+        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const client = new BCSCApiClient('https://example.com', mockLogger as any)
+        const networkError = new AxiosError('Network Error', 'ERR_NETWORK')
+        const getSpy = jest
+          .spyOn(client, 'get')
+          .mockRejectedValueOnce(networkError)
+          .mockResolvedValueOnce({ data: { keys: [mockJwk] } } as any)
+
+        const resultPromise = client.fetchJwk()
+        await jest.advanceTimersByTimeAsync(500)
+        const result = await resultPromise
+
+        expect(result).toEqual(mockJwk)
+        expect(getSpy).toHaveBeenCalledTimes(2)
+        expect(persistJwk).toHaveBeenCalledWith('https://example.com', mockJwk, mockLogger)
+      })
+
+      it('does not retry a non-retryable 4xx error and falls back to the persisted key', async () => {
+        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const client = new BCSCApiClient('https://example.com', mockLogger as any)
+        const clientError = { cause: { response: { status: 400 } } } as any
+        const getSpy = jest.spyOn(client, 'get').mockRejectedValue(clientError)
+        jest.mocked(loadPersistedJwk).mockResolvedValueOnce(mockJwk as any)
+
+        const result = await client.fetchJwk()
+
+        expect(getSpy).toHaveBeenCalledTimes(1)
+        expect(result).toEqual(mockJwk)
+      })
+
+      it('does not retry a well-formed empty keys response and falls back to the persisted key', async () => {
+        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const client = new BCSCApiClient('https://example.com', mockLogger as any)
+        const getSpy = jest.spyOn(client, 'get').mockResolvedValue({ data: { keys: [] } } as any)
+        jest.mocked(loadPersistedJwk).mockResolvedValueOnce(mockJwk as any)
+
+        const result = await client.fetchJwk()
+
+        expect(getSpy).toHaveBeenCalledTimes(1)
+        expect(result).toEqual(mockJwk)
+      })
+
+      it('returns null when all retry attempts fail and nothing is persisted', async () => {
+        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const client = new BCSCApiClient('https://example.com', mockLogger as any)
+        const serverError = { cause: { response: { status: 503 } } } as any
+        const getSpy = jest.spyOn(client, 'get').mockRejectedValue(serverError)
+
+        const resultPromise = client.fetchJwk()
+        await jest.advanceTimersByTimeAsync(500)
+        await jest.advanceTimersByTimeAsync(1000)
+        const result = await resultPromise
+
+        expect(getSpy).toHaveBeenCalledTimes(3)
+        expect(result).toBeNull()
+      })
+
+      it('does not hydrate the in-memory cache from a persisted fallback', async () => {
+        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const client = new BCSCApiClient('https://example.com', mockLogger as any)
+        const clientError = { cause: { response: { status: 400 } } } as any
+        const getSpy = jest.spyOn(client, 'get').mockRejectedValue(clientError)
+        jest.mocked(loadPersistedJwk).mockResolvedValue(mockJwk as any)
+
+        const first = await client.fetchJwk()
+        const second = await client.fetchJwk()
+
+        expect(first).toEqual(mockJwk)
+        expect(second).toEqual(mockJwk)
+        // The network is retried on the second call too — the fallback never populated the in-memory cache.
+        expect(getSpy).toHaveBeenCalledTimes(2)
+      })
     })
   })
 

--- a/app/src/bcsc-theme/api/client.test.ts
+++ b/app/src/bcsc-theme/api/client.test.ts
@@ -964,6 +964,70 @@ describe('BCSC Client', () => {
         expect(getSpy).toHaveBeenCalledTimes(2)
       })
     })
+
+    describe('single-flight dedupe', () => {
+      beforeEach(() => {
+        jest.useFakeTimers()
+      })
+
+      afterEach(() => {
+        jest.useRealTimers()
+      })
+
+      it('joins a single in-flight fetch: two concurrent calls make exactly one request and resolve to the same key', async () => {
+        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const client = new BCSCApiClient('https://example.com', mockLogger as any)
+        const getSpy = jest.spyOn(client, 'get').mockResolvedValue({ data: { keys: [mockJwk] } } as any)
+
+        // Calling fetchJwk() twice without awaiting in between: both calls run synchronously up to
+        // their first await, so the second call's in-flight check sees the promise the first call
+        // already set and joins it instead of starting its own retry loop.
+        const [first, second] = await Promise.all([client.fetchJwk(), client.fetchJwk()])
+
+        expect(getSpy).toHaveBeenCalledTimes(1)
+        expect(first).toEqual(mockJwk)
+        expect(second).toEqual(mockJwk)
+      })
+
+      it('joins a single in-flight retry loop: concurrent calls during a failing fetch share one set of attempts', async () => {
+        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const client = new BCSCApiClient('https://example.com', mockLogger as any)
+        const networkError = new AxiosError('Network Error', 'ERR_NETWORK')
+        const getSpy = jest.spyOn(client, 'get').mockRejectedValue(networkError)
+        jest.mocked(loadPersistedJwk).mockResolvedValueOnce(mockJwk as any)
+
+        const firstPromise = client.fetchJwk()
+        const secondPromise = client.fetchJwk()
+
+        await jest.advanceTimersByTimeAsync(500)
+        await jest.advanceTimersByTimeAsync(1000)
+
+        const [first, second] = await Promise.all([firstPromise, secondPromise])
+
+        // One shared retry loop (3 attempts), not two independent ones (6 attempts).
+        expect(getSpy).toHaveBeenCalledTimes(3)
+        expect(first).toEqual(mockJwk)
+        expect(second).toEqual(mockJwk)
+      })
+
+      it('does not join an in-flight fetch started for a different baseURL', async () => {
+        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const client = new BCSCApiClient('https://example.com', mockLogger as any)
+        const getSpy = jest.spyOn(client, 'get').mockResolvedValue({ data: { keys: [mockJwk] } } as any)
+
+        const firstPromise = client.fetchJwk()
+
+        const mutableClient = client as unknown as { baseURL: string }
+        mutableClient.baseURL = 'https://example.com/other'
+
+        const secondPromise = client.fetchJwk()
+
+        await Promise.all([firstPromise, secondPromise])
+
+        // The second call didn't join the first's in-flight promise — it started its own fetch.
+        expect(getSpy).toHaveBeenCalledTimes(2)
+      })
+    })
   })
 
   describe('tokens race condition smoke test', () => {

--- a/app/src/bcsc-theme/api/client.test.ts
+++ b/app/src/bcsc-theme/api/client.test.ts
@@ -5,6 +5,7 @@ import { ErrorCategory } from '@/errors/errorRegistry'
 import { AppEventCode } from '@/events/appEventCode'
 import { BCSCEventTypes } from '@/events/eventTypes'
 import { localization } from '@/localization'
+import { Analytics } from '@/utils/analytics/analytics-singleton'
 import { initLanguages } from '@bifold/core'
 import { AxiosError } from 'axios'
 import { jwtDecode } from 'jwt-decode'
@@ -839,8 +840,17 @@ describe('BCSC Client', () => {
       it('retries a transient network error up to the max attempts, then returns the persisted key', async () => {
         const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
         const client = new BCSCApiClient('https://example.com', mockLogger as any)
-        const networkError = new AxiosError('Network Error', 'ERR_NETWORK')
-        const getSpy = jest.spyOn(client, 'get').mockRejectedValue(networkError)
+        const trackErrorEventSpy = jest.spyOn(Analytics, 'trackErrorEvent')
+
+        // Real adapter (not a `client.get` spy) so the failure flows through the response
+        // interceptor exactly as it does in production: getAppErrorFromAxiosError converts it into
+        // an AppError with appEvent NO_INTERNET, which is the actual shape isRetryableJwkFetchError's
+        // isNetworkError check receives at runtime (a hand-rolled AxiosError bypasses the interceptor
+        // and never exercises that branch).
+        client.client.defaults.adapter = (config: any) => {
+          return Promise.reject(new AxiosError('Network Error', 'ERR_NETWORK', config))
+        }
+        const axiosGetSpy = jest.spyOn(client.client, 'get')
         jest.mocked(loadPersistedJwk).mockResolvedValueOnce(mockJwk as any)
 
         const resultPromise = client.fetchJwk()
@@ -849,8 +859,15 @@ describe('BCSC Client', () => {
         await jest.advanceTimersByTimeAsync(1000)
         const result = await resultPromise
 
-        expect(getSpy).toHaveBeenCalledTimes(3)
+        expect(axiosGetSpy).toHaveBeenCalledTimes(3)
         expect(result).toEqual(mockJwk)
+        // Exactly one error log total — fetchJwk's own final-exhaustion log (it still logs this even
+        // though a persisted fallback is subsequently found). Zero of the 3 attempts came from the
+        // interceptor: suppressStatusCodeLogs (status 0 for a network error) keeps its log line and
+        // analytics tracking silent, so a transient outage isn't amplified 3x on dashboards.
+        expect(mockLogger.error).toHaveBeenCalledTimes(1)
+        expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to fetch JWK'))
+        expect(trackErrorEventSpy).not.toHaveBeenCalled()
       })
 
       it('succeeds on a retry, caching and persisting the fresh key', async () => {
@@ -899,16 +916,36 @@ describe('BCSC Client', () => {
       it('returns null when all retry attempts fail and nothing is persisted', async () => {
         const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
         const client = new BCSCApiClient('https://example.com', mockLogger as any)
-        const serverError = { cause: { response: { status: 503 } } } as any
-        const getSpy = jest.spyOn(client, 'get').mockRejectedValue(serverError)
+        const trackErrorEventSpy = jest.spyOn(Analytics, 'trackErrorEvent')
+
+        // Real adapter so a 503 flows through the response interceptor and is subject to the same
+        // suppressStatusCodeLogs gate production traffic hits.
+        client.client.defaults.adapter = (config: any) => {
+          return Promise.reject(
+            new AxiosError('Service Unavailable', 'ERR_BAD_RESPONSE', config, null, {
+              status: 503,
+              data: {},
+              statusText: 'Service Unavailable',
+              headers: {} as any,
+              config,
+            })
+          )
+        }
+        const axiosGetSpy = jest.spyOn(client.client, 'get')
 
         const resultPromise = client.fetchJwk()
         await jest.advanceTimersByTimeAsync(500)
         await jest.advanceTimersByTimeAsync(1000)
         const result = await resultPromise
 
-        expect(getSpy).toHaveBeenCalledTimes(3)
+        expect(axiosGetSpy).toHaveBeenCalledTimes(3)
         expect(result).toBeNull()
+        // Exactly one error log total — fetchJwk's own final-exhaustion log. Zero of the 3 attempts
+        // came from the interceptor (suppressed for the retryable 503), and no analytics event was
+        // tracked per attempt.
+        expect(mockLogger.error).toHaveBeenCalledTimes(1)
+        expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to fetch JWK'))
+        expect(trackErrorEventSpy).not.toHaveBeenCalled()
       })
 
       it('does not hydrate the in-memory cache from a persisted fallback', async () => {

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -32,6 +32,15 @@ const TOKEN_EXPIRY_BUFFER_MS = 30 * 1000
 const JWK_FETCH_MAX_ATTEMPTS = 3
 const JWK_FETCH_RETRY_BASE_DELAY_MS = 500
 
+// The retryable JWKS failure shapes (see isRetryableJwkFetchError): 0 for a network error (no HTTP
+// response — see the response interceptor's `error.response?.status ?? 0`), and the full 5xx range.
+// Passed as suppressStatusCodeLogs on the JWKS request so the interceptor's own log line + analytics
+// tracking (see getAppErrorFromAxiosError) don't fire on every retry attempt — fetchJwk already logs
+// a warn per retry and a single error on total exhaustion, so a transient outage isn't amplified 3x
+// across dashboards. A deterministic 4xx is a single, non-retried attempt and is left to log/track
+// normally, since it may indicate a real configuration problem worth surfacing distinctly.
+const JWK_FETCH_RETRYABLE_STATUS_CODES = [0, ...Array.from({ length: 100 }, (_, index) => 500 + index)]
+
 // Extend AxiosRequestConfig to include skipBearerAuth
 declare module 'axios' {
   export interface AxiosRequestConfig {
@@ -440,13 +449,19 @@ class BCSCApiClient {
    * genuinely has no key to offer, so retrying won't help); throws on a request failure so the
    * caller can decide whether that failure is retryable.
    *
-   * `skipOnErrorHandler` keeps the global alert policies from firing on every retry attempt —
-   * fetchJwk owns this error path end-to-end and only ever returns null on total failure.
+   * `skipOnErrorHandler` keeps the global alert policy from firing on every retry attempt.
+   * `suppressStatusCodeLogs` additionally silences the interceptor's own log line + analytics
+   * tracking for the retryable failure shapes (network / 5xx, see JWK_FETCH_RETRYABLE_STATUS_CODES)
+   * so a transient outage isn't amplified across the retry loop — fetchJwk's own logging (a warn per
+   * retry, one error on total exhaustion, one warn if a fallback is used) is the sole signal for
+   * those. A deterministic 4xx is a single, non-retried attempt and still logs/tracks normally via
+   * the interceptor, same as any other endpoint.
    */
   private async fetchJwkFromNetwork(): Promise<JWK | null> {
     const response = await this.get<JWKResponseData>(this.endpoints.jwksURI, {
       skipBearerAuth: true,
       skipOnErrorHandler: true,
+      suppressStatusCodeLogs: JWK_FETCH_RETRYABLE_STATUS_CODES,
     })
 
     if (response.data.keys && response.data.keys.length > 0) {

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -96,6 +96,8 @@ class BCSCApiClient {
   onError?: BCSCClientOnErrorCallback
   private cachedJwk: JWK | null = null // in-memory JWK cache, invalidated when baseURL changes
   private cachedJwkBaseUrl: string | null = null
+  private jwkFetchPromise: Promise<JWK | null> | null = null // single-flight in-progress JWK fetch
+  private jwkFetchPromiseBaseUrl: string | null = null // baseURL the in-flight fetch was started for
 
   constructor(baseURL: string, logger: RemoteLogger) {
     this.baseURL = baseURL
@@ -491,13 +493,21 @@ class BCSCApiClient {
    *
    * Resolution order:
    * 1. In-memory cache hit (reused while the environment / baseURL is unchanged).
-   * 2. Network fetch, retried up to JWK_FETCH_MAX_ATTEMPTS times with linear backoff — but only for
+   * 2. An in-flight fetch for the same baseURL (single-flight — see jwkFetchPromise below).
+   *    Concurrent callers — e.g. BCSCApiClientContext's fire-and-forget warm-up landing alongside
+   *    an early verification call at startup — join the same retry loop instead of each racing
+   *    their own, which would otherwise multiply network requests (up to JWK_FETCH_MAX_ATTEMPTS per
+   *    caller) during an outage.
+   * 3. Network fetch, retried up to JWK_FETCH_MAX_ATTEMPTS times with linear backoff — but only for
    *    transient errors (see isRetryableJwkFetchError); a deterministic failure or an empty key set
-   *    goes straight to step 3.
-   * 3. On network exhaustion/empty, the last-known-good persisted key (survives cold starts) — this
+   *    goes straight to step 4.
+   * 4. On network exhaustion/empty, the last-known-good persisted key (survives cold starts) — this
    *    is network-first: the fallback never hydrates the in-memory cache, so the next call retries
-   *    the network rather than trusting a potentially-rotated key indefinitely.
-   * 4. `null` — the caller fails closed (ERR_111).
+   *    the network rather than trusting a potentially-rotated key indefinitely. The in-flight
+   *    promise is cleared as soon as it settles regardless of outcome, so a fallback result is only
+   *    ever shared by callers that joined it while it was in flight — the next call always starts a
+   *    fresh attempt.
+   * 5. `null` — the caller fails closed (ERR_111).
    *
    * A successful network fetch is cached in-memory and persisted for future fallback use.
    *
@@ -508,6 +518,38 @@ class BCSCApiClient {
       return this.cachedJwk
     }
 
+    // Join an in-flight fetch for the same baseURL rather than starting a parallel retry loop. A
+    // fetch in flight for a since-changed baseURL is never joined — mirrors the baseURL check the
+    // in-memory cache above already uses.
+    if (this.jwkFetchPromise && this.jwkFetchPromiseBaseUrl === this.baseURL) {
+      return this.jwkFetchPromise
+    }
+
+    const requestBaseUrl = this.baseURL
+    this.jwkFetchPromiseBaseUrl = requestBaseUrl
+    this.jwkFetchPromise = this.fetchJwkWithRetry(requestBaseUrl).finally(() => {
+      // Only clear if this settled fetch is still the one being tracked for requestBaseUrl — guards
+      // against a late-settling fetch for an old baseURL clobbering a newer in-flight fetch that
+      // replaced it after a baseURL change.
+      if (this.jwkFetchPromiseBaseUrl === requestBaseUrl) {
+        this.jwkFetchPromise = null
+        this.jwkFetchPromiseBaseUrl = null
+      }
+    })
+
+    return this.jwkFetchPromise
+  }
+
+  /**
+   * The retry loop + persisted fallback behind fetchJwk's cache/single-flight gate above. Always
+   * resolves, never rejects — fetchJwkFromNetwork's thrown errors are caught here, and
+   * persistJwk/loadPersistedJwk never throw — so fetchJwk's shared promise is always safe to await
+   * or fire-and-forget.
+   *
+   * @param baseURL - The baseURL this fetch was started for (captured by fetchJwk at call time, not
+   *   re-read from `this.baseURL`, so a baseURL change mid-flight can't misattribute the result).
+   */
+  private async fetchJwkWithRetry(baseURL: string): Promise<JWK | null> {
     let jwk: JWK | null = null
     let lastError: unknown
 
@@ -530,8 +572,8 @@ class BCSCApiClient {
 
     if (jwk) {
       this.cachedJwk = jwk
-      this.cachedJwkBaseUrl = this.baseURL
-      await persistJwk(this.baseURL, jwk, this.logger)
+      this.cachedJwkBaseUrl = baseURL
+      await persistJwk(baseURL, jwk, this.logger)
       return jwk
     }
 
@@ -541,7 +583,7 @@ class BCSCApiClient {
       this.logger.warn('[BCSCApiClient] JWKS endpoint returned no keys')
     }
 
-    const persistedJwk = await loadPersistedJwk(this.baseURL, this.logger)
+    const persistedJwk = await loadPersistedJwk(baseURL, this.logger)
     if (persistedJwk) {
       this.logger.warn('[BCSCApiClient] last-known-good JWK used; JWKS unreachable')
       return persistedJwk

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -585,7 +585,7 @@ class BCSCApiClient {
 
     const persistedJwk = await loadPersistedJwk(baseURL, this.logger)
     if (persistedJwk) {
-      this.logger.warn('[BCSCApiClient] last-known-good JWK used; JWKS unreachable')
+      this.logger.warn('[BCSCApiClient] Live JWKS fetch failed; using persisted last-known-good JWK')
       return persistedJwk
     }
 

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -565,7 +565,8 @@ class BCSCApiClient {
           break
         }
 
-        this.logger.warn(`[BCSCApiClient] JWK fetch attempt ${attempt} failed, retrying: ${error}`)
+        const message = error instanceof Error ? error.message : String(error)
+        this.logger.warn(`[BCSCApiClient] JWK fetch attempt ${attempt} failed, retrying: ${message}`)
         await new Promise((resolve) => setTimeout(resolve, JWK_FETCH_RETRY_BASE_DELAY_MS * attempt))
       }
     }
@@ -578,7 +579,8 @@ class BCSCApiClient {
     }
 
     if (lastError) {
-      this.logger.error(`Failed to fetch JWK: ${lastError}`)
+      const lastErrorMessage = lastError instanceof Error ? lastError.message : String(lastError)
+      this.logger.error(`Failed to fetch JWK: ${lastErrorMessage}`)
     } else {
       this.logger.warn('[BCSCApiClient] JWKS endpoint returned no keys')
     }

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -13,15 +13,24 @@ import {
   formatAxiosErrorForLogger as formatIASAxiosErrorForLogger,
   formatIasAxiosResponseError,
   getAppErrorFromAxiosError,
+  isNetworkError,
 } from '../utils/axios-error-utils'
 import { AxiosAppError, ErrorMatcherContext } from './clientErrorPolicies'
 import { JWK, JWKResponseData } from './hooks/useJwksApi'
 import { TokenResponse } from './hooks/useTokens'
 import { withAccount } from './hooks/withAccountGuard'
+import { loadPersistedJwk, persistJwk } from './jwk-cache'
 
 // Refresh tokens 30 seconds before they actually expire to avoid
 // expiry-on-the-wire races when multiple requests fire near the boundary.
 const TOKEN_EXPIRY_BUFFER_MS = 30 * 1000
+
+// Bounded retry for the JWKS fetch: 3 attempts total, with linear backoff delays of
+// 500ms then 1000ms between attempts. Only transient errors (network / 5xx) are retried —
+// see isRetryableJwkFetchError. Deliberately small and bounded: this is a background warm-up
+// and an inline verification-path call, not a user-facing loading state.
+const JWK_FETCH_MAX_ATTEMPTS = 3
+const JWK_FETCH_RETRY_BASE_DELAY_MS = 500
 
 // Extend AxiosRequestConfig to include skipBearerAuth
 declare module 'axios' {
@@ -425,12 +434,57 @@ class BCSCApiClient {
   }
 
   /**
-   * Fetches the first JWK from the server's JWKS endpoint.
-   * Used for JWT signature verification.
+   * Single network attempt to fetch the first JWK from the server's JWKS endpoint.
    *
-   * The key is cached in-memory and reused while the environment (baseURL) is unchanged; the cache
-   * is invalidated automatically when baseURL changes. This keeps hot verification paths (user info,
-   * ID token decode) from issuing a network request on every call.
+   * Returns `null` on a well-formed but empty/absent `keys` response (not an error — the server
+   * genuinely has no key to offer, so retrying won't help); throws on a request failure so the
+   * caller can decide whether that failure is retryable.
+   *
+   * `skipOnErrorHandler` keeps the global alert policies from firing on every retry attempt —
+   * fetchJwk owns this error path end-to-end and only ever returns null on total failure.
+   */
+  private async fetchJwkFromNetwork(): Promise<JWK | null> {
+    const response = await this.get<JWKResponseData>(this.endpoints.jwksURI, {
+      skipBearerAuth: true,
+      skipOnErrorHandler: true,
+    })
+
+    if (response.data.keys && response.data.keys.length > 0) {
+      return response.data.keys[0]
+    }
+
+    return null
+  }
+
+  /**
+   * Gates the JWK fetch retry loop to transient failures only: a network error, or an HTTP >= 500
+   * read from the AxiosError the response interceptor attaches as `AppError.cause`. A deterministic
+   * 4xx (or any other error shape) is not retryable — retrying it would just waste the attempt budget
+   * on a request that will fail the same way every time.
+   */
+  private isRetryableJwkFetchError(error: unknown): boolean {
+    if (isNetworkError(error)) {
+      return true
+    }
+
+    const status = (error as Partial<AxiosAppError>)?.cause?.response?.status
+    return typeof status === 'number' && status >= 500
+  }
+
+  /**
+   * Fetches the first JWK from the server's JWKS endpoint. Used for JWT signature verification.
+   *
+   * Resolution order:
+   * 1. In-memory cache hit (reused while the environment / baseURL is unchanged).
+   * 2. Network fetch, retried up to JWK_FETCH_MAX_ATTEMPTS times with linear backoff — but only for
+   *    transient errors (see isRetryableJwkFetchError); a deterministic failure or an empty key set
+   *    goes straight to step 3.
+   * 3. On network exhaustion/empty, the last-known-good persisted key (survives cold starts) — this
+   *    is network-first: the fallback never hydrates the in-memory cache, so the next call retries
+   *    the network rather than trusting a potentially-rotated key indefinitely.
+   * 4. `null` — the caller fails closed (ERR_111).
+   *
+   * A successful network fetch is cached in-memory and persisted for future fallback use.
    *
    * TODO: This should probably not be in the client, move logic elsewhere.
    */
@@ -439,22 +493,46 @@ class BCSCApiClient {
       return this.cachedJwk
     }
 
-    try {
-      const response = await this.get<JWKResponseData>(this.endpoints.jwksURI, {
-        skipBearerAuth: true,
-      })
+    let jwk: JWK | null = null
+    let lastError: unknown
 
-      if (response.data.keys && response.data.keys.length > 0) {
-        this.cachedJwk = response.data.keys[0]
-        this.cachedJwkBaseUrl = this.baseURL
-        return this.cachedJwk
+    for (let attempt = 1; attempt <= JWK_FETCH_MAX_ATTEMPTS; attempt++) {
+      try {
+        jwk = await this.fetchJwkFromNetwork()
+        lastError = undefined
+        break
+      } catch (error) {
+        lastError = error
+
+        if (attempt >= JWK_FETCH_MAX_ATTEMPTS || !this.isRetryableJwkFetchError(error)) {
+          break
+        }
+
+        this.logger.warn(`[BCSCApiClient] JWK fetch attempt ${attempt} failed, retrying: ${error}`)
+        await new Promise((resolve) => setTimeout(resolve, JWK_FETCH_RETRY_BASE_DELAY_MS * attempt))
       }
-
-      return null
-    } catch (error) {
-      this.logger.error(`Failed to fetch JWK: ${error}`)
-      return null
     }
+
+    if (jwk) {
+      this.cachedJwk = jwk
+      this.cachedJwkBaseUrl = this.baseURL
+      await persistJwk(this.baseURL, jwk, this.logger)
+      return jwk
+    }
+
+    if (lastError) {
+      this.logger.error(`Failed to fetch JWK: ${lastError}`)
+    } else {
+      this.logger.warn('[BCSCApiClient] JWKS endpoint returned no keys')
+    }
+
+    const persistedJwk = await loadPersistedJwk(this.baseURL, this.logger)
+    if (persistedJwk) {
+      this.logger.warn('[BCSCApiClient] last-known-good JWK used; JWKS unreachable')
+      return persistedJwk
+    }
+
+    return null
   }
 }
 

--- a/app/src/bcsc-theme/api/client.ts
+++ b/app/src/bcsc-theme/api/client.ts
@@ -515,6 +515,9 @@ class BCSCApiClient {
    */
   async fetchJwk(): Promise<JWK | null> {
     if (this.cachedJwk && this.cachedJwkBaseUrl === this.baseURL) {
+      this.logger.info(
+        `[BCSCApiClient] JWK served from in-memory cache (kid: ${this.cachedJwk.kid}, baseURL: ${this.baseURL})`
+      )
       return this.cachedJwk
     }
 
@@ -522,6 +525,9 @@ class BCSCApiClient {
     // fetch in flight for a since-changed baseURL is never joined — mirrors the baseURL check the
     // in-memory cache above already uses.
     if (this.jwkFetchPromise && this.jwkFetchPromiseBaseUrl === this.baseURL) {
+      // Distinct from the in-memory cache-hit log above — this caller isn't getting a cached key, it's
+      // sharing an active network attempt that hasn't resolved yet.
+      this.logger.info(`[BCSCApiClient] Joining in-flight JWK fetch (baseURL: ${this.baseURL})`)
       return this.jwkFetchPromise
     }
 
@@ -574,6 +580,8 @@ class BCSCApiClient {
     if (jwk) {
       this.cachedJwk = jwk
       this.cachedJwkBaseUrl = baseURL
+      this.logger.info(`[BCSCApiClient] JWK fetched from network (kid: ${jwk.kid}, baseURL: ${baseURL})`)
+      // Logs its own success/failure — see persistJwk in jwk-cache.ts.
       await persistJwk(baseURL, jwk, this.logger)
       return jwk
     }

--- a/app/src/bcsc-theme/api/jwk-cache.test.ts
+++ b/app/src/bcsc-theme/api/jwk-cache.test.ts
@@ -1,0 +1,81 @@
+import { JWK } from '@/bcsc-theme/api/hooks/useJwksApi'
+import { loadPersistedJwk, persistJwk } from '@/bcsc-theme/api/jwk-cache'
+import { BCLocalStorageKeys } from '@/store'
+import { PersistentStorage } from '@bifold/core'
+import { RemoteLogger } from '@bifold/remote-logs'
+
+const baseURL = 'https://example.com'
+const otherBaseURL = 'https://other.example.com'
+const jwk: JWK = { kty: 'RSA', e: 'AQAB', kid: 'test-kid', alg: 'RS256', n: 'test-modulus' }
+
+// Matches the plain-object logger mock convention used elsewhere for RemoteLogger-typed params
+// (e.g. client.test.ts) — RemoteLogger has private fields, so a MockLogger instance (which extends
+// the sibling BifoldLogger base) is not structurally assignable to it.
+const createMockLogger = (): RemoteLogger =>
+  ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }) as unknown as RemoteLogger
+
+describe('jwk-cache', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('persistJwk / loadPersistedJwk round trip', () => {
+    it('loads the persisted JWK for the same baseURL it was persisted under', async () => {
+      const logger = createMockLogger()
+
+      await persistJwk(baseURL, jwk, logger)
+      const result = await loadPersistedJwk(baseURL, logger)
+
+      expect(result).toEqual(jwk)
+    })
+
+    it('returns null when the persisted record belongs to a different baseURL (environment switch)', async () => {
+      const logger = createMockLogger()
+
+      await persistJwk(baseURL, jwk, logger)
+      const result = await loadPersistedJwk(otherBaseURL, logger)
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null when nothing has been persisted', async () => {
+      const logger = createMockLogger()
+      jest.spyOn(PersistentStorage, 'fetchValueForKey').mockResolvedValueOnce(undefined)
+
+      const result = await loadPersistedJwk(baseURL, logger)
+
+      expect(result).toBeNull()
+    })
+
+    it('persists under the canonical CachedJWK storage key', async () => {
+      const logger = createMockLogger()
+      const storeSpy = jest.spyOn(PersistentStorage, 'storeValueForKey').mockResolvedValue()
+
+      await persistJwk(baseURL, jwk, logger)
+
+      expect(storeSpy).toHaveBeenCalledWith(
+        BCLocalStorageKeys.CachedJWK,
+        expect.objectContaining({ baseURL, jwk }),
+        logger
+      )
+    })
+  })
+
+  describe('storage failures are swallowed', () => {
+    it('persistJwk resolves even when storeValueForKey rejects', async () => {
+      const logger = createMockLogger()
+      jest.spyOn(PersistentStorage, 'storeValueForKey').mockRejectedValueOnce(new Error('disk full'))
+
+      await expect(persistJwk(baseURL, jwk, logger)).resolves.toBeUndefined()
+    })
+
+    it('loadPersistedJwk returns null when fetchValueForKey rejects', async () => {
+      const logger = createMockLogger()
+      jest.spyOn(PersistentStorage, 'fetchValueForKey').mockRejectedValueOnce(new Error('read error'))
+
+      const result = await loadPersistedJwk(baseURL, logger)
+
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/app/src/bcsc-theme/api/jwk-cache.ts
+++ b/app/src/bcsc-theme/api/jwk-cache.ts
@@ -30,6 +30,7 @@ export const persistJwk = async (baseURL: string, jwk: JWK, logger: RemoteLogger
 
   try {
     await PersistentStorage.storeValueForKey<PersistedJwkRecord>(BCLocalStorageKeys.CachedJWK, record, logger)
+    logger.info(`[jwk-cache] JWK persisted to disk (kid: ${jwk.kid}, baseURL: ${baseURL})`)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     logger.error(`[jwk-cache] Failed to persist JWK for ${baseURL}: ${message}`)
@@ -50,10 +51,20 @@ export const loadPersistedJwk = async (baseURL: string, logger: RemoteLogger): P
   try {
     const record = await PersistentStorage.fetchValueForKey<PersistedJwkRecord>(BCLocalStorageKeys.CachedJWK, logger)
 
-    if (record?.baseURL !== baseURL) {
+    if (!record) {
       return null
     }
 
+    if (record.baseURL !== baseURL) {
+      // Distinct from "nothing stored" (above): a record exists, just not for this environment — worth
+      // calling out so an env switch (dev/test/prod) doesn't read as an unexplained cache miss.
+      logger.info(
+        `[jwk-cache] Persisted JWK ignored — different environment (persisted baseURL: ${record.baseURL}, current baseURL: ${baseURL})`
+      )
+      return null
+    }
+
+    logger.info(`[jwk-cache] JWK loaded from persisted disk cache (kid: ${record.jwk.kid}, baseURL: ${baseURL})`)
     return record.jwk
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)

--- a/app/src/bcsc-theme/api/jwk-cache.ts
+++ b/app/src/bcsc-theme/api/jwk-cache.ts
@@ -1,0 +1,61 @@
+import { BCLocalStorageKeys } from '@/store'
+import { PersistentStorage } from '@bifold/core'
+import { RemoteLogger } from '@bifold/remote-logs'
+import { JWK } from './hooks/useJwksApi'
+
+/**
+ * Last-known-good JWK persisted to disk so a briefly-unavailable JWKS endpoint (or a cold-start
+ * fetch miss) doesn't block inner-JWS verification. Single record — only the most recently
+ * fetched key/environment pair is kept.
+ */
+export interface PersistedJwkRecord {
+  baseURL: string
+  jwk: JWK
+  fetchedAt: number // epoch ms, logging/diagnostics only — there is no TTL, this is network-first
+}
+
+/**
+ * Persists the last-known-good JWK for `baseURL`.
+ *
+ * Never throws: a storage write failure is logged and swallowed (idempotency-over-erroring) since
+ * this is best-effort caching, not a correctness requirement — `fetchJwk` already has the fresh key
+ * in-memory for the current session regardless of whether persistence succeeds.
+ *
+ * @param baseURL - The IAS environment base URL the key belongs to
+ * @param jwk - The JWK to persist
+ * @param logger - Logger used to record a failure to persist
+ */
+export const persistJwk = async (baseURL: string, jwk: JWK, logger: RemoteLogger): Promise<void> => {
+  const record: PersistedJwkRecord = { baseURL, jwk, fetchedAt: Date.now() }
+
+  try {
+    await PersistentStorage.storeValueForKey<PersistedJwkRecord>(BCLocalStorageKeys.CachedJWK, record, logger)
+  } catch (error) {
+    logger.error(`[jwk-cache] Failed to persist JWK for ${baseURL}: ${error}`)
+  }
+}
+
+/**
+ * Loads the last-known-good JWK for `baseURL`.
+ *
+ * Returns `null` when nothing has been persisted, the persisted record belongs to a different
+ * environment (baseURL mismatch — e.g. a dev/test/prod switch, where a stale key must never be
+ * used), or the read itself fails. Never throws.
+ *
+ * @param baseURL - The IAS environment base URL to match against the persisted record
+ * @param logger - Logger used to record a failure to read
+ */
+export const loadPersistedJwk = async (baseURL: string, logger: RemoteLogger): Promise<JWK | null> => {
+  try {
+    const record = await PersistentStorage.fetchValueForKey<PersistedJwkRecord>(BCLocalStorageKeys.CachedJWK, logger)
+
+    if (!record || record.baseURL !== baseURL) {
+      return null
+    }
+
+    return record.jwk
+  } catch (error) {
+    logger.error(`[jwk-cache] Failed to load persisted JWK for ${baseURL}: ${error}`)
+    return null
+  }
+}

--- a/app/src/bcsc-theme/api/jwk-cache.ts
+++ b/app/src/bcsc-theme/api/jwk-cache.ts
@@ -31,7 +31,8 @@ export const persistJwk = async (baseURL: string, jwk: JWK, logger: RemoteLogger
   try {
     await PersistentStorage.storeValueForKey<PersistedJwkRecord>(BCLocalStorageKeys.CachedJWK, record, logger)
   } catch (error) {
-    logger.error(`[jwk-cache] Failed to persist JWK for ${baseURL}: ${error}`)
+    const message = error instanceof Error ? error.message : String(error)
+    logger.error(`[jwk-cache] Failed to persist JWK for ${baseURL}: ${message}`)
   }
 }
 
@@ -49,13 +50,14 @@ export const loadPersistedJwk = async (baseURL: string, logger: RemoteLogger): P
   try {
     const record = await PersistentStorage.fetchValueForKey<PersistedJwkRecord>(BCLocalStorageKeys.CachedJWK, logger)
 
-    if (!record || record.baseURL !== baseURL) {
+    if (record?.baseURL !== baseURL) {
       return null
     }
 
     return record.jwk
   } catch (error) {
-    logger.error(`[jwk-cache] Failed to load persisted JWK for ${baseURL}: ${error}`)
+    const message = error instanceof Error ? error.message : String(error)
+    logger.error(`[jwk-cache] Failed to load persisted JWK for ${baseURL}: ${message}`)
     return null
   }
 }

--- a/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCApiClientContext.tsx
@@ -115,6 +115,11 @@ export const BCSCApiClientProvider: React.FC<{ children: React.ReactNode }> = ({
         newClient = new BCSCApiClient(store.developer.environment.iasApiBaseUrl, logger as RemoteLogger)
         await newClient.fetchEndpointsAndConfig()
 
+        // Non-blocking warm-up: primes the in-memory/persisted JWK cache so the first inner-JWS
+        // verification (user info, ID token decode) doesn't pay for a cold-start fetch. fetchJwk
+        // never throws, so fire-and-forget is safe and doesn't delay client readiness.
+        void newClient.fetchJwk()
+
         setClientAndSingleton(newClient)
       } catch (err) {
         /**

--- a/app/src/bcsc-theme/contexts/BCSCApiClientProvider.test.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCApiClientProvider.test.tsx
@@ -76,6 +76,59 @@ describe('BCSCApiClientProvider', () => {
     })
   })
 
+  it('should warm up the JWK cache once, after fetchEndpointsAndConfig resolves', async () => {
+    const bifoldMock = jest.mocked(Bifold)
+    const bcscApiClientMock = jest.mocked(BCSCApiClient)
+    const factoryResetMock = jest.mocked(FactoryReset)
+
+    const mockStore: any = {
+      stateLoaded: true,
+      developer: {
+        environment: {
+          iasApiBaseUrl: 'https://example.com',
+        },
+      },
+      bcscSecure: {
+        refreshToken: 'mockRefreshToken',
+        additionalEvidenceData: [],
+      },
+      bcsc: {},
+    }
+
+    const mockLogger = new MockLogger()
+    const dispatchMock = jest.fn()
+    const callOrder: string[] = []
+
+    factoryResetMock.useFactoryReset.mockReturnValue(jest.fn())
+    bifoldMock.useServices.mockReturnValue([mockLogger])
+    bifoldMock.useStore.mockReturnValue([mockStore, dispatchMock])
+
+    bcscApiClientMock.prototype.fetchEndpointsAndConfig = jest.fn().mockImplementation(async () => {
+      callOrder.push('fetchEndpointsAndConfig')
+    })
+    bcscApiClientMock.prototype.fetchJwk = jest.fn().mockImplementation(async () => {
+      callOrder.push('fetchJwk')
+      return null
+    })
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <ErrorAlertProvider>
+        <BCSCStackProvider>
+          <BCSCApiClientProvider>{children}</BCSCApiClientProvider>
+        </BCSCStackProvider>
+      </ErrorAlertProvider>
+    )
+
+    const { result } = renderHook(() => useContext(BCSCApiClientContext), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current?.isClientReady).toBe(true)
+      expect(bcscApiClientMock.prototype.fetchJwk).toHaveBeenCalledTimes(1)
+    })
+
+    expect(callOrder).toEqual(['fetchEndpointsAndConfig', 'fetchJwk'])
+  })
+
   it('should not initialize if store.stateLoaded is false', async () => {
     const bifoldMock = jest.mocked(Bifold)
     const bcscApiClientMock = jest.mocked(BCSCApiClient)
@@ -316,6 +369,7 @@ describe('BCSCApiClientProvider', () => {
       () =>
         ({
           fetchEndpointsAndConfig: fetchMock,
+          fetchJwk: jest.fn().mockResolvedValue(null),
           setErrorHandler: jest.fn(),
           baseURL: store.developer.environment.iasApiBaseUrl,
         }) as any

--- a/app/src/bcsc-theme/utils/axios-error-utils.test.ts
+++ b/app/src/bcsc-theme/utils/axios-error-utils.test.ts
@@ -1,4 +1,5 @@
 import { ErrorRegistry } from '@/errors/errorRegistry'
+import { Analytics } from '@/utils/analytics/analytics-singleton'
 import {
   formatAxiosErrorForLogger,
   formatIasAxiosResponseError,
@@ -83,6 +84,71 @@ describe('Error Utils', () => {
       const appError = getAppErrorFromAxiosError(axiosError)
 
       expect(appError.url).toBeUndefined()
+    })
+
+    // A status pre-declared via suppressStatusCodeLogs is treated as "expected"/already-owned-
+    // elsewhere (e.g. a caller that retries internally and reports its own summary, like
+    // BCSCApiClient.fetchJwk) — analytics tracking is skipped for it too, not just the response
+    // interceptor's own log line, so retries don't inflate dashboards once per attempt.
+    describe('analytics tracking suppression via suppressStatusCodeLogs', () => {
+      beforeEach(() => {
+        jest.restoreAllMocks()
+      })
+
+      it('should skip analytics tracking when the response status is pre-declared', () => {
+        const trackErrorEventSpy = jest.spyOn(Analytics, 'trackErrorEvent')
+        const axiosError = {
+          code: 'ERR_BAD_RESPONSE',
+          message: 'Service Unavailable',
+          config: { suppressStatusCodeLogs: [503] },
+          response: { data: {}, status: 503 },
+        } as any
+
+        getAppErrorFromAxiosError(axiosError)
+
+        expect(trackErrorEventSpy).not.toHaveBeenCalled()
+      })
+
+      it('should skip analytics tracking for a network error (status 0) when 0 is pre-declared', () => {
+        const trackErrorEventSpy = jest.spyOn(Analytics, 'trackErrorEvent')
+        const axiosError = {
+          code: 'ERR_NETWORK',
+          message: 'Network Error',
+          config: { suppressStatusCodeLogs: [0] },
+        } as any
+
+        getAppErrorFromAxiosError(axiosError)
+
+        expect(trackErrorEventSpy).not.toHaveBeenCalled()
+      })
+
+      it('should track analytics normally when the status is not pre-declared', () => {
+        const trackErrorEventSpy = jest.spyOn(Analytics, 'trackErrorEvent')
+        const axiosError = {
+          code: 'ERR_BAD_RESPONSE',
+          message: 'Service Unavailable',
+          config: { suppressStatusCodeLogs: [404] },
+          response: { data: {}, status: 503 },
+        } as any
+
+        getAppErrorFromAxiosError(axiosError)
+
+        expect(trackErrorEventSpy).toHaveBeenCalled()
+      })
+
+      it('should track analytics normally when suppressStatusCodeLogs is not set', () => {
+        const trackErrorEventSpy = jest.spyOn(Analytics, 'trackErrorEvent')
+        const axiosError = {
+          code: 'ERR_BAD_RESPONSE',
+          message: 'Service Unavailable',
+          config: {},
+          response: { data: {}, status: 503 },
+        } as any
+
+        getAppErrorFromAxiosError(axiosError)
+
+        expect(trackErrorEventSpy).toHaveBeenCalled()
+      })
     })
   })
 

--- a/app/src/bcsc-theme/utils/axios-error-utils.ts
+++ b/app/src/bcsc-theme/utils/axios-error-utils.ts
@@ -230,6 +230,12 @@ export const getAxiosErrorDefinition = (errorCode?: string, status?: number): Er
 /**
  * Converts an AxiosError into a structured AppError based on the error code and app event mappings.
  *
+ * A status pre-declared in `error.config.suppressStatusCodeLogs` (e.g. a routine polling 404, or a
+ * retryable failure a caller already reports on its own — see BCSCApiClient.fetchJwk) is treated as
+ * "expected"/already-owned-elsewhere: analytics tracking is skipped for it too, not just the response
+ * interceptor's own log line, so a caller that retries internally doesn't inflate dashboards once per
+ * attempt.
+ *
  * @param error - The AxiosError to convert
  * @returns The resulting AppError with structured information and cause
  */
@@ -238,11 +244,14 @@ export const getAppErrorFromAxiosError = (error: AxiosError): AppError => {
   const errorDefinition =
     getAxiosErrorDefinition(errorCode, error.response?.status) ?? getErrorDefinitionFromAppEventCode(errorCode)
 
+  const statusCode = error.response?.status ?? 0
+  const track = !(error.config?.suppressStatusCodeLogs ?? []).includes(statusCode)
+
   let appError: AppError
 
   // If we have a predefined error definition for this app event code, use it to create the AppError
   if (errorDefinition) {
-    appError = AppError.fromErrorDefinition(errorDefinition, { cause: error })
+    appError = AppError.fromErrorDefinition(errorDefinition, { cause: error, track })
   } else if (isAppEventCode(errorCode)) {
     // Create a generic AppError for known event codes that don't have a predefined error definition
     appError = new AppError(
@@ -251,11 +260,12 @@ export const getAppErrorFromAxiosError = (error: AxiosError): AppError => {
         ...ErrorRegistry.UNKNOWN_SERVER_ERROR,
         appEvent: errorCode,
       },
-      { cause: error }
+      { cause: error, track }
     )
   } else {
     appError = new AppError(`Server Error: Unknown error code (${errorCode})`, ErrorRegistry.UNKNOWN_SERVER_ERROR, {
       cause: error,
+      track,
     })
   }
   // http://x.com is a dummy domain so relative paths still parse correctly

--- a/app/src/store.tsx
+++ b/app/src/store.tsx
@@ -336,6 +336,7 @@ export enum BCLocalStorageKeys {
   DeviceToken = 'deviceToken',
   BCSC = 'BCSC',
   Mode = 'Mode',
+  CachedJWK = 'CachedJWK',
 }
 
 export const initialState: BCState = {


### PR DESCRIPTION
## What

The BC Services Card app fetches a public key (JWK) from the server to verify that user-info and ID-token data it decrypts really came from the server. Today that key isn't saved anywhere, so the app has to fetch it fresh every single time — and if that one fetch has a brief hiccup, the app blocks the user instead of retrying.

This change makes that key fetch resilient: it retries a few times on a brief network blip, and it remembers the last good key on the device so a short server outage doesn't interrupt a user's flow.

## Why

A recent change (#3988) added this signature check to protect user data, but it introduced a new dependency on the key-fetch endpoint being available at that exact moment. A momentary blip there was enough to block a flow that previously didn't depend on it at all. This change removes that fragility without weakening the security check itself — a genuinely bad signature still fails safely, exactly as before.

## Decisions

- Reworked `BCSCApiClient.fetchJwk()` (`app/src/bcsc-theme/api/client.ts`) into: in-memory cache hit → bounded network retry → persist on success → persisted last-known-good fallback on failure.
- New `app/src/bcsc-theme/api/jwk-cache.ts` persists the key via Bifold's `PersistentStorage` (AsyncStorage-backed), keyed by `baseURL`, under a new `CachedJWK` entry in `BCLocalStorageKeys` (`app/src/store.tsx`). Never throws — a storage failure is logged and swallowed.
- **Storage tier: AsyncStorage, not native secure storage.** The JWK is the server's *public* key — no PII, no secret. Worst case, a tampered/stale value simply fails signature verification (fails closed).
- **Retry:** 3 attempts total, 500ms/1000ms linear backoff, gated to transient failures only (network error or HTTP ≥ 500). A deterministic 4xx or a well-formed empty key set goes straight to the persisted fallback rather than retrying.
- **Network-first, no TTL on the persisted key:** the fallback is only used when the live network fetch fails, and it never hydrates the in-memory cache — the next call always retries the network first. A rotated-and-stale persisted key during an outage still fails closed on signature mismatch (ERR_112).
- The JWKS request now sets `skipOnErrorHandler: true` so `fetchJwk` owns its error path end-to-end, instead of firing the global alert policy on every retry attempt.
- Warm-up: `BCSCApiClientContext` now fires a non-blocking `fetchJwk()` right after the client configures, so the cache is primed before the first verification needs it (fire-and-forget — `fetchJwk` never throws).
- No changes to any caller (`useUserApi`, `useTokens`, `FcmViewModel`) — all consume the same `Promise<JWK | null>` signature, and the ERR_111 (no key available) / ERR_112 (signature mismatch) semantics are untouched.
- Evaluated reusing the app's existing file-cache mechanisms (OCA bundle resolver, indy-vdr ledger cache) per a reviewer suggestion on the issue — neither exposes a general key/value API, so this uses Bifold's `PersistentStorage` instead, which is already the app's convention for this kind of small persisted value.
- **Deferred (out of scope for this PR, per issue discussion):** strict `kid` matching / multi-key support — the client still selects `keys[0]`, and the inner JWS `kid` is only visible after native JWE decryption, so this would require native (`packages/bcsc-core`) changes. Filed as a follow-up rather than bundled here. Also out of scope: refetching mid-session on an ERR_112 (rotation-during-session).
- Affects the `bcsc` build target only — the `store.tsx` change is an additive enum key with no `bcwallet` behavior impact.

## Manual Testing

Run the app, observe the logs, you'll see it fetch, save, and use the cached key:
```
[BCSCApiClient] JWK fetched from network (kid: dcs_rsa2, baseURL: https://idsit.gov.bc.ca)  
console.js:661 [jwk-cache] JWK persisted to disk (kid: dcs_rsa2, baseURL: https://idsit.gov.bc.ca)  
```

```
[BCSCApiClient] JWK served from in-memory cache (kid: dcs_rsa2, baseURL: https://idsit.gov.bc.ca)  
```

## Tests

- New `app/src/bcsc-theme/api/jwk-cache.test.ts`: persist/load round trip, `baseURL` mismatch (environment switch) returns null, nothing-stored returns null, storage read/write rejections are swallowed.
- Extended `describe('fetchJwk', ...)` in `app/src/bcsc-theme/api/client.test.ts`: retry-to-3-attempts-then-fallback, success-on-retry (caches + persists), non-retryable 4xx (single attempt then fallback), empty keys (no retry, fallback), all-attempts-exhausted-with-nothing-persisted (returns `null`, preserving the existing ERR_111 path), persisted fallback never hydrates the in-memory cache, `skipOnErrorHandler: true` is set on the request. Pre-existing cache-hit / baseURL-invalidation tests pass unchanged.
- Extended `BCSCApiClientProvider.test.tsx`: successful client configuration triggers exactly one `fetchJwk` warm-up call, after `fetchEndpointsAndConfig`.
- `yarn check` (typecheck, lint, format, full test suite) passes for everything touched. `packages/bcsc-core/ios/BcscCore.swift` fails the local SwiftFormat lint step, but that file isn't part of this diff (last touched in an unrelated, already-merged PR) — pre-existing local noise, not introduced here.

## Verification

- Full app test suite: 278/278 suites, 2710/2710 tests, 159/159 snapshots passing.
- Manual: point `IAS_URL` at an environment, kill connectivity briefly during app launch (or right before a user-info/ID-token decode), confirm the app still verifies using the previously-persisted key instead of failing with ERR_111; confirm a genuinely bad signature still fails closed with ERR_112.

Fixes #4097
