### PR TITLE
fix: allow manual serial entry on camera fail or no permission

### DIFF
--- a/app/src/bcsc-theme/components/CodeScanningCamera.tsx
+++ b/app/src/bcsc-theme/components/CodeScanningCamera.tsx
@@ -995,10 +995,6 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
     [appStateStatus, logger, emitErrorModal, t, onError]
   )
 
-  useEffect(() => {
-    handleCameraError(new CameraRuntimeError('unknown/unknown', 'Bahumbug'))
-  }, [handleCameraError])
-
   const handleSaveScanZones = useCallback(() => {
     if (!containerSize || !frameSize) {
       Alert.alert('Not Ready', 'Camera dimensions not available yet.')

--- a/app/src/bcsc-theme/components/CodeScanningCamera.tsx
+++ b/app/src/bcsc-theme/components/CodeScanningCamera.tsx
@@ -160,6 +160,12 @@ export interface CodeScanningCameraProps {
    * framing overlay reflect alignment (e.g. recolour the outline).
    */
   onScanStateChange?: (state: ScanState) => void
+
+  /**
+   * Called when the camera hits a runtime error that isn't just the app being
+   * backgrounded. Lets the parent fall back to a non-camera path.
+   */
+  onError?: (error: CameraRuntimeError) => void
 }
 
 /** Feature flag: when true, shows Confirm/Try Again buttons on lock.
@@ -180,6 +186,7 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
   torchActive,
   onToggleTorch,
   onScanStateChange,
+  onError,
 }) => {
   // Derive scanner code types from the declared scan zones (deduped)
   const codeTypes = [...new Set(scanZones.flatMap((z) => z.types))] as CodeType[]
@@ -983,9 +990,14 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
         t('BCSC.CameraDisclosure.ErrorMessage'),
         ensureAppError(error, AppEventCode.ADD_CARD_CAMERA_BROKEN)
       )
+      onError?.(error)
     },
-    [appStateStatus, logger, emitErrorModal, t]
+    [appStateStatus, logger, emitErrorModal, t, onError]
   )
+
+  useEffect(() => {
+    handleCameraError(new CameraRuntimeError('unknown/unknown', 'Bahumbug'))
+  }, [handleCameraError])
 
   const handleSaveScanZones = useCallback(() => {
     if (!containerSize || !frameSize) {

--- a/app/src/bcsc-theme/components/PermissionDisabled.tsx
+++ b/app/src/bcsc-theme/components/PermissionDisabled.tsx
@@ -9,6 +9,11 @@ type PermissionDisabledProps = {
   permissionType: PermissionType
   headerPadding?: boolean
   navigateToNextScreen?: () => void
+  secondaryAction?: {
+    title: string
+    onPress: () => void
+    testID?: string
+  }
 }
 
 type PlatformSteps = {
@@ -103,6 +108,7 @@ export const PermissionDisabled = ({
   permissionType,
   headerPadding = false,
   navigateToNextScreen,
+  secondaryAction,
 }: PermissionDisabledProps) => {
   const { t } = useTranslation()
   const { TextTheme, Spacing } = useTheme()
@@ -139,6 +145,15 @@ export const PermissionDisabled = ({
         testID={testIdWithKey('OpenSettings')}
         accessibilityLabel={t('BCSC.PermissionDisabled.OpenSettings')}
       />
+      {secondaryAction ? (
+        <Button
+          title={secondaryAction.title}
+          buttonType={ButtonType.Secondary}
+          onPress={secondaryAction.onPress}
+          testID={secondaryAction.testID}
+          accessibilityLabel={secondaryAction.title}
+        />
+      ) : null}
       {permissionType === 'notifications' && navigateToNextScreen ? (
         <Button
           title={t('BCSC.PermissionDisabled.ContinueWithoutNotifications')}

--- a/app/src/bcsc-theme/features/verify/ScanSerialScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/ScanSerialScreen.test.tsx
@@ -1,7 +1,9 @@
+import { testIdWithKey } from '@bifold/core'
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { render } from '@testing-library/react-native'
+import { act, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
+import { useCameraPermission } from 'react-native-vision-camera'
 import ScanSerialScreen from './ScanSerialScreen'
 
 // Mock react-native-vision-camera
@@ -32,6 +34,12 @@ jest.mock('../../contexts/BCSCActivityContext', () => ({
   })),
 }))
 
+// LoadingScreen (shown while the permission prompt is pending) needs a provider BasicAppContext doesn't supply
+jest.mock('../../contexts/BCSCLoadingContext', () => ({
+  ...jest.requireActual('../../contexts/BCSCLoadingContext'),
+  LoadingScreen: () => null,
+}))
+
 // Mock gesture handler
 const mockGestureChain = () => {
   const chain: any = {}
@@ -58,6 +66,10 @@ describe('ScanSerial', () => {
     mockNavigation = useNavigation()
     jest.clearAllMocks()
     jest.useFakeTimers()
+    ;(useCameraPermission as jest.Mock).mockReturnValue({
+      hasPermission: true,
+      requestPermission: jest.fn().mockResolvedValue(true),
+    })
   })
 
   afterEach(() => {
@@ -72,5 +84,38 @@ describe('ScanSerial', () => {
     )
 
     expect(tree).toMatchSnapshot()
+  })
+
+  it('offers manual entry when camera permission is denied', async () => {
+    ;(useCameraPermission as jest.Mock).mockReturnValue({
+      hasPermission: false,
+      requestPermission: jest.fn().mockResolvedValue(false),
+    })
+
+    const { getByTestId } = render(
+      <BasicAppContext>
+        <ScanSerialScreen navigation={mockNavigation as never} />
+      </BasicAppContext>
+    )
+
+    await waitFor(() => expect(getByTestId(testIdWithKey('EnterManually'))).toBeTruthy())
+    expect(getByTestId(testIdWithKey('OpenSettings'))).toBeTruthy()
+  })
+
+  it('offers manual entry when the camera errors out', async () => {
+    const { UNSAFE_root, getByTestId } = render(
+      <BasicAppContext>
+        <ScanSerialScreen navigation={mockNavigation as never} />
+      </BasicAppContext>
+    )
+
+    const cameraNode = UNSAFE_root.findAll((node) => typeof node.props.onError === 'function')[0]
+
+    act(() => {
+      cameraNode.props.onError(new Error('camera/unknown'))
+    })
+
+    expect(getByTestId(testIdWithKey('EnterManually'))).toBeTruthy()
+    expect(getByTestId(testIdWithKey('RetryCamera'))).toBeTruthy()
   })
 })

--- a/app/src/bcsc-theme/features/verify/ScanSerialScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/ScanSerialScreen.test.tsx
@@ -6,24 +6,37 @@ import React from 'react'
 import { useCameraPermission } from 'react-native-vision-camera'
 import ScanSerialScreen from './ScanSerialScreen'
 
-// Mock react-native-vision-camera
-jest.mock('react-native-vision-camera', () => ({
-  Camera: 'Camera',
-  useCameraDevice: jest.fn(() => ({
-    id: 'back',
-    supportsFocus: true,
-    minZoom: 1,
-    maxZoom: 8,
-    neutralZoom: 1,
-    hasTorch: true,
-  })),
-  useCameraFormat: jest.fn(() => ({})),
-  useCameraPermission: jest.fn(() => ({
-    hasPermission: true,
-    requestPermission: jest.fn(),
-  })),
-  useCodeScanner: jest.fn((config) => config),
-}))
+/** testID on the mocked Camera host element, so tests can drive its props directly. */
+const VISION_CAMERA_TEST_ID = 'vision-camera'
+
+// Mock react-native-vision-camera. Camera renders a host element carrying the props
+// CodeScanningCamera passes it (notably onError), so tests can exercise the real
+// Camera -> handleCameraError -> onError path.
+jest.mock('react-native-vision-camera', () => {
+  const ReactActual = jest.requireActual<typeof React>('react')
+
+  return {
+    Camera: ReactActual.forwardRef((props: Record<string, unknown>, ref: React.Ref<unknown>) =>
+      ReactActual.createElement('VisionCamera', { ...props, ref, testID: 'vision-camera' })
+    ),
+    useCameraDevice: jest.fn(() => ({
+      id: 'back',
+      supportsFocus: true,
+      minZoom: 1,
+      maxZoom: 8,
+      neutralZoom: 1,
+      hasTorch: true,
+    })),
+    useCameraFormat: jest.fn(() => ({})),
+    useCameraPermission: jest.fn(() => ({
+      hasPermission: true,
+      requestPermission: jest.fn(),
+    })),
+    useCodeScanner: jest.fn((config: unknown) => config),
+  }
+})
+
+const mockUseCameraPermission = useCameraPermission as jest.Mock
 
 // Mock BCSCActivityContext — not provided by BasicAppContext
 jest.mock('../../contexts/BCSCActivityContext', () => ({
@@ -66,7 +79,7 @@ describe('ScanSerial', () => {
     mockNavigation = useNavigation()
     jest.clearAllMocks()
     jest.useFakeTimers()
-    ;(useCameraPermission as jest.Mock).mockReturnValue({
+    mockUseCameraPermission.mockReturnValue({
       hasPermission: true,
       requestPermission: jest.fn().mockResolvedValue(true),
     })
@@ -87,7 +100,7 @@ describe('ScanSerial', () => {
   })
 
   it('offers manual entry when camera permission is denied', async () => {
-    ;(useCameraPermission as jest.Mock).mockReturnValue({
+    mockUseCameraPermission.mockReturnValue({
       hasPermission: false,
       requestPermission: jest.fn().mockResolvedValue(false),
     })
@@ -102,17 +115,21 @@ describe('ScanSerial', () => {
     expect(getByTestId(testIdWithKey('OpenSettings'))).toBeTruthy()
   })
 
-  it('offers manual entry when the camera errors out', async () => {
-    const { UNSAFE_root, getByTestId } = render(
+  it('offers manual entry when the camera errors out', () => {
+    const { getByTestId } = render(
       <BasicAppContext>
         <ScanSerialScreen navigation={mockNavigation as never} />
       </BasicAppContext>
     )
 
-    const cameraNode = UNSAFE_root.findAll((node) => typeof node.props.onError === 'function')[0]
-
+    // Fire the error off the Camera itself so the whole
+    // Camera -> handleCameraError -> onError chain runs.
     act(() => {
-      cameraNode.props.onError(new Error('camera/unknown'))
+      getByTestId(VISION_CAMERA_TEST_ID).props.onError(
+        Object.assign(new Error('The camera has been disconnected'), {
+          code: 'system/camera-has-been-disconnected',
+        })
+      )
     })
 
     expect(getByTestId(testIdWithKey('EnterManually'))).toBeTruthy()

--- a/app/src/bcsc-theme/features/verify/ScanSerialScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/ScanSerialScreen.tsx
@@ -6,7 +6,7 @@ import { ScanableCode } from '@/bcsc-theme/utils/decoder-strategy/DecoderStrateg
 import { useAutoRequestPermission } from '@/hooks/useAutoRequestPermission'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LayoutChangeEvent, StyleSheet, Text, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -198,6 +198,8 @@ const ScanSerialScreen: React.FC<ScanSerialScreenProps> = ({ navigation }: ScanS
   // Starts on mount; after the timeout we swap the initial guidance for the
   // steady-hold help text.
   const [showHelp, setShowHelp] = useState(false)
+  const [cameraFailed, setCameraFailed] = useState(false)
+  const [cameraKey, setCameraKey] = useState(0)
 
   useEffect(() => {
     const timer = setTimeout(() => setShowHelp(true), SCAN_HELP_TIMEOUT_MS)
@@ -210,6 +212,19 @@ const ScanSerialScreen: React.FC<ScanSerialScreenProps> = ({ navigation }: ScanS
   }
 
   const toggleTorch = () => setTorchOn((prev) => !prev)
+
+  const goToManualEntry = useCallback(() => navigation.navigate(BCSCScreens.ManualSerial), [navigation])
+
+  const onCameraError = useCallback(() => {
+    setTorchOn(false)
+    setCameraFailed(true)
+  }, [])
+
+  const retryCamera = useCallback(() => {
+    setCameraFailed(false)
+    setScanState('scanning')
+    setCameraKey((prev) => prev + 1)
+  }, [])
 
   const onCodeScanned = async (barcodes: ScanableCode[]): Promise<boolean | void> => {
     let accepted = true
@@ -276,6 +291,12 @@ const ScanSerialScreen: React.FC<ScanSerialScreenProps> = ({ navigation }: ScanS
     buttonBlock: {
       padding: Spacing.lg,
       backgroundColor: ColorPalette.notification.popupOverlay,
+      gap: Spacing.md,
+    },
+    cameraErrorBlock: {
+      flex: 1,
+      justifyContent: 'center',
+      paddingHorizontal: Spacing.lg,
     },
   })
 
@@ -288,55 +309,86 @@ const ScanSerialScreen: React.FC<ScanSerialScreenProps> = ({ navigation }: ScanS
   }
 
   if (!hasPermission) {
-    return <PermissionDisabled permissionType="camera" />
+    return (
+      <PermissionDisabled
+        permissionType="camera"
+        secondaryAction={{
+          title: t('BCSC.Instructions.EnterManually'),
+          onPress: goToManualEntry,
+          testID: testIdWithKey('EnterManually'),
+        }}
+      />
+    )
   }
 
   return (
     <ScreenWrapper padded={false} scrollable={false} edges={[]}>
       <View style={styles.container} onLayout={onContainerLayout}>
-        {/* Camera fills the entire screen */}
-        <CodeScanningCamera
-          onCodeScanned={onCodeScanned}
-          cameraType={'back'}
-          initialZoom={2}
-          scanZones={BCSC_SN_SCAN_ZONES}
-          showScanZoneOverlay={false}
-          showZoomIndicator={false}
-          hideTorchButton
-          torchActive={torchOn}
-          onToggleTorch={toggleTorch}
-          onScanStateChange={setScanState}
-          style={StyleSheet.absoluteFillObject}
-        />
+        {cameraFailed ? (
+          <View style={styles.cameraErrorBlock}>
+            <Text style={styles.instructionText}>{t('BCSC.CameraDisclosure.Error')}</Text>
+            <Text style={styles.instructionSubText}>{t('BCSC.CameraDisclosure.ErrorMessage')}</Text>
+          </View>
+        ) : (
+          <>
+            {/* Camera fills the entire screen */}
+            <CodeScanningCamera
+              key={cameraKey}
+              onCodeScanned={onCodeScanned}
+              cameraType={'back'}
+              initialZoom={2}
+              scanZones={BCSC_SN_SCAN_ZONES}
+              showScanZoneOverlay={false}
+              showZoomIndicator={false}
+              hideTorchButton
+              torchActive={torchOn}
+              onToggleTorch={toggleTorch}
+              onScanStateChange={setScanState}
+              onError={onCameraError}
+              style={StyleSheet.absoluteFillObject}
+            />
 
-        {/* Vertical ID-card framing guide (appearance of MaskType.ID_CARD) */}
-        {size ? <IdCardMaskOverlay width={size.width} height={size.height} strokeColor={frameStrokeColor} /> : null}
+            {/* Vertical ID-card framing guide (appearance of MaskType.ID_CARD) */}
+            {size ? <IdCardMaskOverlay width={size.width} height={size.height} strokeColor={frameStrokeColor} /> : null}
 
-        {/* Instruction text — initial guidance until the timeout, then steady-hold help */}
-        <View style={styles.topBanner} pointerEvents="none">
-          {showHelp ? (
-            <Text style={styles.instructionText}>{t('BCSC.Scan.HoldSteadyHelp')}</Text>
-          ) : (
-            <>
-              <Text style={styles.instructionText}>{t('BCSC.Scan.ScanYourCard')}</Text>
-              <Text style={styles.instructionSubText}>{t('BCSC.Scan.LineUpHelp')}</Text>
-            </>
-          )}
-        </View>
+            {/* Instruction text — initial guidance until the timeout, then steady-hold help */}
+            <View style={styles.topBanner} pointerEvents="none">
+              {showHelp ? (
+                <Text style={styles.instructionText}>{t('BCSC.Scan.HoldSteadyHelp')}</Text>
+              ) : (
+                <>
+                  <Text style={styles.instructionText}>{t('BCSC.Scan.ScanYourCard')}</Text>
+                  <Text style={styles.instructionSubText}>{t('BCSC.Scan.LineUpHelp')}</Text>
+                </>
+              )}
+            </View>
+          </>
+        )}
 
         {/* Torch + manual entry */}
         <View style={styles.bottomBar} pointerEvents="box-none">
-          <View style={styles.torchRow} pointerEvents="box-none">
-            <TorchButton active={torchOn} onPress={toggleTorch} />
-          </View>
+          {cameraFailed ? null : (
+            <View style={styles.torchRow} pointerEvents="box-none">
+              <TorchButton active={torchOn} onPress={toggleTorch} />
+            </View>
+          )}
           <View style={[styles.buttonBlock, { paddingBottom: insets.bottom + Spacing.lg }]}>
             <Button
               title={t('BCSC.Instructions.EnterManually')}
               accessibilityLabel={t('BCSC.Instructions.EnterManually')}
               testID={testIdWithKey('EnterManually')}
-              onPress={() => navigation.navigate(BCSCScreens.ManualSerial)}
+              onPress={goToManualEntry}
               buttonType={ButtonType.Primary}
             />
+            {cameraFailed ? (
+              <Button
+                title={t('BCSC.Scan.TryAgain')}
+                accessibilityLabel={t('BCSC.Scan.TryAgain')}
+                testID={testIdWithKey('RetryCamera')}
+                onPress={retryCamera}
+                buttonType={ButtonType.Secondary}
+              />
+            ) : null}
           </View>
         </View>
       </View>

--- a/app/src/bcsc-theme/features/verify/__snapshots__/ScanSerialScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/__snapshots__/ScanSerialScreen.test.tsx.snap
@@ -269,6 +269,7 @@ exports[`ScanSerial renders correctly 1`] = `
           [
             {
               "backgroundColor": "rgba(0, 0, 0, 0.5)",
+              "gap": 16,
               "padding": 24,
             },
             {

--- a/app/src/bcsc-theme/features/verify/__snapshots__/ScanSerialScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/__snapshots__/ScanSerialScreen.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`ScanSerial renders correctly 1`] = `
         }
         testID="camera-preview-container"
       >
-        <Camera
+        <VisionCamera
           animatedProps={{}}
           codeScanner={
             {
@@ -95,6 +95,7 @@ exports[`ScanSerial renders correctly 1`] = `
               "flex": 1,
             }
           }
+          testID="vision-camera"
           torch="off"
           video={true}
         />


### PR DESCRIPTION
# Summary of Changes

Provide the manual entry option even if the camera throws an error or permission is not granted

# Testing Instructions

From a fresh install, deny camera permissions on the ScanSerialScreen. See that you can still enter manually.

Then, try going to the ScanSerialScreen again once you've added the following snippet to CodeScanningCamera.tsx

```tsx
useEffect(() => {
    handleCameraError(new CameraRuntimeError('unknown/unknown', 'Bahumbug'))
  }, [handleCameraError])
```

See that even if the camera errors out, after dismissing the error modal, you can enter your serial number manually.

# Acceptance Criteria

Works

# Screenshots, videos, or gifs
<img width="284" height="614" alt="permissions_disabled" src="https://github.com/user-attachments/assets/1f2cd4eb-4c30-4d6b-ad00-a6d49a18a932" />
<img width="284" height="614" alt="camera_error" src="https://github.com/user-attachments/assets/f871d869-9277-4d9c-abc0-80a4d7a99ebe" />

# Related Issues

#4305 