### PR TITLE
fix: camera formats + takeSnapshot

### DIFF
--- a/app/src/bcsc-theme/components/MaskedCamera.tsx
+++ b/app/src/bcsc-theme/components/MaskedCamera.tsx
@@ -186,10 +186,10 @@ const MaskedCamera = ({
     try {
       let photo: PhotoFile
       if (cameraFace === 'back') {
-        // Use `takeSnapshot` on back camera: signifigantly faster read and write
+        // Use `takeSnapshot` on back camera: significantly faster read/write
         photo = await cameraRef.current.takeSnapshot({ quality: 90 })
       } else {
-        // Use `takePhoto` on front camera: `takeSnapshot` flips image vertially (front camera bug)
+        // Use `takePhoto` on front camera: `takeSnapshot` flips image vertically (front camera bug)
         photo = await cameraRef.current.takePhoto({
           flash: 'off',
           enableShutterSound: false,

--- a/app/src/bcsc-theme/components/MaskedCamera.tsx
+++ b/app/src/bcsc-theme/components/MaskedCamera.tsx
@@ -23,6 +23,7 @@ import {
   CameraCaptureError,
   CodeScanner,
   FormatFilter,
+  PhotoFile,
   useCameraDevice,
   useCameraFormat,
 } from 'react-native-vision-camera'
@@ -178,16 +179,25 @@ const MaskedCamera = ({
   }
 
   const takePhoto = async () => {
+    if (!cameraRef.current || !isFocused) {
+      return
+    }
+
     try {
-      if (cameraRef.current && isFocused) {
-        const photo = await cameraRef.current.takePhoto({
+      let photo: PhotoFile
+      if (cameraFace === 'back') {
+        // Use `takeSnapshot` on back camera: signifigantly faster read and write
+        photo = await cameraRef.current.takeSnapshot({ quality: 90 })
+      } else {
+        // Use `takePhoto` on front camera: `takeSnapshot` flips image vertially (front camera bug)
+        photo = await cameraRef.current.takePhoto({
           flash: 'off',
           enableShutterSound: false,
         })
-
-        onPhotoTaken(photo.path)
-        logger.info(`Photo taken and saved temporarily: ${photo.path}`)
       }
+
+      onPhotoTaken(photo.path)
+      logger.info(`Photo taken and saved temporarily: ${photo.path}`)
     } catch (error) {
       logger.error(`Error taking photo: ${error}`)
 

--- a/app/src/bcsc-theme/components/utils/camera-format.test.ts
+++ b/app/src/bcsc-theme/components/utils/camera-format.test.ts
@@ -7,6 +7,276 @@ const { getCameraFormat } = jest.requireActual(
   'react-native-vision-camera/src/devices/getCameraFormat'
 ) as typeof import('react-native-vision-camera/src/devices/getCameraFormat')
 
+const RealDevice = {
+  id: 'real-device-id',
+  formats: [
+    {
+      _id: 'format-1',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 60,
+      videoWidth: 192,
+      videoHeight: 144,
+      photoWidth: 4032,
+      photoHeight: 3024,
+      videoStabilizationModes: ['auto', 'off'],
+    },
+    {
+      _id: 'format-2',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 60,
+      videoWidth: 352,
+      videoHeight: 288,
+      photoWidth: 3696,
+      photoHeight: 3024,
+      videoStabilizationModes: ['auto', 'off'],
+    },
+    {
+      _id: 'format-3',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 60,
+      videoWidth: 480,
+      videoHeight: 360,
+      photoWidth: 4032,
+      photoHeight: 3024,
+      videoStabilizationModes: ['auto', 'off'],
+    },
+    {
+      _id: 'format-4',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 60,
+      videoWidth: 640,
+      videoHeight: 480,
+      photoWidth: 4032,
+      photoHeight: 3024,
+      videoStabilizationModes: ['auto', 'off'],
+    },
+    {
+      _id: 'format-5',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 60,
+      videoWidth: 640,
+      videoHeight: 480,
+      photoWidth: 2016,
+      photoHeight: 1512,
+      videoStabilizationModes: ['auto', 'off'],
+    },
+    {
+      _id: 'format-6',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 60,
+      videoWidth: 960,
+      videoHeight: 540,
+      photoWidth: 4224,
+      photoHeight: 2384,
+      videoStabilizationModes: ['auto', 'cinematic', 'off', 'standard', 'cinematic-extended'],
+    },
+    {
+      _id: 'format-7',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 60,
+      videoWidth: 1024,
+      videoHeight: 768,
+      photoWidth: 4032,
+      photoHeight: 3024,
+      videoStabilizationModes: ['auto', 'off', 'standard'],
+    },
+    {
+      _id: 'format-8',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 30,
+      videoWidth: 1280,
+      videoHeight: 720,
+      photoWidth: 4224,
+      photoHeight: 2376,
+      videoStabilizationModes: ['auto', 'cinematic', 'off', 'standard', 'cinematic-extended'],
+    },
+    {
+      _id: 'format-9',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 60,
+      videoWidth: 1280,
+      videoHeight: 720,
+      photoWidth: 4224,
+      photoHeight: 2384,
+      videoStabilizationModes: ['auto', 'cinematic', 'off', 'standard', 'cinematic-extended'],
+    },
+    {
+      _id: 'format-10',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'contrast-detection',
+      maxFps: 60,
+      videoWidth: 1280,
+      videoHeight: 720,
+      photoWidth: 2112,
+      photoHeight: 1188,
+      videoStabilizationModes: ['auto', 'cinematic', 'off', 'standard', 'cinematic-extended'],
+    },
+    {
+      _id: 'format-11',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'contrast-detection',
+      maxFps: 240,
+      videoWidth: 1280,
+      videoHeight: 720,
+      photoWidth: 1280,
+      photoHeight: 720,
+      videoStabilizationModes: ['auto', 'off', 'standard'],
+    },
+    {
+      _id: 'format-12',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 60,
+      videoWidth: 1440,
+      videoHeight: 1080,
+      photoWidth: 2016,
+      photoHeight: 1512,
+      videoStabilizationModes: ['auto', 'off'],
+    },
+    {
+      _id: 'format-13',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 30,
+      videoWidth: 1920,
+      videoHeight: 1080,
+      photoWidth: 4224,
+      photoHeight: 2376,
+      videoStabilizationModes: ['auto', 'cinematic', 'off', 'standard', 'cinematic-extended'],
+    },
+    {
+      _id: 'format-14',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 60,
+      videoWidth: 1920,
+      videoHeight: 1080,
+      photoWidth: 4224,
+      photoHeight: 2384,
+      videoStabilizationModes: ['auto', 'cinematic', 'off', 'standard', 'cinematic-extended'],
+    },
+    {
+      _id: 'format-15',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'contrast-detection',
+      maxFps: 60,
+      videoWidth: 1920,
+      videoHeight: 1080,
+      photoWidth: 2112,
+      photoHeight: 1188,
+      videoStabilizationModes: ['auto', 'cinematic', 'off', 'standard', 'cinematic-extended'],
+    },
+    {
+      _id: 'format-16',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 120,
+      videoWidth: 1920,
+      videoHeight: 1080,
+      photoWidth: 1920,
+      photoHeight: 1080,
+      videoStabilizationModes: ['auto', 'cinematic', 'off', 'standard'],
+    },
+    {
+      _id: 'format-17',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'contrast-detection',
+      maxFps: 240,
+      videoWidth: 1920,
+      videoHeight: 1080,
+      photoWidth: 1920,
+      photoHeight: 1080,
+      videoStabilizationModes: ['auto', 'off', 'standard'],
+    },
+    {
+      _id: 'format-18',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 30,
+      videoWidth: 1920,
+      videoHeight: 1440,
+      photoWidth: 4032,
+      photoHeight: 3024,
+      videoStabilizationModes: ['auto', 'off'],
+    },
+    {
+      _id: 'format-19',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 60,
+      videoWidth: 1920,
+      videoHeight: 1440,
+      photoWidth: 2016,
+      photoHeight: 1512,
+      videoStabilizationModes: ['auto', 'off'],
+    },
+    {
+      _id: 'format-20',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 30,
+      videoWidth: 2592,
+      videoHeight: 1944,
+      photoWidth: 4032,
+      photoHeight: 3024,
+      videoStabilizationModes: ['auto', 'off'],
+    },
+    {
+      _id: 'format-21',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 30,
+      videoWidth: 3264,
+      videoHeight: 2448,
+      photoWidth: 4032,
+      photoHeight: 3024,
+      videoStabilizationModes: ['auto', 'off'],
+    },
+    {
+      _id: 'format-22',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 30,
+      videoWidth: 3840,
+      videoHeight: 2160,
+      photoWidth: 4224,
+      photoHeight: 2376,
+      videoStabilizationModes: ['auto', 'cinematic', 'off', 'standard', 'cinematic-extended'],
+    },
+    {
+      _id: 'format-23',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 60,
+      videoWidth: 3840,
+      videoHeight: 2160,
+      photoWidth: 3840,
+      photoHeight: 2160,
+      videoStabilizationModes: ['auto', 'cinematic', 'off', 'standard', 'cinematic-extended'],
+    },
+    {
+      _id: 'format-24',
+      supportsVideoHdr: false,
+      autoFocusSystem: 'phase-detection',
+      maxFps: 30,
+      videoWidth: 4032,
+      videoHeight: 3024,
+      photoWidth: 4032,
+      photoHeight: 3024,
+      videoStabilizationModes: ['auto', 'off'],
+    },
+  ],
+}
+
 const ModernDevice = {
   id: 'modern-device-id',
   formats: [
@@ -107,10 +377,10 @@ describe('CameraFormat', () => {
   })
 
   describe('MaskedWithBarcodeDetection: ModernDevice', () => {
-    it('should return modern-format-4 for ModernDevice', () => {
+    it('should return modern-format-3 for ModernDevice', () => {
       const format: any = getCameraFormat(ModernDevice as any, CameraFormat.MaskedWithBarcodeDetection)
 
-      expect(format?._id).toBe('modern-format-4')
+      expect(format?._id).toBe('modern-format-3')
     })
   })
 
@@ -118,7 +388,15 @@ describe('CameraFormat', () => {
     it('should return legacy-format-1 for LegacyDevice', () => {
       const format: any = getCameraFormat(LegacyDevice as any, CameraFormat.MaskedWithBarcodeDetection)
 
-      expect(format?._id).toBe('legacy-format-2')
+      expect(format?._id).toBe('legacy-format-1')
+    })
+  })
+
+  describe('MaskedWithBarcodeDetection: RealDevice', () => {
+    it('should return format-3 for RealDevice', () => {
+      const format: any = getCameraFormat(RealDevice as any, CameraFormat.MaskedWithBarcodeDetection)
+
+      expect(format?._id).toBe('format-16')
     })
   })
 

--- a/app/src/bcsc-theme/components/utils/camera-format.test.ts
+++ b/app/src/bcsc-theme/components/utils/camera-format.test.ts
@@ -393,7 +393,7 @@ describe('CameraFormat', () => {
   })
 
   describe('MaskedWithBarcodeDetection: RealDevice', () => {
-    it('should return format-3 for RealDevice', () => {
+    it('should return format-16 for RealDevice', () => {
       const format: any = getCameraFormat(RealDevice as any, CameraFormat.MaskedWithBarcodeDetection)
 
       expect(format?._id).toBe('format-16')

--- a/app/src/bcsc-theme/components/utils/camera.ts
+++ b/app/src/bcsc-theme/components/utils/camera.ts
@@ -8,7 +8,7 @@ import {
   VideoStabilizationMode,
 } from 'react-native-vision-camera'
 
-import { PHOTO_RESOLUTION_1080P, PHOTO_RESOLUTION_720P } from '@/constants'
+import { PHOTO_RESOLUTION_1080P } from '@/constants'
 
 // ─── Shared Types ─────────────────────────────────────────────────────────────
 
@@ -91,17 +91,21 @@ export const CameraFormat = {
     {
       videoHdr: false,
     },
-    // Medium resolution for moderate capture quality
+    // Use phase-detection autofocus for faster and more accurate focusing on barcodes
     {
-      photoResolution: PHOTO_RESOLUTION_720P,
-    },
-    // Moderate FPS for smooth preview without excessive processing load
-    {
-      fps: 30,
+      autoFocusSystem: 'phase-detection',
     },
     // High resolution for better barcode detection
     {
       videoResolution: PHOTO_RESOLUTION_1080P,
+    },
+    // High resolution for better photo quality when capturing the ID card
+    {
+      photoResolution: PHOTO_RESOLUTION_1080P,
+    },
+    // Moderate FPS for smooth preview without excessive processing load
+    {
+      fps: 60,
     },
     // Enable video stabilization for steadier scanning
     {


### PR DESCRIPTION
# Summary of Changes
Attempting to target the best format for capturing evidence while also being able to scan barcodes.

This means: no HDR, phase-detection focus, moderate resolution for both video and photo.

ie:  "video:1920x1080 photo:1920x1080 fps:120 focus:phase stab:auto,cin,off,std hdr:none",
```ts
        "video:192x144 photo:4032x3024 fps:60 focus:phase stab:auto,off hdr:none",
        "video:352x288 photo:3696x3024 fps:60 focus:phase stab:auto,off hdr:none",
        "video:480x360 photo:4032x3024 fps:60 focus:phase stab:auto,off hdr:none",
        "video:640x480 photo:4032x3024 fps:60 focus:phase stab:auto,off hdr:none",
        "video:640x480 photo:2016x1512 fps:60 focus:phase stab:auto,off hdr:none",
        "video:960x540 photo:4224x2384 fps:60 focus:phase stab:auto,cin,off,std,cin-ext hdr:none",
        "video:1024x768 photo:4032x3024 fps:60 focus:phase stab:auto,off,std hdr:none",
        "video:1280x720 photo:4224x2376 fps:30 focus:phase stab:auto,cin,off,std,cin-ext hdr:none",
        "video:1280x720 photo:4224x2384 fps:60 focus:phase stab:auto,cin,off,std,cin-ext hdr:none",
        "video:1280x720 photo:2112x1188 fps:60 focus:contrast stab:auto,cin,off,std,cin-ext hdr:none",
        "video:1280x720 photo:1280x720 fps:240 focus:contrast stab:auto,off,std hdr:none",
        "video:1440x1080 photo:2016x1512 fps:60 focus:phase stab:auto,off hdr:none",
        "video:1920x1080 photo:4224x2376 fps:30 focus:phase stab:auto,cin,off,std,cin-ext hdr:none",
        "video:1920x1080 photo:4224x2384 fps:60 focus:phase stab:auto,cin,off,std,cin-ext hdr:none",
        "video:1920x1080 photo:2112x1188 fps:60 focus:contrast stab:auto,cin,off,std,cin-ext hdr:none",
        "video:1920x1080 photo:1920x1080 fps:120 focus:phase stab:auto,cin,off,std hdr:none",
        "video:1920x1080 photo:1920x1080 fps:240 focus:contrast stab:auto,off,std hdr:none",
        "video:1920x1440 photo:4032x3024 fps:30 focus:phase stab:auto,off hdr:none",
        "video:1920x1440 photo:2016x1512 fps:60 focus:phase stab:auto,off hdr:none",
        "video:2592x1944 photo:4032x3024 fps:30 focus:phase stab:auto,off hdr:none",
        "video:3264x2448 photo:4032x3024 fps:30 focus:phase stab:auto,off hdr:none",
        "video:3840x2160 photo:4224x2376 fps:30 focus:phase stab:auto,cin,off,std,cin-ext hdr:none",
        "video:3840x2160 photo:3840x2160 fps:60 focus:phase stab:auto,cin,off,std,cin-ext hdr:none",
        "video:4032x3024 photo:4032x3024 fps:30 focus:phase stab:auto,off hdr:none"

```

# Testing Instructions

1. Non-BCSC
2. Capture evidence (front and back)

# Acceptance Criteria

1. Camera focuses both android iOS.
2. Image loads quickly after capture

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
