### PR TITLE
fix: e2e parallel runner limitation + tab nav bug 

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,9 @@
 #   workflow_call  — called from main.yaml after builds (PR smoke tests)
 #   workflow_dispatch — manual runs from the Actions UI
 #
-# Constraint: max-parallel=2 (SauceLabs concurrent-session limit).
+# Constraint: the SauceLabs account allows 2 concurrent real-device sessions, shared across every
+# job AND every wdio worker inside them. max-parallel caps the jobs; SAUCE_MAX_INSTANCES (computed
+# in the run step) divides the session budget among the jobs running in parallel.
 name: E2E Tests
 
 permissions:
@@ -141,6 +143,9 @@ jobs:
           SM_PASSWORD: ${{ secrets.SM_PASSWORD }}
           SAUCE_REGION: us
           VARIANT: bcsc-dev
+          DEVICE_MATRIX: ${{ inputs.device_matrix }}
+          # Concurrent real-device sessions the Sauce account allows (its `rds` allowance).
+          SAUCE_RDS_CONCURRENCY: 2
           PLATFORM: ${{ matrix.device.platform }}
           IOS_DEVICE_NAME: ${{ matrix.device.platform == 'iOS' && matrix.device.device || '' }}
           IOS_PLATFORM_VERSION: ${{ matrix.device.platform == 'iOS' && matrix.device.os_version || '' }}
@@ -151,6 +156,16 @@ jobs:
           BUILD_NAME: 'build-${{ inputs.build_number }}'
           TEST_NAME: 'E2E ${{ inputs.suite }} - ${{ matrix.device.platform }} ${{ matrix.device.os_version }}'
         run: |
+          # Split the account's real-device session budget across the jobs running in parallel.
+          # Each matrix entry is a separate wdio process, so without this a 2-device matrix asks
+          # for (jobs x maxInstances) sessions; anything over the limit queues inside
+          # POST /session until the client aborts and reports "Failed to create a session".
+          DEVICE_COUNT=$(printf '%s' "$DEVICE_MATRIX" | jq 'length')
+          [ "$DEVICE_COUNT" -ge 1 ] 2>/dev/null || DEVICE_COUNT=1
+          PARALLEL_JOBS=$(( DEVICE_COUNT > 2 ? 2 : DEVICE_COUNT ))   # strategy.max-parallel is 2
+          export SAUCE_MAX_INSTANCES=$(( SAUCE_RDS_CONCURRENCY / PARALLEL_JOBS ))
+          echo "Devices: $DEVICE_COUNT | parallel jobs: $PARALLEL_JOBS | wdio maxInstances: $SAUCE_MAX_INSTANCES"
+
           case "$SUITE" in
             migration)
               IOS_CONF="configs/sauce/wdio.ios.sauce.migration.conf.ts"

--- a/app/src/bcsc-theme/navigators/TabStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/TabStack.test.tsx
@@ -1,0 +1,202 @@
+import * as Bifold from '@bifold/core'
+import { useNavigation } from '@react-navigation/native'
+import { act, render } from '@testing-library/react-native'
+import React from 'react'
+
+import { FloatingScanButton } from '../features/scan'
+import { useCardStatus } from '../hooks/useCardStatus'
+import { BCSCScreens } from '../types/navigators'
+import BCSCTabStack from './TabStack'
+
+let capturedNavigatorProps: any
+let mockTabBarState: { index: number; routes: { key: string; name: string }[] }
+
+jest.mock('@bifold/core')
+jest.mock('@react-navigation/native')
+jest.mock('@react-navigation/bottom-tabs', () => {
+  const Navigator = (props: any) => {
+    capturedNavigatorProps = props
+    // The real navigator renders the custom tab bar and feeds it the navigator's own state; do the
+    // same here, since that state is what tells the FAB which tab is focused.
+    return props.tabBar({ state: mockTabBarState, descriptors: {}, navigation: {}, insets: {} })
+  }
+  Navigator.displayName = 'Navigator'
+  const Screen = () => null
+  Screen.displayName = 'Screen'
+  const BottomTabBar = () => null
+  BottomTabBar.displayName = 'BottomTabBar'
+  return {
+    createBottomTabNavigator: () => ({ Navigator, Screen }),
+    BottomTabBar,
+  }
+})
+jest.mock('../features/home/Home', () => 'Home')
+jest.mock('../features/services/Services', () => 'Services')
+jest.mock('../features/agent', () => ({
+  AgentReadyGate: 'AgentReadyGate',
+  CredentialsReadyGate: 'CredentialsReadyGate',
+}))
+jest.mock('../features/scan', () => ({
+  FloatingScanButton: jest.fn(() => null),
+}))
+jest.mock('../components/FloatingHelpMenuHeaderButton', () => ({
+  createFloatingHelpMenuButton: jest.fn(() => () => null),
+}))
+jest.mock('../components/HeaderWithBanner', () => ({
+  createTabHeaderWithoutBanner: jest.fn(() => null),
+}))
+jest.mock('../components/SettingsHeaderButton', () => ({
+  createMainSettingsHeaderButton: jest.fn(() => () => null),
+}))
+jest.mock('../hooks/useCardStatus', () => ({
+  useCardStatus: jest.fn(),
+}))
+jest.mock('@/hooks/notifications', () => ({
+  useNotifications: jest.fn(() => []),
+}))
+jest.mock('@/hooks/useCustomNotifications', () => ({
+  useCustomNotifications: jest.fn(() => ({ customNotifications: [] })),
+}))
+jest.mock('react-native-vector-icons/MaterialCommunityIcons', () => 'CommunityIcon')
+jest.mock('react-native-vector-icons/MaterialIcons', () => ({
+  hasIcon: () => true,
+}))
+
+const mockLogger = { debug: jest.fn() }
+
+const TAB_ROUTES = [
+  { key: 'home', name: BCSCScreens.Home },
+  { key: 'services', name: BCSCScreens.Services },
+  { key: 'wallet', name: BCSCScreens.Wallet },
+]
+
+/** Navigator state with `focusedIndex` as the focused tab. */
+const tabState = (focusedIndex: number) => ({ index: focusedIndex, routes: TAB_ROUTES })
+
+describe('BCSCTabStack', () => {
+  let mockNavigation: ReturnType<typeof useNavigation> & { navigate: jest.Mock }
+
+  const getListeners = (routeName: string) => capturedNavigatorProps.screenListeners({ route: { name: routeName } })
+
+  /** The tab the FAB was last told about — it renders only for Home and Wallet. */
+  const activeTabNameSeenByFab = () => jest.mocked(FloatingScanButton).mock.calls.at(-1)?.[0].activeTabName
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    capturedNavigatorProps = undefined
+    mockTabBarState = tabState(0)
+
+    mockNavigation = useNavigation() as typeof mockNavigation
+
+    jest.mocked(Bifold.useTheme).mockReturnValue({
+      TabTheme: {
+        tabBarStyle: {},
+        tabBarActiveTintColor: '#000',
+        tabBarInactiveTintColor: '#fff',
+        tabBarSecondaryBackgroundColor: '#fff',
+        tabBarContainerStyle: {},
+        tabBarTextStyle: { fontSize: 12 },
+      },
+      TextTheme: { bold: { fontFamily: 'bold' }, normal: { fontFamily: 'normal' } },
+      ColorPalette: {
+        brand: { highlight: '#123456' },
+        notification: { errorIcon: '#f00' },
+      },
+      Spacing: { md: 16, lg: 24 },
+    } as any)
+    jest.mocked(Bifold.useServices).mockReturnValue([mockLogger] as any)
+    jest.mocked(Bifold.testIdWithKey).mockImplementation((key: string) => key)
+
+    jest.mocked(useCardStatus).mockReturnValue({ isActivelyVerified: true, isExpired: false } as any)
+  })
+
+  it('renders without crashing', () => {
+    render(<BCSCTabStack />)
+    expect(capturedNavigatorProps).toBeDefined()
+  })
+
+  describe('unverified Services gating', () => {
+    beforeEach(() => {
+      jest.mocked(useCardStatus).mockReturnValue({ isActivelyVerified: false, isExpired: false } as any)
+    })
+
+    it('prevents the tab press and redirects to the verify prompt', () => {
+      render(<BCSCTabStack />)
+      const event = { preventDefault: jest.fn() }
+
+      act(() => getListeners(BCSCScreens.Services).tabPress(event))
+
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.MainVerifyPrompt)
+    })
+
+    it('redirects to ReverifyAccount when the card is expired', () => {
+      jest.mocked(useCardStatus).mockReturnValue({ isActivelyVerified: false, isExpired: true } as any)
+      render(<BCSCTabStack />)
+      const event = { preventDefault: jest.fn() }
+
+      act(() => getListeners(BCSCScreens.Services).tabPress(event))
+
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCScreens.ReverifyAccount, { isExpired: true })
+    })
+
+    it('keeps the scan FAB on Home after a prevented Services press', () => {
+      const { rerender } = render(<BCSCTabStack />)
+      expect(activeTabNameSeenByFab()).toBe(BCSCScreens.Home)
+
+      act(() => getListeners(BCSCScreens.Services).tabPress({ preventDefault: jest.fn() }))
+
+      // The press was prevented, so the navigator never left Home. Returning from the verify prompt
+      // must land on a Home tab that still shows the FAB.
+      rerender(<BCSCTabStack />)
+      expect(activeTabNameSeenByFab()).toBe(BCSCScreens.Home)
+    })
+  })
+
+  describe('active tab tracking', () => {
+    it('follows the focused tab reported by the navigator', () => {
+      const { rerender } = render(<BCSCTabStack />)
+      expect(activeTabNameSeenByFab()).toBe(BCSCScreens.Home)
+
+      mockTabBarState = tabState(1)
+      rerender(<BCSCTabStack />)
+      expect(activeTabNameSeenByFab()).toBe(BCSCScreens.Services)
+
+      mockTabBarState = tabState(2)
+      rerender(<BCSCTabStack />)
+      expect(activeTabNameSeenByFab()).toBe(BCSCScreens.Wallet)
+    })
+
+    it('follows a tab change that happens without a tab press, such as back navigation', () => {
+      mockTabBarState = tabState(1)
+      const { rerender } = render(<BCSCTabStack />)
+      expect(activeTabNameSeenByFab()).toBe(BCSCScreens.Services)
+
+      // Hardware back moves focus to Home with no tabPress event of any kind.
+      mockTabBarState = tabState(0)
+      rerender(<BCSCTabStack />)
+      expect(activeTabNameSeenByFab()).toBe(BCSCScreens.Home)
+    })
+  })
+
+  describe('verified navigation', () => {
+    it('does not prevent the Services tab press', () => {
+      render(<BCSCTabStack />)
+      const event = { preventDefault: jest.fn() }
+
+      act(() => getListeners(BCSCScreens.Services).tabPress(event))
+
+      expect(event.preventDefault).not.toHaveBeenCalled()
+      expect(mockNavigation.navigate).not.toHaveBeenCalled()
+    })
+
+    it('does not redirect on Services focus', () => {
+      render(<BCSCTabStack />)
+
+      act(() => getListeners(BCSCScreens.Services).focus())
+
+      expect(mockNavigation.navigate).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/app/src/bcsc-theme/navigators/TabStack.tsx
+++ b/app/src/bcsc-theme/navigators/TabStack.tsx
@@ -12,7 +12,7 @@ import {
 import { BottomTabBar, BottomTabBarProps, createBottomTabNavigator } from '@react-navigation/bottom-tabs'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Animated, Platform, StyleSheet, Text, useWindowDimensions, View } from 'react-native'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -135,6 +135,22 @@ const AnimatedTabBar: React.FC<AnimatedTabBarProps> = ({ onActiveTabChange, ...p
   )
 }
 
+/**
+ * Builds the navigator's `tabBar` renderer. A factory rather than an inline arrow so the component
+ * isn't redefined inside {@link BCSCTabStack} on every render, which would remount the tab bar and
+ * restart its indicator animation.
+ *
+ * @param onActiveTabChange - Called with the route name of the tab the navigator has focused.
+ * @returns A React component that renders the animated tab bar.
+ */
+const createAnimatedTabBar = (onActiveTabChange: (routeName: string) => void) => {
+  const AnimatedTabBarRenderer = (props: BottomTabBarProps): React.JSX.Element => (
+    <AnimatedTabBar {...props} onActiveTabChange={onActiveTabChange} />
+  )
+
+  return AnimatedTabBarRenderer
+}
+
 const BCSCTabStack: React.FC = () => {
   const Tab = createBottomTabNavigator<BCSCTabStackParams>()
   const theme = useTheme()
@@ -147,6 +163,8 @@ const BCSCTabStack: React.FC = () => {
   const { isActivelyVerified, isExpired } = useCardStatus()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const defaultStackOptions = useDefaultStackOptions(theme)
+  // `setActiveTab` is a stable state setter, so the tab bar component is built once per mount.
+  const tabBar = useMemo(() => createAnimatedTabBar(setActiveTab), [])
 
   const { TabTheme, ColorPalette, Spacing } = theme
 
@@ -200,7 +218,7 @@ const BCSCTabStack: React.FC = () => {
           },
         })}
         initialRouteName={BCSCScreens.Home}
-        tabBar={(props) => <AnimatedTabBar {...props} onActiveTabChange={setActiveTab} />}
+        tabBar={tabBar}
         screenOptions={{
           ...defaultStackOptions,
           // Show the header's own (native) shadow. TabHeaderWithoutBanner draws no drop-shadow caster,

--- a/app/src/bcsc-theme/navigators/TabStack.tsx
+++ b/app/src/bcsc-theme/navigators/TabStack.tsx
@@ -81,7 +81,16 @@ const TAB_BAR_HEIGHT = Platform.select({ ios: 49, android: 56, default: 56 })
 const ACTIVE_INDICATOR_HEIGHT = 3
 const ACTIVE_INDICATOR_DURATION_MS = 100
 
-const AnimatedTabBar: React.FC<BottomTabBarProps> = (props) => {
+type AnimatedTabBarProps = BottomTabBarProps & {
+  /**
+   * Reports the tab that is actually focused. The navigator's own state is the only reliable
+   * source for this: a `tabPress` that gets `preventDefault()`ed (the unverified Services gate)
+   * never changes the focused tab, and back navigation changes it without any press at all.
+   */
+  onActiveTabChange: (routeName: string) => void
+}
+
+const AnimatedTabBar: React.FC<AnimatedTabBarProps> = ({ onActiveTabChange, ...props }) => {
   const { ColorPalette } = useTheme()
   const { state } = props
   const tabCount = state.routes.length
@@ -90,6 +99,13 @@ const AnimatedTabBar: React.FC<BottomTabBarProps> = (props) => {
   const indicatorWidth = tabWidth * 0.8
   const indicatorOffset = (tabWidth - indicatorWidth) / 2
   const translateX = useRef(new Animated.Value(state.index * tabWidth + indicatorOffset)).current
+  const activeTabName = state.routes[state.index]?.name
+
+  useEffect(() => {
+    if (activeTabName) {
+      onActiveTabChange(activeTabName)
+    }
+  }, [activeTabName, onActiveTabChange])
 
   useEffect(() => {
     Animated.timing(translateX, {
@@ -181,12 +197,10 @@ const BCSCTabStack: React.FC = () => {
                 navigation.navigate(BCSCScreens.MainVerifyPrompt)
               }
             }
-
-            setActiveTab(route.name)
           },
         })}
         initialRouteName={BCSCScreens.Home}
-        tabBar={(props) => <AnimatedTabBar {...props} />}
+        tabBar={(props) => <AnimatedTabBar {...props} onActiveTabChange={setActiveTab} />}
         screenOptions={{
           ...defaultStackOptions,
           // Show the header's own (native) shadow. TabHeaderWithoutBanner draws no drop-shadow caster,

--- a/e2e/configs/sauce/wdio.shared.sauce.conf.ts
+++ b/e2e/configs/sauce/wdio.shared.sauce.conf.ts
@@ -31,6 +31,15 @@ config.region = (process.env.SAUCE_REGION || 'us') as 'us' | 'eu'
  */
 config.maxInstances = Number(process.env.SAUCE_MAX_INSTANCES) || 1
 
+/**
+ * Raised well above the shared default (180s) because on Sauce it also bounds `POST /session`, which
+ * stays open while the run queues for a free concurrency slot and a matching device — Sauce itself
+ * keeps hunting for up to 15 min. A short value turns an ordinary queue wait into "Failed to create
+ * a session". The lower default stays in place for local Appium runs, where a session that cannot be
+ * created should fail fast rather than hang.
+ */
+config.connectionRetryTimeout = 600_000
+
 config.services = [
   [
     'sauce',

--- a/e2e/configs/sauce/wdio.shared.sauce.conf.ts
+++ b/e2e/configs/sauce/wdio.shared.sauce.conf.ts
@@ -15,7 +15,21 @@ const config = { ...baseConfig }
 config.user = process.env.SAUCE_USERNAME
 config.key = process.env.SAUCE_ACCESS_KEY
 config.region = (process.env.SAUCE_REGION || 'us') as 'us' | 'eu'
-config.maxInstances = 2
+
+/**
+ * Workers per wdio process. The Sauce account allows 2 concurrent real-device sessions (`rds`),
+ * and that budget is shared by EVERY wdio process running at once — each CI device-matrix entry is
+ * its own process, so `max-parallel` caps GitHub jobs, not Sauce sessions. Two jobs x two workers
+ * asks for four sessions against a two-session limit.
+ *
+ * Over-subscribing does not fail fast: Sauce holds `POST /session` open while the request waits for
+ * a free slot/device, so the excess workers sit in the queue until the client aborts at
+ * `connectionRetryTimeout` and reports "Failed to create a session".
+ *
+ * Default to 1 so the two-platform matrix stays inside the budget; CI raises it when fewer jobs
+ * run in parallel (see SAUCE_MAX_INSTANCES in .github/workflows/e2e.yml).
+ */
+config.maxInstances = Number(process.env.SAUCE_MAX_INSTANCES) || 1
 
 config.services = [
   [

--- a/e2e/configs/wdio.shared.conf.ts
+++ b/e2e/configs/wdio.shared.conf.ts
@@ -74,7 +74,12 @@ export const config: WebdriverIO.Config = {
   // mochaOpts.bail below.
   bail: 0,
   waitforTimeout: 20_000,
-  connectionRetryTimeout: 180_000,
+  // Also the ceiling on how long `POST /session` may take. On Sauce that request stays open while
+  // the run queues for a free concurrency slot and a matching device — Sauce itself keeps hunting
+  // for up to 15 min — so a short value turns an ordinary queue wait into "Failed to create a
+  // session". Session creation happens outside any Mocha test, so this is its only bound; in-test
+  // commands are still bounded first by mochaOpts.timeout below.
+  connectionRetryTimeout: 600_000,
   connectionRetryCount: 2,
 
   framework: 'mocha',

--- a/e2e/configs/wdio.shared.conf.ts
+++ b/e2e/configs/wdio.shared.conf.ts
@@ -74,12 +74,11 @@ export const config: WebdriverIO.Config = {
   // mochaOpts.bail below.
   bail: 0,
   waitforTimeout: 20_000,
-  // Also the ceiling on how long `POST /session` may take. On Sauce that request stays open while
-  // the run queues for a free concurrency slot and a matching device — Sauce itself keeps hunting
-  // for up to 15 min — so a short value turns an ordinary queue wait into "Failed to create a
-  // session". Session creation happens outside any Mocha test, so this is its only bound; in-test
-  // commands are still bounded first by mochaOpts.timeout below.
-  connectionRetryTimeout: 600_000,
+  // Also the ceiling on how long `POST /session` may take, and session creation happens outside any
+  // Mocha test so this is its only bound (in-test commands are bounded first by mochaOpts.timeout
+  // below). Kept short here so a local run against a missing Appium server or an unavailable device
+  // fails promptly; the Sauce config raises it to cover that grid's device-queue wait.
+  connectionRetryTimeout: 180_000,
   connectionRetryCount: 2,
 
   framework: 'mocha',


### PR DESCRIPTION
# Summary of Changes

Two unrelated fixes found while running the `verify` e2e suite.

**QR scan FAB disappears from Home.** `TabStack` tracked the active tab from the `tabPress` event, but `setActiveTab(route.name)` ran even on the path that calls `event.preventDefault()` — the unverified Services gate. The tab never changed, yet state recorded Services as active, so returning from the verify prompt landed on Home with the FAB hidden (`TABS_WITH_SCAN_FAB` is Home + Wallet) until another tab press. The active tab now comes from the navigator's own state via the tab bar, which also fixes the same symptom on hardware back, where no `tabPress` fires at all. Adds `TabStack.test.tsx`.

**E2E dispatch jobs failing to get Sauce sessions.** The account allows 2 concurrent real-device sessions (`rds`), but `max-parallel: 2` caps GitHub jobs, not sessions — each matrix entry is its own wdio process with `maxInstances: 2`, so a 2-device matrix requested 4 sessions against a limit of 2. Sauce queues the excess inside `POST /session` rather than rejecting it, so the extra workers died at `connectionRetryTimeout` with `Failed to create a session` (not the inactivity timeout the error resembles). `maxInstances` is now derived from the session budget, and `connectionRetryTimeout` goes 180s → 600s so a legitimate queue wait doesn't fail the spec (Sauce keeps hunting for a device for up to 15 min).

# Testing Instructions

QR FAB:

1. `cd app && yarn jest src/bcsc-theme/navigators/TabStack.test.tsx`
2. On device/emulator as an **unverified** user, from Home tap the **Services** tab → redirected to "Verify your account" → tap back → confirm Home still shows the **Scan** FAB.
3. Tap **Wallet**, then Android hardware back to Home → confirm the FAB is still there.
4. Confirm the FAB is absent on Services for a verified user.

E2E concurrency:

5. Dispatch `e2e.yml` with the `verify` suite and the default 2-device matrix. In the "Run WDIO tests" step confirm the log line reads `Devices: 2 | parallel jobs: 2 | wdio maxInstances: 1`, and that no spec fails with `Failed to create a session`.
6. Dispatch again with a single-device matrix and confirm it reads `maxInstances: 2`.

# Acceptance Criteria

- [ ] Scan FAB remains on Home after an unverified Services tap + back
- [ ] Scan FAB remains after returning to Home via hardware back
- [ ] Unverified Services / expired redirects to `MainVerifyPrompt` / `ReverifyAccount` are unchanged
- [ ] `TabStack.test.tsx` passes; app typecheck and lint clean
- [ ] Total Sauce sessions per run stays at 2 for every matrix size (2-device dispatch, single-device, 4-device nightly)
- [ ] `verify` dispatch completes without session-creation timeouts

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A
