### PR TITLE
fix: prevent zombie store recreation on factory reset mid-verification

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useFactoryReset.test.ts
+++ b/app/src/bcsc-theme/api/hooks/useFactoryReset.test.ts
@@ -1,7 +1,7 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { useFactoryReset } from '@/bcsc-theme/api/hooks/useFactoryReset'
 import { useBCSCAgentSafe } from '@/bcsc-theme/features/agent/BCSCAgentProvider'
-import { deleteWalletStore, purgeWalletStore, shutdownAgent } from '@/bcsc-theme/features/agent/services/agent-service'
+import { purgeWalletStore } from '@/bcsc-theme/features/agent/services/agent-service'
 import { useBCSCApiClientState } from '@/bcsc-theme/hooks/useBCSCApiClient'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCDispatchAction } from '@/store'
@@ -21,11 +21,11 @@ jest.mock('@/bcsc-theme/features/agent/BCSCAgentProvider', () => ({
   useBCSCAgentSafe: jest.fn(),
 }))
 // Factory mock (not automock) so the agent-service module's heavy transitive deps
-// (Credo, indy-vdr-shared, etc.) are never loaded by this hook test.
+// (Credo, indy-vdr-shared, etc.) are never loaded by this hook test. Only
+// purgeWalletStore is called directly by useFactoryReset now — the live-agent
+// shutdown/delete path is delegated to agentCtx.teardownAgent (mocked separately).
 jest.mock('@/bcsc-theme/features/agent/services/agent-service', () => ({
-  deleteWalletStore: jest.fn().mockResolvedValue(undefined),
   purgeWalletStore: jest.fn().mockResolvedValue(undefined),
-  shutdownAgent: jest.fn().mockResolvedValue(undefined),
 }))
 jest.mock('react-native-config', () => ({ Config: { INDY_VDR_PROXY_URL: '' } }))
 
@@ -141,7 +141,7 @@ describe('useFactoryReset', () => {
     expect(deleteRegistrationMock).toHaveBeenCalledWith('native-token', 'test-client-id')
   })
 
-  it('should delete the wallet store and shut down the agent before clearing state', async () => {
+  it('awaits agentCtx.teardownAgent before clearing state when a live agent exists', async () => {
     const bcscCoreMock = jest.mocked(BcscCore)
     const useSecureActionsMock = jest.mocked(useSecureActions)
     const bifoldMock = jest.mocked(Bifold)
@@ -150,14 +150,13 @@ describe('useFactoryReset', () => {
 
     const clearSecureStateMock = jest.fn()
     const deleteSecureDataMock = jest.fn().mockResolvedValue(undefined)
+    const teardownAgentMock = jest.fn()
 
     const callOrder: string[] = []
-    // Both teardown ops now route through the serialized agent-service helpers.
-    jest.mocked(deleteWalletStore).mockImplementation(async () => {
-      callOrder.push('deleteStore')
-    })
-    jest.mocked(shutdownAgent).mockImplementation(async () => {
-      callOrder.push('shutdown')
+    // Agent shutdown + wallet store deletion are now owned by useAgentSetupViewModel's
+    // teardownAgent (see its own test suite); useFactoryReset just awaits it.
+    teardownAgentMock.mockImplementation(async () => {
+      callOrder.push('teardownAgent')
     })
     deleteSecureDataMock.mockImplementation(async () => {
       callOrder.push('deleteSecureData')
@@ -173,6 +172,7 @@ describe('useFactoryReset', () => {
       error: null,
       retry: jest.fn(),
       resetWallet: jest.fn(),
+      teardownAgent: teardownAgentMock,
     })
 
     useBCSCApiClientStateMock.mockReturnValue({
@@ -202,33 +202,32 @@ describe('useFactoryReset', () => {
       expect(result.success).toBe(true)
     })
 
-    // Routed through the wallet-op queue rather than calling the agent directly.
-    expect(deleteWalletStore).toHaveBeenCalledWith(agent)
-    expect(shutdownAgent).toHaveBeenCalledWith(agent, expect.anything())
-    // Shut down before deleting (so shutdown closes a still-open store instead of
-    // throwing onCloseContext on a removed one), and both before the key-clearing
-    // steps so the wallet is removed before re-onboarding can derive a new key.
-    expect(callOrder.indexOf('shutdown')).toBeLessThan(callOrder.indexOf('deleteStore'))
-    expect(callOrder.indexOf('deleteStore')).toBeLessThan(callOrder.indexOf('deleteSecureData'))
-    expect(callOrder.indexOf('deleteStore')).toBeLessThan(callOrder.indexOf('clearSecureState'))
+    expect(teardownAgentMock).toHaveBeenCalledTimes(1)
+    // teardownAgent must complete (agent shut down, store deleted) before the rest of
+    // the reset proceeds, so nothing can race a mounted consumer against the deleted store.
+    expect(callOrder.indexOf('teardownAgent')).toBeLessThan(callOrder.indexOf('deleteSecureData'))
+    expect(callOrder.indexOf('teardownAgent')).toBeLessThan(callOrder.indexOf('clearSecureState'))
   })
 
-  it('should still succeed if the wallet store delete throws', async () => {
+  it('dispatches CLEAR_BCSC, then clearSecureState, then DID_AUTHENTICATE(false)', async () => {
     const bcscCoreMock = jest.mocked(BcscCore)
     const useSecureActionsMock = jest.mocked(useSecureActions)
     const bifoldMock = jest.mocked(Bifold)
     const useRegistrationApiMock = jest.mocked(useRegistrationApi)
     const useBCSCApiClientStateMock = jest.mocked(useBCSCApiClientState)
-    const warnLogMock = jest.fn()
 
-    jest.mocked(deleteWalletStore).mockRejectedValue(new Error('boom'))
-    jest.mocked(shutdownAgent).mockResolvedValue(undefined)
-    jest.mocked(useBCSCAgentSafe).mockReturnValue({
-      agent: { id: 'agent' } as any,
-      loading: false,
-      error: null,
-      retry: jest.fn(),
-      resetWallet: jest.fn(),
+    const callOrder: string[] = []
+    const clearSecureStateMock = jest.fn(() => {
+      callOrder.push('clearSecureState')
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dispatchMock = jest.fn((action: any) => {
+      if (action.type === BCDispatchAction.CLEAR_BCSC) {
+        callOrder.push('CLEAR_BCSC')
+      }
+      if (action.type === DispatchAction.DID_AUTHENTICATE) {
+        callOrder.push('DID_AUTHENTICATE')
+      }
     })
 
     useBCSCApiClientStateMock.mockReturnValue({
@@ -242,14 +241,14 @@ describe('useFactoryReset', () => {
     bcscCoreMock.getAccount.mockResolvedValue({ clientID: 'test-client-id' } as any)
     bcscCoreMock.removeAccount.mockResolvedValue(undefined)
     useSecureActionsMock.mockReturnValue({
-      clearSecureState: jest.fn(),
+      clearSecureState: clearSecureStateMock,
       deleteSecureData: jest.fn().mockResolvedValue(undefined),
     } as any)
     bifoldMock.useStore.mockReturnValue([
       { bcscSecure: { registrationAccessToken: 'token', additionalEvidenceData: [] } } as any,
-      jest.fn(),
+      dispatchMock,
     ])
-    bifoldMock.useServices.mockReturnValue([{ info: jest.fn(), warn: warnLogMock, error: jest.fn() }] as any)
+    bifoldMock.useServices.mockReturnValue([{ info: jest.fn(), warn: jest.fn(), error: jest.fn() }] as any)
 
     const hook = renderHook(() => useFactoryReset())
 
@@ -258,10 +257,10 @@ describe('useFactoryReset', () => {
       expect(result.success).toBe(true)
     })
 
-    expect(warnLogMock).toHaveBeenCalledWith(
-      expect.stringContaining('deleteStore() failed'),
-      expect.objectContaining({ error: expect.any(Error) })
-    )
+    // hasAccount (CLEAR_BCSC) must flip false before bcscSecure clears, so RootStack
+    // short-circuits to OnboardingStack before it ever derives showVerifyStack —
+    // this is what prevents the transient MainStack mount described in #4336.
+    expect(callOrder).toStrictEqual(['CLEAR_BCSC', 'clearSecureState', 'DID_AUTHENTICATE'])
   })
 
   it('purges an orphaned wallet store when no live agent is held but a wallet key exists', async () => {
@@ -276,7 +275,7 @@ describe('useFactoryReset', () => {
     const useRegistrationApiMock = jest.mocked(useRegistrationApi)
     const useBCSCApiClientStateMock = jest.mocked(useBCSCApiClientState)
 
-    // No live agent (mid-reinitialization), so the direct deleteWalletStore path
+    // No live agent (mid-reinitialization), so the agentCtx.teardownAgent path
     // is unavailable.
     jest.mocked(useBCSCAgentSafe).mockReturnValue(null)
 
@@ -318,7 +317,6 @@ describe('useFactoryReset', () => {
     expect(purgeWalletStore).toHaveBeenCalledWith(
       expect.objectContaining({ walletSecret: expect.objectContaining({ key: 'stale-wallet-key' }) })
     )
-    expect(deleteWalletStore).not.toHaveBeenCalled()
     expect(bcscCoreMock.removeAccount).toHaveBeenCalledWith()
   })
 

--- a/app/src/bcsc-theme/api/hooks/useFactoryReset.test.ts
+++ b/app/src/bcsc-theme/api/hooks/useFactoryReset.test.ts
@@ -203,8 +203,11 @@ describe('useFactoryReset', () => {
     })
 
     expect(teardownAgentMock).toHaveBeenCalledTimes(1)
-    // teardownAgent must complete (agent shut down, store deleted) before the rest of
-    // the reset proceeds, so nothing can race a mounted consumer against the deleted store.
+    // useFactoryReset awaits agentCtx.teardownAgent() before continuing, and
+    // teardownAgentMock only pushes 'teardownAgent' to callOrder once its own async
+    // implementation resolves — so finding it before 'deleteSecureData'/'clearSecureState'
+    // proves teardownAgent COMPLETED (not just started) before the rest of the reset
+    // proceeds, so nothing can race a mounted consumer against the deleted store.
     expect(callOrder.indexOf('teardownAgent')).toBeLessThan(callOrder.indexOf('deleteSecureData'))
     expect(callOrder.indexOf('teardownAgent')).toBeLessThan(callOrder.indexOf('clearSecureState'))
   })

--- a/app/src/bcsc-theme/api/hooks/useFactoryReset.test.ts
+++ b/app/src/bcsc-theme/api/hooks/useFactoryReset.test.ts
@@ -150,20 +150,23 @@ describe('useFactoryReset', () => {
 
     const clearSecureStateMock = jest.fn()
     const deleteSecureDataMock = jest.fn().mockResolvedValue(undefined)
-    const teardownAgentMock = jest.fn()
 
-    const callOrder: string[] = []
-    // Agent shutdown + wallet store deletion are now owned by useAgentSetupViewModel's
-    // teardownAgent (see its own test suite); useFactoryReset just awaits it.
-    teardownAgentMock.mockImplementation(async () => {
-      callOrder.push('teardownAgent')
+    // A manually-resolved deferred promise, rather than a callOrder array pushed to
+    // from inside async mock bodies. Timing-based approaches (an internal `await
+    // Promise.resolve()`, or even a macrotask `await new Promise(setTimeout)`) are
+    // unreliable here: whether or not the call site actually awaits
+    // agentCtx.teardownAgent(), the rest of the reset's own await chain
+    // (removeAccountArtifacts -> getAccount/deleteRegistration/deleteSecureData/
+    // removeAccount) gives a fire-and-forget call's continuation plenty of scheduler
+    // turns to resolve before assertion time anyway — so a timing-only test can't
+    // distinguish "awaited" from "dropped await". Holding teardownAgent open until we
+    // explicitly resolve it, and asserting nothing past it has run in the meantime,
+    // proves the call site actually blocks on it regardless of scheduling.
+    let resolveTeardown: () => void = () => undefined
+    const teardownPromise = new Promise<void>((resolve) => {
+      resolveTeardown = resolve
     })
-    deleteSecureDataMock.mockImplementation(async () => {
-      callOrder.push('deleteSecureData')
-    })
-    clearSecureStateMock.mockImplementation(() => {
-      callOrder.push('clearSecureState')
-    })
+    const teardownAgentMock = jest.fn().mockReturnValue(teardownPromise)
 
     const agent = { id: 'agent' } as any
     jest.mocked(useBCSCAgentSafe).mockReturnValue({
@@ -197,19 +200,32 @@ describe('useFactoryReset', () => {
 
     const hook = renderHook(() => useFactoryReset())
 
-    await act(async () => {
-      const result = await hook.result.current()
-      expect(result.success).toBe(true)
+    let resultPromise!: ReturnType<typeof hook.result.current>
+    act(() => {
+      resultPromise = hook.result.current()
     })
 
+    // Flush several microtask turns without resolving teardownPromise. If the call site
+    // dropped its `await`, execution falls through to removeAccountArtifacts (and on to
+    // clearSecureState) regardless of whether teardownAgent has settled — getAccount
+    // would already have been called by now.
+    await act(async () => {
+      for (let i = 0; i < 5; i++) {
+        await Promise.resolve()
+      }
+    })
+
+    expect(bcscCoreMock.getAccount).not.toHaveBeenCalled()
+    expect(clearSecureStateMock).not.toHaveBeenCalled()
+
+    resolveTeardown()
+
+    const result = await act(async () => resultPromise)
+
+    expect(result.success).toBe(true)
     expect(teardownAgentMock).toHaveBeenCalledTimes(1)
-    // useFactoryReset awaits agentCtx.teardownAgent() before continuing, and
-    // teardownAgentMock only pushes 'teardownAgent' to callOrder once its own async
-    // implementation resolves — so finding it before 'deleteSecureData'/'clearSecureState'
-    // proves teardownAgent COMPLETED (not just started) before the rest of the reset
-    // proceeds, so nothing can race a mounted consumer against the deleted store.
-    expect(callOrder.indexOf('teardownAgent')).toBeLessThan(callOrder.indexOf('deleteSecureData'))
-    expect(callOrder.indexOf('teardownAgent')).toBeLessThan(callOrder.indexOf('clearSecureState'))
+    expect(bcscCoreMock.getAccount).toHaveBeenCalled()
+    expect(clearSecureStateMock).toHaveBeenCalled()
   })
 
   it('dispatches CLEAR_BCSC, then clearSecureState, then DID_AUTHENTICATE(false)', async () => {

--- a/app/src/bcsc-theme/api/hooks/useFactoryReset.tsx
+++ b/app/src/bcsc-theme/api/hooks/useFactoryReset.tsx
@@ -1,5 +1,5 @@
 import { useBCSCAgentSafe } from '@/bcsc-theme/features/agent/BCSCAgentProvider'
-import { deleteWalletStore, purgeWalletStore, shutdownAgent } from '@/bcsc-theme/features/agent/services/agent-service'
+import { purgeWalletStore } from '@/bcsc-theme/features/agent/services/agent-service'
 import { useBCSCApiClientState } from '@/bcsc-theme/hooks/useBCSCApiClient'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { ledgerResolver } from '@/configs/ledgers/indy/ledgerResolver'
@@ -120,22 +120,16 @@ export const useFactoryReset = () => {
 
         // Tear the agent down before clearing keys/state: if keys were cleared first,
         // re-onboarding would derive a new wallet key and the next agent init would
-        // trip on the stale on-disk wallet (duplicate-store error, code 3). Shut down
-        // BEFORE deleting (same order as resetWallet) — deleting first leaves the
-        // agent's askar context pointing at a removed store, so its shutdown's
-        // onCloseContext throws "There is no open store". Both ops route through the
-        // agent-service wallet-op queue, and shutdownAgent is idempotent so the
-        // shutdown the provider fires on DID_AUTHENTICATE -> false unmount is a no-op.
+        // trip on the stale on-disk wallet (duplicate-store error, code 3).
+        // teardownAgent shuts down before deleting (deleting first leaves the agent's
+        // askar context pointing at a removed store, so its shutdown's onCloseContext
+        // throws "There is no open store"), nulls the provider's agent reference, and
+        // is itself best-effort/non-throwing. Both ops route through the agent-service
+        // wallet-op queue, so they never race the shutdown the provider fires on
+        // DID_AUTHENTICATE -> false unmount (also idempotent).
         if (agentCtx?.agent) {
-          const agent = agentCtx.agent
-          // shutdownAgent is best-effort and logs its own errors.
-          await shutdownAgent(agent, logger)
-          try {
-            logger.info('FactoryReset: Deleting wallet store...')
-            await deleteWalletStore(agent)
-          } catch (err) {
-            logger.warn('FactoryReset: wallet deleteStore() failed; wallet file may persist', { error: err })
-          }
+          logger.info('FactoryReset: Tearing down agent and wallet store...')
+          await agentCtx.teardownAgent()
         } else if (store.bcscSecure.walletKey) {
           // No live agent, but a reset may have been interrupted mid-rebuild and
           // left an on-disk store keyed with this about-to-be-cleared key. Purge
@@ -161,11 +155,17 @@ export const useFactoryReset = () => {
 
         await removeAccountArtifacts()
 
-        // Reset BCSC state to initial state
+        // Reset BCSC state to initial state. CLEAR_BCSC (which flips hasAccount to
+        // false) must dispatch BEFORE clearSecureState (which resets bcscSecure,
+        // including verifiedStatus out of IN_PROGRESS) — RootStack short-circuits to
+        // OnboardingStack on `hasAccount === false` before it ever derives
+        // showVerifyStack, so ordering it first prevents the transient MainStack
+        // mount that let Bifold's provider tree fire storage reads against the
+        // wallet store this reset just deleted.
         logger.info('FactoryReset: Clearing secure and plain BCSC state...')
+        dispatch({ type: BCDispatchAction.CLEAR_BCSC, payload: bcscState ? [bcscState] : undefined })
         clearSecureState()
 
-        dispatch({ type: BCDispatchAction.CLEAR_BCSC, payload: bcscState ? [bcscState] : undefined })
         client.clearTokens()
 
         logger.info('FactoryReset: Logging out user...')

--- a/app/src/bcsc-theme/features/agent/BCSCAgentProvider.test.tsx
+++ b/app/src/bcsc-theme/features/agent/BCSCAgentProvider.test.tsx
@@ -30,6 +30,7 @@ describe('BCSCAgentProvider', () => {
       error: null,
       retry: jest.fn(),
       resetWallet: jest.fn(),
+      teardownAgent: jest.fn(),
     })
 
     const { getByText } = render(
@@ -48,6 +49,7 @@ describe('BCSCAgentProvider', () => {
       error: null,
       retry: jest.fn(),
       resetWallet: jest.fn(),
+      teardownAgent: jest.fn(),
     })
 
     const { getByText } = render(
@@ -62,7 +64,14 @@ describe('BCSCAgentProvider', () => {
   it('exposes the agent and loading=false when ready', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const agent = {} as any
-    mockViewModel.mockReturnValue({ agent, status: 'ready', error: null, retry: jest.fn(), resetWallet: jest.fn() })
+    mockViewModel.mockReturnValue({
+      agent,
+      status: 'ready',
+      error: null,
+      retry: jest.fn(),
+      resetWallet: jest.fn(),
+      teardownAgent: jest.fn(),
+    })
 
     const { getByText } = render(
       <BCSCAgentProvider>
@@ -75,7 +84,14 @@ describe('BCSCAgentProvider', () => {
 
   it('exposes the error and loading=false when init fails', () => {
     const error = AppError.fromErrorDefinition(ErrorRegistry.AGENT_INITIALIZATION_ERROR)
-    mockViewModel.mockReturnValue({ agent: null, status: 'error', error, retry: jest.fn(), resetWallet: jest.fn() })
+    mockViewModel.mockReturnValue({
+      agent: null,
+      status: 'error',
+      error,
+      retry: jest.fn(),
+      resetWallet: jest.fn(),
+      teardownAgent: jest.fn(),
+    })
 
     const { getByText } = render(
       <BCSCAgentProvider>

--- a/app/src/bcsc-theme/features/agent/BCSCAgentProvider.tsx
+++ b/app/src/bcsc-theme/features/agent/BCSCAgentProvider.tsx
@@ -11,6 +11,7 @@ export interface BCSCAgentContextValue {
   error: AppError | null
   retry: () => void
   resetWallet: () => Promise<void>
+  teardownAgent: () => Promise<void>
 }
 
 const BCSCAgentContext = createContext<BCSCAgentContextValue | null>(null)
@@ -48,7 +49,7 @@ export const useBCSCAgentSafe = (): BCSCAgentContextValue | null => useContext(B
  * through `useBCSCAgent().agent` rather than Bifold's `useAgent()`.
  */
 const BCSCAgentProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  const { agent, status, error, retry, resetWallet } = useAgentSetupViewModel()
+  const { agent, status, error, retry, resetWallet, teardownAgent } = useAgentSetupViewModel()
 
   const value = useMemo<BCSCAgentContextValue>(
     () => ({
@@ -57,8 +58,9 @@ const BCSCAgentProvider: React.FC<PropsWithChildren> = ({ children }) => {
       error,
       retry,
       resetWallet,
+      teardownAgent,
     }),
-    [agent, status, error, retry, resetWallet]
+    [agent, status, error, retry, resetWallet, teardownAgent]
   )
 
   return <BCSCAgentContext.Provider value={value}>{children}</BCSCAgentContext.Provider>

--- a/app/src/bcsc-theme/features/agent/BifoldScope.test.tsx
+++ b/app/src/bcsc-theme/features/agent/BifoldScope.test.tsx
@@ -30,6 +30,7 @@ describe('BifoldScope', () => {
       error: null,
       retry: jest.fn(),
       resetWallet: jest.fn(),
+      teardownAgent: jest.fn(),
     })
 
     const { getByText } = render(
@@ -45,7 +46,14 @@ describe('BifoldScope', () => {
   it('mounts AgentProvider with the live agent when ready', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const agent = {} as Agent
-    mockUseBCSCAgent.mockReturnValue({ agent, loading: false, error: null, retry: jest.fn(), resetWallet: jest.fn() })
+    mockUseBCSCAgent.mockReturnValue({
+      agent,
+      loading: false,
+      error: null,
+      retry: jest.fn(),
+      resetWallet: jest.fn(),
+      teardownAgent: jest.fn(),
+    })
 
     const { getByText } = render(
       <BifoldScope>

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
@@ -397,6 +397,99 @@ describe('useAgentSetupViewModel', () => {
     })
   })
 
+  describe('teardownAgent', () => {
+    it('shuts down the live agent, deletes the store, and nulls the agent', async () => {
+      const agent1 = mockAgent()
+      jest.mocked(agentService.buildAgent).mockReturnValue(agent1)
+
+      const { result } = renderHook(() => useAgentSetupViewModel())
+      await waitFor(() => expect(result.current.status).toBe('ready'))
+
+      await act(async () => {
+        await result.current.teardownAgent()
+      })
+
+      expect(agentService.shutdownAgent).toHaveBeenCalledWith(agent1, logger)
+      expect(agentService.deleteWalletStore).toHaveBeenCalledWith(agent1)
+      expect(result.current.agent).toBeNull()
+      expect(result.current.status).toBe('idle')
+    })
+
+    it('does not trigger re-initialization (unlike resetWallet)', async () => {
+      const agent1 = mockAgent()
+      jest.mocked(agentService.buildAgent).mockReturnValue(agent1)
+
+      const { result } = renderHook(() => useAgentSetupViewModel())
+      await waitFor(() => expect(result.current.status).toBe('ready'))
+
+      await act(async () => {
+        await result.current.teardownAgent()
+      })
+
+      expect(result.current.status).toBe('idle')
+      // Give any spurious re-init effect a chance to fire before asserting it didn't.
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0))
+      })
+      expect(agentService.buildAgent).toHaveBeenCalledTimes(1)
+      expect(result.current.status).toBe('idle')
+      expect(result.current.agent).toBeNull()
+    })
+
+    it('stops the attestation monitor before shutting down the agent', async () => {
+      const agent1 = mockAgent()
+      jest.mocked(agentService.buildAgent).mockReturnValue(agent1)
+
+      const { result } = renderHook(() => useAgentSetupViewModel())
+      await waitFor(() => expect(result.current.status).toBe('ready'))
+
+      await act(async () => {
+        await result.current.teardownAgent()
+      })
+
+      expect(attestationMonitor.stop).toHaveBeenCalled()
+      expect(agentService.shutdownAgent).toHaveBeenCalledWith(agent1, logger)
+      // invocationCallOrder is a shared, monotonically increasing counter across all
+      // mocks, so comparing the two mocks' first-call indices proves relative order
+      // without attaching a stateful mockImplementation to the shared monitor mock.
+      const stopOrder = attestationMonitor.stop.mock.invocationCallOrder[0]
+      const shutdownOrder = jest.mocked(agentService.shutdownAgent).mock.invocationCallOrder[0]
+      expect(stopOrder).toBeLessThan(shutdownOrder)
+    })
+
+    it('logs a warning and still nulls the agent when deleteWalletStore rejects', async () => {
+      const agent1 = mockAgent()
+      jest.mocked(agentService.buildAgent).mockReturnValue(agent1)
+      jest.mocked(agentService.deleteWalletStore).mockRejectedValueOnce(new Error('store gone'))
+
+      const { result } = renderHook(() => useAgentSetupViewModel())
+      await waitFor(() => expect(result.current.status).toBe('ready'))
+
+      await act(async () => {
+        await expect(result.current.teardownAgent()).resolves.toBeUndefined()
+      })
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('AgentTeardown: wallet store deleteStore() failed'))
+      expect(result.current.agent).toBeNull()
+      expect(result.current.status).toBe('idle')
+    })
+
+    it('is a no-op when there is no live agent', async () => {
+      jest.mocked(Bifold.useStore).mockReturnValue(mockedStore({ bcscSecure: { walletKey: undefined } }) as never)
+
+      const { result } = renderHook(() => useAgentSetupViewModel())
+      await waitFor(() => expect(result.current.status).toBe('error'))
+
+      await act(async () => {
+        await result.current.teardownAgent()
+      })
+
+      expect(agentService.shutdownAgent).not.toHaveBeenCalled()
+      expect(agentService.deleteWalletStore).not.toHaveBeenCalled()
+      expect(result.current.status).toBe('error')
+    })
+  })
+
   it('shuts down agent when didAuthenticate flips to false', async () => {
     const store: Record<string, unknown> = {
       authentication: { didAuthenticate: true },

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
@@ -469,7 +469,9 @@ describe('useAgentSetupViewModel', () => {
         await expect(result.current.teardownAgent()).resolves.toBeUndefined()
       })
 
-      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('AgentTeardown: wallet store deleteStore() failed'))
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('AgentTeardown: wallet store deleteStore() failed')
+      )
       expect(result.current.agent).toBeNull()
       expect(result.current.status).toBe('idle')
     })

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
@@ -436,7 +436,16 @@ describe('useAgentSetupViewModel', () => {
       expect(result.current.agent).toBeNull()
     })
 
-    it('stops the attestation monitor before shutting down the agent', async () => {
+    it('stops both the attestation and credential-provisioning monitors before shutting down the agent', async () => {
+      // The default harness stubs credentialProvisioningMonitor as undefined (position 3
+      // of the useServices tuple), which every other test relies on. Override it here,
+      // scoped to this test, so `credentialProvisioningMonitor?.stop()` is actually
+      // exercised rather than silently no-op'd via optional chaining.
+      const credentialProvisioningMonitor = { start: jest.fn(), stop: jest.fn() }
+      jest
+        .mocked(Bifold.useServices)
+        .mockReturnValue([logger, attestationMonitor, credentialProvisioningMonitor, [], [], ocaBundleResolver] as never)
+
       const agent1 = mockAgent()
       jest.mocked(agentService.buildAgent).mockReturnValue(agent1)
 
@@ -447,14 +456,23 @@ describe('useAgentSetupViewModel', () => {
         await result.current.teardownAgent()
       })
 
-      expect(attestationMonitor.stop).toHaveBeenCalled()
+      // Ready-transition setup also calls refreshMonitors (stop+start, to rebind the
+      // listener to the new agent), so each monitor's stop() is called twice in this
+      // test: once during setup, once from teardownAgent. Take the LAST invocation —
+      // shutdownAgent is only ever called from teardownAgent, so comparing against its
+      // (single) call correctly isolates the teardown-phase stop from the earlier
+      // setup-phase one instead of trivially comparing against the setup call.
+      const lastCallOrder = (mock: jest.Mock) => mock.mock.invocationCallOrder.at(-1)
+
+      expect(attestationMonitor.stop).toHaveBeenCalledTimes(2)
+      expect(credentialProvisioningMonitor.stop).toHaveBeenCalledTimes(2)
       expect(agentService.shutdownAgent).toHaveBeenCalledWith(agent1, logger)
-      // invocationCallOrder is a shared, monotonically increasing counter across all
-      // mocks, so comparing the two mocks' first-call indices proves relative order
-      // without attaching a stateful mockImplementation to the shared monitor mock.
-      const stopOrder = attestationMonitor.stop.mock.invocationCallOrder[0]
-      const shutdownOrder = jest.mocked(agentService.shutdownAgent).mock.invocationCallOrder[0]
-      expect(stopOrder).toBeLessThan(shutdownOrder)
+
+      const stopOrder = lastCallOrder(attestationMonitor.stop)
+      const provisioningStopOrder = lastCallOrder(credentialProvisioningMonitor.stop)
+      const shutdownOrder = lastCallOrder(jest.mocked(agentService.shutdownAgent))
+      expect(stopOrder).toBeLessThan(shutdownOrder as number)
+      expect(provisioningStopOrder).toBeLessThan(shutdownOrder as number)
     })
 
     it('logs a warning and still nulls the agent when deleteWalletStore rejects', async () => {

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.test.ts
@@ -444,7 +444,14 @@ describe('useAgentSetupViewModel', () => {
       const credentialProvisioningMonitor = { start: jest.fn(), stop: jest.fn() }
       jest
         .mocked(Bifold.useServices)
-        .mockReturnValue([logger, attestationMonitor, credentialProvisioningMonitor, [], [], ocaBundleResolver] as never)
+        .mockReturnValue([
+          logger,
+          attestationMonitor,
+          credentialProvisioningMonitor,
+          [],
+          [],
+          ocaBundleResolver,
+        ] as never)
 
       const agent1 = mockAgent()
       jest.mocked(agentService.buildAgent).mockReturnValue(agent1)

--- a/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
+++ b/app/src/bcsc-theme/features/agent/useAgentSetupViewModel.ts
@@ -30,6 +30,7 @@ export interface AgentSetupResult {
   error: AppError | null
   retry: () => void
   resetWallet: () => Promise<void>
+  teardownAgent: () => Promise<void>
 }
 
 const useAgentSetupViewModel = (): AgentSetupResult => {
@@ -355,7 +356,54 @@ const useAgentSetupViewModel = (): AgentSetupResult => {
     }
   }, [logger, attestationMonitor, walletKey, mediatorUrl, walletLabel, enableProxy])
 
-  return { agent, status, error, retry, resetWallet }
+  // Permanent agent teardown (e.g. factory reset). Unlike resetWallet this never
+  // re-initializes: it shuts down, deletes the wallet store, and nulls the agent so
+  // any consumer still mounted against a transient render (see RootStack's
+  // hasAccount/showVerifyStack derivation) sees `agent: null` and skips its
+  // mount-time storage reads instead of racing Credo's store-not-found ->
+  // auto-provision fallback against the just-deleted store.
+  //
+  // Guards against a concurrent resetWallet (and a re-entrant teardownAgent) via
+  // resettingRef, but — unlike resetWallet — does NOT check initializingRef: this is
+  // a destructive path that must always delete the store when a live agent exists,
+  // never silently no-op just because an init happens to be in flight.
+  const teardownAgent = useCallback(async () => {
+    if (resettingRef.current) {
+      logger.info('AgentTeardown: a reset is already in progress, ignoring request')
+      return
+    }
+
+    const currentAgent = agentRef.current
+    if (!currentAgent) {
+      return
+    }
+
+    resettingRef.current = true
+
+    try {
+      // Stop both monitors — a provisioning/attestation poll firing against the
+      // about-to-be-deleted store is exactly the "mounted consumer issuing a
+      // storage op against a deleted store" scenario this teardown exists to prevent.
+      attestationMonitor?.stop()
+      credentialProvisioningMonitor?.stop()
+
+      await shutdownAgent(currentAgent, logger)
+
+      try {
+        await deleteWalletStore(currentAgent)
+      } catch (err) {
+        logger.warn(`AgentTeardown: wallet store deleteStore() failed; wallet file may persist: ${err}`)
+      }
+    } finally {
+      agentRef.current = null
+      setAgent(null)
+      setError(null)
+      setStatus('idle')
+      resettingRef.current = false
+    }
+  }, [logger, attestationMonitor, credentialProvisioningMonitor])
+
+  return { agent, status, error, retry, resetWallet, teardownAgent }
 }
 
 export default useAgentSetupViewModel

--- a/app/src/bcsc-theme/features/qr-core/QRDisplay.test.tsx
+++ b/app/src/bcsc-theme/features/qr-core/QRDisplay.test.tsx
@@ -60,6 +60,7 @@ describe('QRDisplay', () => {
       error: null,
       retry: jest.fn(),
       resetWallet: jest.fn(),
+      teardownAgent: jest.fn(),
     })
   }
   const setNoAgent = () => {
@@ -69,6 +70,7 @@ describe('QRDisplay', () => {
       error: null,
       retry: jest.fn(),
       resetWallet: jest.fn(),
+      teardownAgent: jest.fn(),
     })
   }
 


### PR DESCRIPTION
## What

Removing the account while in the middle of ID verification (e.g. after taking a selfie) could leave the app in a broken state where it could no longer set up the credential wallet or receive digital credentials — the only way out was clearing app data or reinstalling. Removing the account from Home/Settings already worked correctly; this only affected the mid-verification path.

This fix makes account removal reliable no matter where in the app the user triggers it, which is a prerequisite for the upcoming "Remove account" option inside the verification flow itself (#4292 / PR #4331).

## Why

People need to be able to reset and start over at any point during verification — wrong info entered, switching devices, or just changing their mind. If the underlying reset doesn't work reliably from inside verification, that "start over" option can't ship.

## Decisions

Root cause: factory reset mid-verification caused a brief, unintended navigation change that mounted Bifold's credential provider tree against an agent whose wallet store had just been deleted. Credo's storage layer auto-provisions a new store when it can't find one, recreating the wallet under the *old* key. Re-onboarding then derives a *new* key, and the agent can never open the old-keyed store again.

Implemented the two changes recommended in the issue, as belt-and-braces:

- **Reorder dispatches in `useFactoryReset`** so `CLEAR_BCSC` (which flips `hasAccount` to `false`) fires before `clearSecureState` (which resets `bcscSecure`, including `verifiedStatus`). `RootStack` short-circuits to `OnboardingStack` as soon as `hasAccount` is `false`, before it ever derives whether to show the verification stack — so the transient `MainStack` mount that triggered the bug can no longer happen.
- **Add a permanent `teardownAgent` to `useAgentSetupViewModel`**, threaded through `BCSCAgentProvider`, that shuts the agent down, deletes the wallet store, and nulls the provider's agent reference (unlike `resetWallet`, it never re-initializes). This is belt-and-braces: even if some other transient mount slips through in the future, Bifold's provider tree will see `agent: undefined` and skip the storage reads that previously raced the deleted store.

`useFactoryReset` now awaits `agentCtx.teardownAgent()` on the live-agent branch instead of calling `shutdownAgent`/`deleteWalletStore` directly — that ordering-sensitive logic now lives in one place. The no-live-agent orphaned-store purge branch (`purgeWalletStore`) is unchanged.

`teardownAgent` guards against a concurrent `resetWallet` (via the existing `resettingRef`) but deliberately does **not** check `initializingRef` — this is a destructive path and must always delete the store when a live agent exists, never silently no-op because an init happens to be mid-flight (that would reproduce the same orphaned-store bug through a different door). The mirror case — `teardownAgent` called while `resetWallet` is already running — is left unguarded to match today's existing behavior for concurrent `resetWallet` calls; `resetWallet`'s own path still deletes the store unconditionally, so the store isn't left behind either way.

## Tests

- New `describe('teardownAgent', ...)` in `useAgentSetupViewModel.test.ts`: shuts down + deletes + nulls the agent, does not trigger re-initialization, stops both the attestation and credential-provisioning monitors before shutdown, logs a warning and still nulls the agent when store deletion rejects, and no-ops when there's no live agent.
- `useFactoryReset.test.ts` updated to assert the reset awaits `agentCtx.teardownAgent()` to completion before continuing, and dispatches `CLEAR_BCSC` before `clearSecureState` before `DID_AUTHENTICATE`.
- `yarn check` (typecheck, lint, format, full test suite — 283 suites / 2832 tests) passes.

## Verification

1. Start verification (e.g. through taking a selfie / submitting an evidence photo).
2. Open the `?` help menu and remove the account.
3. Confirm the app returns cleanly to onboarding with no console errors about "table config already exists" / store creation.
4. Re-onboard and confirm the new wallet initializes and can receive a credential.
5. Repeat account removal from Home and from Settings to confirm no regression there.

Fixes #4336
