### PR TITLE
fix: prevent 2822 account-not-found alert on source device after account removal post-transfer

### DIFF
--- a/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.test.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.test.tsx
@@ -47,6 +47,16 @@ const createDeferredGetAccount = () => {
   return { promise, resolve }
 }
 
+// Same pattern as createDeferredGetAccount, for holding the createDeviceSignedJWT() await
+// "in flight" so a test can control exactly when the signed JWT comes back.
+const createDeferredJwt = () => {
+  let resolve!: (value: string) => void
+  const promise = new Promise<string>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
 describe('TransferQRDisplayScreen', () => {
   let mockNavigation: any
 
@@ -443,6 +453,43 @@ describe('TransferQRDisplayScreen', () => {
       } finally {
         process.off('unhandledRejection', onUnhandledRejection)
       }
+    })
+  })
+
+  // Copilot-flagged follow-up for issue #4273: createToken() guarded after `await
+  // getAccount()` but not after the subsequent `await createDeviceSignedJWT(...)`. Add the
+  // symmetric guard so a screen unmounted (or a transfer completed) while the JWT signing
+  // await was in flight doesn't apply a stale QR update on the way back out.
+  describe('post-JWT-signing guard (issue #4273 follow-up)', () => {
+    it('does not apply a pending QR update after unmount when createDeviceSignedJWT resolves late', async () => {
+      jest.mocked(getAccount).mockResolvedValueOnce(mockAccount)
+
+      const deferredJwt = createDeferredJwt()
+      jest.mocked(createDeviceSignedJWT).mockReturnValueOnce(deferredJwt.promise)
+
+      const { unmount } = render(
+        <BasicAppContext>
+          <TransferQRDisplayScreen />
+        </BasicAppContext>
+      )
+
+      await waitFor(() => {
+        expect(createDeviceSignedJWT).toHaveBeenCalledTimes(1)
+      })
+
+      unmount()
+
+      // The in-flight JWT signing resolves after teardown, as it would if the native signer
+      // answered late. Without the post-JWT guard, the continuation would still run
+      // jwtDecode/setQRValue/setIsLoading against an unmounted screen.
+      await act(async () => {
+        deferredJwt.resolve('late-signed-jwt')
+      })
+
+      // The guard must short-circuit before any of the post-JWT work — jwtDecode is the
+      // first thing that work does, so it not being called proves setQRValue/setIsLoading
+      // (and the QR value/render they'd produce) never ran either.
+      expect(jwtDecode).not.toHaveBeenCalled()
     })
   })
 })

--- a/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.test.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.test.tsx
@@ -395,4 +395,54 @@ describe('TransferQRDisplayScreen', () => {
       expect(mockNavigation.navigate).toHaveBeenCalledTimes(1)
     })
   })
+
+  // Copilot-flagged follow-up for issue #4273: createToken() can *throw* (rather than
+  // resolve null) when the native module is asked about an account mid-removal. Both call
+  // sites (refreshToken's await, and the QR-refresh interval's fire-and-forget call) must
+  // contain that rejection instead of leaking it as an unhandled promise rejection.
+  describe('createToken rejection handling (issue #4273 follow-up)', () => {
+    it('contains a createToken rejection during refresh: no unhandled rejection and the QR-refresh interval is not started', async () => {
+      const unhandledRejections: unknown[] = []
+      const onUnhandledRejection = (reason: unknown) => {
+        unhandledRejections.push(reason)
+      }
+      process.on('unhandledRejection', onUnhandledRejection)
+
+      try {
+        const rejectionError = new Error('native storage error')
+        jest.mocked(getAccount).mockRejectedValueOnce(rejectionError)
+
+        render(
+          <BasicAppContext>
+            <TransferQRDisplayScreen />
+          </BasicAppContext>
+        )
+
+        await waitFor(() => {
+          expect(getAccount).toHaveBeenCalledTimes(1)
+        })
+
+        // Give the rejection's microtask chain a chance to surface as an unhandled rejection,
+        // as it would if refreshToken's try/catch didn't contain it (refreshToken is invoked
+        // un-awaited from both the mount effect and the "Get New QR Code" button).
+        await act(async () => {
+          await Promise.resolve()
+          await Promise.resolve()
+        })
+
+        expect(unhandledRejections).toHaveLength(0)
+
+        // A failed refresh must not start the QR-refresh interval — advancing well past the
+        // 50s mark should produce no further getAccount() calls.
+        await act(async () => {
+          jest.advanceTimersByTime(150000)
+        })
+
+        expect(getAccount).toHaveBeenCalledTimes(1)
+        expect(mockAccountNotFoundAlert).not.toHaveBeenCalled()
+      } finally {
+        process.off('unhandledRejection', onUnhandledRejection)
+      }
+    })
+  })
 })

--- a/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.test.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.test.tsx
@@ -35,6 +35,18 @@ const mockAccount = {
   clientID: 'mock-client-id',
 }
 
+// Resolves manually so a test can hold a getAccount() call "in flight" and control exactly
+// when (and with what value) it settles relative to unmount/completion.
+type GetAccountResult = Awaited<ReturnType<typeof getAccount>>
+
+const createDeferredGetAccount = () => {
+  let resolve!: (value: GetAccountResult) => void
+  const promise = new Promise<GetAccountResult>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
 describe('TransferQRDisplayScreen', () => {
   let mockNavigation: any
 
@@ -281,6 +293,106 @@ describe('TransferQRDisplayScreen', () => {
       expect(calledWithJti).toBeDefined()
       expect(typeof calledWithJti).toBe('string')
       expect(calledWithJti.length).toBeGreaterThan(0)
+    })
+  })
+
+  // Regression coverage for issue #4273: on the source device, an in-flight createToken()
+  // call could resolve *after* the screen unmounted (or after the transfer completed),
+  // reinstalling an orphaned QR-refresh interval or firing the account-not-found (2822)
+  // alert from a screen that no longer legitimately owns the check.
+  describe('unmount and completion races (issue #4273)', () => {
+    it('does not leave an orphaned QR-refresh interval running when unmounted while createToken is in flight', async () => {
+      const deferred = createDeferredGetAccount()
+      jest.mocked(getAccount).mockReturnValueOnce(deferred.promise)
+
+      const { unmount } = render(
+        <BasicAppContext>
+          <TransferQRDisplayScreen />
+        </BasicAppContext>
+      )
+
+      expect(getAccount).toHaveBeenCalledTimes(1)
+
+      unmount()
+
+      // The in-flight call resolves after teardown, as it would if the native module answered
+      // late. Without the isMountedRef guard, refreshToken would still call startInterval()
+      // here, installing a new 50s interval that nothing would ever clear.
+      await act(async () => {
+        deferred.resolve(mockAccount)
+      })
+
+      await act(async () => {
+        jest.advanceTimersByTime(150000)
+      })
+
+      // No orphaned interval means no further getAccount()/alert activity, ever.
+      expect(getAccount).toHaveBeenCalledTimes(1)
+      expect(mockAccountNotFoundAlert).not.toHaveBeenCalled()
+    })
+
+    it('does not show the account not found alert when an in-flight createToken resolves null after unmount', async () => {
+      const deferred = createDeferredGetAccount()
+      jest.mocked(getAccount).mockReturnValueOnce(deferred.promise)
+
+      const { unmount } = render(
+        <BasicAppContext>
+          <TransferQRDisplayScreen />
+        </BasicAppContext>
+      )
+
+      unmount()
+
+      await act(async () => {
+        deferred.resolve(null)
+      })
+
+      expect(mockAccountNotFoundAlert).not.toHaveBeenCalled()
+    })
+
+    it('does not show the account not found alert when an in-flight createToken resolves null after the transfer has completed', async () => {
+      jest.mocked(getAccount).mockResolvedValueOnce(mockAccount)
+      mockCheckAttestationStatus.mockResolvedValue(false)
+
+      render(
+        <BasicAppContext>
+          <TransferQRDisplayScreen />
+        </BasicAppContext>
+      )
+
+      await waitFor(() => {
+        expect(createDeviceSignedJWT).toHaveBeenCalledTimes(1)
+      })
+
+      const deferred = createDeferredGetAccount()
+      jest.mocked(getAccount).mockReturnValueOnce(deferred.promise)
+
+      // The QR-refresh interval ticks, kicking off a second createToken() call that suspends
+      // on the still-pending getAccount().
+      await act(async () => {
+        jest.advanceTimersByTime(50000)
+      })
+
+      expect(getAccount).toHaveBeenCalledTimes(2)
+
+      // The transfer completes: the next attestation poll resolves true, latching
+      // completedRef and navigating away while the second createToken() call is still pending.
+      mockCheckAttestationStatus.mockResolvedValue(true)
+      await act(async () => {
+        jest.advanceTimersByTime(3000)
+      })
+
+      await waitFor(() => {
+        expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.TransferAccountSuccess)
+      })
+
+      // The stale createToken() call finally resolves with null, well after completion latched.
+      await act(async () => {
+        deferred.resolve(null)
+      })
+
+      expect(mockAccountNotFoundAlert).not.toHaveBeenCalled()
+      expect(mockNavigation.navigate).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
@@ -94,6 +94,11 @@ const TransferQRDisplayScreen: React.FC = () => {
       jti: newJti,
     })
 
+    if (completedRef.current || !isMountedRef.current) {
+      logger.info('[TransferQRDisplayScreen] Skipping QR token creation: transfer completed or screen unmounted')
+      return false
+    }
+
     // Ensure we are using the correct JTI in case the createDeviceSignedJWT method
     // uses a fallback JTI instead of our provided one or mutates it in-place
     const decoded = jwtDecode<{ jti?: string }>(jwt)

--- a/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
@@ -38,6 +38,7 @@ const TransferQRDisplayScreen: React.FC = () => {
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
   const attestationIntervalRef = useRef<NodeJS.Timeout | null>(null)
   const completedRef = useRef(false)
+  const isMountedRef = useRef(true)
   const [isLoading, setIsLoading] = useState(true)
   const navigation = useNavigation<StackNavigationProp<BCSCMainStackParams>>()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
@@ -66,8 +67,15 @@ const TransferQRDisplayScreen: React.FC = () => {
   })
 
   const createToken = useCallback(async (): Promise<boolean> => {
+    if (completedRef.current || !isMountedRef.current) {
+      return false
+    }
     const timeInSeconds = Math.floor(Date.now() / 1000)
     const account = await getAccount()
+    if (completedRef.current || !isMountedRef.current) {
+      logger.info('[TransferQRDisplayScreen] Skipping QR token creation: transfer completed or screen unmounted')
+      return false
+    }
     if (!account) {
       logger.error('[TransferQRDisplayScreen] Account not found in native storage')
       accountNotFoundAlert()
@@ -122,7 +130,7 @@ const TransferQRDisplayScreen: React.FC = () => {
       clearInterval(intervalRef.current)
     }
     intervalRef.current = setInterval(() => {
-      if (completedRef.current) {
+      if (completedRef.current || !isMountedRef.current) {
         return
       }
       createToken()
@@ -138,10 +146,16 @@ const TransferQRDisplayScreen: React.FC = () => {
     }
 
     const success = await createToken()
-    if (success && !completedRef.current) {
+    if (success && !completedRef.current && isMountedRef.current) {
       startInterval()
     }
   }, [createToken, startInterval])
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
 
   useEffect(() => {
     refreshToken()

--- a/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferer/TransferQRDisplayScreen.tsx
@@ -133,9 +133,11 @@ const TransferQRDisplayScreen: React.FC = () => {
       if (completedRef.current || !isMountedRef.current) {
         return
       }
-      createToken()
+      createToken().catch((error) => {
+        logger.error('[TransferQRDisplayScreen] Failed to refresh QR token on interval', error as Error)
+      })
     }, qrCodeRefreshInterval)
-  }, [createToken])
+  }, [createToken, logger])
 
   const refreshToken = useCallback(async () => {
     if (completedRef.current) {
@@ -145,11 +147,18 @@ const TransferQRDisplayScreen: React.FC = () => {
       clearInterval(intervalRef.current)
     }
 
-    const success = await createToken()
+    let success = false
+    try {
+      success = await createToken()
+    } catch (error) {
+      logger.error('[TransferQRDisplayScreen] Failed to refresh QR token', error as Error)
+      return
+    }
+
     if (success && !completedRef.current && isMountedRef.current) {
       startInterval()
     }
-  }, [createToken, startInterval])
+  }, [createToken, startInterval, logger])
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## What

When transferring an account to a new device, the source device shows a QR code while the transfer completes in the background. In one intermittent case, after the transfer finished and the user removed the account from the source device (via "Remove Account"), a critical "account not found" error popped up — even though everything had actually worked correctly. This was confusing and alarming for users, since it looked like a real problem right after they'd just successfully finished the transfer.

## Why

The QR-display screen refreshes its QR code roughly every 50 seconds by checking the account and generating a new signed token. If the screen was torn down (navigated away from, or the account was removed) while one of those checks was still in progress, the check could finish *after* teardown and — in rare timing windows — end up installing a new background timer that nothing was left to clean up. That orphaned timer kept ticking every 50 seconds; once the account was gone, its next check found nothing and raised the critical error from whatever screen happened to be showing at the time (typically the app's intro screen). This was reported in Grafana as error code 2822 and confirmed against the user's report (RP3B-9BQE).

## Decisions

- Root cause confirmed: `accountNotFoundAlert()` in `TransferQRDisplayScreen`'s `createToken()` is the only app-wide trigger for error 2822. The 50s QR-refresh interval could leak past unmount when an in-flight `createToken()` resolved after the screen's cleanup ran, because `refreshToken()`'s post-`createToken` check only guarded on `completedRef`, not on whether the screen was still mounted.
- Fix: added an `isMountedRef` latch, checked (alongside the existing `completedRef` transfer-completed latch) at the top of `createToken`, again immediately after the `await getAccount()` suspension point (state can change while that await is pending), in `refreshToken`'s post-`createToken` restart decision, and in the QR-refresh interval's tick callback.
- A `null` account seen after unmount or after the transfer already completed is now treated as an expected, idempotent no-op (logged at `info`), not an error. A `null` account seen while the screen is actively mounted and displaying the QR code still raises the alert unchanged — that case is a genuine problem and needed to keep working exactly as before.
- Scope was kept to the transferer (source device) QR screen only, per the plan — no changes to alerting/error-registry code, i18n, native code, or the transferee side. No render-output changes (confirmed no snapshot diff).

## Tests

Added three regression tests to `TransferQRDisplayScreen.test.tsx` using a deferred (manually-resolved) `getAccount` mock to simulate the race:
- An in-flight `createToken()` that resolves successfully *after* unmount no longer installs an orphaned refresh interval (`getAccount` called exactly once total, even after advancing fake timers 150s).
- An in-flight `createToken()` that resolves with `null` *after* unmount does not raise the alert.
- An in-flight `createToken()` that resolves with `null` *after* the transfer has already completed (attestation confirmed, navigated away) does not raise the alert.

Before committing these, I confirmed each one actually fails against the pre-fix code (e.g., `getAccount` called 4 times instead of 1 in the leaked-interval case) to make sure they genuinely exercise the bug, then confirmed all 15 tests in the file pass with the fix restored.

Full verification: `yarn typecheck`, `yarn lint:app`, `bcsc-core`'s `lint:ts`, both workspaces' TS `format:check`, and the full `yarn test` suite (280 suites / 2717 tests / 159 snapshots) all pass. `yarn check`'s Swift lint step fails on pre-existing `packages/bcsc-core/ios/BcscCore.swift` findings unrelated to this change (confirmed byte-identical to latest `origin/main`), consistent with a known local SwiftFormat false-fail.

## Verification

1. Start a transfer from an old device to a new device and let it complete normally on the source (old) device.
2. Immediately after the transfer completes, tap "Remove Account" on the source device.
3. Confirm no "account not found" critical error appears.
4. Leave the transfer QR screen open and idle for several minutes without removing the account — confirm the QR code still refreshes normally and no spurious errors appear.

#4273
