### PR TITLE
fix: prevent foreground non-bcsc notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ lib
 local.properties
 .jest
 .npmrc
+.kotlin/
 
 # Swift Package Manager
 .build/

--- a/app/firebase.json
+++ b/app/firebase.json
@@ -1,7 +1,7 @@
 {
   "react-native": {
     "messaging_ios_auto_register_for_remote_messages": true,
-    "messaging_ios_foreground_presentation_options": ["badge", "sound", "banner"],
+    "messaging_ios_foreground_presentation_options": [],
     "messaging_android_notification_channel_id": "default",
     "messaging_android_headless_task_timeout": 60000
   }

--- a/app/ios/BCWallet/AppDelegate.swift
+++ b/app/ios/BCWallet/AppDelegate.swift
@@ -31,7 +31,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // Configure Firebase
     FirebaseApp.configure()
 
-    // Set notification delegate to allow foreground notifications
+    // Claim the notification center delegate before React Native starts: RNFB Messaging and notifee
+    // each wrap whichever delegate is set at launch and forward to it, so anything this class
+    // implements stays in the chain. Foreground presentation is decided by those libraries
     UNUserNotificationCenter.current().delegate = self
 
     let delegate = ReactNativeDelegate()

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.test.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.test.ts
@@ -504,7 +504,8 @@ describe('FcmViewModel', () => {
     })
 
     it('logs an error when the display fails', async () => {
-      ;(notifee.displayNotification as jest.Mock).mockRejectedValueOnce(new Error('Notification failed'))
+      const mockDisplayNotification = notifee.displayNotification as jest.Mock
+      mockDisplayNotification.mockRejectedValueOnce(new Error('Notification failed'))
 
       await capturedMessageHandler?.(message, { source: 'foreground' })
 

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.test.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.test.ts
@@ -1,7 +1,8 @@
 import { Mode } from '@/constants'
 import { AppError } from '@/errors/appError'
 import { AppEventCode } from '@/events/appEventCode'
-import { DeviceEventEmitter } from 'react-native'
+import notifee from '@notifee/react-native'
+import { DeviceEventEmitter, Platform } from 'react-native'
 import { decodeLoginChallenge, showLocalNotification } from 'react-native-bcsc-core'
 import { BCSCEventTypes } from '../../../events/eventTypes'
 import { getBCSCApiClient } from '../../contexts/BCSCApiClientContext'
@@ -9,7 +10,9 @@ import { BCSCEvent, BCSCReason } from '../../utils/id-token'
 import { PairingService } from '../pairing'
 import { VerificationResponseService } from '../verification-response'
 import { FcmViewModel } from './FcmViewModel'
-import { FcmMessage, FcmService } from './services/fcm-service'
+import { FcmDeliveryContext, FcmMessage, FcmService } from './services/fcm-service'
+
+jest.mock('@notifee/react-native')
 
 jest.mock('@/utils/analytics/analytics-singleton', () => ({
   Analytics: {
@@ -51,7 +54,7 @@ describe('FcmViewModel', () => {
   let mockLogger: { info: jest.Mock; warn: jest.Mock; error: jest.Mock; debug: jest.Mock }
   let mockPairingService: jest.Mocked<PairingService>
   let mockVerificationResponseService: jest.Mocked<VerificationResponseService>
-  let capturedMessageHandler: ((message: FcmMessage) => void) | null = null
+  let capturedMessageHandler: ((message: FcmMessage, delivery?: FcmDeliveryContext) => void) | null = null
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -177,7 +180,7 @@ describe('FcmViewModel', () => {
       expect(showLocalNotification).not.toHaveBeenCalled()
     })
 
-    it('does not show local notification for status when FCM payload has notification block', async () => {
+    it('does not re-show a status notification the OS already presented', async () => {
       const message = {
         type: 'status',
         data: {
@@ -205,7 +208,7 @@ describe('FcmViewModel', () => {
 
       await capturedMessageHandler?.(message)
 
-      expect(showLocalNotification).toHaveBeenCalledWith('Test Title', 'Test Body')
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('Handling generic notification'))
     })
 
     it('logs warning for unknown message types', async () => {
@@ -442,27 +445,68 @@ describe('FcmViewModel', () => {
       viewModel.initialize()
     })
 
-    it('shows notification when title and body are present', async () => {
+    // Notifications without a `bcsc_*` data key belong to the mediator, not IAS - the OS presents them
+    // while backgrounded and we never re-present them in the foreground.
+    it.each(['foreground', 'background'] as const)('never displays a notification (%s delivery)', async (source) => {
       const message = {
         type: 'notification',
         data: { title: 'Hello', body: 'World' },
       } as FcmMessage
 
-      await capturedMessageHandler?.(message)
+      await capturedMessageHandler?.(message, { source })
 
-      expect(showLocalNotification).toHaveBeenCalledWith('Hello', 'World')
+      expect(showLocalNotification).not.toHaveBeenCalled()
+      expect(notifee.displayNotification).not.toHaveBeenCalled()
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('Notification not owned by BCSC'))
+    })
+  })
+
+  describe('foreground display of status notifications', () => {
+    const message = {
+      type: 'status',
+      data: { bcsc_status_notification: 'approved', title: 'Status Update', message: 'Approved!' },
+      rawMessage: { data: {}, notification: undefined },
+    } as FcmMessage
+
+    beforeEach(() => {
+      viewModel.initialize()
     })
 
-    it('logs error when showLocalNotification throws', async () => {
-      const mockShowNotification = showLocalNotification as jest.Mock
-      mockShowNotification.mockRejectedValue(new Error('Notification failed'))
+    afterEach(() => {
+      Platform.OS = 'ios'
+    })
 
-      const message = {
-        type: 'notification',
-        data: { title: 'Hello', body: 'World' },
-      } as FcmMessage
+    it('displays via notifee on iOS, which is unaffected by the empty foreground presentation options', async () => {
+      Platform.OS = 'ios'
 
-      await capturedMessageHandler?.(message)
+      await capturedMessageHandler?.(message, { source: 'foreground' })
+
+      expect(notifee.displayNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Status Update', body: 'Approved!' })
+      )
+      expect(showLocalNotification).not.toHaveBeenCalled()
+    })
+
+    it('displays via the native local notification on Android', async () => {
+      Platform.OS = 'android'
+
+      await capturedMessageHandler?.(message, { source: 'foreground' })
+
+      expect(showLocalNotification).toHaveBeenCalledWith('Status Update', 'Approved!')
+      expect(notifee.displayNotification).not.toHaveBeenCalled()
+    })
+
+    it('leaves background delivery to the OS', async () => {
+      await capturedMessageHandler?.(message, { source: 'background' })
+
+      expect(showLocalNotification).not.toHaveBeenCalled()
+      expect(notifee.displayNotification).not.toHaveBeenCalled()
+    })
+
+    it('logs an error when the display fails', async () => {
+      ;(notifee.displayNotification as jest.Mock).mockRejectedValueOnce(new Error('Notification failed'))
+
+      await capturedMessageHandler?.(message, { source: 'foreground' })
 
       expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to show local notification'))
     })

--- a/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
+++ b/app/src/bcsc-theme/features/fcm/FcmViewModel.ts
@@ -4,6 +4,7 @@ import { ErrorRegistry } from '@/errors/errorRegistry'
 import { BCSCEventTypes } from '@/events/eventTypes'
 import { toAppError } from '@bcsc-theme/utils/native-error-map'
 import { AbstractBifoldLogger } from '@bifold/core'
+import notifee from '@notifee/react-native'
 import { getApp } from '@react-native-firebase/app'
 import { getMessaging, getToken } from '@react-native-firebase/messaging'
 import { DeviceEventEmitter, Platform } from 'react-native'
@@ -113,7 +114,7 @@ export class FcmViewModel {
         break
       case 'notification':
         this.logger.info(`[FcmViewModel] Handling generic notification`)
-        await this.handleGenericNotification(message.data)
+        this.handleGenericNotification(message.data)
         break
       default:
         this.logger.warn(`[FcmViewModel] Unknown message type`)
@@ -198,12 +199,8 @@ export class FcmViewModel {
   private async handleStatusNotification(data: StatusNotification, delivery?: FcmDeliveryContext) {
     this.logger.info(`[FcmViewModel] Status notification received: ${JSON.stringify(data)}`)
 
-    if (Platform.OS === 'android' && delivery?.source === 'foreground' && data.title && data.message) {
-      try {
-        await showLocalNotification(data.title, data.message)
-      } catch (error) {
-        this.logger.error(`[FcmViewModel] Failed to show local notification: ${error}`)
-      }
+    if (delivery?.source === 'foreground' && data.title && data.message) {
+      await this.showForegroundNotification(data.title, data.message)
     }
 
     // Check if this is a verification request reviewed notification (send-video)
@@ -241,12 +238,40 @@ export class FcmViewModel {
     }
   }
 
-  private async handleGenericNotification(data: BasicNotification) {
-    const { title, body } = data
+  /**
+   * A push with a notification payload but no `bcsc_*` data key isn't ours - in practice it's the
+   * DIDComm mediator telling us a message is waiting. The OS already shows those while the app is
+   * backgrounded, and while it's in the foreground the mediator's message is picked up by the agent
+   * anyway, so we never re-present them.
+   */
+  private handleGenericNotification(data: BasicNotification) {
+    this.logger.info(
+      `[FcmViewModel] Notification not owned by BCSC backend (likely mediator), not displaying: "${data.title}"`
+    )
+  }
 
+  /**
+   * Displays an IAS notification that arrived while the app was in the foreground, where neither
+   * platform presents it for us: Android never shows a foreground FCM payload, and iOS no longer
+   * does either since `messaging_ios_foreground_presentation_options` is empty (that config is
+   * all-or-nothing, so leaving it on would also surface mediator notifications).
+   *
+   * iOS goes through notifee because it carries its own per-notification presentation options and so
+   * is unaffected by the empty messaging config; a plain UNNotificationRequest would be suppressed
+   * by it.
+   */
+  private async showForegroundNotification(title: string, body: string): Promise<void> {
     this.logger.info(`[FcmViewModel] Showing local notification: title="${title}", body="${body}"`)
     try {
-      await showLocalNotification(title, body)
+      if (Platform.OS === 'ios') {
+        await notifee.displayNotification({
+          title,
+          body,
+          ios: { sound: 'default', foregroundPresentationOptions: { banner: true, list: true, sound: true } },
+        })
+      } else {
+        await showLocalNotification(title, body)
+      }
       this.logger.info(`[FcmViewModel] Local notification shown successfully`)
     } catch (error) {
       this.logger.error(`[FcmViewModel] Failed to show local notification: ${error}`)


### PR DESCRIPTION
# Summary of Changes

This PR prevents foreground notifications for non-BCSC notifications like mediator notifications

# Testing Instructions

Verify and confirm those notifications still work the same, then go through the showcase and ensure you don't get notifications during proof requests and such.

# Acceptance Criteria

Get notifications as appropriate

# Screenshots, videos, or gifs

N/A

# Related Issues

#4312 