### PR TITLE
fix(bcsc): remove dead navigate call after in-person verification

### DIFF
--- a/app/src/bcsc-theme/features/verify/_models/useVerificationResponseViewModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/_models/useVerificationResponseViewModel.test.ts
@@ -3,6 +3,7 @@ import * as useRegistrationServiceModule from '@/bcsc-theme/services/hooks/useRe
 import * as useTokenServiceModule from '@/bcsc-theme/services/hooks/useTokenService'
 import { BCDispatchAction, BCState } from '@/store'
 import * as Bifold from '@bifold/core'
+import { useNavigation } from '@react-navigation/native'
 import { act, renderHook } from '@testing-library/react-native'
 
 const mockGetCachedIdTokenMetadata = jest.fn().mockResolvedValue(undefined)
@@ -292,6 +293,21 @@ describe('useVerificationResponseViewModel', () => {
           await result.current.handleAccountSetup()
         })
       ).resolves.not.toThrow()
+    })
+
+    it('should not perform imperative navigation on success (#4368)', async () => {
+      mockRegistrationService.updateRegistration.mockResolvedValue(undefined)
+
+      const nav = useNavigation()
+      const { result } = renderHook(() => useVerificationResponseViewModel())
+
+      await act(async () => {
+        await result.current.handleAccountSetup()
+      })
+
+      expect(nav.navigate).not.toHaveBeenCalled()
+      expect(nav.reset).not.toHaveBeenCalled()
+      expect(nav.dispatch).not.toHaveBeenCalled()
     })
   })
 

--- a/app/src/bcsc-theme/features/verify/_models/useVerificationResponseViewModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useVerificationResponseViewModel.tsx
@@ -1,16 +1,12 @@
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { useRegistrationService } from '@/bcsc-theme/services/hooks/useRegistrationService'
 import { useTokenService } from '@/bcsc-theme/services/hooks/useTokenService'
-import { BCSCMainStackParams, BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
 import { getShortDisplayName } from '@/bcsc-theme/utils/account-utils'
 import { BCDispatchAction, BCState } from '@/store'
 import { TOKENS, useServices, useStore } from '@bifold/core'
-import { useNavigation } from '@react-navigation/native'
-import { StackNavigationProp } from '@react-navigation/stack'
 import { useCallback, useState } from 'react'
 
 const useVerificationResponseViewModel = () => {
-  const navigation = useNavigation<StackNavigationProp<BCSCMainStackParams>>()
   const [store, dispatch] = useStore<BCState>()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const registration = useRegistrationService()
@@ -56,8 +52,9 @@ const useVerificationResponseViewModel = () => {
       dispatch({ type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_REQUEST_STATUS_MESSAGE, payload: [undefined] })
       dispatch({ type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_VIDEO_SUBMITTED_AT, payload: [undefined] })
       setIsSettingUpAccount(false)
-      // all done here, back to the home screen
-      navigation.navigate(BCSCStacks.Tab, { screen: BCSCScreens.Home })
+      // no navigation call here: RootStack watches `verified` (via useVerificationStatus) and
+      // swaps VerifyStack for BCSCMainStack, which mounts at the Tab stack's Home route. An
+      // imperative navigate fired here targets a stack not yet mounted and is unreachable (#4368).
     } catch (error) {
       const errMessage = error instanceof Error ? error.message : String(error)
       logger.error(`[handleAccountSetup] Failed to clean up verification process: ${errMessage}`)
@@ -70,7 +67,6 @@ const useVerificationResponseViewModel = () => {
     getCachedIdTokenMetadata,
     logger,
     updateNicknameInLocalStorage,
-    navigation,
     dispatch,
   ])
   return {

--- a/app/src/bcsc-theme/features/verify/_models/useVerificationResponseViewModel.tsx
+++ b/app/src/bcsc-theme/features/verify/_models/useVerificationResponseViewModel.tsx
@@ -52,9 +52,7 @@ const useVerificationResponseViewModel = () => {
       dispatch({ type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_REQUEST_STATUS_MESSAGE, payload: [undefined] })
       dispatch({ type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_VIDEO_SUBMITTED_AT, payload: [undefined] })
       setIsSettingUpAccount(false)
-      // no navigation call here: RootStack watches `verified` (via useVerificationStatus) and
-      // swaps VerifyStack for BCSCMainStack, which mounts at the Tab stack's Home route. An
-      // imperative navigate fired here targets a stack not yet mounted and is unreachable (#4368).
+      // RootStack swaps to MainStack on `verified` flip — no imperative navigate needed (#4368)
     } catch (error) {
       const errMessage = error instanceof Error ? error.message : String(error)
       logger.error(`[handleAccountSetup] Failed to clean up verification process: ${errMessage}`)


### PR DESCRIPTION
## What

After a user finishes verifying their identity in person and lands back on the Home screen, a navigation error was silently logged in the background. This change removes the leftover navigation call that was causing the error — the app already correctly lands users on Home, this was just noisy dead code firing along the way.

## Why

The error (`The action 'NAVIGATE' ... was not handled by any navigator`) was harmless in that users still ended up on Home, but it polluted logs and made real navigation issues harder to spot. Cleaning it up removes noise without changing any user-facing behavior.

## Decisions

- `handleAccountSetup` in `useVerificationResponseViewModel.tsx` called `navigation.navigate(BCSCStacks.Tab, { screen: BCSCScreens.Home })` right after `updateVerified(true)`. At that point in the tree, `VerificationSuccessScreen` lives inside `VerifyStack`, and `BCSCRootStack` renders exactly one of Onboarding/Auth/Verify/Main — so no `BCSCTabStack` route exists yet when the action dispatches, and it bubbles unhandled.
- The user still lands on Home because the `verified` state flip (via `useVerificationStatus`) makes `RootStack` swap `VerifyStack` for `BCSCMainStack`, which mounts with `initialRouteName = BCSCStacks.Tab` → Home. The imperative navigate call was dead code and has been removed, along with the now-unused `useNavigation`/`StackNavigationProp` hook and `BCSCMainStackParams`/`BCSCScreens`/`BCSCStacks` imports.

## Manual Testing

1. Do an In-Person verification
2. After you finish ID Check continue the process on the mobile device until you reach the home screen.
3.  You should not see any NAVIGATION exceptions in the metro logs.

## Tests

Added a regression test asserting that after a successful `handleAccountSetup()`, the navigation mock's `navigate`, `reset`, and `dispatch` were never called.

## Verification

`yarn check` (typecheck, lint, format, full test suite) passes.

Fixes #4368