### PR TITLE
feat: trigger DSC auto issuance by schema ID as well as cred def ID

### DIFF
--- a/app/src/bcsc-theme/features/qr-core/ConnectionLoadingScreen.test.tsx
+++ b/app/src/bcsc-theme/features/qr-core/ConnectionLoadingScreen.test.tsx
@@ -1,15 +1,34 @@
 import { BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
-import { Connection } from '@bifold/core'
+import { Connection, CredentialProvisioningEventTypes, LoadingPlaceholder } from '@bifold/core'
 import { CommonActions } from '@react-navigation/native'
-import { render } from '@testing-library/react-native'
+import { act, render } from '@testing-library/react-native'
 import React from 'react'
-import { BackHandler } from 'react-native'
+import { BackHandler, DeviceEventEmitter } from 'react-native'
 
 import ConnectionLoadingScreen from './ConnectionLoadingScreen'
+
+const mockProvisioningMonitor = { workflowInProgress: false }
 
 jest.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }))
 jest.mock('@bifold/core', () => ({
   Connection: jest.fn().mockReturnValue(null),
+  CredentialProvisioningEventTypes: {
+    Started: 'CredentialProvisioningEvent.Started',
+    Completed: 'CredentialProvisioningEvent.Completed',
+    FailedHandleOffer: 'CredentialProvisioningEvent.FailedHandleOffer',
+    FailedHandleProof: 'CredentialProvisioningEvent.FailedHandleProof',
+    FailedRequestCredential: 'CredentialProvisioningEvent.FailedRequestCredential',
+  },
+  LoadingPlaceholder: jest.fn().mockReturnValue(null),
+  LoadingPlaceholderWorkflowType: {
+    Connection: 'Connection',
+    ReceiveOffer: 'ReceiveOffer',
+    ProofRequested: 'ProofRequested',
+  },
+  testIdWithKey: (key: string) => `com.ariesbifold:id/${key}`,
+  TOKENS: { UTIL_CREDENTIAL_PROVISIONING_MONITOR: 'utility.credential-provisioning-monitor' },
+  useServices: jest.fn(() => [mockProvisioningMonitor]),
+  useTheme: jest.fn(() => ({ ColorPalette: { brand: { primaryBackground: '#000000' } } })),
 }))
 // `@react-navigation/native` isn't transformed by jest (see transformIgnorePatterns), so
 // pull-through imports like NavigationContext come back as undefined. Spread the real module
@@ -113,6 +132,62 @@ describe('ConnectionLoadingScreen', () => {
       const handler = spy.mock.calls.at(-1)![1] as () => boolean
       expect(handler()).toBe(true)
       expect(navigation.goBack).not.toHaveBeenCalled()
+    })
+  })
+
+  // The wrapper holds a loading overlay while AutoCredentialMonitor fetches a
+  // missing credential in the background, because Bifold's Connection screen
+  // has no provisioning gate and its ProofRequest registers listeners too late
+  // to reliably catch Started.
+  describe('credential provisioning gate', () => {
+    const LoadingPlaceholderMock = LoadingPlaceholder as jest.MockedFunction<typeof LoadingPlaceholder>
+
+    afterEach(() => {
+      mockProvisioningMonitor.workflowInProgress = false
+    })
+
+    it('shows the overlay on Started and hides it on Completed', () => {
+      const { navigation, route } = mkProps()
+      render(<ConnectionLoadingScreen navigation={navigation} route={route} />)
+      expect(LoadingPlaceholderMock).not.toHaveBeenCalled()
+
+      act(() => {
+        DeviceEventEmitter.emit(CredentialProvisioningEventTypes.Started)
+      })
+      expect(LoadingPlaceholderMock).toHaveBeenCalled()
+
+      LoadingPlaceholderMock.mockClear()
+      act(() => {
+        DeviceEventEmitter.emit(CredentialProvisioningEventTypes.Completed)
+      })
+      expect(LoadingPlaceholderMock).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      CredentialProvisioningEventTypes.FailedHandleProof,
+      CredentialProvisioningEventTypes.FailedHandleOffer,
+      CredentialProvisioningEventTypes.FailedRequestCredential,
+    ])('hides the overlay on %s', (failureEvent) => {
+      const { navigation, route } = mkProps()
+      render(<ConnectionLoadingScreen navigation={navigation} route={route} />)
+      act(() => {
+        DeviceEventEmitter.emit(CredentialProvisioningEventTypes.Started)
+      })
+
+      LoadingPlaceholderMock.mockClear()
+      act(() => {
+        DeviceEventEmitter.emit(failureEvent, new Error('provisioning failed'))
+      })
+      expect(LoadingPlaceholderMock).not.toHaveBeenCalled()
+    })
+
+    it('shows the overlay immediately when a workflow is already in progress at mount', () => {
+      // DeviceEventEmitter has no replay: a Started emitted before this screen
+      // mounts (e.g. entry from a home notification) would otherwise be missed.
+      mockProvisioningMonitor.workflowInProgress = true
+      const { navigation, route } = mkProps()
+      render(<ConnectionLoadingScreen navigation={navigation} route={route} />)
+      expect(LoadingPlaceholderMock).toHaveBeenCalled()
     })
   })
 })

--- a/app/src/bcsc-theme/features/qr-core/ConnectionLoadingScreen.tsx
+++ b/app/src/bcsc-theme/features/qr-core/ConnectionLoadingScreen.tsx
@@ -1,10 +1,19 @@
 import { BCSCMainStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
-import { Connection } from '@bifold/core'
+import {
+  Connection,
+  CredentialProvisioningEventTypes,
+  LoadingPlaceholder,
+  LoadingPlaceholderWorkflowType,
+  testIdWithKey,
+  TOKENS,
+  useServices,
+  useTheme,
+} from '@bifold/core'
 import { NavigationContext } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack'
-import React, { useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { BackHandler } from 'react-native'
+import { BackHandler, DeviceEventEmitter, StyleSheet, View } from 'react-native'
 
 import { createBifoldNavigationAdapter } from './BifoldNavigationAdapter'
 
@@ -24,6 +33,37 @@ const ConnectionLoadingScreen: React.FC<Props> = ({ navigation, route }) => {
   const { t } = useTranslation()
   const adaptedNavigation = useMemo(() => createBifoldNavigationAdapter(navigation, { t }), [navigation, t])
   const { credentialId, proofId } = route.params
+  const [credentialProvisioningMonitor] = useServices([TOKENS.UTIL_CREDENTIAL_PROVISIONING_MONITOR])
+  const { ColorPalette } = useTheme()
+
+  // Bifold's Connection screen has no hold for auto credential provisioning
+  // (only attestation), and Bifold's ProofRequest registers its provisioning
+  // listeners too late to reliably catch Started — so the user briefly sees
+  // "credential missing, can't proceed" while the wallet is fetching it in the
+  // background. Gate here instead: this wrapper mounts at QR-scan time, well
+  // before the proof arrives. Seeded from workflowInProgress because
+  // DeviceEventEmitter has no replay and this screen can also mount after
+  // Started fired (entry from a home notification). Remove once Bifold gates
+  // Connection on CredentialProvisioningEventTypes.
+  const [provisioningLoading, setProvisioningLoading] = useState<boolean>(
+    () => credentialProvisioningMonitor?.workflowInProgress ?? false
+  )
+
+  useEffect(() => {
+    if (!credentialProvisioningMonitor) {
+      return
+    }
+    const handleStarted = () => setProvisioningLoading(true)
+    const handleEnded = () => setProvisioningLoading(false)
+    const subscriptions = [
+      DeviceEventEmitter.addListener(CredentialProvisioningEventTypes.Started, handleStarted),
+      DeviceEventEmitter.addListener(CredentialProvisioningEventTypes.Completed, handleEnded),
+      DeviceEventEmitter.addListener(CredentialProvisioningEventTypes.FailedHandleProof, handleEnded),
+      DeviceEventEmitter.addListener(CredentialProvisioningEventTypes.FailedHandleOffer, handleEnded),
+      DeviceEventEmitter.addListener(CredentialProvisioningEventTypes.FailedRequestCredential, handleEnded),
+    ]
+    return () => subscriptions.forEach((subscription) => subscription.remove())
+  }, [credentialProvisioningMonitor])
 
   // Bifold's Connection screen blocks the Android hardware back button for its
   // entire lifetime (it assumes a locked QR handshake flow). Offers / proof
@@ -57,7 +97,18 @@ const ConnectionLoadingScreen: React.FC<Props> = ({ navigation, route }) => {
 
   return (
     <NavigationContext.Provider value={adaptedNavigation as any}>
-      <Connection navigation={adaptedNavigation as any} route={bifoldRoute as any} />
+      <View style={{ flex: 1 }}>
+        <Connection navigation={adaptedNavigation as any} route={bifoldRoute as any} />
+        {provisioningLoading && (
+          <View style={[StyleSheet.absoluteFill, { backgroundColor: ColorPalette.brand.primaryBackground }]}>
+            <LoadingPlaceholder
+              workflowType={LoadingPlaceholderWorkflowType.ProofRequested}
+              loadingProgressPercent={30}
+              testID={testIdWithKey('ProvisioningLoading')}
+            />
+          </View>
+        )}
+      </View>
     </NavigationContext.Provider>
   )
 }

--- a/app/src/bcsc-theme/services/digitalServicesCardProvisioner.test.ts
+++ b/app/src/bcsc-theme/services/digitalServicesCardProvisioner.test.ts
@@ -30,6 +30,13 @@ describe('digitalServicesCardProvisioner', () => {
       expect(rule.triggerCredDefIds).toHaveLength(expected.length)
     })
 
+    it('flattens every schema ID from AutoFetchCredentialConfig into triggerSchemaIds', () => {
+      const rule = buildDigitalServicesCardCredentialRule()
+      const expected = Object.values(AutoFetchCredentialConfig).flatMap((env) => [...env.schemaIDs])
+      expect(rule.triggerSchemaIds).toEqual(expect.arrayContaining(expected))
+      expect(rule.triggerSchemaIds).toHaveLength(expected.length)
+    })
+
     it('defaults autoAcceptIssuerProofRequest and autoAcceptCredentialOffer to true', () => {
       const rule = buildDigitalServicesCardCredentialRule()
       expect(rule.autoAcceptIssuerProofRequest).toBe(true)

--- a/app/src/bcsc-theme/services/digitalServicesCardProvisioner.ts
+++ b/app/src/bcsc-theme/services/digitalServicesCardProvisioner.ts
@@ -40,10 +40,18 @@ const allDigitalServicesCardCredDefIds = (): string[] =>
   Object.values(AutoFetchCredentialConfig).flatMap((env) => [...env.credDefIDs])
 
 /**
+ * All DigitalServicesCard schema IDs across all environments, flattened into a single
+ * array for use as the `triggerSchemaIds` of the AutoCredentialRule.
+ */
+const allDigitalServicesCardSchemaIds = (): string[] =>
+  Object.values(AutoFetchCredentialConfig).flatMap((env) => [...env.schemaIDs])
+
+/**
  * Builds the AutoCredentialRule for the DigitalServicesCard just-in-time workflow
  */
 export const buildDigitalServicesCardCredentialRule = (): AutoCredentialRule => ({
   triggerCredDefIds: allDigitalServicesCardCredDefIds(),
+  triggerSchemaIds: allDigitalServicesCardSchemaIds(),
   getInvitationUrl: getDigitalServicesCardInvitationUrl,
   autoAcceptIssuerProofRequest: true,
   autoAcceptCredentialOffer: true,

--- a/app/src/bcsc-theme/services/digitalServicesCardProvisioner.ts
+++ b/app/src/bcsc-theme/services/digitalServicesCardProvisioner.ts
@@ -32,17 +32,9 @@ const getDigitalServicesCardInvitationUrl = async (): Promise<string> => {
   return response.data.invitation_url
 }
 
-/**
- * All DigitalServicesCard cred def IDs across all environments, flattened into a single
- * array for use as the `triggerCredDefIds` of the AutoCredentialRule.
- */
 const allDigitalServicesCardCredDefIds = (): string[] =>
   Object.values(AutoFetchCredentialConfig).flatMap((env) => [...env.credDefIDs])
 
-/**
- * All DigitalServicesCard schema IDs across all environments, flattened into a single
- * array for use as the `triggerSchemaIds` of the AutoCredentialRule.
- */
 const allDigitalServicesCardSchemaIds = (): string[] =>
   Object.values(AutoFetchCredentialConfig).flatMap((env) => [...env.schemaIDs])
 

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -21,13 +21,7 @@ export interface AutoFetchCredentialConfigEntry {
   schemaIDs: readonly string[]
 }
 
-/**
- * Per-environment Person Credential cred def IDs and schema IDs.
- * AutoCredentialMonitor flattens these into its trigger sets; a proof
- * requesting a cred def or schema in either set tells the wallet a Person
- * Credential is missing and the BCSC-initiated flow (POST
- * /credentials/v1/person) is used to mint an issuer invitation.
- */
+/** Per-environment Person Credential identifiers flattened into AutoCredentialMonitor trigger sets. */
 export const AutoFetchCredentialConfig: Record<string, AutoFetchCredentialConfigEntry> = {
   Development: {
     credDefIDs: ['XpgeQa93eZvGSZBZef3PHn:3:CL:28075:PersonDEV'],

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -244,12 +244,9 @@ export const TEMPORARY_ACCOUNT_CLIENT_ID = ''
 
 // Credential constants
 // TODO (MD): Pull these values from well-known urls or remote config (ie: Firebase Remote Config)
-export const DIGITAL_SERVICES_CARD_CREDENTIAL_DEFINITION_IDS = [
-  'RGjWbW1eycP7FrMf4QJvX8:3:CL:13:Person',
-  'KCxVC8GkKywjhWJnUfCmkW:3:CL:20:PersonQA',
-  '7xjfawcnyTUcduWVysLww5:3:CL:28075:PersonSIT',
-  'XpgeQa93eZvGSZBZef3PHn:3:CL:28075:PersonDEV',
-]
+export const DIGITAL_SERVICES_CARD_CREDENTIAL_DEFINITION_IDS = Object.values(AutoFetchCredentialConfig).flatMap(
+  (env) => [...env.credDefIDs]
+)
 export const DIGITAL_SERVICES_CARD_SCHEMA_IDS = Object.values(AutoFetchCredentialConfig).flatMap((env) => [
   ...env.schemaIDs,
 ])

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -18,26 +18,32 @@ export interface CredentialRestrictionEnvironment {
 
 export interface AutoFetchCredentialConfigEntry {
   credDefIDs: readonly string[]
+  schemaIDs: readonly string[]
 }
 
 /**
- * Per-environment Person Credential cred def IDs. AutoCredentialMonitor
- * flattens these into its trigger set; a proof requesting any of them tells
- * the wallet a Person Credential is missing and the BCSC-initiated flow
- * (POST /credentials/v1/person) is used to mint an issuer invitation.
+ * Per-environment Person Credential cred def IDs and schema IDs.
+ * AutoCredentialMonitor flattens these into its trigger sets; a proof
+ * requesting a cred def or schema in either set tells the wallet a Person
+ * Credential is missing and the BCSC-initiated flow (POST
+ * /credentials/v1/person) is used to mint an issuer invitation.
  */
 export const AutoFetchCredentialConfig: Record<string, AutoFetchCredentialConfigEntry> = {
   Development: {
     credDefIDs: ['XpgeQa93eZvGSZBZef3PHn:3:CL:28075:PersonDEV'],
+    schemaIDs: ['XpgeQa93eZvGSZBZef3PHn:2:Person:1.0'],
   },
   SIT: {
     credDefIDs: ['7xjfawcnyTUcduWVysLww5:3:CL:28075:PersonSIT'],
+    schemaIDs: ['7xjfawcnyTUcduWVysLww5:2:Person:1.0'],
   },
   QA: {
     credDefIDs: ['KCxVC8GkKywjhWJnUfCmkW:3:CL:20:PersonQA'],
+    schemaIDs: ['KCxVC8GkKywjhWJnUfCmkW:2:Person:1.0'],
   },
   Production: {
     credDefIDs: ['RGjWbW1eycP7FrMf4QJvX8:3:CL:13:Person'],
+    schemaIDs: ['RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0'],
   },
 } as const
 
@@ -244,9 +250,6 @@ export const DIGITAL_SERVICES_CARD_CREDENTIAL_DEFINITION_IDS = [
   '7xjfawcnyTUcduWVysLww5:3:CL:28075:PersonSIT',
   'XpgeQa93eZvGSZBZef3PHn:3:CL:28075:PersonDEV',
 ]
-export const DIGITAL_SERVICES_CARD_SCHEMA_IDS = [
-  'RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0',
-  'KCxVC8GkKywjhWJnUfCmkW:2:Person:1.0',
-  '7xjfawcnyTUcduWVysLww5:2:Person:1.0',
-  'XpgeQa93eZvGSZBZef3PHn:2:Person:1.0',
-]
+export const DIGITAL_SERVICES_CARD_SCHEMA_IDS = Object.values(AutoFetchCredentialConfig).flatMap((env) => [
+  ...env.schemaIDs,
+])

--- a/app/src/services/auto-credential.test.ts
+++ b/app/src/services/auto-credential.test.ts
@@ -64,9 +64,11 @@ const createMockAgent = () => {
 }
 
 const TRIGGER_CRED_DEF_ID = 'issuer:3:CL:1:Person'
+const TRIGGER_SCHEMA_ID = 'issuer:2:Person:1.0'
 
 const buildRule = (overrides: Partial<AutoCredentialRule> = {}): AutoCredentialRule => ({
   triggerCredDefIds: [TRIGGER_CRED_DEF_ID],
+  triggerSchemaIds: [TRIGGER_SCHEMA_ID],
   getInvitationUrl: jest.fn().mockResolvedValue('https://issuer.example?c_i=abc'),
   autoAcceptIssuerProofRequest: true,
   autoAcceptCredentialOffer: true,
@@ -87,11 +89,11 @@ const accountUnavailableError = (reason: 'suspended' | 'deactivated'): AppError 
   return error
 }
 
-const proofFormat = (credDefId: string) => ({
+const proofFormat = (restriction: Record<string, unknown>) => ({
   request: {
     anoncreds: {
       requested_attributes: {
-        group1: { restrictions: [{ cred_def_id: credDefId }] },
+        group1: { restrictions: [restriction] },
       },
       requested_predicates: {},
     },
@@ -134,7 +136,7 @@ describe('AutoCredentialMonitor', () => {
 
     it('does not trigger a workflow when the proof does not match any rule', async () => {
       const { monitor, rule } = buildMonitor()
-      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat('unrelated:cred:def'))
+      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat({ cred_def_id: 'unrelated:cred:def' }))
 
       await agent.emit(DidCommProofEventTypes.ProofStateChanged, {
         proofRecord: { id: 'p1', state: DidCommProofState.RequestReceived },
@@ -146,7 +148,7 @@ describe('AutoCredentialMonitor', () => {
 
     it('does not trigger a workflow when the matching credential is already in the wallet', async () => {
       const { monitor, rule } = buildMonitor()
-      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat(TRIGGER_CRED_DEF_ID))
+      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat({ cred_def_id: TRIGGER_CRED_DEF_ID }))
       mockedCredentialsMatchForProof.mockResolvedValue({
         proofFormats: { anoncreds: { attributes: { group1: [{ credentialId: 'c-1' }] }, predicates: {} } },
       })
@@ -159,10 +161,66 @@ describe('AutoCredentialMonitor', () => {
       expect(monitor.workflowInProgress).toBe(false)
     })
 
+    it('triggers a workflow when the restriction matches by schema_id only and the credential is missing', async () => {
+      agent.didcomm.oob.parseInvitation.mockResolvedValue({ id: 'inv-1' })
+      agent.didcomm.oob.receiveInvitation.mockResolvedValue({ connectionRecord: { id: 'conn-1' } })
+      const { monitor, rule } = buildMonitor()
+      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat({ schema_id: TRIGGER_SCHEMA_ID }))
+      mockedCredentialsMatchForProof.mockResolvedValue({
+        proofFormats: { anoncreds: { attributes: {}, predicates: {} } },
+      })
+
+      await agent.emit(DidCommProofEventTypes.ProofStateChanged, {
+        proofRecord: { id: 'p1', state: DidCommProofState.RequestReceived },
+      })
+
+      expect(rule.getInvitationUrl).toHaveBeenCalled()
+      expect(monitor.workflowInProgress).toBe(true)
+    })
+
+    it('does not trigger a workflow when the restriction schema_id matches no rule', async () => {
+      const { monitor, rule } = buildMonitor()
+      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat({ schema_id: 'unrelated:2:Schema:1.0' }))
+
+      await agent.emit(DidCommProofEventTypes.ProofStateChanged, {
+        proofRecord: { id: 'p1', state: DidCommProofState.RequestReceived },
+      })
+
+      expect(rule.getInvitationUrl).not.toHaveBeenCalled()
+      expect(monitor.workflowInProgress).toBe(false)
+    })
+
+    it('does not trigger a workflow when the schema-matched credential is already in the wallet', async () => {
+      const { monitor, rule } = buildMonitor()
+      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat({ schema_id: TRIGGER_SCHEMA_ID }))
+      mockedCredentialsMatchForProof.mockResolvedValue({
+        proofFormats: { anoncreds: { attributes: { group1: [{ credentialId: 'c-1' }] }, predicates: {} } },
+      })
+
+      await agent.emit(DidCommProofEventTypes.ProofStateChanged, {
+        proofRecord: { id: 'p1', state: DidCommProofState.RequestReceived },
+      })
+
+      expect(rule.getInvitationUrl).not.toHaveBeenCalled()
+      expect(monitor.workflowInProgress).toBe(false)
+    })
+
+    it('ignores schema_id restrictions when the rule has no triggerSchemaIds (backward compat)', async () => {
+      const { monitor, rule } = buildMonitor(buildRule({ triggerSchemaIds: undefined }))
+      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat({ schema_id: TRIGGER_SCHEMA_ID }))
+
+      await agent.emit(DidCommProofEventTypes.ProofStateChanged, {
+        proofRecord: { id: 'p1', state: DidCommProofState.RequestReceived },
+      })
+
+      expect(rule.getInvitationUrl).not.toHaveBeenCalled()
+      expect(monitor.workflowInProgress).toBe(false)
+    })
+
     it('ignores further proof requests once a workflow is already in progress', async () => {
       agent.didcomm.oob.parseInvitation.mockResolvedValue({ id: 'inv-1' })
       agent.didcomm.oob.receiveInvitation.mockResolvedValue({ connectionRecord: { id: 'conn-1' } })
-      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat(TRIGGER_CRED_DEF_ID))
+      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat({ cred_def_id: TRIGGER_CRED_DEF_ID }))
       mockedCredentialsMatchForProof.mockResolvedValue({
         proofFormats: { anoncreds: { attributes: {}, predicates: {} } },
       })
@@ -186,7 +244,7 @@ describe('AutoCredentialMonitor', () => {
     beforeEach(() => {
       agent.didcomm.oob.parseInvitation.mockResolvedValue({ id: 'inv-1' })
       agent.didcomm.oob.receiveInvitation.mockResolvedValue({ connectionRecord: { id: 'conn-1' } })
-      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat(TRIGGER_CRED_DEF_ID))
+      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat({ cred_def_id: TRIGGER_CRED_DEF_ID }))
       mockedCredentialsMatchForProof.mockResolvedValue({
         proofFormats: { anoncreds: { attributes: {}, predicates: {} } },
       })
@@ -369,7 +427,7 @@ describe('AutoCredentialMonitor', () => {
     it('returns false and warns when a workflow is already in progress', async () => {
       agent.didcomm.oob.parseInvitation.mockResolvedValue({ id: 'inv-1' })
       agent.didcomm.oob.receiveInvitation.mockResolvedValue({ connectionRecord: { id: 'conn-1' } })
-      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat(TRIGGER_CRED_DEF_ID))
+      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat({ cred_def_id: TRIGGER_CRED_DEF_ID }))
       mockedCredentialsMatchForProof.mockResolvedValue({
         proofFormats: { anoncreds: { attributes: {}, predicates: {} } },
       })
@@ -409,7 +467,7 @@ describe('AutoCredentialMonitor', () => {
     it('tears down workflow subscriptions and resets in-flight workflow state', async () => {
       agent.didcomm.oob.parseInvitation.mockResolvedValue({ id: 'inv-1' })
       agent.didcomm.oob.receiveInvitation.mockResolvedValue({ connectionRecord: { id: 'conn-1' } })
-      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat(TRIGGER_CRED_DEF_ID))
+      agent.didcomm.proofs.getFormatData.mockResolvedValue(proofFormat({ cred_def_id: TRIGGER_CRED_DEF_ID }))
       mockedCredentialsMatchForProof.mockResolvedValue({
         proofFormats: { anoncreds: { attributes: {}, predicates: {} } },
       })

--- a/app/src/services/auto-credential.ts
+++ b/app/src/services/auto-credential.ts
@@ -224,17 +224,7 @@ export class AutoCredentialMonitor implements CredentialProvisioningMonitor {
         (restriction.schema_id && rule.triggerSchemaIds?.includes(restriction.schema_id))
     )
 
-  /**
-   * Returns true if the proof requests one of the rule's trigger cred def IDs
-   * or schema IDs AND the wallet has no credential that satisfies it.
-   *
-   * For example:
-   * Rule: CredDefId: A
-   * Proof request received: request credential with CredDefId A
-   * Wallet: No Credential with CredDefId A
-   *
-   * Proof request triggers the rule AND credential is missing, return true to trigger a workflow
-   */
+  /** True when the proof requests a trigger ID and the wallet lacks a matching credential. */
   private async isCredentialMissingForRule(
     proofId: string,
     proofFormat: ProofRequestFormat,
@@ -244,7 +234,6 @@ export class AutoCredentialMonitor implements CredentialProvisioningMonitor {
       return false
     }
 
-    // Step 1: does the proof's restrictions reference any of our trigger cred def IDs or schema IDs?
     const triggeredAttributeKeys = new Set<string>()
     const triggeredPredicateKeys = new Set<string>()
 
@@ -457,7 +446,6 @@ export class AutoCredentialMonitor implements CredentialProvisioningMonitor {
     ]
 
     for (const rule of this.rules) {
-      // compare the cred def id/schema id against the rule trigger IDs, if any match then this proof is requesting a credential that would trigger the workflow
       const proofRequestsWatchedCredential = restrictions.some((restriction) =>
         this.restrictionMatchesRule(restriction, rule)
       )

--- a/app/src/services/auto-credential.ts
+++ b/app/src/services/auto-credential.ts
@@ -1,6 +1,10 @@
 import { getDigitalServiceCardAccountProblem } from '@/bcsc-theme/utils/getDigitalServiceCardAccountProblem'
 import { AbstractBifoldLogger, CredentialProvisioningEventTypes, CredentialProvisioningMonitor } from '@bifold/core'
-import { AnonCredsRequestedAttribute, AnonCredsRequestedPredicate } from '@credo-ts/anoncreds'
+import {
+  AnonCredsProofRequestRestriction,
+  AnonCredsRequestedAttribute,
+  AnonCredsRequestedPredicate,
+} from '@credo-ts/anoncreds'
 import { Agent } from '@credo-ts/core'
 import {
   DidCommCredentialEventTypes,
@@ -35,6 +39,9 @@ interface PausableAttestationMonitor {
 export interface AutoCredentialRule {
   /** Cred def IDs whose absence in the wallet triggers this rule. */
   triggerCredDefIds: string[]
+
+  /** Schema IDs whose absence in the wallet triggers this rule, checked in addition to triggerCredDefIds. */
+  triggerSchemaIds?: string[]
 
   /**
    * Returns the OOB invitation URL for the issuer that can provide the missing
@@ -207,9 +214,19 @@ export class AutoCredentialMonitor implements CredentialProvisioningMonitor {
   // Private — credential check
   // ---------------------------------------------------------------------------
 
+  /** True if a proof restriction references one of the rule's trigger cred def IDs or schema IDs. */
+  private readonly restrictionMatchesRule = (
+    restriction: AnonCredsProofRequestRestriction,
+    rule: AutoCredentialRule
+  ): boolean =>
+    Boolean(
+      (restriction.cred_def_id && rule.triggerCredDefIds.includes(restriction.cred_def_id)) ||
+        (restriction.schema_id && rule.triggerSchemaIds?.includes(restriction.schema_id))
+    )
+
   /**
    * Returns true if the proof requests one of the rule's trigger cred def IDs
-   * AND the wallet has no credential that satisfies it.
+   * or schema IDs AND the wallet has no credential that satisfies it.
    *
    * For example:
    * Rule: CredDefId: A
@@ -227,17 +244,17 @@ export class AutoCredentialMonitor implements CredentialProvisioningMonitor {
       return false
     }
 
-    // Step 1: does the proof's restrictions reference any of our trigger cred def IDs?
+    // Step 1: does the proof's restrictions reference any of our trigger cred def IDs or schema IDs?
     const triggeredAttributeKeys = new Set<string>()
     const triggeredPredicateKeys = new Set<string>()
 
     for (const [key, attr] of Object.entries(proofFormat.requested_attributes ?? {})) {
-      if ((attr.restrictions ?? []).some((r) => r.cred_def_id && rule.triggerCredDefIds.includes(r.cred_def_id))) {
+      if ((attr.restrictions ?? []).some((r) => this.restrictionMatchesRule(r, rule))) {
         triggeredAttributeKeys.add(key)
       }
     }
     for (const [key, pred] of Object.entries(proofFormat.requested_predicates ?? {})) {
-      if ((pred.restrictions ?? []).some((r) => r.cred_def_id && rule.triggerCredDefIds.includes(r.cred_def_id))) {
+      if ((pred.restrictions ?? []).some((r) => this.restrictionMatchesRule(r, rule))) {
         triggeredPredicateKeys.add(key)
       }
     }
@@ -440,9 +457,9 @@ export class AutoCredentialMonitor implements CredentialProvisioningMonitor {
     ]
 
     for (const rule of this.rules) {
-      // compare the cred def id against the rule trigger IDs, if any match then this proof is requesting a credential that would trigger the workflow
-      const proofRequestsWatchedCredential = restrictions.some(
-        (restriction) => restriction.cred_def_id && rule.triggerCredDefIds.includes(restriction.cred_def_id)
+      // compare the cred def id/schema id against the rule trigger IDs, if any match then this proof is requesting a credential that would trigger the workflow
+      const proofRequestsWatchedCredential = restrictions.some((restriction) =>
+        this.restrictionMatchesRule(restriction, rule)
       )
 
       this.log?.info(
@@ -454,8 +471,9 @@ export class AutoCredentialMonitor implements CredentialProvisioningMonitor {
 
       try {
         const isMissing = await this.isCredentialMissingForRule(proof.id, requestFormat, rule)
+        const triggerIds = [...rule.triggerCredDefIds, ...(rule.triggerSchemaIds ?? [])]
         this.log?.info(
-          `[AutoCredentialMonitor] Credential (${rule.triggerCredDefIds.join(', ')}) is ${isMissing ? 'NOT ' : ''}in the wallet`
+          `[AutoCredentialMonitor] Credential (${triggerIds.join(', ')}) is ${isMissing ? 'NOT ' : ''}in the wallet`
         )
         if (isMissing) {
           // Fire and forget — inside runWorkflow drives its own subscriptions


### PR DESCRIPTION
## What

The BC Digital Services Card auto-issuance flow — the one that quietly fetches a missing Person Credential when a verifier's proof request asks for it — currently only recognizes that request if the verifier restricted it by credential definition ID. This change also recognizes it when the verifier restricted it by schema ID instead, so the auto-issuance flow works either way.

## Why

Some verifiers write their proof requests using schema ID restrictions rather than credential definition ID restrictions. Those users would hit a proof request for a credential they don't have yet, without the app automatically fetching it for them first. This closes that gap.

## Decisions

- Added a `schemaIDs` field per environment to `AutoFetchCredentialConfig` in `app/src/constants.ts`, paired with each environment's existing cred def ID, using the Person schema IDs already present in `DIGITAL_SERVICES_CARD_SCHEMA_IDS`.
- Redefined `DIGITAL_SERVICES_CARD_SCHEMA_IDS` as derived from `AutoFetchCredentialConfig` (`Object.values(...).flatMap(...)`) instead of a separately maintained literal list, so the two can't drift apart.
- `AutoCredentialRule` gained an optional `triggerSchemaIds?: string[]`, kept optional for backward compatibility with any other rule that doesn't set it.
- Centralized the restriction-matching logic (cred_def_id OR schema_id) into one private `restrictionMatchesRule` helper on `AutoCredentialMonitor`, used by all three places that previously checked cred_def_id only.
- Matching stays exact-string, matching the existing cred def ID behavior (no qualified/unqualified schema ID normalization).
- `buildDigitalServicesCardCredentialRule` now also flattens and sets `triggerSchemaIds` from `AutoFetchCredentialConfig`.

## Tests

- Added tests in `app/src/services/auto-credential.test.ts` covering: schema-only-restriction triggers a workflow when credential missing; schema_id restriction that matches no rule doesn't trigger; schema-matched credential already in wallet doesn't trigger; a rule without `triggerSchemaIds` ignores schema_id restrictions (backward compat). Existing cred-def-triggered tests pass unchanged.
- Added a test in `app/src/bcsc-theme/services/digitalServicesCardProvisioner.test.ts` asserting `triggerSchemaIds` is the flattened set of `schemaIDs` from every `AutoFetchCredentialConfig` environment.
- `yarn check` (typecheck + lint + format + full test suite) passes: 287 suites, 2882 tests passed.

Fixes #4383