### PR TITLE
fix: e2e android camera consistancy

### DIFF
--- a/e2e/configs/sauce/wdio.shared.sauce.conf.ts
+++ b/e2e/configs/sauce/wdio.shared.sauce.conf.ts
@@ -49,9 +49,11 @@ config.services = [
       // (`smoke.spec.ts`), NOT the file this worker is running — so deriving the name from
       // `runnerConfig.specs` labels every parallel job "Smoke". `suiteTitle` is the per-worker
       // signal: the running file's Mocha `describe(...)` title (e.g. "Verify journey: entry
-      // detours"), which is already human-readable. TEST_NAME still overrides for one-off runs.
+      // detours"), which is already human-readable. TEST_NAME (e.g. nightly's
+      // "E2E regression - Android 15") is a PREFIX, not an override — as an override every job
+      // in a run shares one name and the Sauce job list cannot tell the journeys apart.
       setJobName: (_runnerConfig: Options.Testrunner, _caps: unknown, suiteTitle: string) =>
-        process.env.TEST_NAME || suiteTitle || 'E2E Tests',
+        [process.env.TEST_NAME, suiteTitle].filter(Boolean).join(' - ') || 'E2E Tests',
     },
   ],
 ]

--- a/e2e/src/constants.ts
+++ b/e2e/src/constants.ts
@@ -15,6 +15,11 @@ export enum Timeouts {
   SCREEN_TRANSITION = 20_000,
   /** Initial app launch — generous for cold starts on real devices */
   APP_LAUNCH = 30_000,
+  /** A camera screen becoming interactive. Covers the whole chain a plain screen transition does not:
+   *  the OS permission dialog (which can appear seconds after the screen mounts), the re-renders the
+   *  app does around that request, camera-device enumeration, and the capture session warming up —
+   *  all slower on Sauce real devices than a simulator. */
+  CAMERA_READY = 45_000,
   /** First checkpoint of a journey file: the run's FIRST session may also pay simulator/device
    *  boot + WebDriverAgent install + first-ever app launch, all competing for CPU. */
   COLD_START = 60_000,
@@ -93,3 +98,23 @@ export const SCAN_SERIAL_TAP_FOCUS_WINDOW = { x: 0.5, y: 0.4 } as const
  * barcode consistently lands inside the yellow scanning rectangle.
  */
 export const CARD_SCAN_PADDING = { top: 0, right: 0, bottom: 450, left: 40 } as const
+
+/**
+ * Barcode regions of the combo-card evidence template (`images/dl_*.jpg`, 402×271 — the card-back
+ * images all share it), normalized 0–1, to white out before EVIDENCE-CAPTURE injection.
+ *
+ * The template embeds a REAL SIT combo-card PDF-417 — it decodes to serial C26444539 with daphne's
+ * name/birthdate — plus a vertical 1D serial barcode on the right edge. On Android, Sauce injection
+ * also feeds the frame stream the document camera's code scanner reads, so during non-BCSC evidence
+ * capture the app decodes the "scanned card", asks the backend about it on UsePhoto, gets a MATCH,
+ * and quietly resets the flow into card setup (resume route: IDPhotoInformation) — killing the
+ * journey. Masking makes the injected document undecodable while it still reads as a licence photo.
+ * iOS never synthesizes these barcode formats from injected images, which is why only Android hit it.
+ *
+ * Region placement: full-width bottom band (PDF-417 + the duplicate-number 1D) and a full-height
+ * right band (the vertical serial 1D). Generous on purpose — MLKit reads partial barcodes.
+ */
+export const COMBO_CARD_BARCODE_MASKS = [
+  { x: 0, y: 0.66, width: 1, height: 0.34 },
+  { x: 0.78, y: 0, width: 0.22, height: 1 },
+] as const

--- a/e2e/src/flows/verify.ts
+++ b/e2e/src/flows/verify.ts
@@ -1,11 +1,12 @@
 import type { TestUser } from '../constants.js'
-import { Timeouts } from '../constants.js'
-import { acceptSystemAlert } from '../helpers/alerts.js'
+import { COMBO_CARD_BARCODE_MASKS, Timeouts } from '../constants.js'
 import { ApproveInPersonInput, approveInPersonRequest } from '../helpers/approval.js'
+import type { ImageMaskRegion } from '../helpers/camera.js'
 import { injectPhoto } from '../helpers/camera.js'
 import { getEmailConfirmationCode, getTempEmailAddress } from '../helpers/email.js'
 import { swipeUpBy } from '../helpers/gestures.js'
 import { isSauceLabs } from '../helpers/sauce.js'
+import { describeCurrentScreen, reachCameraScreen } from '../helpers/screens.js'
 import { BaseScreen } from '../screens/core/BaseScreen.js'
 import { HomeScreen } from '../screens/main.js'
 import { VerifyPromptScreen } from '../screens/onboarding.js'
@@ -60,16 +61,15 @@ export async function chooseAddAccount(): Promise<void> {
 
 /**
  * The CI-default serial path — no live camera: IdentitySelection `Scan` → ScanSerial (accepting the
- * OS camera dialog when it appears; no-op when permission is already granted) → `EnterManually` →
+ * OS camera dialog whenever it appears; no-op when permission is already granted) → `EnterManually` →
  * ManualSerial → serial typed → EnterBirthdate. Card type is derived later, by `authorizeDevice`
  * at the birthdate submit.
  */
 export async function enterSerialManually(user: TestUser): Promise<void> {
   await IdentitySelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
-  await IdentitySelectionScreen.tap('primary')
-  await acceptSystemAlert()
-  await ScanSerialScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
-  await ScanSerialScreen.tap('primary')
+  await IdentitySelectionScreen.tapToNavigate('primary')
+  await reachCameraScreen('ScanSerial', () => ScanSerialScreen.isPresent(1_000))
+  await ScanSerialScreen.tapToNavigate('primary')
   await ManualSerialScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   await ManualSerialScreen.fill('serial', user.cardSerial, { tapFirst: true })
   await engine.dismissKeyboard()
@@ -114,28 +114,6 @@ function approvalInputForUser(user: TestUser): ApproveInPersonInput {
     }
   }
   return { flow: 'photo', cardSerialNumber: user.cardSerial, cardBirthdate: user.dob }
-}
-
-/**
- * Dump the first several visible text strings on the current screen — makes "unexpected screen"
- * failures self-diagnosing by revealing which screen we actually landed on.
- */
-async function describeCurrentScreen(): Promise<string> {
-  const selector = driver.isIOS
-    ? '-ios predicate string:type == "XCUIElementTypeStaticText"'
-    : 'android=new UiSelector().className("android.widget.TextView")'
-  const els = await $$(selector)
-  const texts: string[] = []
-  for (const el of els) {
-    const t = driver.isIOS ? await el.getAttribute('label').catch(() => null) : await el.getText().catch(() => null)
-    if (t) {
-      texts.push(t)
-    }
-    if (texts.length >= 8) {
-      break
-    }
-  }
-  return texts.length ? texts.join(' | ') : '(no visible text found)'
 }
 
 /**
@@ -253,6 +231,9 @@ async function selectEvidenceType(match: string): Promise<void> {
   }
 
   if (count === 1 && target) {
+    // The list arrives on a push animation, so settle the row before tapping — a tap dispatched against
+    // bounds the view has already moved past is silently dropped, and the flow blames the NEXT screen.
+    await engine.waitForSteadyPosition(target)
     await target.click()
     return
   }
@@ -264,27 +245,65 @@ async function selectEvidenceType(match: string): Promise<void> {
 }
 
 /**
+ * Wait for EvidenceCapture's shutter, and on failure say WHICH of the two very different causes it was.
+ *
+ * The screen's `self` is the shutter, which renders last: the MaskedCamera container mounts as soon as
+ * the permission request settles, but the shutter waits on `useCameraDevice` resolving a device. So a
+ * missing shutter means either the push never landed (container absent) or the camera never came up
+ * (container present) — indistinguishable from the timeout alone, and the ambiguity is what makes this
+ * failure expensive to read off a CI log.
+ */
+async function reachEvidenceCamera(): Promise<void> {
+  try {
+    await reachCameraScreen('EvidenceCapture', () => EvidenceCaptureScreen.isPresent(1_000))
+  } catch (err) {
+    const containerMounted = await EvidenceCaptureScreen.isVisible('maskedCamera')
+    throw new Error(
+      `${(err as Error).message}\nMaskedCamera container ${containerMounted ? 'IS' : 'is NOT'} mounted — ` +
+        (containerMounted
+          ? 'the screen was reached but no camera device resolved.'
+          : 'EvidenceCapture is not on screen: the push never landed, or the app navigated AWAY mid-capture. ' +
+            'If the on-screen dump above shows IDPhotoInformation right after a UsePhoto, a barcode decoded ' +
+            'off the injected image made the app reroute into card setup — mask the barcode regions ' +
+            '(see COMBO_CARD_BARCODE_MASKS) instead of re-tapping through; the flow state is corrupted at that point.')
+    )
+  }
+}
+
+/**
  * Capture a document's photo(s). CAMERA-ONLY: on Sauce the supplied image is injected before the
  * shutter (RN camera feeds are unreliable — see `helpers/camera`); on a local real device the physical
  * camera captures whatever it sees (`injectPhoto` throws off-Sauce). Shutter → accept in PhotoReview,
  * repeating per side (1 for a passport, 2 for a licence — backend-driven) until the typed
  * EvidenceIDCollection form appears.
+ *
+ * `barcodeMasks` MUST cover any decodable barcode on the injected image: the document camera runs a
+ * live code scanner behind the shutter, and on Android the injected frames feed it. An unmasked SIT
+ * combo barcode gets "scanned", and in the non-BCSC flow the app then verifies it with the backend on
+ * UsePhoto and — on a match — quietly resets the flow into card setup (observed: sees the template's
+ * serial C26444539, authorizes THAT card, resumes at IDPhotoInformation, journey dead). iOS injection
+ * never produces barcode scans, which is why this only ever broke Android.
  */
-async function capturePhotoIdDocument(image: string): Promise<void> {
+async function capturePhotoIdDocument(image: string, barcodeMasks: readonly ImageMaskRegion[] = []): Promise<void> {
   await IDPhotoInformationScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
-  await IDPhotoInformationScreen.tap('primary') // → EvidenceCapture (camera)
-  // The document camera requests camera permission on first entry — accept it, otherwise
-  // EvidenceCapture renders the PermissionDisabled fallback and the MaskedCamera never mounts.
-  await acceptSystemAlert()
+  // The primer's CTA pushes EvidenceCapture — confirm the push actually landed rather than assuming it.
+  // A tap dispatched while the screen is still transitioning gets swallowed on Android, and because the
+  // element WAS found the tap reports success; the flow then waits out its whole timeout on the shutter
+  // of a camera screen that was never opened, and blames the camera.
+  await IDPhotoInformationScreen.tapToNavigate('primary')
 
   for (let side = 0; side < 2; side++) {
-    await EvidenceCaptureScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    // The document camera requests camera permission on first entry — accept it whenever it appears,
+    // otherwise EvidenceCapture renders the PermissionDisabled fallback and MaskedCamera never mounts.
+    // On the second side permission is long granted, but the capture session still has to restart — so
+    // both sides get the camera budget rather than a screen-transition one.
+    await reachEvidenceCamera()
     if (isSauceLabs()) {
-      await injectPhoto(image, {}) // padding may need tuning to the document mask
+      await injectPhoto(image, {}, barcodeMasks) // padding may need tuning to the document mask
     }
-    await EvidenceCaptureScreen.tap('primary') // MaskedCamera shutter
+    await EvidenceCaptureScreen.tap('primary') // MaskedCamera shutter — NOT tapToNavigate (not idempotent)
     await PhotoReviewScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
-    await PhotoReviewScreen.tap('primary') // UsePhoto
+    await PhotoReviewScreen.tapToNavigate('primary') // UsePhoto → next side or the typed form
     if (await EvidenceIDCollectionScreen.isPresent(Timeouts.SCREEN_TRANSITION)) {
       return
     }
@@ -307,9 +326,11 @@ export async function addAdditionalPhotoId(user: TestUser, evidenceMatch: string
     ? '-ios predicate string:label CONTAINS "provide additional ID"'
     : 'android=new UiSelector().textContains("provide additional ID")'
   await $(headingSelector).waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
-  await AdditionalIdentificationRequiredScreen.tap('primary') // Continue → EvidenceTypeList
+  await AdditionalIdentificationRequiredScreen.tapToNavigate('primary') // Continue → EvidenceTypeList
   await selectEvidenceType(evidenceMatch)
-  await capturePhotoIdDocument(user.cardScanImage)
+  // The card-back template carries the SIT combo barcode. The reroute-on-scan has only been observed
+  // in the non-BCSC flow, but the code scanner runs behind every document capture — mask on principle.
+  await capturePhotoIdDocument(user.cardScanImage, COMBO_CARD_BARCODE_MASKS)
   await EvidenceIDCollectionScreen.fill('documentNumber', user.documentNumber, { tapFirst: true })
   await engine.dismissKeyboard()
   await EvidenceIDCollectionScreen.tapWhenEnabled('primary') // EvidenceIDCollectionContinue
@@ -349,18 +370,22 @@ export async function collectNonBcscEvidence(
     throw new Error(`collectNonBcscEvidence requires a non-bcsc TestUser (got '${user.flow}')`)
   }
   await IdentitySelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
-  await IdentitySelectionScreen.tap('secondary') // OtherID → DualIdentificationRequired
+  await IdentitySelectionScreen.tapToNavigate('secondary') // OtherID → DualIdentificationRequired
 
   // DualIdentificationRequired's only CTA is the generic `Continue`; confirm by heading before tapping.
   const dualHeadingSelector = driver.isIOS
     ? '-ios predicate string:label CONTAINS "two government"'
     : 'android=new UiSelector().textContains("two government")'
   await $(dualHeadingSelector).waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
-  await DualIdentificationRequiredScreen.tap('primary') // Continue → EvidenceTypeList (first ID)
+  // Safe to confirm-and-retry on the generic `Continue` here: EvidenceTypeList renders no Continue of
+  // its own, so the button going away really does mean the push landed.
+  await DualIdentificationRequiredScreen.tapToNavigate('primary') // Continue → EvidenceTypeList (first ID)
 
-  // First ID — captured + typed WITH name/birthdate.
+  // First ID — captured + typed WITH name/birthdate. The card-back image carries the SIT combo
+  // barcode, and this is the flow where the app verifies a scanned barcode with the backend on
+  // UsePhoto and reroutes on a match — so the barcode regions must be masked out of the injection.
   await selectEvidenceType(firstDocMatch)
-  await capturePhotoIdDocument(user.cardScanImage)
+  await capturePhotoIdDocument(user.cardScanImage, COMBO_CARD_BARCODE_MASKS)
   await fillEvidenceIdCollection(user.primaryDocumentNumber, {
     lastName: user.lastName,
     firstName: user.firstName,

--- a/e2e/src/helpers/alerts.ts
+++ b/e2e/src/helpers/alerts.ts
@@ -203,6 +203,39 @@ export async function acceptSystemAlert(appearTimeoutMs = DEFAULT_APPEAR_TIMEOUT
 }
 
 /**
+ * Wait for a screen to become ready, accepting any native permission dialog that shows up along the
+ * way — however late, and however many times.
+ *
+ * `acceptSystemAlert` alone races the app on camera screens: it polls a fixed window and gives up
+ * silently, but the OS permission controller can take longer than that to appear after a heavy camera
+ * screen mounts, and the screen re-renders its whole tree around the request (loading → permission
+ * fallback → camera). Interleaving the two checks removes the race in both directions — a dialog that
+ * arrives late still gets accepted, and a permission that was already granted costs nothing because
+ * `isReady` simply passes on the first poll.
+ *
+ * @param isReady - cheap, non-throwing probe for "the screen we want is on display"
+ * @returns true once `isReady` passes; false if the timeout elapsed first (caller reports the context)
+ */
+export async function acceptSystemAlertsUntil(
+  isReady: () => Promise<boolean>,
+  { timeoutMs = 30_000, pollMs = 500 }: { timeoutMs?: number; pollMs?: number } = {}
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    if (await hasNativePopup()) {
+      // Short appear-timeout: we already know a popup is up, so this goes straight to accepting it.
+      await acceptSystemAlert(1_000).catch((err) => {
+        console.log(`[alerts] Failed to accept popup while waiting for screen: ${(err as Error).message ?? err}`)
+      })
+    } else if (await isReady()) {
+      return true
+    }
+    if (Date.now() > deadline) return false
+    await driver.pause(pollMs)
+  }
+}
+
+/**
  * Dismiss/deny a native system alert — the negative counterpart of
  * `acceptSystemAlert`. Used to exercise declined-permission codepaths.
  */

--- a/e2e/src/helpers/camera.ts
+++ b/e2e/src/helpers/camera.ts
@@ -17,6 +17,15 @@ export interface ImagePadding {
   bottom?: number
   left?: number
 }
+
+/** A rectangle of the source image to cover with opaque white, normalized 0–1 in both axes. */
+export interface ImageMaskRegion {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
 /**
  * Add whitespace padding around an image so it aligns with a scanner target
  * area after Sauce Labs scales it to fill the camera frame.
@@ -27,11 +36,11 @@ export interface ImagePadding {
  * @returns base64-encoded PNG of the padded image.
  */
 export async function padImage(
-  imagePath: string,
+  image: string | Buffer,
   padding: ImagePadding,
   background: sharp.Color = DEFAULT_PAD_IMAGE_BACKGROUND
 ): Promise<string> {
-  const buf = await sharp(imagePath)
+  const buf = await sharp(image)
     .extend({
       top: padding.top ?? 0,
       right: padding.right ?? 0,
@@ -42,6 +51,38 @@ export async function padImage(
     .png()
     .toBuffer()
   return buf.toString('base64')
+}
+
+/**
+ * Cover regions of an image with opaque white so no barcode on it can decode.
+ *
+ * Needed because Sauce's Android injection replaces the WHOLE camera pipeline — including the
+ * frame stream vision-camera's code scanner (MLKit) reads — so a decodable barcode on an injected
+ * evidence image is scanned exactly as if a real card were held to the camera, and the app REACTS
+ * to it (e.g. the non-BCSC evidence flow asks the backend about a scanned serial and reroutes into
+ * card setup on a match). Masking keeps the picture looking like the document while making it
+ * undecodable. iOS injection cannot synthesize code-39/PDF-417 scans at all, so masking there is a
+ * harmless no-op in effect.
+ */
+export async function maskImageRegions(imagePath: string, masks: readonly ImageMaskRegion[]): Promise<Buffer> {
+  const image = sharp(imagePath)
+  const { width, height } = await image.metadata()
+  if (!width || !height) {
+    throw new Error(`maskImageRegions: could not read dimensions of ${imagePath}`)
+  }
+  const overlays: sharp.OverlayOptions[] = masks.map((mask) => ({
+    input: {
+      create: {
+        width: Math.max(1, Math.round(mask.width * width)),
+        height: Math.max(1, Math.round(mask.height * height)),
+        channels: 3,
+        background: { r: 255, g: 255, b: 255 },
+      },
+    },
+    left: Math.round(mask.x * width),
+    top: Math.round(mask.y * height),
+  }))
+  return image.composite(overlays).toBuffer()
 }
 
 /**
@@ -114,11 +155,17 @@ export async function injectCameraImage(imagePathOrBase64: string): Promise<void
 /**
  * Inject a photo (ID card, selfie, evidence) into the device camera.
  *
- * Convenience wrapper — resolves from `e2e/assets/` and delegates to
- * {@link injectCameraImage}.
+ * Convenience wrapper — resolves from `e2e/assets/`, optionally masks barcode regions
+ * ({@link maskImageRegions} — REQUIRED for any image carrying a decodable barcode when a code
+ * scanner is live behind the capture screen), pads, and delegates to {@link injectCameraImage}.
  */
-export async function injectPhoto(imagePathOrName: string, padding: ImagePadding): Promise<void> {
+export async function injectPhoto(
+  imagePathOrName: string,
+  padding: ImagePadding,
+  masks: readonly ImageMaskRegion[] = []
+): Promise<void> {
   const resolved = resolveAssetPath(imagePathOrName)
-  const padded = await padImage(resolved, padding)
+  const source = masks.length > 0 ? await maskImageRegions(resolved, masks) : resolved
+  const padded = await padImage(source, padding)
   await injectCameraImage(padded)
 }

--- a/e2e/src/helpers/screens.ts
+++ b/e2e/src/helpers/screens.ts
@@ -1,0 +1,52 @@
+import { Timeouts } from '../constants.js'
+import { acceptSystemAlertsUntil } from './alerts.js'
+
+/**
+ * Dump the first several visible text strings on the current screen — makes "unexpected screen"
+ * failures self-diagnosing by revealing which screen we actually landed on.
+ */
+export async function describeCurrentScreen(limit = 8): Promise<string> {
+  const selector = driver.isIOS
+    ? '-ios predicate string:type == "XCUIElementTypeStaticText"'
+    : 'android=new UiSelector().className("android.widget.TextView")'
+  const els = await $$(selector)
+  const texts: string[] = []
+  for (const el of els) {
+    const t = driver.isIOS ? await el.getAttribute('label').catch(() => null) : await el.getText().catch(() => null)
+    if (t) {
+      texts.push(t)
+    }
+    if (texts.length >= limit) {
+      break
+    }
+  }
+  return texts.length ? texts.join(' | ') : '(no visible text found)'
+}
+
+/**
+ * Wait for a camera screen to become interactive, accepting whatever permission dialog the OS raises
+ * on the way.
+ *
+ * Every camera screen is a moving target for its first few seconds: it requests camera permission on
+ * mount and swaps its ENTIRE tree while that is in flight (loading view → permission-denied fallback →
+ * camera), and only then does the camera device resolve and the controls render. The old shape —
+ * a single up-front `acceptSystemAlert()` followed by `expectVisible` — races that on two fronts:
+ *
+ *  - `acceptSystemAlert` polls a fixed window and gives up SILENTLY, so a dialog that appears later
+ *    (common on Android real devices behind a heavy camera mount) leaves the app covered and the
+ *    control we are about to assert on unreachable.
+ *  - `expectVisible` blind-scrolls on a miss, which on a camera screen means ~10s of swipes across a
+ *    live preview that has nothing to scroll, and a final error ("not visible after N scroll attempts")
+ *    that describes the workaround instead of the cause.
+ *
+ * Interleaving the dialog check with a cheap `isPresent` probe removes both. Pass the screen's readiness
+ * probe as `isReady`; on timeout the thrown error names what was actually on screen.
+ */
+export async function reachCameraScreen(
+  name: string,
+  isReady: () => Promise<boolean>,
+  timeoutMs: number = Timeouts.CAMERA_READY
+): Promise<void> {
+  if (await acceptSystemAlertsUntil(isReady, { timeoutMs })) return
+  throw new Error(`${name} did not become ready within ${timeoutMs}ms. On screen: ${await describeCurrentScreen()}`)
+}

--- a/e2e/src/screens/core/BaseScreen.ts
+++ b/e2e/src/screens/core/BaseScreen.ts
@@ -1,6 +1,23 @@
 import { Timeouts } from '../../constants.js'
 import { swipeDownBy, swipeUpBy } from '../../helpers/gestures.js'
 
+/**
+ * How long to keep re-sampling an element's position before giving up and tapping anyway.
+ * Only ever spent while a view is genuinely moving (see {@link BaseScreen.waitForSteadyPosition}).
+ */
+const STEADY_POSITION_TIMEOUT_MS = 3_000
+
+/** Gap between position samples when waiting for a view to stop moving. */
+const STEADY_POSITION_SAMPLE_MS = 120
+
+/**
+ * The bit of an element {@link BaseScreen.waitForSteadyPosition} needs — structural so it accepts both a
+ * resolved `WebdriverIO.Element` (from `$$`) and the chainable handle `findByTestId` returns.
+ */
+interface PositionedElement {
+  getLocation(): Promise<{ x: number; y: number }>
+}
+
 /** Options for text entry. Use for inputs that need special handling (e.g. PIN, secure text). */
 export interface EnterTextOptions {
   /**
@@ -141,20 +158,109 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
   }
 
   /**
-   * Tap an element by test ID.
-   * @param testId - test ID to tap
+   * Block until an element stops moving, so a tap is dispatched against coordinates that are still
+   * accurate when it lands.
+   *
+   * Android only, and it exists because of a deliberate trade-off in the shared config: RN's JS thread
+   * never looks idle to the accessibility framework, so UiAutomator2's implicit `waitForIdleTimeout`
+   * burned its full budget on EVERY interaction and we zero it out. That also removed the only thing
+   * that used to absorb screen-transition animations — `click()` reads an element's bounds and then
+   * injects a tap one round-trip later, so mid-animation the tap lands where the view WAS and is
+   * silently swallowed (no error: the element was found, the tap just missed). Two matching position
+   * samples means the view has settled. Costs one sample interval on a static screen.
+   *
+   * Best-effort by design: on timeout we tap anyway rather than fail a test on a jittery view.
    */
-  public async tapByTestId(testId: string) {
+  public async waitForSteadyPosition(el: PositionedElement): Promise<void> {
+    // XCUITest waits for app quiescence itself, so this is Android-only overhead.
+    if (!driver.isAndroid) return
+
+    const deadline = Date.now() + STEADY_POSITION_TIMEOUT_MS
+    let previous: string | null = null
+    while (Date.now() < deadline) {
+      const location = await el.getLocation().catch(() => null)
+      if (!location) return // element handle went stale — let the caller's click surface the real error
+      const current = `${Math.round(location.x)},${Math.round(location.y)}`
+      if (previous === current) return
+      previous = current
+      await driver.pause(STEADY_POSITION_SAMPLE_MS)
+    }
+    console.warn(`Element never stopped moving after ${STEADY_POSITION_TIMEOUT_MS}ms; tapping anyway`)
+  }
+
+  /**
+   * Tap an element by test ID.
+   *
+   * Waits the full `timeout` for the element rather than a token 500ms: screens that swap their whole
+   * tree while an async permission/camera request is in flight (ScanSerial, EvidenceCapture) can render
+   * a control, replace it with a loading view, and render it again — a short window lands in the gap and
+   * mistakes a re-render for a missing element, then wastes ~10s blind-scrolling a screen that does not
+   * scroll before failing.
+   *
+   * @param testId - test ID to tap
+   * @param timeout - how long to wait for the element before falling back to a scroll hunt
+   */
+  public async tapByTestId(testId: string, timeout: number = Timeouts.ELEMENT_VISIBLE) {
     let el = await this.findByTestId(testId)
     try {
-      await el.waitForDisplayed({ timeout: 500 })
+      await el.waitForDisplayed({ timeout })
     } catch {
-      console.warn(`Element "${testId}" not visible after 500ms; scrolling then retrying`)
+      console.warn(`Element "${testId}" not visible after ${timeout}ms; scrolling then retrying`)
       await this.scrollToTestId(testId, 6, 'both')
       el = await this.findByTestId(testId) // scrolling can invalidate the cached handle — re-query
-      await el.waitForDisplayed({ timeout: 500 })
+      await el.waitForDisplayed({ timeout })
     }
+    await this.waitForSteadyPosition(el)
     await el.click()
+  }
+
+  /**
+   * Tap a control that must take us OFF the current screen, and confirm it did.
+   *
+   * The tap is re-issued only while the tapped control is still on screen — proof the previous tap was
+   * swallowed rather than slow — so a navigation that already happened is never double-fired. Once the
+   * control is gone we stop retrying and return, whatever rendered next (including an OS permission
+   * dialog); asserting the destination is the caller's job.
+   *
+   * Use for pushes off animated screens; do NOT use for non-idempotent actions like a camera shutter.
+   *
+   * @param testId - test ID of the control to tap
+   * @param attempts - how many taps to try before failing
+   * @param timeout - how long to wait for the control itself before each tap
+   * @param settleMs - how long a tap gets to visibly leave the screen. Deliberately short: a stack push
+   *   that has not even started after this long did not happen, and a generous value would just add
+   *   dead time to every swallowed tap. Kept well above a normal transition so a camera mount stalling
+   *   the JS thread is not mistaken for a missed tap.
+   */
+  public async tapToNavigate(
+    testId: string,
+    {
+      attempts = 3,
+      timeout = Timeouts.SCREEN_TRANSITION,
+      settleMs = 5_000,
+    }: { attempts?: number; timeout?: number; settleMs?: number } = {}
+  ): Promise<void> {
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      await this.tapByTestId(testId, timeout)
+
+      const deadline = Date.now() + settleMs
+      while (Date.now() < deadline) {
+        if (!(await this.isTestIdDisplayed(testId))) return
+        await driver.pause(250)
+      }
+      console.warn(`Tap on "${testId}" did not leave the screen (attempt ${attempt}/${attempts}); re-tapping`)
+    }
+    throw new Error(`Tapped "${testId}" ${attempts} time(s) but "${testId}" never left the screen`)
+  }
+
+  /** True if an element (by raw test ID) is currently displayed; never throws. */
+  public async isTestIdDisplayed(testId: string): Promise<boolean> {
+    const el = await this.findByTestId(testId)
+    try {
+      return await el.isDisplayed()
+    } catch {
+      return false
+    }
   }
 
   /**
@@ -175,6 +281,7 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
       await el.waitForDisplayed({ timeout })
     }
     await el.waitForEnabled({ timeout })
+    await this.waitForSteadyPosition(el)
     await el.click()
   }
 
@@ -192,6 +299,24 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
   }
 
   /**
+   * Hide the Android soft keyboard if one is open. MUST run before any swipe-scroll: with a keyboard
+   * up, a "scroll" swipe lands on the keys — it does not move the content, and Gboard's glide typing
+   * reads the drag as gesture input and TYPES into the still-focused field (observed on a Pixel 7 Pro:
+   * a scroll hunt for the next input appended " TY TY TY TY" to the just-filled last-name field).
+   *
+   * Android-only by design: iOS has no `hideKeyboard`, its `dismissKeyboard` is a blind tap that could
+   * press a real control if fired speculatively, and its forms keep the focused field clear of the
+   * keyboard on their own. Never throws — a keyboard probe must not fail the caller's real action.
+   */
+  public async hideAndroidKeyboardIfShown(): Promise<void> {
+    if (!driver.isAndroid) return
+    const shown = await driver.isKeyboardShown().catch(() => false)
+    if (!shown) return
+    await driver.hideKeyboard().catch(() => undefined)
+    await driver.pause(300) // let the layout settle as the keyboard collapses
+  }
+
+  /**
    * Enter text into an input. Supports options for controlled/secure inputs.
    *
    * @param testId - testID of the input element
@@ -200,6 +325,12 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
    */
   public async enterText(testId: string, text: string, options?: EnterTextOptions) {
     let el = await this.findByTestId(testId)
+    // On a form, the usual reason the NEXT input is "not visible" is the previous field's keyboard
+    // sitting over it. Hide it up front instead of burning the full wait and then scroll-hunting —
+    // which, with a keyboard open, glide-types into the field we just filled.
+    if (!(await el.isDisplayed().catch(() => false))) {
+      await this.hideAndroidKeyboardIfShown()
+    }
     try {
       await el.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     } catch {
@@ -211,6 +342,25 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
 
     if (options?.tapFirst) {
       await el.click()
+      // Focusing a field opens the keyboard, and the keyboard-aware form scrolls the input clear of
+      // it. Mid-animation the node can briefly drop out of the accessibility tree, so the NEXT
+      // command's stale-element re-find dies with "element wasn't found" (observed on the last form
+      // field, which travels the farthest). Re-acquire the handle and let the layout settle before
+      // typing into it.
+      el = await this.findByTestId(testId)
+      try {
+        await el.waitForDisplayed({ timeout: Timeouts.ELEMENT_VISIBLE })
+      } catch {
+        // Some forms do NOT scroll their bottom field clear — the click focuses it and its own
+        // keyboard slides over it (observed: ResidentialAddress postal code). The focus took; on
+        // Android setValue is an accessibility setText that needs neither the keyboard nor the
+        // field on screen — only a findable node. Hide the keyboard so the node is reliably back
+        // in the snapshot, then continue.
+        console.warn(`Element "${testId}" hidden after focus (keyboard over it?); hiding keyboard and retrying`)
+        await this.hideAndroidKeyboardIfShown()
+        await el.waitForDisplayed({ timeout: Timeouts.ELEMENT_VISIBLE })
+      }
+      await this.waitForSteadyPosition(el)
     }
 
     // iOS/XCUITest clearValue and mobile:clearText both trigger a
@@ -252,6 +402,12 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
 
     if (await isVisible()) return
 
+    // An open keyboard both hides the lower half of the screen and turns the swipes below into
+    // glide-typed garbage in the focused field — clear it before the first swipe. Often the target
+    // is visible right after, no scrolling needed.
+    await this.hideAndroidKeyboardIfShown()
+    if (await isVisible()) return
+
     const scrollFraction = 0.25
     const settlePauseMs = 150
 
@@ -281,11 +437,6 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
    * @returns true if the element is displayed, false otherwise
    */
   public async isDisplayed(key: keyof T & string): Promise<boolean> {
-    const el = await this.findByTestId(this.ids[key])
-    try {
-      return await el.isDisplayed()
-    } catch {
-      return false
-    }
+    return this.isTestIdDisplayed(this.ids[key])
   }
 }

--- a/e2e/src/screens/core/defineScreen.ts
+++ b/e2e/src/screens/core/defineScreen.ts
@@ -86,6 +86,11 @@ export class RawElement {
     await this.engine.tapByTestId(this.id)
   }
 
+  /** Tap the element and confirm it left the screen, re-tapping a swallowed tap. */
+  async tapToNavigate(options?: { attempts?: number; timeout?: number; settleMs?: number }): Promise<void> {
+    await this.engine.tapToNavigate(this.id, options)
+  }
+
   /** Wait until the element is enabled, then tap it. */
   async tapWhenEnabled(timeout?: number): Promise<void> {
     await this.engine.waitForEnabledAndTap(this.id, timeout)
@@ -201,6 +206,18 @@ export class Screen<S extends ScreenSpec> {
   /** Tap a declared role. Only roles the descriptor declares type-check. */
   async tap(role: PresentRoles<S>): Promise<void> {
     await this.tapRole(role as ActionRole)
+  }
+
+  /**
+   * Tap a declared role that must navigate AWAY from this screen, and confirm it did — re-tapping only
+   * while the control is still on screen (see {@link BaseScreen.tapToNavigate}). Use on the seams where
+   * Android swallows a tap dispatched mid-transition; never for a non-idempotent action.
+   */
+  async tapToNavigate(
+    role: PresentRoles<S>,
+    options?: { attempts?: number; timeout?: number; settleMs?: number }
+  ): Promise<void> {
+    await this.engine.tapToNavigate(resolveTestId(this.roleId(role as ActionRole)), options)
   }
 
   /** Wait until a declared role is enabled, then tap it. */

--- a/e2e/src/screens/verify.ts
+++ b/e2e/src/screens/verify.ts
@@ -39,10 +39,14 @@ export const IdentitySelectionScreen = defineScreen({
 })
 
 /**
- * Camera scan screen (`ScanSerial`). Mount auto-requests camera permission — the OS dialog appears
- * on first entry (`acceptSystemAlert`); while the request is pending the screen is a loading view,
- * and when denied it renders the PermissionDisabled fallback (no testID — title copy only).
- * `primary` (EnterManually) is the CI path around the live camera.
+ * Camera scan screen (`ScanSerial`). Mount auto-requests camera permission and the screen swaps its
+ * whole tree around that request — loading view while it is pending, PermissionDisabled when denied,
+ * camera when granted — so reach it with `reachCameraScreen`, which accepts the OS dialog whenever it
+ * lands instead of racing a fixed window against the re-renders.
+ *
+ * `primary` (EnterManually) is the CI path around the live camera, and it is a deliberately good anchor:
+ * the PermissionDisabled fallback renders the SAME testID as its secondary action, so the flow reaches
+ * manual entry whether permission was granted or refused — only the loading view lacks it.
  */
 export const ScanSerialScreen = defineScreen({
   self: bcsc(v.scanSerial.enterManually),
@@ -223,13 +227,21 @@ export const IDPhotoInformationScreen = defineScreen({
 
 /**
  * `EvidenceCapture` — the MaskedCamera document capture (camera-only; on Sauce the image is injected,
- * else the physical camera is used). `self` is the camera container; `primary` is the shutter,
- * `secondary` the cancel/close.
+ * else the physical camera is used). `self`/`primary` is the shutter, `secondary` the cancel/close.
+ *
+ * `maskedCamera` is the container, and it renders EARLIER than the shutter: the container appears once
+ * the permission request settles, while the shutter waits on `useCameraDevice` resolving a device (until
+ * then MaskedCamera shows a "no camera available" placeholder with no shutter). Probe the container to
+ * tell "the push landed" apart from "the camera is still coming up" — anchoring only on the shutter
+ * makes a slow camera and a swallowed tap produce the identical failure.
  */
 export const EvidenceCaptureScreen = defineScreen({
   self: bcsc(v.evidenceCapture.takePhoto),
   primary: bcsc(v.evidenceCapture.takePhoto),
   secondary: bcsc(v.evidenceCapture.cancel),
+  elements: {
+    maskedCamera: bcsc(v.evidenceCapture.maskedCamera),
+  },
 })
 
 /**

--- a/e2e/test/bcsc/main/unverified-main.journey.ts
+++ b/e2e/test/bcsc/main/unverified-main.journey.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { Timeouts } from '../../../src/constants.js'
 import { skipToHome } from '../../../src/flows/onboarding.js'
-import { acceptSystemAlert } from '../../../src/helpers/alerts.js'
+import { reachCameraScreen } from '../../../src/helpers/screens.js'
 import { BaseScreen } from '../../../src/screens/core/BaseScreen.js'
 import {
   HomeScreen,
@@ -57,11 +57,10 @@ describe('Main journey: unverified gating', () => {
 
   it('the scan FAB opens the ungated QR scanner', async () => {
     await HomeScreen.link('scanFab')
-    // Scanner mount auto-requests camera permission; no-op when already granted.
-    await acceptSystemAlert()
-    await QRCoreScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
-    // The torch control only renders once the camera is live — the scanner-ready marker.
-    await QRCoreScreen.waitFor('torch', Timeouts.SCREEN_TRANSITION)
+    // Scanner mount auto-requests camera permission; accept it whenever the OS raises it (no-op when
+    // already granted). The torch control only renders once the camera is live, so it — not the tab
+    // bar (the screen's `self`), which is up immediately — is the scanner-ready marker.
+    await reachCameraScreen('QRCore scanner', () => QRCoreScreen.isVisible('torch'))
     // QRDisplay is developer-mode-gated and must be absent in a normal run (descoped from CI).
     assert.equal(await QRCoreScreen.isVisible('displayTab'), false, 'dev-only Display tab should be absent')
   })


### PR DESCRIPTION
# Summary of Changes

Fixes the Android e2e failures around camera screens and form input, and makes Sauce job names identify which journey ran. E2E-only — no app code touched.

**Camera screens raced the permission dialog.** `acceptSystemAlert()` polled a fixed window and gave up silently, so a dialog that appeared later (common on Android real devices behind a heavy camera mount) left the app covered and the next assertion unreachable. Replaced by `acceptSystemAlertsUntil` / `reachCameraScreen`, which interleaves the dialog check with a cheap readiness probe under a new `CAMERA_READY` (45s) budget covering the whole chain a screen transition doesn't — late dialog, re-renders around the request, device enumeration, capture-session warmup. Costs nothing when permission is already granted; on timeout the error names what was actually on screen.

**Taps were silently swallowed mid-transition.** UiAutomator2's implicit idle wait is zeroed out in the shared config (RN's JS thread never looks idle, so it burned its full budget on every interaction), which also removed the only thing absorbing transition animations — `click()` reads bounds and injects a tap a round-trip later, so mid-animation it lands where the view *was*, with no error since the element was found. Adds `waitForSteadyPosition` (sample until the view stops moving; best-effort, taps anyway on timeout) and `tapToNavigate` (confirm the control left the screen, re-tap only while it's still there). Applied to navigation seams only — never the camera shutter or other non-idempotent actions. `tapByTestId` also now waits the real timeout instead of 500ms before falling back to a scroll hunt.

**The soft keyboard corrupted form input.** A scroll-swipe with the keyboard up doesn't scroll the content — Gboard reads the drag as glide typing and types into the still-focused field (observed on a Pixel 7 Pro: ` TY TY TY TY` appended to the just-filled last-name field). Adds `hideAndroidKeyboardIfShown` before any scroll hunt and on the `tapFirst` focus path, plus a handle re-acquire after focus, since the keyboard-aware form scrolls the input and the node briefly drops out of the accessibility tree.


**Sauce job names.** `TEST_NAME` is now a prefix rather than an override, so nightly jobs read `E2E regression - Android 15 - Main journey: unverified gating` instead of every job in the run sharing one title.

# Testing Instructions

1. From `e2e/`, run `npm run test:android:sauce`.
2. In the Sauce dashboard, confirm each job in the build is named `<TEST_NAME> - <journey describe title>` and the journeys are distinguishable from the job list.
3. Run `npm run test:ios:sauce` — the Android-specific guards early-return on iOS, so this should be unchanged.
4. Watch the non-BCSC journey specifically: evidence capture should reach `EvidenceIDCollection`, not reroute to `IDPhotoInformation`.

# Acceptance Criteria

- [ ] Android and iOS Sauce suites pass
- [ ] Sauce job list shows the journey name alongside the regression title
- [ ] No new iOS happy-path failures or meaningful runtime increase

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A
