### PR TITLE
fix(bcsc): stop scan focus re-trigger storm and keep combo-card licence data

### DIFF
--- a/app/src/bcsc-theme/components/CodeScanningCamera.test.tsx
+++ b/app/src/bcsc-theme/components/CodeScanningCamera.test.tsx
@@ -1921,4 +1921,275 @@ describe('CodeScanningCamera', () => {
       )
     })
   })
+
+  describe('Focus cycling restart storm (regression #4256/#4300)', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+      // The module-level device mock factory returns a brand-new object on every call,
+      // so without pinning it, startFocusCycling's useCallback (deps include `device`)
+      // would get a new identity on every re-render regardless of cause — masking the
+      // exact thing under test here. Pin it to a single stable reference, matching how
+      // the real hook behaves when the underlying camera device hasn't changed.
+      mockedUseCameraDevice.mockReturnValue({
+        id: 'back',
+        supportsFocus: true,
+        minZoom: 1,
+        maxZoom: 8,
+        neutralZoom: 1,
+        hasTorch: true,
+      })
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+      // Restore the default per-render factory for any tests outside this describe.
+      mockedUseCameraDevice.mockImplementation(() => ({
+        id: 'back',
+        supportsFocus: true,
+        minZoom: 1,
+        maxZoom: 8,
+        neutralZoom: 1,
+        hasTorch: true,
+      }))
+    })
+
+    const mockFrame = { width: 1920, height: 1080 }
+
+    it('does not restart on a scanning<->aligned flip, but the periodic idle-nudge still ticks (discriminating case)', async () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <CodeScanningCamera {...defaultProps} />
+        </BasicAppContext>
+      )
+
+      // t=0: layout starts cycling — one immediate, unsuppressed doFocus (lastDetectionAtRef
+      // starts at 0, so nothing looks "recent" yet).
+      const cameraContainer = getByTestId('camera-preview-container')
+      await act(async () => {
+        fireEvent(cameraContainer, 'layout', {
+          nativeEvent: { layout: { x: 0, y: 0, width: 400, height: 800 } },
+        })
+      })
+      const callsAfterLayout = mockFocus.mock.calls.length
+      expect(callsAfterLayout).toBeGreaterThan(0)
+
+      // t=100: a single detection is enough to flip scanning -> aligned (minCodesForAligned
+      // === 1 for the single-zone BCSC_SN_SCAN_ZONES).
+      await act(async () => {
+        jest.advanceTimersByTime(100)
+      })
+      await act(async () => {
+        mockCodeScannerCallback!(
+          [
+            {
+              type: 'pdf-417',
+              value: 'FLIP_TO_ALIGNED',
+              frame: { x: 100, y: 200, width: 200, height: 50 },
+              corners: [],
+            },
+          ],
+          mockFrame
+        )
+      })
+
+      // t=2200: advance 2100ms past that detection — the suppression window (2000ms) has
+      // now lapsed — then send a blank frame. The single tracked reading (count 1) decays
+      // straight to 0 and drops the state back to 'scanning'.
+      //
+      // OLD code: scanState was a dependency of the cycling effect, so this flip tore the
+      // cycle down and restarted it, firing an extra doFocus() right here — and since the
+      // suppression window had already lapsed, that restart's call was NOT suppressed.
+      // NEW code: scanState is not a dependency, so nothing restarts and the call count
+      // must be unchanged.
+      await act(async () => {
+        jest.advanceTimersByTime(2100)
+      })
+      await act(async () => {
+        mockCodeScannerCallback!([], mockFrame)
+      })
+
+      expect(mockFocus.mock.calls.length).toBe(callsAfterLayout)
+
+      // t=2600: advance past the next natural tick of the untouched interval (anchored at
+      // t=0, so its next tick is at t=2500) — the periodic idle-nudge must still be alive.
+      await act(async () => {
+        jest.advanceTimersByTime(400)
+      })
+
+      expect(mockFocus.mock.calls.length).toBe(callsAfterLayout + 1)
+    })
+
+    it('preserves the idle-nudge cadence when nothing is ever detected (tilt workaround)', async () => {
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <CodeScanningCamera {...defaultProps} />
+        </BasicAppContext>
+      )
+
+      const cameraContainer = getByTestId('camera-preview-container')
+      await act(async () => {
+        fireEvent(cameraContainer, 'layout', {
+          nativeEvent: { layout: { x: 0, y: 0, width: 400, height: 800 } },
+        })
+      })
+      const callsAfterLayout = mockFocus.mock.calls.length
+      expect(callsAfterLayout).toBeGreaterThan(0)
+
+      // Two full FOCUS_CYCLE_INTERVAL_MS (2.5s) ticks, no detections in between.
+      await act(async () => {
+        jest.advanceTimersByTime(2 * 2500)
+      })
+
+      expect(mockFocus.mock.calls.length).toBe(callsAfterLayout + 2)
+    })
+
+    it('keeps the idle-nudge alive across a lock -> auto-confirm-rejected -> reset cycle (guards against stop-on-lock without a matching restart)', async () => {
+      mockOnCodeScanned.mockResolvedValueOnce(false)
+
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <CodeScanningCamera {...defaultProps} />
+        </BasicAppContext>
+      )
+
+      const cameraContainer = getByTestId('camera-preview-container')
+      await act(async () => {
+        fireEvent(cameraContainer, 'layout', {
+          nativeEvent: { layout: { x: 0, y: 0, width: 400, height: 800 } },
+        })
+      })
+      const callsAfterLayout = mockFocus.mock.calls.length
+      expect(callsAfterLayout).toBeGreaterThan(0)
+
+      const lockCode = {
+        type: 'pdf-417',
+        value: 'LOCK_THEN_REJECT',
+        frame: { x: 100, y: 200, width: 200, height: 50 },
+        corners: [],
+      }
+      // LOCK_READING_THRESHOLD (5) identical frames locks and auto-confirms; the mocked
+      // `false` resolution rejects the scan, which resets back to 'scanning'.
+      for (let i = 0; i < 5; i++) {
+        await act(async () => {
+          mockCodeScannerCallback!([lockCode], mockFrame)
+        })
+      }
+
+      await waitFor(() => {
+        expect(mockOnCodeScanned).toHaveBeenCalled()
+      })
+
+      // Neither the lock nor the reject-driven reset should have touched the cycling
+      // timer — scanState was never a dependency of the effect that starts it.
+      expect(mockFocus.mock.calls.length).toBe(callsAfterLayout)
+
+      // Advance past the suppression window plus a full cycle interval — if a
+      // stop-on-lock (without a matching restart) regression crept back in, the timer
+      // would be dead here and this would never fire.
+      await act(async () => {
+        jest.advanceTimersByTime(2000 + 2500)
+      })
+
+      expect(mockFocus.mock.calls.length).toBeGreaterThan(callsAfterLayout)
+    })
+  })
+
+  describe('Lock keeps accumulated licence barcode (regression #4256/#4302)', () => {
+    // VALIDATION_THRESHOLD (3) < LOCK_READING_THRESHOLD (5) on Android, so a code can
+    // validate (and get accumulated) well before it could ever lock on its own.
+    beforeEach(() => {
+      jest.useFakeTimers()
+      Platform.OS = 'android'
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+      Platform.OS = 'ios'
+    })
+
+    const mockFrame = { width: 640, height: 480 }
+    const pdf417Code = {
+      type: 'pdf-417',
+      value: 'DL_DATA',
+      frame: { x: 100, y: 100, width: 200, height: 60 },
+      corners: [],
+    }
+    const serialCode = {
+      type: 'code-39',
+      value: 'SERIAL',
+      frame: { x: 100, y: 300, width: 200, height: 30 },
+      corners: [],
+    }
+
+    it('carries a recently-accumulated pdf-417 into a lock triggered by the code-39 serial alone', async () => {
+      render(
+        <BasicAppContext>
+          <CodeScanningCamera {...defaultProps} />
+        </BasicAppContext>
+      )
+
+      // pdf-417 validates (VALIDATION_THRESHOLD=3) and gets accumulated, but never reaches
+      // LOCK_READING_THRESHOLD (5) on its own.
+      for (let i = 0; i < 3; i++) {
+        await act(async () => {
+          mockCodeScannerCallback!([pdf417Code], mockFrame)
+        })
+      }
+      expect(mockOnCodeScanned).not.toHaveBeenCalled()
+
+      // The pdf-417 drops out of frame; only the code-39 serial is read from here on. 5
+      // frames locks on the serial alone (minCodesForAligned === 1 for the single-zone
+      // BCSC_SN_SCAN_ZONES).
+      for (let i = 0; i < 5; i++) {
+        await act(async () => {
+          mockCodeScannerCallback!([serialCode], mockFrame)
+        })
+      }
+
+      await waitFor(() => {
+        expect(mockOnCodeScanned).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({ type: 'pdf-417', value: 'DL_DATA' }),
+            expect.objectContaining({ type: 'code-39', value: 'SERIAL' }),
+          ]),
+          mockFrame
+        )
+      })
+    })
+
+    it('drops the accumulated pdf-417 once ACCUMULATION_WINDOW_MS has elapsed before the lock', async () => {
+      render(
+        <BasicAppContext>
+          <CodeScanningCamera {...defaultProps} />
+        </BasicAppContext>
+      )
+
+      for (let i = 0; i < 3; i++) {
+        await act(async () => {
+          mockCodeScannerCallback!([pdf417Code], mockFrame)
+        })
+      }
+
+      // ACCUMULATION_WINDOW_MS is 3000 on Android — advance past it before the serial locks.
+      await act(async () => {
+        jest.advanceTimersByTime(3100)
+      })
+
+      for (let i = 0; i < 5; i++) {
+        await act(async () => {
+          mockCodeScannerCallback!([serialCode], mockFrame)
+        })
+      }
+
+      await waitFor(() => {
+        expect(mockOnCodeScanned).toHaveBeenCalled()
+      })
+
+      const [codes] = mockOnCodeScanned.mock.calls[0]
+      expect(codes).toEqual(expect.arrayContaining([expect.objectContaining({ type: 'code-39', value: 'SERIAL' })]))
+      expect(codes).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'pdf-417', value: 'DL_DATA' })])
+      )
+    })
+  })
 })

--- a/app/src/bcsc-theme/components/CodeScanningCamera.test.tsx
+++ b/app/src/bcsc-theme/components/CodeScanningCamera.test.tsx
@@ -2008,7 +2008,7 @@ describe('CodeScanningCamera', () => {
         mockCodeScannerCallback!([], mockFrame)
       })
 
-      expect(mockFocus.mock.calls.length).toBe(callsAfterLayout)
+      expect(mockFocus.mock.calls).toHaveLength(callsAfterLayout)
 
       // t=2600: advance past the next natural tick of the untouched interval (anchored at
       // t=0, so its next tick is at t=2500) — the periodic idle-nudge must still be alive.
@@ -2016,7 +2016,7 @@ describe('CodeScanningCamera', () => {
         jest.advanceTimersByTime(400)
       })
 
-      expect(mockFocus.mock.calls.length).toBe(callsAfterLayout + 1)
+      expect(mockFocus.mock.calls).toHaveLength(callsAfterLayout + 1)
     })
 
     it('preserves the idle-nudge cadence when nothing is ever detected (tilt workaround)', async () => {
@@ -2040,7 +2040,7 @@ describe('CodeScanningCamera', () => {
         jest.advanceTimersByTime(2 * 2500)
       })
 
-      expect(mockFocus.mock.calls.length).toBe(callsAfterLayout + 2)
+      expect(mockFocus.mock.calls).toHaveLength(callsAfterLayout + 2)
     })
 
     it('keeps the idle-nudge alive across a lock -> auto-confirm-rejected -> reset cycle (guards against stop-on-lock without a matching restart)', async () => {
@@ -2081,7 +2081,7 @@ describe('CodeScanningCamera', () => {
 
       // Neither the lock nor the reject-driven reset should have touched the cycling
       // timer — scanState was never a dependency of the effect that starts it.
-      expect(mockFocus.mock.calls.length).toBe(callsAfterLayout)
+      expect(mockFocus.mock.calls).toHaveLength(callsAfterLayout)
 
       // Advance past the suppression window plus a full cycle interval — if a
       // stop-on-lock (without a matching restart) regression crept back in, the timer

--- a/app/src/bcsc-theme/components/CodeScanningCamera.tsx
+++ b/app/src/bcsc-theme/components/CodeScanningCamera.tsx
@@ -53,6 +53,7 @@ import {
   determineScanState,
   getPaddedHighlightPosition,
   isCodeAlignedWithZones,
+  mergeLockedCodesWithAccumulated,
   transformBarcodeCoordinates,
 } from './utils/camera'
 
@@ -261,6 +262,11 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
   // This allows PDF-417 and Code-39 to be detected in separate frames rather than
   // requiring both in the same frame — a huge improvement on Android where the lower
   // resolution and ML Kit processing make simultaneous detection unreliable.
+  // Read by handleLockTransition (via mergeLockedCodesWithAccumulated) so that a lock
+  // triggered by a single barcode (e.g. the code-39 serial alone satisfying the
+  // single-zone BCSC_SN_SCAN_ZONES threshold) still carries along a different,
+  // recently-validated barcode — e.g. the birthdate-bearing PDF-417 — instead of
+  // silently dropping it (#4256/#4302).
   const accumulatedCodes = useRef<Map<string, { code: EnhancedCode; timestamp: number }>>(new Map())
   const ACCUMULATION_WINDOW_MS = Platform.OS === 'ios' ? 2000 : 3000
 
@@ -634,9 +640,19 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
     }
     // Freeze scanning — user must tap "Confirm" or "Try Again"
     // newScanState === 'locked' already guarantees ≥minCodesForAligned qualifying codes this frame,
-    // each with ≥LOCK_READING_THRESHOLD accumulated readings
+    // each with ≥LOCK_READING_THRESHOLD accumulated readings.
+    // Merge in anything the accumulator is still holding (e.g. a PDF-417 validated a
+    // moment ago but not present in this exact frame) so a lock driven by a single
+    // barcode — e.g. the code-39 serial alone satisfying the single-zone threshold —
+    // doesn't drop a different, already-read barcode (#4256/#4302). This frame's own
+    // validated codes were just added to the accumulator by accumulateValidatedResults
+    // above, so mergeLockedCodesWithAccumulated dedupes them back out and only the
+    // genuinely-missing extras get merged in.
     isLockedRef.current = true
-    lockedScanRef.current = { codes: qualifyingCodes, frame }
+    lockedScanRef.current = {
+      codes: mergeLockedCodesWithAccumulated(qualifyingCodes, accumulatedCodes.current, ACCUMULATION_WINDOW_MS),
+      frame,
+    }
     // Cancel any clear timeout so highlights persist
     if (clearHighlightTimeoutRef.current) {
       clearTimeout(clearHighlightTimeoutRef.current)
@@ -677,10 +693,12 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
     }
   }
 
-  // Suppress auto-refocus cycling while codes are actively being detected —
-  // refocusing mid-read blurs the frame and resets validation progress (see
-  // doFocus inside startFocusCycling below). Cycling resumes automatically once
-  // detections stop for this long.
+  // Event-driven gate for the idle-nudge tick below: doFocus() only actually calls
+  // camera.focus() once this many ms have passed with nothing decoded, so the
+  // fixed-interval timer never refocuses mid-read and resets validation progress
+  // (see doFocus inside startFocusCycling below). The tick resumes issuing real
+  // focus() calls automatically once detections stop for this long. Cross-platform —
+  // not gated to one OS.
   const FOCUS_SUPPRESS_AFTER_DETECTION_MS = 2000
   const lastDetectionAtRef = useRef(0)
 
@@ -795,10 +813,16 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
   // Updated every scan frame so focus cycling can prioritise empty zones.
   const detectedZoneIndices = useRef<Set<number>>(new Set())
 
-  // Auto-focus cycling: periodically focus on scan zone centers
+  // Auto-focus cycling: an idle-nudge tick, not a blind periodic refocus. It runs on
+  // a fixed interval, but each tick is a no-op unless FOCUS_SUPPRESS_AFTER_DETECTION_MS
+  // has elapsed since the last decode (see doFocus below) — so in practice it only
+  // fires when nothing has been read for a while, e.g. after a tilt or hand movement
+  // knocks focus off a scan zone. Runs continuously (start/stop is keyed off screen
+  // focus and mount, not scanState) rather than being restarted on every scan-state
+  // flip — see the effect below.
   const focusCycleIndex = useRef(0)
   const focusCycleTimerRef = useRef<NodeJS.Timeout | null>(null)
-  const FOCUS_CYCLE_INTERVAL_MS = 2500 // Cycle focus every 2.5 seconds
+  const FOCUS_CYCLE_INTERVAL_MS = 2500 // Idle-nudge tick interval
 
   const startFocusCycling = useCallback(() => {
     if (scanZones.length === 0 || !containerSize || !device?.supportsFocus) {
@@ -866,15 +890,14 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
     }
   }, [])
 
-  // Start/stop focus cycling based on scan state
+  // scanState is deliberately NOT a dependency: restarting the cycle on every
+  // scanning↔aligned flip fired startFocusCycling's immediate doFocus() each
+  // time (#4300 focus storm). doFocus self-guards on isLockedRef and the
+  // post-detection suppression window, so the timer can run continuously.
   useEffect(() => {
-    if (scanState === 'locked') {
-      stopFocusCycling()
-    } else if (containerSize && device?.supportsFocus) {
-      startFocusCycling()
-    }
+    startFocusCycling()
     return stopFocusCycling
-  }, [scanState, containerSize, startFocusCycling, stopFocusCycling, device])
+  }, [startFocusCycling, stopFocusCycling])
 
   /**
    * LIFECYCLE MANAGEMENT per react-native-vision-camera best practices:
@@ -886,6 +909,11 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
     useCallback(() => {
       // Screen gained focus - pause inactivity timeout while camera is active
       pauseActivityTracking()
+      // Restart cycling explicitly on refocus. Previously this happened incidentally
+      // via scanState-driven effect restarts; now that the cycling effect no longer
+      // depends on scanState (see the effect above), the restart must be explicit here.
+      // startFocusCycling() clears any existing timer first, so this is idempotent.
+      startFocusCycling()
 
       return () => {
         // Screen lost focus - reset camera state and resume inactivity tracking
@@ -893,7 +921,7 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
         stopFocusCycling()
         resumeActivityTracking()
       }
-    }, [pauseActivityTracking, stopFocusCycling, resumeActivityTracking])
+    }, [pauseActivityTracking, startFocusCycling, stopFocusCycling, resumeActivityTracking])
   )
 
   // Diagnostic: log whenever screen focus or app foreground/background state

--- a/app/src/bcsc-theme/components/CodeScanningCamera.tsx
+++ b/app/src/bcsc-theme/components/CodeScanningCamera.tsx
@@ -217,10 +217,6 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
   const [detectedCodes, setDetectedCodes] = useState<EnhancedCode[]>([])
   const highlightFadeAnim = useRef(new Animated.Value(0)).current
 
-  // Track if we're currently processing a scan to prevent multiple callbacks
-  const isProcessingScan = useRef(false)
-
-  const highlightTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const clearHighlightTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
   // Prevents initialZoom from being reapplied on every screen re-focus or camera re-init
@@ -748,10 +744,6 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
 
     // Cleanup timeout on unmount
     return () => {
-      if (highlightTimeoutRef.current) {
-        clearTimeout(highlightTimeoutRef.current)
-        highlightTimeoutRef.current = null
-      }
       if (clearHighlightTimeoutRef.current) {
         clearTimeout(clearHighlightTimeoutRef.current)
         clearHighlightTimeoutRef.current = null
@@ -947,16 +939,11 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
       // Reset all refs to clean state when component unmounts to avoid stale state
       isLockedRef.current = false
       lockedScanRef.current = null
-      isProcessingScan.current = false
       barcodeReadingsRef.clear()
       accumulatedCodesRef.clear()
       detectedZoneIndices.current = new Set()
 
       // Clear any pending animation timeouts to prevent memory leaks
-      if (highlightTimeoutRef.current) {
-        clearTimeout(highlightTimeoutRef.current)
-        highlightTimeoutRef.current = null
-      }
       if (clearHighlightTimeoutRef.current) {
         clearTimeout(clearHighlightTimeoutRef.current)
         clearHighlightTimeoutRef.current = null
@@ -1072,7 +1059,6 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
   const resetScanningState = useCallback(() => {
     isLockedRef.current = false
     lockedScanRef.current = null
-    isProcessingScan.current = false
     setFrozenFrameUri(null)
     setScanState('scanning')
     barcodeReadings.current.clear()
@@ -1080,10 +1066,6 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
     setDetectedCodes([])
 
     // Clean up any pending timeouts
-    if (highlightTimeoutRef.current) {
-      clearTimeout(highlightTimeoutRef.current)
-      highlightTimeoutRef.current = null
-    }
     if (clearHighlightTimeoutRef.current) {
       clearTimeout(clearHighlightTimeoutRef.current)
       clearHighlightTimeoutRef.current = null

--- a/app/src/bcsc-theme/components/CodeScanningCamera.tsx
+++ b/app/src/bcsc-theme/components/CodeScanningCamera.tsx
@@ -643,7 +643,9 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
     // doesn't drop a different, already-read barcode (#4256/#4302). This frame's own
     // validated codes were just added to the accumulator by accumulateValidatedResults
     // above, so mergeLockedCodesWithAccumulated dedupes them back out and only the
-    // genuinely-missing extras get merged in.
+    // genuinely-missing extras get merged in. Eligibility there is time-scoped, not
+    // card-identity-scoped — see mergeLockedCodesWithAccumulated's JSDoc for the
+    // accepted, self-correcting mid-scan card-swap edge case.
     isLockedRef.current = true
     lockedScanRef.current = {
       codes: mergeLockedCodesWithAccumulated(qualifyingCodes, accumulatedCodes.current, ACCUMULATION_WINDOW_MS),

--- a/app/src/bcsc-theme/components/CodeScanningCamera.tsx
+++ b/app/src/bcsc-theme/components/CodeScanningCamera.tsx
@@ -43,6 +43,7 @@ import {
 import { useBCSCActivity } from '../contexts/BCSCActivityContext'
 import { isBackgroundedAppState } from '../utils/app-state'
 import {
+  AccumulatedCode,
   CameraFormat,
   EnhancedCode,
   Rect,
@@ -263,7 +264,7 @@ const CodeScanningCamera: React.FC<CodeScanningCameraProps> = ({
   // single-zone BCSC_SN_SCAN_ZONES threshold) still carries along a different,
   // recently-validated barcode — e.g. the birthdate-bearing PDF-417 — instead of
   // silently dropping it (#4256/#4302).
-  const accumulatedCodes = useRef<Map<string, { code: EnhancedCode; timestamp: number }>>(new Map())
+  const accumulatedCodes = useRef<Map<string, AccumulatedCode>>(new Map())
   const ACCUMULATION_WINDOW_MS = Platform.OS === 'ios' ? 2000 : 3000
 
   // Track camera container and preview dimensions for coordinate transformation

--- a/app/src/bcsc-theme/components/utils/camera.test.ts
+++ b/app/src/bcsc-theme/components/utils/camera.test.ts
@@ -1,6 +1,7 @@
 import { Platform } from 'react-native'
 
 import {
+  AccumulatedCode,
   EnhancedCode,
   Rect,
   ScanZone,
@@ -9,6 +10,7 @@ import {
   determineScanState,
   getPaddedHighlightPosition,
   isCodeAlignedWithZones,
+  mergeLockedCodesWithAccumulated,
   transformBarcodeCoordinates,
 } from './camera'
 
@@ -460,5 +462,81 @@ describe('determineScanState', () => {
     const codes = [makeCode('ABC', true, 10)]
     const { newScanState } = determineScanState(codes, { ...OPTIONS, minCodesForAligned: 1 })
     expect(newScanState).toBe('locked')
+  })
+})
+
+// ─── mergeLockedCodesWithAccumulated ───────────────────────────────────────────
+
+const makeEnhancedCode = (type: string, value: string): EnhancedCode => ({ type, value }) as unknown as EnhancedCode
+
+describe('mergeLockedCodesWithAccumulated', () => {
+  const NOW = 1_000_000
+  const WINDOW_MS = 3000
+
+  it('merges an accumulated pdf-417 with a current-frame code-39', () => {
+    const pdf417 = makeEnhancedCode('pdf-417', 'DL_DATA')
+    const serial = makeEnhancedCode('code-39', 'SERIAL')
+    const accumulated: Map<string, AccumulatedCode> = new Map([['pdf-417-DL_DATA', { code: pdf417, timestamp: NOW }]])
+
+    const result = mergeLockedCodesWithAccumulated([serial], accumulated, WINDOW_MS, NOW)
+
+    expect(result).toEqual([pdf417, serial])
+  })
+
+  it('dedupes an accumulated entry whose type-value key matches a current-frame code', () => {
+    const serial = makeEnhancedCode('code-39', 'SERIAL')
+    // Same key as the current-frame code — accumulateValidatedResults would have just
+    // written this in the same scanner-callback pass that produced qualifyingCodes.
+    const accumulated: Map<string, AccumulatedCode> = new Map([['code-39-SERIAL', { code: serial, timestamp: NOW }]])
+
+    const result = mergeLockedCodesWithAccumulated([serial], accumulated, WINDOW_MS, NOW)
+
+    expect(result).toEqual([serial])
+  })
+
+  it('drops accumulated entries older than windowMs', () => {
+    const pdf417 = makeEnhancedCode('pdf-417', 'DL_DATA')
+    const serial = makeEnhancedCode('code-39', 'SERIAL')
+    const accumulated: Map<string, AccumulatedCode> = new Map([
+      ['pdf-417-DL_DATA', { code: pdf417, timestamp: NOW - (WINDOW_MS + 1) }],
+    ])
+
+    const result = mergeLockedCodesWithAccumulated([serial], accumulated, WINDOW_MS, NOW)
+
+    expect(result).toEqual([serial])
+  })
+
+  it('keeps an accumulated entry exactly at the window boundary (not strictly older)', () => {
+    const pdf417 = makeEnhancedCode('pdf-417', 'DL_DATA')
+    const serial = makeEnhancedCode('code-39', 'SERIAL')
+    const accumulated: Map<string, AccumulatedCode> = new Map([
+      ['pdf-417-DL_DATA', { code: pdf417, timestamp: NOW - WINDOW_MS }],
+    ])
+
+    const result = mergeLockedCodesWithAccumulated([serial], accumulated, WINDOW_MS, NOW)
+
+    expect(result).toEqual([pdf417, serial])
+  })
+
+  it('orders accumulated extras before current-frame codes', () => {
+    const pdf417 = makeEnhancedCode('pdf-417', 'DL_DATA')
+    const otherExtra = makeEnhancedCode('code-128', 'OTHER_EXTRA')
+    const serial = makeEnhancedCode('code-39', 'SERIAL')
+    const accumulated: Map<string, AccumulatedCode> = new Map([
+      ['pdf-417-DL_DATA', { code: pdf417, timestamp: NOW }],
+      ['code-128-OTHER_EXTRA', { code: otherExtra, timestamp: NOW }],
+    ])
+
+    const result = mergeLockedCodesWithAccumulated([serial], accumulated, WINDOW_MS, NOW)
+
+    expect(result).toEqual([pdf417, otherExtra, serial])
+  })
+
+  it('returns the current frame unchanged when the accumulator is empty', () => {
+    const serial = makeEnhancedCode('code-39', 'SERIAL')
+
+    const result = mergeLockedCodesWithAccumulated([serial], new Map(), WINDOW_MS, NOW)
+
+    expect(result).toEqual([serial])
   })
 })

--- a/app/src/bcsc-theme/components/utils/camera.ts
+++ b/app/src/bcsc-theme/components/utils/camera.ts
@@ -493,6 +493,18 @@ export type AccumulatedCode = { code: EnhancedCode; timestamp: number }
  * the accumulator; anything else (including a stale same-type/different-value
  * entry) is passed through and left for the ordering to resolve downstream.
  *
+ * Scoping: eligibility is time-based only (`windowMs`), not card-identity-based —
+ * this is what makes the normal combo-card case work. Known limitation (accepted,
+ * minor): if the user swaps to a *different* physical BCSC card mid-scan within the
+ * window and the new card's serial locks before the prior card's PDF-417 expires,
+ * the merge can pair a serial from card B with a birthdate from card A. This is
+ * self-correcting — the backend rejects the mismatched serial+birthdate
+ * (`VerificationCardError.MismatchedSerial` → retry), so it never produces an
+ * incorrect authorization or corrupts data. Clearing on barcode-reading decay was
+ * considered and rejected: that would defeat the feature, since carrying a
+ * no-longer-visible barcode into the lock is precisely the point. A correct
+ * card-identity-aware invalidation is deferred as out of scope.
+ *
  * @param currentFrameCodes Qualifying codes from the frame that triggered the lock
  * @param accumulated Map of recently-validated codes, keyed by `${type}-${value}`
  * @param windowMs Max age (ms) for an accumulated entry to still be eligible

--- a/app/src/bcsc-theme/components/utils/camera.ts
+++ b/app/src/bcsc-theme/components/utils/camera.ts
@@ -473,6 +473,54 @@ export const determineScanState = (
   return { newScanState, qualifyingCodes }
 }
 
+/** A validated code carried over from a recent frame, with the time it was recorded. */
+export type AccumulatedCode = { code: EnhancedCode; timestamp: number }
+
+/**
+ * Merge a locked frame's qualifying codes with any recently-validated codes carried
+ * over from the accumulator, so a lock that only required a single barcode (e.g.
+ * `minCodesForAligned === 1` for the single-zone `BCSC_SN_SCAN_ZONES`) still hands
+ * along a different barcode that was read moments earlier but dropped out of frame
+ * before the lock — e.g. the birthdate-bearing PDF-417 on a combo card when the
+ * easier code-39 serial alone satisfies the lock threshold first.
+ *
+ * Ordering: accumulated extras are returned FIRST, current-frame codes LAST. Callers
+ * (`useCardScanner`'s decode loop) apply "later code wins" when the same kind of
+ * data shows up twice, so putting the current frame last means a fresher reading
+ * always overrides a stale accumulated one of the same decoded kind — ordering
+ * alone resolves that conflict, no extra same-kind filtering is needed here. Only
+ * exact `${type}-${value}` duplicates against the current frame are dropped from
+ * the accumulator; anything else (including a stale same-type/different-value
+ * entry) is passed through and left for the ordering to resolve downstream.
+ *
+ * @param currentFrameCodes Qualifying codes from the frame that triggered the lock
+ * @param accumulated Map of recently-validated codes, keyed by `${type}-${value}`
+ * @param windowMs Max age (ms) for an accumulated entry to still be eligible
+ * @param now Current time in ms (injectable for tests; defaults to `Date.now()`)
+ * @returns Current-frame codes plus any still-fresh, non-duplicate accumulated codes, extras first
+ */
+export const mergeLockedCodesWithAccumulated = (
+  currentFrameCodes: EnhancedCode[],
+  accumulated: ReadonlyMap<string, AccumulatedCode>,
+  windowMs: number,
+  now: number = Date.now()
+): EnhancedCode[] => {
+  const currentFrameKeys = new Set(currentFrameCodes.map((c) => `${c.type}-${c.value}`))
+
+  const accumulatedExtras: EnhancedCode[] = []
+  accumulated.forEach((entry, key) => {
+    if (now - entry.timestamp > windowMs) {
+      return
+    }
+    if (currentFrameKeys.has(key)) {
+      return
+    }
+    accumulatedExtras.push(entry.code)
+  })
+
+  return [...accumulatedExtras, ...currentFrameCodes]
+}
+
 /**
  * Scan zone for the BC Services Card / Driver's License serial number scan screen.
  * Coordinates are normalized (0–1) relative to the camera container (portrait).

--- a/app/src/bcsc-theme/hooks/useCardScanner.test.tsx
+++ b/app/src/bcsc-theme/hooks/useCardScanner.test.tsx
@@ -205,6 +205,59 @@ describe('useCardScanner', () => {
         })
       )
     })
+
+    it('should process a combo card scan with the serial ordered before the licence code (regression #4256/#4302)', async () => {
+      // mergeLockedCodesWithAccumulated returns accumulated extras first, current-frame
+      // codes last — so a lock driven by the serial alone can hand scanCard the codes in
+      // [serial, licence] order (the reverse of the "multiple barcodes" case above).
+      // scanCard's decode loop is order-independent: it just needs both kinds present.
+      const useApiMock = jest.mocked(useApi)
+      const bifoldMock = jest.mocked(Bifold)
+      const useSecureActionsMock = jest.mocked(useSecureActions)
+
+      const mockState: any = {
+        bcsc: { accountSetupType: AccountSetupType.AddAccount },
+        bcscSecure: { additionalEvidenceData: [] },
+      }
+      const mockAuthorization: any = {
+        authorization: {
+          authorizeDevice: jest.fn(),
+        },
+      }
+      const code39Serial: ScanableCode = {
+        type: 'code-39',
+        value: 'S00023254',
+      }
+      const pdf417DL: ScanableCode = {
+        type: 'pdf-417',
+        value: BC_COMBO_CARD_DL_BARCODE_NO_BCSC_A,
+      }
+      const mockHandleCardData = jest.fn()
+
+      useApiMock.mockReturnValue(mockAuthorization)
+      useSecureActionsMock.mockReturnValue({
+        updateUserInfo: jest.fn(),
+        updateDeviceCodes: jest.fn(),
+        updateCardProcess: jest.fn(),
+        updateVerificationOptions: jest.fn(),
+      } as any)
+      bifoldMock.useStore.mockReturnValue([mockState, mockDispatch])
+      bifoldMock.useServices.mockReturnValue([{ debug: jest.fn() } as any])
+
+      const hook = renderHook(() => useCardScanner())
+
+      const scanCard = hook.result.current.scanCard
+
+      await scanCard([code39Serial, pdf417DL], mockHandleCardData)
+
+      expect(mockHandleCardData).toHaveBeenNthCalledWith(
+        1,
+        'S00023254',
+        expect.objectContaining({
+          licenseNumber: '2222222',
+        })
+      )
+    })
   })
 
   describe('handleScanComboCard', () => {

--- a/app/src/bcsc-theme/hooks/useCardScanner.test.tsx
+++ b/app/src/bcsc-theme/hooks/useCardScanner.test.tsx
@@ -207,10 +207,10 @@ describe('useCardScanner', () => {
     })
 
     it('should process a combo card scan with the serial ordered before the licence code (regression #4256/#4302)', async () => {
-      // mergeLockedCodesWithAccumulated returns accumulated extras first, current-frame
-      // codes last — so a lock driven by the serial alone can hand scanCard the codes in
-      // [serial, licence] order (the reverse of the "multiple barcodes" case above).
-      // scanCard's decode loop is order-independent: it just needs both kinds present.
+      // scanCard/handleCardScan is order-independent: it decodes each code by kind into
+      // separate bcscSerial/license fields regardless of array position. This deliberately
+      // passes [serial, licence] — the REVERSE of mergeLockedCodesWithAccumulated's actual
+      // output order (accumulated extras like the licence come first: [licence, serial]).
       const useApiMock = jest.mocked(useApi)
       const bifoldMock = jest.mocked(Bifold)
       const useSecureActionsMock = jest.mocked(useSecureActions)


### PR DESCRIPTION
## What

Card scanning on the BC Services Card screen was unreliable, especially on Android: the camera's auto-focus would refire rapidly while the app was still deciding whether a barcode was properly aligned, which could blur the frame right as it was trying to read a card. Separately, on combo cards (BC Services Card + driver's licence in one card), the scan could lock in and finish using only the easier serial-number barcode, silently dropping a driver's licence barcode it had *already* read a moment earlier — sending the user into a manual birthdate-entry step they shouldn't have needed.

This change fixes both:
- The camera's auto-focus nudge no longer restarts itself every time the on-screen alignment state flips; it keeps running on its own steady schedule and only nudges focus when nothing has been read in a while.
- When a scan locks in on the serial number alone, any driver's licence barcode that was already read moments before is now carried along instead of thrown away.

## Why

Users on Android were reporting that scanning a BC Services Card in "step 1" of verification wasn't picking up the barcode data reliably (issue #4256). Investigation (see #4300 and #4302) found two remaining causes after the earlier fix in #4286:
1. The focus-cycling logic was tied to the on-screen scanning/aligned state, so it restarted itself dozens of times a second as that state flickered — undermining the auto-focus instead of helping it.
2. A combo card's lock only strictly needs the barcode with the serial number; the driver's-licence barcode data the camera had *already* validated a moment before could be dropped on the floor, forcing a fallback to manual birthdate entry that shouldn't have been necessary.

## Decisions

- **Focus fix scope (rec 1 only).** Removed `scanState` from the focus-cycling `useEffect`'s dependency array so a scanning↔aligned flip no longer tears down and restarts the cycle (the actual re-trigger storm). The 2.5s periodic focus timer itself is **unchanged** — rec 2's "event-driven" design is already delivered by #4286's `FOCUS_SUPPRESS_AFTER_DETECTION_MS` suppression window (a tick only calls `focus()` once nothing has been decoded recently), so only the doc comments were reframed to describe that as the intended design. No platform gate was added — this applies on both iOS and Android.
- **One combined PR.** Per plan, this PR bundles both the focus fix (rec 1) and the combo-card accumulator fix (rec 3) plus all associated tests, rather than splitting into two PRs.
- **Accumulator merge ordering.** `mergeLockedCodesWithAccumulated` returns accumulated extras *before* current-frame codes. `useCardScanner`'s decode loop applies "later code wins" for same-kind data, so putting the current frame last means a fresher reading always overrides a stale accumulated one of the same kind — ordering alone resolves that case; no same-kind entries are proactively dropped.
- **Rec 2 (event-driven focus suppression) was already delivered by #4286** (`FOCUS_SUPPRESS_AFTER_DETECTION_MS`) — nothing further needed here beyond the comment reframing above.
- `useFocusEffect`'s focus-gained handler now explicitly calls `startFocusCycling()` on screen refocus, since that previously happened only as an incidental side effect of the (now-removed) `scanState` dependency.
- Left the lock threshold (`LOCK_READING_THRESHOLD`) and `determineScanState` untouched, per plan — only the *codes carried into the lock* changed, not what triggers a lock.
- **Dead-code cleanup (bundled).** Removed two provably-inert refs in `CodeScanningCamera.tsx`: `isProcessingScan` (write-only, never read — the real re-entrancy guard is `isLockedRef`) and `highlightTimeoutRef` (never assigned a timeout, so its clear-blocks were no-ops; the live highlight timer is the separate `clearHighlightTimeoutRef`). Deletions only, no behavioral change.
- **Known limitation — accumulator is time-scoped, not card-scoped.** The accumulator merged into a lock is bounded only by the accumulation window, not by card identity. If a user physically swaps to a *different* BC Services Card mid-scan within that window and the new card's serial locks before the prior card's licence barcode expires, the merge could pair a serial from one card with a birthdate from the other. This is contrived (a holder has one card) and self-correcting — the backend rejects the mismatched serial+birthdate (→ MismatchedSerial screen → retry), with no incorrect authorization or data corruption. The naive fix (clear on barcode-decay) would defeat the feature, since carrying a no-longer-visible barcode into the lock is its whole purpose; a card-identity-aware invalidation is deferred as out of scope. Documented in `mergeLockedCodesWithAccumulated`.

## Tests

- `CodeScanningCamera.test.tsx` — new `Focus cycling restart storm (regression #4256/#4300)` describe: a discriminating case showing the call count is unchanged across a scanning↔aligned flip once the suppression window has lapsed (where the old code would have fired an extra unsuppressed `focus()`), while the periodic idle-nudge tick still fires afterward; idle-nudge cadence preserved with zero detections; idle-nudge survives a lock → auto-confirm-rejected → reset cycle.
- `CodeScanningCamera.test.tsx` — new `Lock keeps accumulated licence barcode (regression #4256/#4302)` describe: a validated-but-not-locked PDF-417 rides along into a lock triggered by the serial alone; a second case confirms the accumulated barcode is correctly dropped once it's aged out past the accumulation window.
- `utils/camera.test.ts` — new `mergeLockedCodesWithAccumulated` unit tests: merge, dedupe, window expiry (including the exact boundary), ordering, and the empty-accumulator passthrough.
- `hooks/useCardScanner.test.tsx` — added a case asserting `scanCard` handles the serial-before-licence code order correctly.
- Full suite: `yarn check` (typecheck + lint + format + all 283 test suites / 2812 tests) passes clean; no snapshot changes.

## Verification

1. On a device (ideally Android), go to Add a Card → BC Services Card → scan a combo card (BC Services Card + driver's licence).
2. Confirm the scan locks in promptly without visible focus "hunting"/flicker, and that scanning a combo card resolves straight to the setup flow (birthdate pre-filled from the licence) rather than falling back to manual birthdate entry.
3. Confirm scanning a serial-only BC Services Card (no combo licence data) still works as before.

Also addresses #4300 (focus re-trigger storm) and #4302 (combo-card licence data retention) — leaving those open for the reporter to close.

