### PR TITLE
fix: prevent camera errors when app backgrounded

### DIFF
--- a/app/src/bcsc-theme/components/CodeScanningCamera.test.tsx
+++ b/app/src/bcsc-theme/components/CodeScanningCamera.test.tsx
@@ -1,9 +1,11 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import { Platform } from 'react-native'
+import { useCameraDevice, useCameraPermission, useCodeScanner } from 'react-native-vision-camera'
 
 import { AppEventCode } from '@/events/appEventCode'
 import { BasicAppContext } from '@mocks/helpers/app'
+import { useBCSCActivity } from '../contexts/BCSCActivityContext'
 import CodeScanningCamera, { ScanZone } from './CodeScanningCamera'
 import { BCSC_SN_SCAN_ZONES } from './utils/camera'
 
@@ -25,10 +27,8 @@ jest.mock('@/errors/errorHandler', () => ({
 
 // Mock react-native-vision-camera
 jest.mock('react-native-vision-camera', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const React = require('react')
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { View } = require('react-native')
+  const React = jest.requireActual('react')
+  const { View } = jest.requireActual('react-native')
 
   // Forward ref Camera component mock
   // eslint-disable-next-line react/display-name
@@ -132,6 +132,12 @@ jest.mock('react-native-gesture-handler', () => ({
   GestureDetector: ({ children }: any) => children,
 }))
 
+// Typed handles to the mocked hooks above, for use in test bodies
+const mockedUseBCSCActivity = useBCSCActivity as jest.Mock
+const mockedUseCameraDevice = useCameraDevice as jest.Mock
+const mockedUseCameraPermission = useCameraPermission as jest.Mock
+const mockedUseCodeScanner = useCodeScanner as jest.Mock
+
 describe('CodeScanningCamera', () => {
   const mockOnCodeScanned = jest.fn()
   const defaultProps = {
@@ -146,9 +152,7 @@ describe('CodeScanningCamera', () => {
     mockEmitErrorModal.mockClear()
     // Reset to the default 'active' state in case a previous test overrode it —
     // jest.clearAllMocks() clears call history but not a mockReturnValue implementation.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { useBCSCActivity } = require('../contexts/BCSCActivityContext')
-    useBCSCActivity.mockReturnValue({
+    mockedUseBCSCActivity.mockReturnValue({
       appStateStatus: 'active',
       pauseActivityTracking: mockPauseActivityTracking,
       resumeActivityTracking: mockResumeActivityTracking,
@@ -196,9 +200,7 @@ describe('CodeScanningCamera', () => {
       </BasicAppContext>
     )
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { useCodeScanner } = require('react-native-vision-camera')
-    expect(useCodeScanner).toHaveBeenCalledWith(
+    expect(mockedUseCodeScanner).toHaveBeenCalledWith(
       expect.objectContaining({
         codeTypes: expect.arrayContaining(['code-128', 'pdf-417']),
       })
@@ -230,13 +232,11 @@ describe('CodeScanningCamera', () => {
   describe('Camera Permission', () => {
     it('renders permission required message when no permission', () => {
       // Mock no permission
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const visionCamera = require('react-native-vision-camera')
-      visionCamera.useCameraPermission.mockReturnValueOnce({
+      mockedUseCameraPermission.mockReturnValueOnce({
         hasPermission: false,
         requestPermission: mockRequestPermission,
       })
-      visionCamera.useCameraDevice.mockReturnValueOnce(null)
+      mockedUseCameraDevice.mockReturnValueOnce(null)
 
       const { getByText } = render(
         <BasicAppContext>
@@ -248,9 +248,7 @@ describe('CodeScanningCamera', () => {
     })
 
     it('requests permission when not granted', () => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const visionCamera = require('react-native-vision-camera')
-      visionCamera.useCameraPermission.mockReturnValueOnce({
+      mockedUseCameraPermission.mockReturnValueOnce({
         hasPermission: false,
         requestPermission: mockRequestPermission,
       })
@@ -356,9 +354,7 @@ describe('CodeScanningCamera', () => {
         </BasicAppContext>
       )
 
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { useCodeScanner } = require('react-native-vision-camera')
-      expect(useCodeScanner).toHaveBeenCalledWith(
+      expect(mockedUseCodeScanner).toHaveBeenCalledWith(
         expect.objectContaining({
           codeTypes: ['code-39', 'code-128', 'pdf-417'],
           onCodeScanned: expect.any(Function),
@@ -1009,9 +1005,7 @@ describe('CodeScanningCamera', () => {
 
   describe('Device without focus support', () => {
     it('renders correctly when device does not support focus', () => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const visionCamera = require('react-native-vision-camera')
-      visionCamera.useCameraDevice.mockReturnValueOnce({
+      mockedUseCameraDevice.mockReturnValueOnce({
         id: 'back',
         supportsFocus: false,
         minZoom: 1,
@@ -1524,9 +1518,7 @@ describe('CodeScanningCamera', () => {
     })
 
     it('ignores camera errors and does not show an error modal while the app is backgrounded', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { useBCSCActivity } = require('../contexts/BCSCActivityContext')
-      useBCSCActivity.mockReturnValue({
+      mockedUseBCSCActivity.mockReturnValue({
         appStateStatus: 'background',
         pauseActivityTracking: mockPauseActivityTracking,
         resumeActivityTracking: mockResumeActivityTracking,

--- a/app/src/bcsc-theme/components/CodeScanningCamera.test.tsx
+++ b/app/src/bcsc-theme/components/CodeScanningCamera.test.tsx
@@ -144,6 +144,15 @@ describe('CodeScanningCamera', () => {
     mockHasPermission = true
     mockCodeScannerCallback = null
     mockEmitErrorModal.mockClear()
+    // Reset to the default 'active' state in case a previous test overrode it —
+    // jest.clearAllMocks() clears call history but not a mockReturnValue implementation.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { useBCSCActivity } = require('../contexts/BCSCActivityContext')
+    useBCSCActivity.mockReturnValue({
+      appStateStatus: 'active',
+      pauseActivityTracking: mockPauseActivityTracking,
+      resumeActivityTracking: mockResumeActivityTracking,
+    })
   })
 
   it('renders correctly with default props', () => {
@@ -1512,6 +1521,34 @@ describe('CodeScanningCamera', () => {
         'BCSC.CameraDisclosure.ErrorMessage',
         expectedAppError
       )
+    })
+
+    it('ignores camera errors and does not show an error modal while the app is backgrounded', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { useBCSCActivity } = require('../contexts/BCSCActivityContext')
+      useBCSCActivity.mockReturnValue({
+        appStateStatus: 'background',
+        pauseActivityTracking: mockPauseActivityTracking,
+        resumeActivityTracking: mockResumeActivityTracking,
+      })
+
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <CodeScanningCamera {...defaultProps} />
+        </BasicAppContext>
+      )
+
+      const camera = getByTestId('mock-camera')
+      const runtimeError = new Error('Runtime camera failure while backgrounded')
+
+      await act(async () => {
+        camera.props.onError(runtimeError)
+      })
+
+      // Backgrounded camera errors are expected (the session is being torn down) and not
+      // actionable — no error should be normalized or surfaced to the user.
+      expect(mockEnsureAppError).not.toHaveBeenCalled()
+      expect(mockEmitErrorModal).not.toHaveBeenCalled()
     })
   })
 })

--- a/app/src/bcsc-theme/components/CodeScanningCamera.tsx
+++ b/app/src/bcsc-theme/components/CodeScanningCamera.tsx
@@ -30,6 +30,7 @@ import {
   Camera,
   CameraCaptureError,
   CameraProps,
+  CameraRuntimeError,
   Code,
   CodeScannerFrame,
   CodeType,
@@ -186,7 +187,7 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
   const { ColorPalette, Spacing } = useTheme()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const { emitErrorModal } = useErrorAlert()
-  const { pauseActivityTracking, resumeActivityTracking } = useBCSCActivity()
+  const { appStateStatus, pauseActivityTracking, resumeActivityTracking } = useBCSCActivity()
   const camera = useRef<Camera>(null)
   const [torchEnabled, setTorchEnabled] = useState(false)
   // When `torchActive`/`onToggleTorch` are provided, the parent owns torch state.
@@ -900,7 +901,13 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
   }, [initialZoom, getEffectiveZoom, logger, device, format, zoom, cameraIsReady])
 
   const handleCameraError = useCallback(
-    (error: unknown) => {
+    (error: CameraRuntimeError) => {
+      if (appStateStatus === 'background') {
+        // Ignore camera errors when the app is in the background — they are expected and not actionable.
+        logger.info('[CodeScanningCamera] Camera error ignored while app is in background')
+        return
+      }
+
       logger.error('CodeScanningCamera runtime error', error as Error)
       emitErrorModal(
         t('BCSC.CameraDisclosure.Error'),
@@ -908,7 +915,7 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
         ensureAppError(error, AppEventCode.ADD_CARD_CAMERA_BROKEN)
       )
     },
-    [logger, emitErrorModal, t]
+    [appStateStatus, logger, emitErrorModal, t]
   )
 
   const handleSaveScanZones = useCallback(() => {
@@ -1172,7 +1179,7 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
           logger.debug('Camera container size', { width, height })
         }}
       >
-        {/* 
+        {/*
             resizeMode="cover" fills the container without black bars by cropping the camera feed.
             The coordinate transformation logic accounts for the cropped portion to ensure
             highlight boxes align correctly with visible barcodes.

--- a/app/src/bcsc-theme/components/MaskedCamera.test.tsx
+++ b/app/src/bcsc-theme/components/MaskedCamera.test.tsx
@@ -1,0 +1,143 @@
+import { act, render } from '@testing-library/react-native'
+import React from 'react'
+
+import { AppEventCode } from '@/events/appEventCode'
+import { useNavigation } from '@mocks/custom/@react-navigation/core'
+import { BasicAppContext } from '@mocks/helpers/app'
+import MaskedCamera from './MaskedCamera'
+
+const mockTakePhoto = jest.fn().mockResolvedValue({ path: '/tmp/photo.jpg' })
+const mockEmitErrorModal = jest.fn()
+const mockEnsureAppError = jest.fn<{ name: string; message: string }, [unknown, AppEventCode]>(() => ({
+  name: 'AppError',
+  message: 'mocked error',
+}))
+
+jest.mock('@/errors/errorHandler', () => ({
+  ensureAppError: (error: unknown, eventCode: AppEventCode) => mockEnsureAppError(error, eventCode),
+}))
+
+// useAlerts pulls in a heavy dependency chain (factory reset, stack context, etc.) unrelated
+// to camera error handling — stub the one function MaskedCamera actually calls.
+jest.mock('@/hooks/useAlerts', () => ({
+  useAlerts: jest.fn(() => ({
+    failedToWriteToLocalStorageAlert: jest.fn(),
+  })),
+}))
+
+// Mock react-native-vision-camera — overrides the silent default mock from jestSetup.js so the
+// Camera renders into the tree (with its onError prop reachable) and reports a real device.
+jest.mock('react-native-vision-camera', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const React = require('react')
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { View } = require('react-native')
+
+  // Forward ref Camera component mock
+  // eslint-disable-next-line react/display-name
+  const MockCamera = React.forwardRef(({ children, ...props }: any, ref: any) => {
+    React.useImperativeHandle(ref, () => ({
+      takePhoto: mockTakePhoto,
+    }))
+
+    return (
+      <View testID="mock-camera" {...props}>
+        {children}
+      </View>
+    )
+  })
+
+  return {
+    Camera: MockCamera,
+    useCameraDevice: jest.fn(() => ({
+      id: 'back',
+      hasTorch: true,
+    })),
+    useCameraFormat: jest.fn(() => ({
+      maxFps: 30,
+    })),
+    CameraCaptureError: class CameraCaptureError extends Error {
+      code: string
+      constructor(code: string, message: string) {
+        super(message)
+        this.code = code
+      }
+    },
+  }
+})
+
+// Mock BCSCActivityContext — not provided by BasicAppContext
+const mockUseBCSCActivity = jest.fn(() => ({ appStateStatus: 'active' }))
+jest.mock('../contexts/BCSCActivityContext', () => ({
+  useBCSCActivity: () => mockUseBCSCActivity(),
+}))
+
+// Mock ErrorAlertContext for camera runtime error handling
+jest.mock('@/contexts/ErrorAlertContext', () => {
+  const actual = jest.requireActual('@/contexts/ErrorAlertContext')
+  return {
+    ...actual,
+    useErrorAlert: jest.fn(() => ({
+      emitErrorModal: mockEmitErrorModal,
+    })),
+  }
+})
+
+describe('MaskedCamera', () => {
+  const mockOnPhotoTaken = jest.fn()
+  let mockNavigation: ReturnType<typeof useNavigation>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseBCSCActivity.mockReturnValue({ appStateStatus: 'active' })
+    mockNavigation = useNavigation()
+  })
+
+  const renderCamera = () => {
+    return render(
+      <BasicAppContext>
+        <MaskedCamera navigation={mockNavigation as never} cameraFace="back" onPhotoTaken={mockOnPhotoTaken} />
+      </BasicAppContext>
+    )
+  }
+
+  describe('Camera runtime error handling', () => {
+    it('shows an error modal when camera onError fires while the app is active', async () => {
+      const { getByTestId } = renderCamera()
+
+      const camera = getByTestId('mock-camera')
+      const runtimeError = new Error('Runtime camera failure')
+      const expectedAppError = { name: 'NormalizedAppError', message: 'normalized' }
+      mockEnsureAppError.mockReturnValueOnce(expectedAppError)
+
+      await act(async () => {
+        camera.props.onError(runtimeError)
+      })
+
+      expect(mockEnsureAppError).toHaveBeenCalledWith(runtimeError, AppEventCode.ADD_CARD_CAMERA_BROKEN)
+      expect(mockEmitErrorModal).toHaveBeenCalledWith(
+        'BCSC.CameraDisclosure.Error',
+        'BCSC.CameraDisclosure.ErrorMessage',
+        expectedAppError
+      )
+    })
+
+    it('ignores camera errors and does not show an error modal while the app is backgrounded', async () => {
+      mockUseBCSCActivity.mockReturnValue({ appStateStatus: 'background' })
+
+      const { getByTestId } = renderCamera()
+
+      const camera = getByTestId('mock-camera')
+      const runtimeError = new Error('Runtime camera failure while backgrounded')
+
+      await act(async () => {
+        camera.props.onError(runtimeError)
+      })
+
+      // Backgrounded camera errors are expected (the session is being torn down) and not
+      // actionable — no error should be normalized or surfaced to the user.
+      expect(mockEnsureAppError).not.toHaveBeenCalled()
+      expect(mockEmitErrorModal).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/app/src/bcsc-theme/components/MaskedCamera.test.tsx
+++ b/app/src/bcsc-theme/components/MaskedCamera.test.tsx
@@ -28,10 +28,8 @@ jest.mock('@/hooks/useAlerts', () => ({
 // Mock react-native-vision-camera — overrides the silent default mock from jestSetup.js so the
 // Camera renders into the tree (with its onError prop reachable) and reports a real device.
 jest.mock('react-native-vision-camera', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const React = require('react')
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { View } = require('react-native')
+  const React = jest.requireActual('react')
+  const { View } = jest.requireActual('react-native')
 
   // Forward ref Camera component mock
   // eslint-disable-next-line react/display-name

--- a/app/src/bcsc-theme/components/MaskedCamera.tsx
+++ b/app/src/bcsc-theme/components/MaskedCamera.tsx
@@ -26,6 +26,7 @@ import {
   useCameraDevice,
   useCameraFormat,
 } from 'react-native-vision-camera'
+import { useBCSCActivity } from '../contexts/BCSCActivityContext'
 
 type MaskedCameraProps = {
   navigation: NavigationProp<ParamListBase>
@@ -70,6 +71,7 @@ const MaskedCamera = ({
   const { failedToWriteToLocalStorageAlert } = useAlerts(navigation)
   const { emitErrorModal } = useErrorAlert()
   const { preventDoublePress } = usePreventDoublePress()
+  const { appStateStatus } = useBCSCActivity()
   const hasTorch = device?.hasTorch ?? false
 
   const styles = StyleSheet.create({
@@ -132,6 +134,12 @@ const MaskedCamera = ({
 
   const onError = useCallback(
     (error: unknown) => {
+      if (appStateStatus === 'background') {
+        // Ignore camera errors when the app is in the background — they are expected and not actionable.
+        logger.info('[MaskedCamera] Camera error ignored while app is in background')
+        return
+      }
+
       logger.error('MaskedCamera runtime error', error as Error)
       emitErrorModal(
         t('BCSC.CameraDisclosure.Error'),
@@ -139,7 +147,7 @@ const MaskedCamera = ({
         ensureAppError(error, AppEventCode.ADD_CARD_CAMERA_BROKEN)
       )
     },
-    [logger, emitErrorModal, t]
+    [appStateStatus, logger, emitErrorModal, t]
   )
   if (!device) {
     return (

--- a/app/src/bcsc-theme/features/verify/TakePhotoScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/TakePhotoScreen.test.tsx
@@ -12,6 +12,15 @@ jest.mock('react-native-vision-camera', () => ({
   CameraRuntimeError: class extends Error {},
 }))
 
+// MaskedCamera reads appStateStatus from BCSCActivityContext, which BasicAppContext doesn't provide.
+jest.mock('@/bcsc-theme/contexts/BCSCActivityContext', () => ({
+  useBCSCActivity: jest.fn().mockReturnValue({
+    appStateStatus: 'active',
+    pauseActivityTracking: jest.fn(),
+    resumeActivityTracking: jest.fn(),
+  }),
+}))
+
 describe('TakePhoto', () => {
   let mockNavigation: any
 

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.test.tsx
@@ -7,6 +7,15 @@ import { render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import EvidenceCaptureScreen from './EvidenceCaptureScreen'
 
+// MaskedCamera reads appStateStatus from BCSCActivityContext, which BasicAppContext doesn't provide.
+jest.mock('@/bcsc-theme/contexts/BCSCActivityContext', () => ({
+  useBCSCActivity: jest.fn().mockReturnValue({
+    appStateStatus: 'active',
+    pauseActivityTracking: jest.fn(),
+    resumeActivityTracking: jest.fn(),
+  }),
+}))
+
 describe('EvidenceCapture', () => {
   let mockNavigation: any
 


### PR DESCRIPTION
# Summary of Changes

Prevent camera errors while the app is backgrounded

# Testing Instructions

1. Scan card
2. Wait for screen to timeout
3. Check logs (below screenshot)
4. Repeat - took me about 6 times for it to error on Android.
5. Resume app with no error modal

<img width="525" height="84" alt="image" src="https://github.com/user-attachments/assets/ce5f0603-acb1-44e9-b346-a88e7fce7178" />

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues
https://github.com/bcgov/bc-wallet-mobile/issues/4259
