### PR TITLE
feat: added error modals for tos and web view component

### DIFF
--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.test.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.test.tsx
@@ -130,6 +130,90 @@ describe('TermsOfUseContent', () => {
     expect(tree.queryByTestId('mocked-webview')).toBeNull()
   })
 
+  it('shows the error modal and retry button when the terms response has no content once outer document tags are stripped', async () => {
+    const useApiMock = jest.mocked(useApi)
+    useApiMock.mockReturnValue({
+      config: {
+        getTermsOfUse: jest.fn().mockResolvedValue({
+          ...mockTermsOfUseResponse,
+          html: '<!DOCTYPE html><html><head></head><body></body></html>',
+        }),
+        getServerStatus: jest.fn(),
+      },
+    } as any)
+
+    const tree = render(
+      <BasicAppContext>
+        <TermsOfUseContent onAccept={jest.fn()} />
+      </BasicAppContext>
+    )
+
+    await waitFor(() => {
+      expect(tree.getByTestId(testIdWithKey('RetryTermsOfUse'))).toBeTruthy()
+    })
+
+    expect(tree.getByText('Alerts.TermsOfUseLoadFailed.Title')).toBeTruthy()
+    expect(tree.getByText('Alerts.TermsOfUseLoadFailed.Description')).toBeTruthy()
+    expect(tree.queryByTestId('mocked-webview')).toBeNull()
+  })
+
+  it('does not show an error while the initial fetch is still in flight', () => {
+    const useApiMock = jest.mocked(useApi)
+    useApiMock.mockReturnValue({
+      config: {
+        getTermsOfUse: jest.fn().mockReturnValue(new Promise(() => {})), // never resolves
+        getServerStatus: jest.fn(),
+      },
+    } as any)
+
+    const tree = render(
+      <BasicAppContext>
+        <TermsOfUseContent onAccept={jest.fn()} />
+      </BasicAppContext>
+    )
+
+    // Regression check: termsOfUse is still null at this point because the fetch hasn't
+    // resolved yet, which must not be mistaken for a "loaded but empty" error.
+    expect(tree.queryByTestId(testIdWithKey('RetryTermsOfUse'))).toBeNull()
+    expect(tree.queryByText('Alerts.TermsOfUseLoadFailed.Title')).toBeNull()
+  })
+
+  it('re-fetches terms and hides the error modal when Retry succeeds after empty HTML', async () => {
+    const getTermsOfUse = jest
+      .fn()
+      .mockResolvedValueOnce({ ...mockTermsOfUseResponse, html: '   ' })
+      .mockResolvedValueOnce(mockTermsOfUseResponse)
+    const useApiMock = jest.mocked(useApi)
+    useApiMock.mockReturnValue({
+      config: {
+        getTermsOfUse,
+        getServerStatus: jest.fn(),
+      },
+    } as any)
+
+    const tree = render(
+      <BasicAppContext>
+        <TermsOfUseContent onAccept={jest.fn()} />
+      </BasicAppContext>
+    )
+
+    await waitFor(() => {
+      expect(tree.getByTestId(testIdWithKey('HeaderText'))).toBeTruthy()
+    })
+
+    // The error modal overlays the whole screen, so the user must dismiss it
+    // before the Retry button underneath is reachable.
+    fireEvent.press(tree.getByTestId(testIdWithKey('CloseButton')))
+    fireEvent.press(tree.getByTestId(testIdWithKey('RetryTermsOfUse')))
+
+    await waitFor(() => {
+      expect(tree.queryByTestId('mocked-webview')).toBeTruthy()
+    })
+
+    expect(getTermsOfUse).toHaveBeenCalledTimes(2)
+    expect(tree.queryByTestId(testIdWithKey('HeaderText'))).toBeNull()
+  })
+
   it('dismisses the error modal without clearing the retry button', async () => {
     const useApiMock = jest.mocked(useApi)
     useApiMock.mockReturnValue({

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.test.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.test.tsx
@@ -106,6 +106,30 @@ describe('TermsOfUseContent', () => {
     expect(tree.getByText('Alerts.TermsOfUseLoadFailed.Description')).toBeTruthy()
   })
 
+  it('shows the error modal and retry button when the terms response has empty HTML', async () => {
+    const useApiMock = jest.mocked(useApi)
+    useApiMock.mockReturnValue({
+      config: {
+        getTermsOfUse: jest.fn().mockResolvedValue({ ...mockTermsOfUseResponse, html: '   ' }),
+        getServerStatus: jest.fn(),
+      },
+    } as any)
+
+    const tree = render(
+      <BasicAppContext>
+        <TermsOfUseContent onAccept={jest.fn()} />
+      </BasicAppContext>
+    )
+
+    await waitFor(() => {
+      expect(tree.getByTestId(testIdWithKey('RetryTermsOfUse'))).toBeTruthy()
+    })
+
+    expect(tree.getByText('Alerts.TermsOfUseLoadFailed.Title')).toBeTruthy()
+    expect(tree.getByText('Alerts.TermsOfUseLoadFailed.Description')).toBeTruthy()
+    expect(tree.queryByTestId('mocked-webview')).toBeNull()
+  })
+
   it('dismisses the error modal without clearing the retry button', async () => {
     const useApiMock = jest.mocked(useApi)
     useApiMock.mockReturnValue({

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.test.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.test.tsx
@@ -79,7 +79,7 @@ describe('TermsOfUseContent', () => {
     )
 
     await waitFor(() => {
-      expect(tree.getByTestId('com.ariesbifold:id/RetryTermsOfUse')).toBeTruthy()
+      expect(tree.getByTestId(testIdWithKey('RetryTermsOfUse'))).toBeTruthy()
     })
   })
 
@@ -128,7 +128,7 @@ describe('TermsOfUseContent', () => {
     fireEvent.press(tree.getByTestId(testIdWithKey('CloseButton')))
 
     expect(tree.queryByTestId(testIdWithKey('HeaderText'))).toBeNull()
-    expect(tree.getByTestId('com.ariesbifold:id/RetryTermsOfUse')).toBeTruthy()
+    expect(tree.getByTestId(testIdWithKey('RetryTermsOfUse'))).toBeTruthy()
   })
 
   it('re-fetches terms and hides the error modal when Retry succeeds', async () => {
@@ -157,7 +157,7 @@ describe('TermsOfUseContent', () => {
     // The error modal overlays the whole screen, so the user must dismiss it
     // before the Retry button underneath is reachable.
     fireEvent.press(tree.getByTestId(testIdWithKey('CloseButton')))
-    fireEvent.press(tree.getByTestId('com.ariesbifold:id/RetryTermsOfUse'))
+    fireEvent.press(tree.getByTestId(testIdWithKey('RetryTermsOfUse')))
 
     await waitFor(() => {
       expect(tree.queryByTestId('mocked-webview')).toBeTruthy()
@@ -182,7 +182,7 @@ describe('TermsOfUseContent', () => {
 
     // Simulate the webview finishing loading to enable the accept button
     fireEvent(tree.getByTestId('mocked-webview'), 'load')
-    fireEvent.press(tree.getByTestId('com.ariesbifold:id/AcceptAndContinue'))
+    fireEvent.press(tree.getByTestId(testIdWithKey('AcceptAndContinue')))
 
     await waitFor(() => {
       expect(onAccept).toHaveBeenCalledWith(mockTermsOfUseResponse)

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.test.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.test.tsx
@@ -1,4 +1,5 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
+import { testIdWithKey } from '@bifold/core'
 import { BasicAppContext } from '@mocks/helpers/app'
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
@@ -80,6 +81,90 @@ describe('TermsOfUseContent', () => {
     await waitFor(() => {
       expect(tree.getByTestId('com.ariesbifold:id/RetryTermsOfUse')).toBeTruthy()
     })
+  })
+
+  it('shows the error modal with the correct title and description on load failure', async () => {
+    const useApiMock = jest.mocked(useApi)
+    useApiMock.mockReturnValue({
+      config: {
+        getTermsOfUse: jest.fn().mockRejectedValue(new Error('Network error')),
+        getServerStatus: jest.fn(),
+      },
+    } as any)
+
+    const tree = render(
+      <BasicAppContext>
+        <TermsOfUseContent onAccept={jest.fn()} />
+      </BasicAppContext>
+    )
+
+    await waitFor(() => {
+      expect(tree.getByTestId(testIdWithKey('HeaderText'))).toBeTruthy()
+    })
+
+    expect(tree.getByText('Alerts.TermsOfUseLoadFailed.Title')).toBeTruthy()
+    expect(tree.getByText('Alerts.TermsOfUseLoadFailed.Description')).toBeTruthy()
+  })
+
+  it('dismisses the error modal without clearing the retry button', async () => {
+    const useApiMock = jest.mocked(useApi)
+    useApiMock.mockReturnValue({
+      config: {
+        getTermsOfUse: jest.fn().mockRejectedValue(new Error('Network error')),
+        getServerStatus: jest.fn(),
+      },
+    } as any)
+
+    const tree = render(
+      <BasicAppContext>
+        <TermsOfUseContent onAccept={jest.fn()} />
+      </BasicAppContext>
+    )
+
+    await waitFor(() => {
+      expect(tree.getByTestId(testIdWithKey('HeaderText'))).toBeTruthy()
+    })
+
+    fireEvent.press(tree.getByTestId(testIdWithKey('CloseButton')))
+
+    expect(tree.queryByTestId(testIdWithKey('HeaderText'))).toBeNull()
+    expect(tree.getByTestId('com.ariesbifold:id/RetryTermsOfUse')).toBeTruthy()
+  })
+
+  it('re-fetches terms and hides the error modal when Retry succeeds', async () => {
+    const getTermsOfUse = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockResolvedValueOnce(mockTermsOfUseResponse)
+    const useApiMock = jest.mocked(useApi)
+    useApiMock.mockReturnValue({
+      config: {
+        getTermsOfUse,
+        getServerStatus: jest.fn(),
+      },
+    } as any)
+
+    const tree = render(
+      <BasicAppContext>
+        <TermsOfUseContent onAccept={jest.fn()} />
+      </BasicAppContext>
+    )
+
+    await waitFor(() => {
+      expect(tree.getByTestId(testIdWithKey('HeaderText'))).toBeTruthy()
+    })
+
+    // The error modal overlays the whole screen, so the user must dismiss it
+    // before the Retry button underneath is reachable.
+    fireEvent.press(tree.getByTestId(testIdWithKey('CloseButton')))
+    fireEvent.press(tree.getByTestId('com.ariesbifold:id/RetryTermsOfUse'))
+
+    await waitFor(() => {
+      expect(tree.queryByTestId('mocked-webview')).toBeTruthy()
+    })
+
+    expect(getTermsOfUse).toHaveBeenCalledTimes(2)
+    expect(tree.queryByTestId(testIdWithKey('HeaderText'))).toBeNull()
   })
 
   it('calls onAccept with the loaded terms when accept is pressed', async () => {

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.tsx
@@ -63,11 +63,16 @@ export const TermsOfUseContent = ({ onAccept, headerText }: TermsOfUseContentPro
       setError(false)
       setTermsOfUse(data)
     } catch (err) {
-      logger.error('Failed to fetch Terms of Use', err instanceof Error ? err : new Error(String(err)))
+      const normalizedError = err instanceof Error ? err : new Error(String(err))
+      logger.error('Failed to fetch Terms of Use', normalizedError)
       setError(true)
       // using translation tools directly causes an infinite re render loop
       // pass in the translated strings to avoid this
-      emitErrorModal(loadFailedTitle, loadFailedDescription, ensureAppError(err, AppEventCode.TERMS_OF_USE_LOAD_FAILED))
+      emitErrorModal(
+        loadFailedTitle,
+        loadFailedDescription,
+        ensureAppError(normalizedError, AppEventCode.TERMS_OF_USE_LOAD_FAILED)
+      )
     } finally {
       setIsLoading(false)
     }

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.tsx
@@ -3,6 +3,9 @@ import { TermsOfUseResponseData } from '@/bcsc-theme/api/hooks/useConfigApi'
 import { ContentShadow } from '@/bcsc-theme/components/ContentShadow'
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import { createTermsOfUseHtml } from '@/bcsc-theme/utils/webview-utils'
+import { useErrorAlert } from '@/contexts/ErrorAlertContext'
+import { ensureAppError } from '@/errors/errorHandler'
+import { AppEventCode } from '@/events/appEventCode'
 import {
   Button,
   ButtonType,
@@ -42,11 +45,14 @@ export const TermsOfUseContent = ({ onAccept, headerText }: TermsOfUseContentPro
   const { Spacing, ColorPalette, TextTheme } = useTheme()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const { config } = useApi()
+  const { emitErrorModal } = useErrorAlert()
   const [termsOfUse, setTermsOfUse] = useState<TermsOfUseResponseData | null>(null)
   const [webViewIsLoaded, setWebViewIsLoaded] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState(false)
   const { fontScale } = useWindowDimensions()
+  const loadFailedTitle = t('Alerts.TermsOfUseLoadFailed.Title')
+  const loadFailedDescription = t('Alerts.TermsOfUseLoadFailed.Description')
 
   const fetchTermsOfUse = useCallback(async () => {
     try {
@@ -57,10 +63,11 @@ export const TermsOfUseContent = ({ onAccept, headerText }: TermsOfUseContentPro
     } catch (err) {
       logger.error('Failed to fetch Terms of Use', err instanceof Error ? err : new Error(String(err)))
       setError(true)
+      emitErrorModal(loadFailedTitle, loadFailedDescription, ensureAppError(err, AppEventCode.TERMS_OF_USE_LOAD_FAILED))
     } finally {
       setIsLoading(false)
     }
-  }, [config, logger])
+  }, [config, logger, emitErrorModal, loadFailedTitle, loadFailedDescription])
 
   useEffect(() => {
     fetchTermsOfUse()
@@ -116,8 +123,8 @@ export const TermsOfUseContent = ({ onAccept, headerText }: TermsOfUseContentPro
       <ScreenWrapper padded={false} controls={controls} scrollViewContainerStyle={styles.scrollContainer}>
         <View style={styles.loadingContainer}>
           {error && !isLoading ? (
-            <View style={{ flexDirection: 'row' }}>
-              <ThemedText style={{ flexWrap: 'wrap', flexShrink: 1, textAlign: 'center' }}>
+            <View style={{ width: '100%' }}>
+              <ThemedText style={{ textAlign: 'center', flexShrink: 1, flexWrap: 'wrap' }}>
                 {t('BCSC.Onboarding.TermsOfUseLoadError')}
               </ThemedText>
             </View>

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.tsx
@@ -2,7 +2,7 @@ import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { TermsOfUseResponseData } from '@/bcsc-theme/api/hooks/useConfigApi'
 import { ContentShadow } from '@/bcsc-theme/components/ContentShadow'
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
-import { createTermsOfUseHtml } from '@/bcsc-theme/utils/webview-utils'
+import { createTermsOfUseHtml, stripOuterDocumentTags } from '@/bcsc-theme/utils/webview-utils'
 import { useErrorAlert } from '@/contexts/ErrorAlertContext'
 import { ensureAppError } from '@/errors/errorHandler'
 import { AppEventCode } from '@/events/appEventCode'
@@ -17,7 +17,7 @@ import {
   useTheme,
 } from '@bifold/core'
 import { a11yLabel } from '@utils/accessibility'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, StyleSheet, useWindowDimensions, View } from 'react-native'
 import { WebViewContent } from '../webview/WebViewContent'
@@ -53,20 +53,20 @@ export const TermsOfUseContent = ({ onAccept, headerText }: TermsOfUseContentPro
   const { fontScale } = useWindowDimensions()
   const loadFailedTitle = t('Alerts.TermsOfUseLoadFailed.Title')
   const loadFailedDescription = t('Alerts.TermsOfUseLoadFailed.Description')
+  const resolvedHeaderText = headerText ?? t('BCSC.Onboarding.TermsOfUseHeader')
 
   const fetchTermsOfUse = useCallback(async () => {
     try {
       setIsLoading(true)
       const data = await config.getTermsOfUse()
 
-      if (!data.html?.trim()) {
-        throw new Error('Terms of Use response contained empty HTML content')
-      }
       setError(false)
       setTermsOfUse(data)
     } catch (err) {
       logger.error('Failed to fetch Terms of Use', err instanceof Error ? err : new Error(String(err)))
       setError(true)
+      // using translation tools directly causes an infinite re render loop
+      // pass in the translated strings to avoid this
       emitErrorModal(loadFailedTitle, loadFailedDescription, ensureAppError(err, AppEventCode.TERMS_OF_USE_LOAD_FAILED))
     } finally {
       setIsLoading(false)
@@ -88,6 +88,39 @@ export const TermsOfUseContent = ({ onAccept, headerText }: TermsOfUseContentPro
       alignItems: 'center',
     },
   })
+
+  const termsOfUseHtml = useMemo(() => {
+    // check if html is an empty string after clean up
+    if (!termsOfUse || stripOuterDocumentTags(termsOfUse.html) === '') {
+      return null
+    }
+
+    return createTermsOfUseHtml(
+      {
+        termsOfUse,
+        colorPalette: ColorPalette,
+        textColor: TextTheme.normal.color,
+        headerText: resolvedHeaderText,
+        subtitlePrefix: t('BCSC.Onboarding.TermsOfUseSubtitle'),
+        versionLabel: t('BCSC.Onboarding.TermsOfUseVersion'),
+      },
+      fontScale
+    )
+  }, [termsOfUse, ColorPalette, TextTheme.normal.color, resolvedHeaderText, t, fontScale])
+
+  useEffect(() => {
+    // shortcut to wait for the api response to land
+    if (!termsOfUse || termsOfUseHtml) {
+      return
+    }
+
+    const err = new Error('Terms of Use response contained empty HTML content')
+    logger.error('Failed to fetch Terms of Use', err)
+    setError(true)
+    // using translation tools directly causes an infinite re render loop
+    // pass in the translated strings to avoid this
+    emitErrorModal(loadFailedTitle, loadFailedDescription, ensureAppError(err, AppEventCode.TERMS_OF_USE_LOAD_FAILED))
+  }, [termsOfUse, termsOfUseHtml, logger, emitErrorModal, loadFailedTitle, loadFailedDescription])
 
   const controls = (
     <View style={{ width: '100%' }}>
@@ -122,7 +155,7 @@ export const TermsOfUseContent = ({ onAccept, headerText }: TermsOfUseContentPro
     </View>
   )
 
-  if (!termsOfUse) {
+  if (!termsOfUse || !termsOfUseHtml) {
     return (
       <ScreenWrapper padded={false} controls={controls} scrollViewContainerStyle={styles.scrollContainer}>
         <View style={styles.loadingContainer}>
@@ -147,20 +180,7 @@ export const TermsOfUseContent = ({ onAccept, headerText }: TermsOfUseContentPro
       controls={controls}
       scrollViewContainerStyle={styles.scrollContainer}
     >
-      <WebViewContent
-        html={createTermsOfUseHtml(
-          {
-            termsOfUse,
-            colorPalette: ColorPalette,
-            textColor: TextTheme.normal.color,
-            headerText: headerText ?? t('BCSC.Onboarding.TermsOfUseHeader'),
-            subtitlePrefix: t('BCSC.Onboarding.TermsOfUseSubtitle'),
-            versionLabel: t('BCSC.Onboarding.TermsOfUseVersion'),
-          },
-          fontScale
-        )}
-        onLoaded={() => setWebViewIsLoaded(true)}
-      />
+      <WebViewContent html={termsOfUseHtml} onLoaded={() => setWebViewIsLoaded(true)} />
     </ScreenWrapper>
   )
 }

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.tsx
@@ -120,7 +120,7 @@ export const TermsOfUseContent = ({ onAccept, headerText }: TermsOfUseContentPro
     }
 
     const err = new Error('Terms of Use response contained empty HTML content')
-    logger.error('Failed to fetch Terms of Use', err)
+    logger.error(err.message, err)
     setError(true)
     // using translation tools directly causes an infinite re render loop
     // pass in the translated strings to avoid this

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.tsx
@@ -58,6 +58,10 @@ export const TermsOfUseContent = ({ onAccept, headerText }: TermsOfUseContentPro
     try {
       setIsLoading(true)
       const data = await config.getTermsOfUse()
+      // data.html = ''
+      if (!data.html?.trim()) {
+        throw new Error('Terms of Use response contained empty HTML content')
+      }
       setError(false)
       setTermsOfUse(data)
     } catch (err) {

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.tsx
@@ -58,7 +58,7 @@ export const TermsOfUseContent = ({ onAccept, headerText }: TermsOfUseContentPro
     try {
       setIsLoading(true)
       const data = await config.getTermsOfUse()
-      // data.html = ''
+
       if (!data.html?.trim()) {
         throw new Error('Terms of Use response contained empty HTML content')
       }

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.test.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.test.tsx
@@ -1,7 +1,7 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { BCLocalStorageKeys } from '@/store'
-import { PersistentStorage } from '@bifold/core'
+import { PersistentStorage, testIdWithKey } from '@bifold/core'
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
@@ -50,7 +50,7 @@ describe('TermsOfUseScreen', () => {
 
     // Simulate the webview finishing loading to enable the accept button
     fireEvent(tree.getByTestId('mocked-webview'), 'load')
-    fireEvent.press(tree.getByTestId('com.ariesbifold:id/AcceptAndContinue'))
+    fireEvent.press(tree.getByTestId(testIdWithKey('AcceptAndContinue')))
 
     return tree
   }

--- a/app/src/bcsc-theme/features/webview/WebViewContent.tsx
+++ b/app/src/bcsc-theme/features/webview/WebViewContent.tsx
@@ -1,7 +1,11 @@
 import { useBCSCApiClient } from '@/bcsc-theme/hooks/useBCSCApiClient'
+import { useErrorAlert } from '@/contexts/ErrorAlertContext'
+import { ensureAppError } from '@/errors/errorHandler'
+import { AppEventCode } from '@/events/appEventCode'
 import { TOKENS, useServices, useTheme } from '@bifold/core'
 import { getUserAgentString } from '@utils/user-agent'
 import React, { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, StyleSheet, useWindowDimensions, View } from 'react-native'
 import { WebView } from 'react-native-webview'
 import type { WebViewErrorEvent, WebViewHttpErrorEvent } from 'react-native-webview/lib/WebViewTypes'
@@ -36,9 +40,11 @@ type WebViewContentProps = (WebViewUrlSource | WebViewHtmlSource) & {
  * @returns {*} {React.ReactElement} The rendered WebView component.
  */
 const WebViewContent: React.FC<WebViewContentProps> = ({ url, html, onLoaded }) => {
+  const { t } = useTranslation()
   const { ColorPalette } = useTheme()
   const client = useBCSCApiClient()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const { emitErrorModal } = useErrorAlert()
   const { fontScale } = useWindowDimensions()
 
   const styles = StyleSheet.create({
@@ -58,8 +64,13 @@ const WebViewContent: React.FC<WebViewContentProps> = ({ url, html, onLoaded }) 
     (syntheticEvent: WebViewErrorEvent) => {
       const { nativeEvent } = syntheticEvent
       logger.error('WebView Error:', { ...nativeEvent })
+      emitErrorModal(
+        t('Alerts.WebViewLoadFailed.Title'),
+        t('Alerts.WebViewLoadFailed.Description'),
+        ensureAppError(new Error(nativeEvent.description), AppEventCode.WEBVIEW_LOAD_FAILED)
+      )
     },
-    [logger]
+    [logger, emitErrorModal, t]
   )
 
   const handleHttpError = useCallback(
@@ -70,8 +81,16 @@ const WebViewContent: React.FC<WebViewContentProps> = ({ url, html, onLoaded }) 
         statusCode: nativeEvent.statusCode,
         description: nativeEvent.description,
       })
+      emitErrorModal(
+        t('Alerts.WebViewHttpError.Title'),
+        t('Alerts.WebViewHttpError.Description'),
+        ensureAppError(
+          new Error(`${nativeEvent.statusCode}: ${nativeEvent.description}`),
+          AppEventCode.WEBVIEW_HTTP_ERROR
+        )
+      )
     },
-    [logger]
+    [logger, emitErrorModal, t]
   )
 
   if (!html && !url) {

--- a/app/src/bcsc-theme/features/webview/WebViewScreen.test.tsx
+++ b/app/src/bcsc-theme/features/webview/WebViewScreen.test.tsx
@@ -1,5 +1,5 @@
 import { BasicAppContext } from '@mocks/helpers/app'
-import { render } from '@testing-library/react-native'
+import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 import { WebViewScreen } from './WebViewScreen'
 
@@ -22,5 +22,37 @@ describe('WebViewScreen', () => {
     )
 
     expect(tree).toMatchSnapshot()
+  })
+
+  it('shows the error modal with the correct title and description on a native load failure', () => {
+    const route = { params: { url: 'https://example.com', title: 'Test' } }
+    const tree = render(
+      <BasicAppContext>
+        <WebViewScreen route={route as never} />
+      </BasicAppContext>
+    )
+
+    fireEvent(tree.getByTestId('mocked-webview'), 'error', {
+      nativeEvent: { description: 'net::ERR_NAME_NOT_RESOLVED' },
+    })
+
+    expect(tree.getByText('Alerts.WebViewLoadFailed.Title')).toBeTruthy()
+    expect(tree.getByText('Alerts.WebViewLoadFailed.Description')).toBeTruthy()
+  })
+
+  it('shows the error modal with the correct title and description on an HTTP error', () => {
+    const route = { params: { url: 'https://example.com', title: 'Test' } }
+    const tree = render(
+      <BasicAppContext>
+        <WebViewScreen route={route as never} />
+      </BasicAppContext>
+    )
+
+    fireEvent(tree.getByTestId('mocked-webview'), 'httpError', {
+      nativeEvent: { url: 'https://example.com', statusCode: 500, description: 'Internal Server Error' },
+    })
+
+    expect(tree.getByText('Alerts.WebViewHttpError.Title')).toBeTruthy()
+    expect(tree.getByText('Alerts.WebViewHttpError.Description')).toBeTruthy()
   })
 })

--- a/app/src/bcsc-theme/utils/webview-utils.ts
+++ b/app/src/bcsc-theme/utils/webview-utils.ts
@@ -16,7 +16,7 @@ const formatLongDate = (dateStr: string): string => {
  * leaving only the inner body content. This prevents invalid nested HTML when wrapping
  * API-returned HTML in our own document structure.
  */
-const stripOuterDocumentTags = (html: string): string => {
+export const stripOuterDocumentTags = (html: string): string => {
   return html
     .replace(/<\/?html[^>]*>/gi, '')
     .replace(/<\/?head[^>]*>/gi, '')

--- a/app/src/errors/errorRegistry.ts
+++ b/app/src/errors/errorRegistry.ts
@@ -1005,6 +1005,13 @@ export const ErrorRegistry = {
     category: ErrorCategory.GENERAL,
     message: 'Signing key sent during initial registration was not found in the server-confirmed key set',
   },
+  TERMS_OF_USE_LOAD_FAILED: {
+    statusCode: 2833,
+    appEvent: AppEventCode.TERMS_OF_USE_LOAD_FAILED,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.GENERAL,
+    message: 'Failed to fetch Terms of Use — user cannot view or accept the Terms of Use',
+  },
 
   // ============================================
   // Wallet/Agent Errors (2900-2999)

--- a/app/src/errors/errorRegistry.ts
+++ b/app/src/errors/errorRegistry.ts
@@ -1012,6 +1012,20 @@ export const ErrorRegistry = {
     category: ErrorCategory.GENERAL,
     message: 'Failed to fetch Terms of Use — user cannot view or accept the Terms of Use',
   },
+  WEBVIEW_LOAD_FAILED: {
+    statusCode: 2834,
+    appEvent: AppEventCode.WEBVIEW_LOAD_FAILED,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.GENERAL,
+    message: 'WebView failed to load — native load error (e.g. offline, DNS/TLS failure)',
+  },
+  WEBVIEW_HTTP_ERROR: {
+    statusCode: 2835,
+    appEvent: AppEventCode.WEBVIEW_HTTP_ERROR,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.GENERAL,
+    message: 'WebView request returned a non-2xx HTTP response',
+  },
 
   // ============================================
   // Wallet/Agent Errors (2900-2999)

--- a/app/src/events/appEventCode.ts
+++ b/app/src/events/appEventCode.ts
@@ -23,6 +23,7 @@ export enum AppEventCode {
   ADD_CARD_SERVER_CONFIGURATION = 'add_card_server_configuration',
   ADD_CARD_SERVER_ERROR = 'add_card_server_error',
   ADD_CARD_TERMS_OF_USE = 'add_card_terms_of_use',
+  TERMS_OF_USE_LOAD_FAILED = 'terms_of_use_load_failed', // Non-IAS error code — GET /v3/terms fetch failure
   ADD_CARD_DYNAMIC_REGISTRATION_APPVERSION_NOT_SUPPORTED = 'add_card_dynamic_registration_appversion_not_supported',
   ANDROID_APP_UPDATE_REQUIRED = 'android_app_update_required',
   ANDROID_DEVICE_PROTECTION_REQUIRED = 'android_device_protection_required',

--- a/app/src/events/appEventCode.ts
+++ b/app/src/events/appEventCode.ts
@@ -24,6 +24,8 @@ export enum AppEventCode {
   ADD_CARD_SERVER_ERROR = 'add_card_server_error',
   ADD_CARD_TERMS_OF_USE = 'add_card_terms_of_use',
   TERMS_OF_USE_LOAD_FAILED = 'terms_of_use_load_failed', // Non-IAS error code — GET /v3/terms fetch failure
+  WEBVIEW_LOAD_FAILED = 'webview_load_failed', // Non-IAS error code — WebView onError (native load failure)
+  WEBVIEW_HTTP_ERROR = 'webview_http_error', // Non-IAS error code — WebView onHttpError (non-2xx response)
   ADD_CARD_DYNAMIC_REGISTRATION_APPVERSION_NOT_SUPPORTED = 'add_card_dynamic_registration_appversion_not_supported',
   ANDROID_APP_UPDATE_REQUIRED = 'android_app_update_required',
   ANDROID_DEVICE_PROTECTION_REQUIRED = 'android_device_protection_required',

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -1415,6 +1415,14 @@ const translation = {
       "Title": "Terms of Use unavailable",
       "Description": "We couldn't load the Terms of Use. Please check your connection and try again."
     },
+    "WebViewLoadFailed": {
+      "Title": "Page unavailable",
+      "Description": "We couldn't load this page. Please check your connection and try again."
+    },
+    "WebViewHttpError": {
+      "Title": "Page unavailable",
+      "Description": "We couldn't load this page right now. Please try again later."
+    },
     "KeychainUnavailable": {
       "Title": "Secure Storage Unavailable",
       "Description": "Your device's secure storage is temporarily unavailable. Please wait a moment and try again.\n\nIf the issue persists, restart your device and try again."

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -1409,6 +1409,10 @@ const translation = {
       "Title": "Something went wrong",
       "Description": "We're having trouble with the app. Please try again later.\n\nIf the issue persists, close and re-open the app, then try again."
     },
+    "TermsOfUseLoadFailed": {
+      "Title": "Terms of Use unavailable",
+      "Description": "We couldn't load the Terms of Use. Please check your connection and try again."
+    },
     "KeychainUnavailable": {
       "Title": "Secure Storage Unavailable",
       "Description": "Your device's secure storage is temporarily unavailable. Please wait a moment and try again.\n\nIf the issue persists, restart your device and try again."

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -1415,6 +1415,14 @@ const translation = {
       "Title": "Terms of Use unavailable (FR)",
       "Description": "We couldn't load the Terms of Use. Please check your connection and try again. (FR)"
     },
+    "WebViewLoadFailed": {
+      "Title": "Page unavailable (FR)",
+      "Description": "We couldn't load this page. Please check your connection and try again. (FR)"
+    },
+    "WebViewHttpError": {
+      "Title": "Page unavailable (FR)",
+      "Description": "We couldn't load this page right now. Please try again later. (FR)"
+    },
     "KeychainUnavailable": {
       "Title": "Secure Storage Unavailable (FR)",
       "Description": "Your device's secure storage is temporarily unavailable. Please wait a moment and try again.\n\nIf the issue persists, restart your device and try again. (FR)"

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -1409,6 +1409,10 @@ const translation = {
       "Title": "Something went wrong (FR)",
       "Description": "We're having trouble with the app. Please try again later.\n\nIf the issue persists, close and re-open the app, then try again. (FR)"
     },
+    "TermsOfUseLoadFailed": {
+      "Title": "Terms of Use unavailable (FR)",
+      "Description": "We couldn't load the Terms of Use. Please check your connection and try again. (FR)"
+    },
     "KeychainUnavailable": {
       "Title": "Secure Storage Unavailable (FR)",
       "Description": "Your device's secure storage is temporarily unavailable. Please wait a moment and try again.\n\nIf the issue persists, restart your device and try again. (FR)"

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -1415,6 +1415,14 @@ const translation = {
       "Title": "Terms of Use unavailable (PT-BR)",
       "Description": "We couldn't load the Terms of Use. Please check your connection and try again. (PT-BR)"
     },
+    "WebViewLoadFailed": {
+      "Title": "Page unavailable (PT-BR)",
+      "Description": "We couldn't load this page. Please check your connection and try again. (PT-BR)"
+    },
+    "WebViewHttpError": {
+      "Title": "Page unavailable (PT-BR)",
+      "Description": "We couldn't load this page right now. Please try again later. (PT-BR)"
+    },
     "KeychainUnavailable": {
       "Title": "Secure Storage Unavailable (PT-BR)",
       "Description": "Your device's secure storage is temporarily unavailable. Please wait a moment and try again.\n\nIf the issue persists, restart your device and try again. (PT-BR)"

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -1409,6 +1409,10 @@ const translation = {
       "Title": "Something went wrong (PT-BR)",
       "Description": "We're having trouble with the app. Please try again later.\n\nIf the issue persists, close and re-open the app, then try again. (PT-BR)"
     },
+    "TermsOfUseLoadFailed": {
+      "Title": "Terms of Use unavailable (PT-BR)",
+      "Description": "We couldn't load the Terms of Use. Please check your connection and try again. (PT-BR)"
+    },
     "KeychainUnavailable": {
       "Title": "Secure Storage Unavailable (PT-BR)",
       "Description": "Your device's secure storage is temporarily unavailable. Please wait a moment and try again.\n\nIf the issue persists, restart your device and try again. (PT-BR)"


### PR DESCRIPTION
# Summary of Changes

- added error modal for  Terms of Service api endpoint
- added error modal for Terms of Service empty response
- added error modal for `WebViewContent` to handle unreachable URL
- added error modal for `WebViewContent` to handle a bad response from the url
- updated tests

# Testing Instructions
### Failed API
- pull down changes
- modify Line: `50` in `useConfigApi` replace: `/v3/terms` with `/v3/terms123` (forces the request to fail)
- go through onboarding and see error modal Terms of Service screen (gif below)

### Empty API Response
- modify Line: `62` in `TermsOfUseContent` add: `data.html = ''` (forces an empty payload error)
- go through onboarding and see error modal at Terms of Service screen (screenshot below)

### HTTP Bad response
- modify Line: `203` in `FloatingHelpMenuheaderButton` replace: `url: learnMoreUrl, title` with: `url: 'https://httpbin.org/status/500', title` (forces an empty payload error)
- Open the help menu (top right)
- Click `Learn more` button and see error modal (screenshot below)

### URL unreachable
- modify Line: `203` in `FloatingHelpMenuheaderButton` replace: `url: learnMoreUrl, title` with: `url: 'this is a junk url', title` (forces an empty payload error)
- Open the help menu (top right)
- Click `Learn more` button and see error modal (screenshot below)


# Acceptance Criteria

- error modals appear
- app continues to work as expected

# Screenshots, videos, or gifs

### Unreachable url
<img width="367" height="471" alt="handleError" src="https://github.com/user-attachments/assets/bb99ed07-9dab-4b0d-bead-b6b0155178ee" />

### HTTP error
<img width="365" height="438" alt="handleHttpError" src="https://github.com/user-attachments/assets/8243cea1-942e-41e0-9c19-2a483fe0a8b2" />

### Empty API response
<img width="367" height="482" alt="handleEmptyPayload" src="https://github.com/user-attachments/assets/6551c578-e059-4489-89be-5f03cdb0678f" />

### Failed API response
<img width="400" height="885" alt="tos-error" src="https://github.com/user-attachments/assets/ab7906e4-7377-4cac-b673-abdda1edca99" />

# Related Issues

[BC-Wallet: 4310](https://github.com/bcgov/bc-wallet-mobile/issues/4310)
