### PR TITLE
fix: retry after cancelled verification review no longer strands user

### DIFF
--- a/app/src/bcsc-theme/features/notifications/CancelledReviewNotification.tsx
+++ b/app/src/bcsc-theme/features/notifications/CancelledReviewNotification.tsx
@@ -21,7 +21,7 @@ const CancelledReviewNotification = () => {
       icon="information"
       hideIconCircle={true}
       iconColor={ColorPalette.brand.primary}
-      onPress={() => navigation.navigate(BCSCScreens.CancelledReview, { agentReason })}
+      onPress={() => navigation.navigate(BCSCScreens.MainCancelledReview, { agentReason })}
     />
   )
 }

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
@@ -16,12 +16,12 @@ jest.mock('@/bcsc-theme/hooks/useVerificationReset', () => ({
 }))
 
 const mockCleanUpVerificationData = jest.fn()
-const mockGoToMethodSelection = jest.fn()
+const mockResumeVerification = jest.fn()
 jest.mock('./CancelledReviewViewModel', () => ({
   __esModule: true,
   default: jest.fn(() => ({
     cleanUpVerificationData: mockCleanUpVerificationData,
-    goToMethodSelection: mockGoToMethodSelection,
+    resumeVerification: mockResumeVerification,
   })),
 }))
 
@@ -97,7 +97,7 @@ describe('CancelledReview', () => {
 
   // MainStack and VerifyStack register this screen under distinct route names, so it must
   // leave via store state (a stack swap), never an in-stack navigation.
-  it('re-enters the verify flow via goToMethodSelection without navigating in-stack', async () => {
+  it('re-enters the verify flow via resumeVerification without navigating in-stack', async () => {
     const agentReason = 'Test reason'
     const route = {
       params: {
@@ -115,7 +115,7 @@ describe('CancelledReview', () => {
     fireEvent.press(okButton)
 
     await waitFor(() => {
-      expect(mockGoToMethodSelection).toHaveBeenCalledTimes(1)
+      expect(mockResumeVerification).toHaveBeenCalledTimes(1)
     })
     expect(mockNavigation.reset).not.toHaveBeenCalled()
     expect(mockNavigation.goBack).not.toHaveBeenCalled()
@@ -161,7 +161,7 @@ describe('CancelledReview', () => {
     fireEvent.press(okButton)
 
     await waitFor(() => {
-      expect(mockGoToMethodSelection).toHaveBeenCalledTimes(1)
+      expect(mockResumeVerification).toHaveBeenCalledTimes(1)
     })
 
     fireEvent.press(okButton)
@@ -169,7 +169,7 @@ describe('CancelledReview', () => {
     await waitFor(() => {
       expect(mockVerificationReset).toHaveBeenCalledTimes(2)
     })
-    expect(mockGoToMethodSelection).toHaveBeenCalledTimes(2)
+    expect(mockResumeVerification).toHaveBeenCalledTimes(2)
   })
 
   it('blocks a second tap while a reset is already in flight', async () => {
@@ -203,7 +203,7 @@ describe('CancelledReview', () => {
     await waitFor(() => {
       expect(mockStopLoading).toHaveBeenCalledTimes(1)
     })
-    expect(mockGoToMethodSelection).toHaveBeenCalledTimes(1)
+    expect(mockResumeVerification).toHaveBeenCalledTimes(1)
   })
 
   it('re-enables the button and does not navigate when the reset fails', async () => {
@@ -228,7 +228,7 @@ describe('CancelledReview', () => {
       expect(mockStopLoading).toHaveBeenCalledTimes(1)
     })
 
-    expect(mockGoToMethodSelection).not.toHaveBeenCalled()
+    expect(mockResumeVerification).not.toHaveBeenCalled()
     const buttonTouchable = tree.getByTestId(testIdWithKey('SystemModalButton'))
     expect(buttonTouchable.props.accessibilityState?.disabled).toBeFalsy()
   })

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
@@ -95,7 +95,9 @@ describe('CancelledReview', () => {
     expect(tree.getByText('BCSC.CancelledVerification.Label')).toBeTruthy()
   })
 
-  it('re-enters the verify flow via goToMethodSelection and resets the stack to IdentitySelection', async () => {
+  // This screen is hosted by both MainStack and VerifyStack, and the verify routes exist only
+  // in the latter — so it must leave via store state, never an in-stack navigation.
+  it('re-enters the verify flow via goToMethodSelection without navigating in-stack', async () => {
     const agentReason = 'Test reason'
     const route = {
       params: {
@@ -115,10 +117,7 @@ describe('CancelledReview', () => {
     await waitFor(() => {
       expect(mockGoToMethodSelection).toHaveBeenCalledTimes(1)
     })
-    expect(mockNavigation.reset).toHaveBeenCalledWith({
-      index: 0,
-      routes: [{ name: 'New Setup ID Confirmation' }],
-    })
+    expect(mockNavigation.reset).not.toHaveBeenCalled()
     expect(mockNavigation.goBack).not.toHaveBeenCalled()
   })
 

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
@@ -1,26 +1,56 @@
+import * as BCSCLoadingContextModule from '@/bcsc-theme/contexts/BCSCLoadingContext'
+import { testIdWithKey } from '@bifold/core'
 import { useNavigation } from '@mocks/@react-navigation/native'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { fireEvent, render } from '@testing-library/react-native'
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import CancelledReview from './CancelledReview'
 
+jest.mock('@/bcsc-theme/contexts/BCSCLoadingContext', () => ({
+  useLoadingScreen: jest.fn(),
+}))
+
+const mockVerificationReset = jest.fn().mockResolvedValue(true)
+jest.mock('@/bcsc-theme/hooks/useVerificationReset', () => ({
+  useVerificationReset: jest.fn(() => mockVerificationReset),
+}))
+
 const mockCleanUpVerificationData = jest.fn()
+const mockGoToMethodSelection = jest.fn()
 jest.mock('./CancelledReviewViewModel', () => ({
   __esModule: true,
   default: jest.fn(() => ({
     cleanUpVerificationData: mockCleanUpVerificationData,
+    goToMethodSelection: mockGoToMethodSelection,
   })),
 }))
+
+const mockStopLoading = jest.fn()
+const mockStartLoading = jest.fn().mockReturnValue(mockStopLoading)
 
 describe('CancelledReview', () => {
   let mockNavigation: any
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.useFakeTimers()
     mockNavigation = useNavigation()
+    mockVerificationReset.mockResolvedValue(true)
+    jest.mocked(BCSCLoadingContextModule.useLoadingScreen).mockReturnValue({
+      startLoading: mockStartLoading,
+    } as any)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
   })
 
   it('renders correctly with agent reason', () => {
-    const route = { params: { agentReason: 'Face does not match ID document' } } as any
+    const agentReason = 'Face does not match ID document'
+    const route = {
+      params: {
+        agentReason,
+      },
+    } as any
 
     const tree = render(
       <BasicAppContext>
@@ -34,7 +64,11 @@ describe('CancelledReview', () => {
   })
 
   it('renders with default message when no agent reason provided', () => {
-    const route = { params: { agentReason: undefined } } as any
+    const route = {
+      params: {
+        agentReason: undefined,
+      },
+    } as any
 
     const tree = render(
       <BasicAppContext>
@@ -47,7 +81,9 @@ describe('CancelledReview', () => {
   })
 
   it('renders with empty object params', () => {
-    const route = { params: {} } as any
+    const route = {
+      params: {},
+    } as any
 
     const tree = render(
       <BasicAppContext>
@@ -59,20 +95,13 @@ describe('CancelledReview', () => {
     expect(tree.getByText('BCSC.CancelledVerification.Label')).toBeTruthy()
   })
 
-  it('cleans up verification data on mount', () => {
-    const route = { params: { agentReason: 'Test reason' } } as any
-
-    render(
-      <BasicAppContext>
-        <CancelledReview route={route} />
-      </BasicAppContext>
-    )
-
-    expect(mockCleanUpVerificationData).toHaveBeenCalledTimes(1)
-  })
-
-  it('cleans up verification data and resets stack to VerificationMethodSelection on press', () => {
-    const route = { params: { agentReason: 'Test reason' } } as any
+  it('re-enters the verify flow via goToMethodSelection and resets the stack to IdentitySelection', async () => {
+    const agentReason = 'Test reason'
+    const route = {
+      params: {
+        agentReason,
+      },
+    } as any
 
     const tree = render(
       <BasicAppContext>
@@ -80,19 +109,137 @@ describe('CancelledReview', () => {
       </BasicAppContext>
     )
 
-    jest.clearAllMocks()
-    fireEvent.press(tree.getByText('BCSC.CancelledVerification.Button'))
+    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
+    fireEvent.press(okButton)
 
-    expect(mockCleanUpVerificationData).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(mockGoToMethodSelection).toHaveBeenCalledTimes(1)
+    })
     expect(mockNavigation.reset).toHaveBeenCalledWith({
       index: 0,
-      routes: [{ name: 'Verify Options' }],
+      routes: [{ name: 'New Setup ID Confirmation' }],
     })
     expect(mockNavigation.goBack).not.toHaveBeenCalled()
   })
 
+  it('shows a loading screen while the reset is in flight and hides it once settled', async () => {
+    const route = {
+      params: {
+        agentReason: 'Test reason',
+      },
+    } as any
+
+    const tree = render(
+      <BasicAppContext>
+        <CancelledReview route={route} />
+      </BasicAppContext>
+    )
+
+    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
+    fireEvent.press(okButton)
+
+    expect(mockStartLoading).toHaveBeenCalledWith('Alerts.RestartVerification.Loading')
+
+    await waitFor(() => {
+      expect(mockStopLoading).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('does not start a second reset when pressed again after success', async () => {
+    const route = {
+      params: {
+        agentReason: 'Test reason',
+      },
+    } as any
+
+    const tree = render(
+      <BasicAppContext>
+        <CancelledReview route={route} />
+      </BasicAppContext>
+    )
+
+    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
+    fireEvent.press(okButton)
+
+    await waitFor(() => {
+      expect(mockGoToMethodSelection).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.press(okButton)
+
+    await waitFor(() => {
+      expect(mockVerificationReset).toHaveBeenCalledTimes(2)
+    })
+    expect(mockGoToMethodSelection).toHaveBeenCalledTimes(2)
+  })
+
+  it('blocks a second tap while a reset is already in flight', async () => {
+    let resolveReset: (value: boolean) => void = () => {}
+    mockVerificationReset.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveReset = resolve
+      })
+    )
+
+    const route = {
+      params: {
+        agentReason: 'Test reason',
+      },
+    } as any
+
+    const tree = render(
+      <BasicAppContext>
+        <CancelledReview route={route} />
+      </BasicAppContext>
+    )
+
+    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
+    fireEvent.press(okButton)
+    fireEvent.press(okButton)
+
+    expect(mockVerificationReset).toHaveBeenCalledTimes(1)
+    expect(mockStartLoading).toHaveBeenCalledTimes(1)
+
+    resolveReset(true)
+    await waitFor(() => {
+      expect(mockStopLoading).toHaveBeenCalledTimes(1)
+    })
+    expect(mockGoToMethodSelection).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-enables the button and does not navigate when the reset fails', async () => {
+    mockVerificationReset.mockResolvedValue(false)
+
+    const route = {
+      params: {
+        agentReason: 'Test reason',
+      },
+    } as any
+
+    const tree = render(
+      <BasicAppContext>
+        <CancelledReview route={route} />
+      </BasicAppContext>
+    )
+
+    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
+    fireEvent.press(okButton)
+
+    await waitFor(() => {
+      expect(mockStopLoading).toHaveBeenCalledTimes(1)
+    })
+
+    expect(mockGoToMethodSelection).not.toHaveBeenCalled()
+    const buttonTouchable = tree.getByTestId(testIdWithKey('SystemModalButton'))
+    expect(buttonTouchable.props.accessibilityState?.disabled).toBeFalsy()
+  })
+
   it('displays OK button', () => {
-    const route = { params: { agentReason: 'Test reason' } } as any
+    const route = {
+      params: {
+        agentReason: 'Test reason',
+      },
+    } as any
 
     const tree = render(
       <BasicAppContext>
@@ -101,5 +248,23 @@ describe('CancelledReview', () => {
     )
 
     expect(tree.getByText('BCSC.CancelledVerification.Button')).toBeTruthy()
+  })
+
+  it('renders SystemModal component', () => {
+    const agentReason = 'Test reason'
+    const route = {
+      params: {
+        agentReason,
+      },
+    } as any
+
+    const tree = render(
+      <BasicAppContext>
+        <CancelledReview route={route} />
+      </BasicAppContext>
+    )
+
+    // SystemModal should render with the header text
+    expect(tree.getByText('BCSC.CancelledVerification.Title')).toBeTruthy()
   })
 })

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
@@ -1,56 +1,26 @@
-import * as BCSCLoadingContextModule from '@/bcsc-theme/contexts/BCSCLoadingContext'
-import { testIdWithKey } from '@bifold/core'
 import { useNavigation } from '@mocks/@react-navigation/native'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { fireEvent, render, waitFor } from '@testing-library/react-native'
+import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 import CancelledReview from './CancelledReview'
 
-jest.mock('@/bcsc-theme/contexts/BCSCLoadingContext', () => ({
-  useLoadingScreen: jest.fn(),
-}))
-
-const mockVerificationReset = jest.fn().mockResolvedValue(true)
-jest.mock('@/bcsc-theme/hooks/useVerificationReset', () => ({
-  useVerificationReset: jest.fn(() => mockVerificationReset),
-}))
-
 const mockCleanUpVerificationData = jest.fn()
-const mockGoToMethodSelection = jest.fn()
 jest.mock('./CancelledReviewViewModel', () => ({
   __esModule: true,
   default: jest.fn(() => ({
     cleanUpVerificationData: mockCleanUpVerificationData,
-    goToMethodSelection: mockGoToMethodSelection,
   })),
 }))
-
-const mockStopLoading = jest.fn()
-const mockStartLoading = jest.fn().mockReturnValue(mockStopLoading)
 
 describe('CancelledReview', () => {
   let mockNavigation: any
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.useFakeTimers()
     mockNavigation = useNavigation()
-    mockVerificationReset.mockResolvedValue(true)
-    jest.mocked(BCSCLoadingContextModule.useLoadingScreen).mockReturnValue({
-      startLoading: mockStartLoading,
-    } as any)
-  })
-
-  afterEach(() => {
-    jest.useRealTimers()
   })
 
   it('renders correctly with agent reason', () => {
-    const agentReason = 'Face does not match ID document'
-    const route = {
-      params: {
-        agentReason,
-      },
-    } as any
+    const route = { params: { agentReason: 'Face does not match ID document' } } as any
 
     const tree = render(
       <BasicAppContext>
@@ -64,11 +34,7 @@ describe('CancelledReview', () => {
   })
 
   it('renders with default message when no agent reason provided', () => {
-    const route = {
-      params: {
-        agentReason: undefined,
-      },
-    } as any
+    const route = { params: { agentReason: undefined } } as any
 
     const tree = render(
       <BasicAppContext>
@@ -81,9 +47,7 @@ describe('CancelledReview', () => {
   })
 
   it('renders with empty object params', () => {
-    const route = {
-      params: {},
-    } as any
+    const route = { params: {} } as any
 
     const tree = render(
       <BasicAppContext>
@@ -95,13 +59,20 @@ describe('CancelledReview', () => {
     expect(tree.getByText('BCSC.CancelledVerification.Label')).toBeTruthy()
   })
 
-  it('re-enters the verify flow via goToMethodSelection and resets the stack to IdentitySelection', async () => {
-    const agentReason = 'Test reason'
-    const route = {
-      params: {
-        agentReason,
-      },
-    } as any
+  it('cleans up verification data on mount', () => {
+    const route = { params: { agentReason: 'Test reason' } } as any
+
+    render(
+      <BasicAppContext>
+        <CancelledReview route={route} />
+      </BasicAppContext>
+    )
+
+    expect(mockCleanUpVerificationData).toHaveBeenCalledTimes(1)
+  })
+
+  it('cleans up verification data and resets stack to VerificationMethodSelection on press', () => {
+    const route = { params: { agentReason: 'Test reason' } } as any
 
     const tree = render(
       <BasicAppContext>
@@ -109,137 +80,19 @@ describe('CancelledReview', () => {
       </BasicAppContext>
     )
 
-    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
-    fireEvent.press(okButton)
+    jest.clearAllMocks()
+    fireEvent.press(tree.getByText('BCSC.CancelledVerification.Button'))
 
-    await waitFor(() => {
-      expect(mockGoToMethodSelection).toHaveBeenCalledTimes(1)
-    })
+    expect(mockCleanUpVerificationData).toHaveBeenCalledTimes(1)
     expect(mockNavigation.reset).toHaveBeenCalledWith({
       index: 0,
-      routes: [{ name: 'New Setup ID Confirmation' }],
+      routes: [{ name: 'Verify Options' }],
     })
     expect(mockNavigation.goBack).not.toHaveBeenCalled()
   })
 
-  it('shows a loading screen while the reset is in flight and hides it once settled', async () => {
-    const route = {
-      params: {
-        agentReason: 'Test reason',
-      },
-    } as any
-
-    const tree = render(
-      <BasicAppContext>
-        <CancelledReview route={route} />
-      </BasicAppContext>
-    )
-
-    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
-    fireEvent.press(okButton)
-
-    expect(mockStartLoading).toHaveBeenCalledWith('Alerts.RestartVerification.Loading')
-
-    await waitFor(() => {
-      expect(mockStopLoading).toHaveBeenCalledTimes(1)
-    })
-  })
-
-  it('does not start a second reset when pressed again after success', async () => {
-    const route = {
-      params: {
-        agentReason: 'Test reason',
-      },
-    } as any
-
-    const tree = render(
-      <BasicAppContext>
-        <CancelledReview route={route} />
-      </BasicAppContext>
-    )
-
-    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
-    fireEvent.press(okButton)
-
-    await waitFor(() => {
-      expect(mockGoToMethodSelection).toHaveBeenCalledTimes(1)
-    })
-
-    fireEvent.press(okButton)
-
-    await waitFor(() => {
-      expect(mockVerificationReset).toHaveBeenCalledTimes(2)
-    })
-    expect(mockGoToMethodSelection).toHaveBeenCalledTimes(2)
-  })
-
-  it('blocks a second tap while a reset is already in flight', async () => {
-    let resolveReset: (value: boolean) => void = () => {}
-    mockVerificationReset.mockReturnValue(
-      new Promise<boolean>((resolve) => {
-        resolveReset = resolve
-      })
-    )
-
-    const route = {
-      params: {
-        agentReason: 'Test reason',
-      },
-    } as any
-
-    const tree = render(
-      <BasicAppContext>
-        <CancelledReview route={route} />
-      </BasicAppContext>
-    )
-
-    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
-    fireEvent.press(okButton)
-    fireEvent.press(okButton)
-
-    expect(mockVerificationReset).toHaveBeenCalledTimes(1)
-    expect(mockStartLoading).toHaveBeenCalledTimes(1)
-
-    resolveReset(true)
-    await waitFor(() => {
-      expect(mockStopLoading).toHaveBeenCalledTimes(1)
-    })
-    expect(mockGoToMethodSelection).toHaveBeenCalledTimes(1)
-  })
-
-  it('re-enables the button and does not navigate when the reset fails', async () => {
-    mockVerificationReset.mockResolvedValue(false)
-
-    const route = {
-      params: {
-        agentReason: 'Test reason',
-      },
-    } as any
-
-    const tree = render(
-      <BasicAppContext>
-        <CancelledReview route={route} />
-      </BasicAppContext>
-    )
-
-    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
-    fireEvent.press(okButton)
-
-    await waitFor(() => {
-      expect(mockStopLoading).toHaveBeenCalledTimes(1)
-    })
-
-    expect(mockGoToMethodSelection).not.toHaveBeenCalled()
-    const buttonTouchable = tree.getByTestId(testIdWithKey('SystemModalButton'))
-    expect(buttonTouchable.props.accessibilityState?.disabled).toBeFalsy()
-  })
-
   it('displays OK button', () => {
-    const route = {
-      params: {
-        agentReason: 'Test reason',
-      },
-    } as any
+    const route = { params: { agentReason: 'Test reason' } } as any
 
     const tree = render(
       <BasicAppContext>
@@ -248,23 +101,5 @@ describe('CancelledReview', () => {
     )
 
     expect(tree.getByText('BCSC.CancelledVerification.Button')).toBeTruthy()
-  })
-
-  it('renders SystemModal component', () => {
-    const agentReason = 'Test reason'
-    const route = {
-      params: {
-        agentReason,
-      },
-    } as any
-
-    const tree = render(
-      <BasicAppContext>
-        <CancelledReview route={route} />
-      </BasicAppContext>
-    )
-
-    // SystemModal should render with the header text
-    expect(tree.getByText('BCSC.CancelledVerification.Title')).toBeTruthy()
   })
 })

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
@@ -95,7 +95,7 @@ describe('CancelledReview', () => {
     expect(tree.getByText('BCSC.CancelledVerification.Label')).toBeTruthy()
   })
 
-  it('re-enters the verify flow via goToMethodSelection when reset succeeds, without calling goBack', async () => {
+  it('re-enters the verify flow via goToMethodSelection and resets the stack to IdentitySelection', async () => {
     const agentReason = 'Test reason'
     const route = {
       params: {
@@ -114,6 +114,10 @@ describe('CancelledReview', () => {
 
     await waitFor(() => {
       expect(mockGoToMethodSelection).toHaveBeenCalledTimes(1)
+    })
+    expect(mockNavigation.reset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [{ name: 'New Setup ID Confirmation' }],
     })
     expect(mockNavigation.goBack).not.toHaveBeenCalled()
   })

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
@@ -141,7 +141,7 @@ describe('CancelledReview', () => {
     })
   })
 
-  it('keeps the button disabled after a successful reset so a second press does not start another reset', async () => {
+  it('does not start a second reset when pressed again after success', async () => {
     const route = {
       params: {
         agentReason: 'Test reason',
@@ -161,11 +161,12 @@ describe('CancelledReview', () => {
       expect(mockGoToMethodSelection).toHaveBeenCalledTimes(1)
     })
 
-    const buttonTouchable = tree.getByTestId(testIdWithKey('SystemModalButton'))
-    expect(buttonTouchable.props.accessibilityState?.disabled).toBe(true)
-
     fireEvent.press(okButton)
-    expect(mockVerificationReset).toHaveBeenCalledTimes(1)
+
+    await waitFor(() => {
+      expect(mockVerificationReset).toHaveBeenCalledTimes(2)
+    })
+    expect(mockGoToMethodSelection).toHaveBeenCalledTimes(2)
   })
 
   it('blocks a second tap while a reset is already in flight', async () => {

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
@@ -1,17 +1,32 @@
+import * as BCSCLoadingContextModule from '@/bcsc-theme/contexts/BCSCLoadingContext'
 import { useNavigation } from '@mocks/@react-navigation/native'
 import { BasicAppContext } from '@mocks/helpers/app'
+import { testIdWithKey } from '@bifold/core'
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import CancelledReview from './CancelledReview'
 
-jest.mock('@/bcsc-theme/hooks/useVerificationReset', () => ({
-  useVerificationReset: jest.fn(() => jest.fn().mockResolvedValue(true)),
+jest.mock('@/bcsc-theme/contexts/BCSCLoadingContext', () => ({
+  useLoadingScreen: jest.fn(),
 }))
 
+const mockVerificationReset = jest.fn().mockResolvedValue(true)
+jest.mock('@/bcsc-theme/hooks/useVerificationReset', () => ({
+  useVerificationReset: jest.fn(() => mockVerificationReset),
+}))
+
+const mockCleanUpVerificationData = jest.fn()
+const mockGoToMethodSelection = jest.fn()
 jest.mock('./CancelledReviewViewModel', () => ({
   __esModule: true,
-  default: jest.fn(() => ({ cleanUpVerificationData: jest.fn() })),
+  default: jest.fn(() => ({
+    cleanUpVerificationData: mockCleanUpVerificationData,
+    goToMethodSelection: mockGoToMethodSelection,
+  })),
 }))
+
+const mockStopLoading = jest.fn()
+const mockStartLoading = jest.fn().mockReturnValue(mockStopLoading)
 
 describe('CancelledReview', () => {
   let mockNavigation: any
@@ -19,6 +34,10 @@ describe('CancelledReview', () => {
     jest.clearAllMocks()
     jest.useFakeTimers()
     mockNavigation = useNavigation()
+    mockVerificationReset.mockResolvedValue(true)
+    jest.mocked(BCSCLoadingContextModule.useLoadingScreen).mockReturnValue({
+      startLoading: mockStartLoading,
+    } as any)
   })
 
   afterEach(() => {
@@ -76,7 +95,7 @@ describe('CancelledReview', () => {
     expect(tree.getByText('BCSC.CancelledVerification.Label')).toBeTruthy()
   })
 
-  it('calls goBack when OK button is pressed', async () => {
+  it('re-enters the verify flow via goToMethodSelection when reset succeeds, without calling goBack', async () => {
     const agentReason = 'Test reason'
     const route = {
       params: {
@@ -94,8 +113,120 @@ describe('CancelledReview', () => {
     fireEvent.press(okButton)
 
     await waitFor(() => {
-      expect(mockNavigation.goBack).toHaveBeenCalled()
+      expect(mockGoToMethodSelection).toHaveBeenCalledTimes(1)
     })
+    expect(mockNavigation.goBack).not.toHaveBeenCalled()
+  })
+
+  it('shows a loading screen while the reset is in flight and hides it once settled', async () => {
+    const route = {
+      params: {
+        agentReason: 'Test reason',
+      },
+    } as any
+
+    const tree = render(
+      <BasicAppContext>
+        <CancelledReview route={route} />
+      </BasicAppContext>
+    )
+
+    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
+    fireEvent.press(okButton)
+
+    expect(mockStartLoading).toHaveBeenCalledWith('Alerts.RestartVerification.Loading')
+
+    await waitFor(() => {
+      expect(mockStopLoading).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('keeps the button disabled after a successful reset so a second press does not start another reset', async () => {
+    const route = {
+      params: {
+        agentReason: 'Test reason',
+      },
+    } as any
+
+    const tree = render(
+      <BasicAppContext>
+        <CancelledReview route={route} />
+      </BasicAppContext>
+    )
+
+    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
+    fireEvent.press(okButton)
+
+    await waitFor(() => {
+      expect(mockGoToMethodSelection).toHaveBeenCalledTimes(1)
+    })
+
+    const buttonTouchable = tree.getByTestId(testIdWithKey('SystemModalButton'))
+    expect(buttonTouchable.props.accessibilityState?.disabled).toBe(true)
+
+    fireEvent.press(okButton)
+    expect(mockVerificationReset).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks a second tap while a reset is already in flight', async () => {
+    let resolveReset: (value: boolean) => void = () => {}
+    mockVerificationReset.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveReset = resolve
+      })
+    )
+
+    const route = {
+      params: {
+        agentReason: 'Test reason',
+      },
+    } as any
+
+    const tree = render(
+      <BasicAppContext>
+        <CancelledReview route={route} />
+      </BasicAppContext>
+    )
+
+    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
+    fireEvent.press(okButton)
+    fireEvent.press(okButton)
+
+    expect(mockVerificationReset).toHaveBeenCalledTimes(1)
+    expect(mockStartLoading).toHaveBeenCalledTimes(1)
+
+    resolveReset(true)
+    await waitFor(() => {
+      expect(mockStopLoading).toHaveBeenCalledTimes(1)
+    })
+    expect(mockGoToMethodSelection).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-enables the button and does not navigate when the reset fails', async () => {
+    mockVerificationReset.mockResolvedValue(false)
+
+    const route = {
+      params: {
+        agentReason: 'Test reason',
+      },
+    } as any
+
+    const tree = render(
+      <BasicAppContext>
+        <CancelledReview route={route} />
+      </BasicAppContext>
+    )
+
+    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
+    fireEvent.press(okButton)
+
+    await waitFor(() => {
+      expect(mockStopLoading).toHaveBeenCalledTimes(1)
+    })
+
+    expect(mockGoToMethodSelection).not.toHaveBeenCalled()
+    const buttonTouchable = tree.getByTestId(testIdWithKey('SystemModalButton'))
+    expect(buttonTouchable.props.accessibilityState?.disabled).toBeFalsy()
   })
 
   it('displays OK button', () => {

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
@@ -95,8 +95,8 @@ describe('CancelledReview', () => {
     expect(tree.getByText('BCSC.CancelledVerification.Label')).toBeTruthy()
   })
 
-  // This screen is hosted by both MainStack and VerifyStack, and the verify routes exist only
-  // in the latter — so it must leave via store state, never an in-stack navigation.
+  // MainStack and VerifyStack register this screen under distinct route names, so it must
+  // leave via store state (a stack swap), never an in-stack navigation.
   it('re-enters the verify flow via goToMethodSelection without navigating in-stack', async () => {
     const agentReason = 'Test reason'
     const route = {

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
@@ -1,7 +1,7 @@
 import * as BCSCLoadingContextModule from '@/bcsc-theme/contexts/BCSCLoadingContext'
+import { testIdWithKey } from '@bifold/core'
 import { useNavigation } from '@mocks/@react-navigation/native'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { testIdWithKey } from '@bifold/core'
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import CancelledReview from './CancelledReview'

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
@@ -143,7 +143,9 @@ describe('CancelledReview', () => {
     })
   })
 
-  it('does not start a second reset when pressed again after success', async () => {
+  // In the app a successful reset unmounts this screen, so a second press is unreachable; rendered
+  // in isolation it still fires, which is what proves the guard releases rather than latching.
+  it('releases the double-press guard once a reset has settled', async () => {
     const route = {
       params: {
         agentReason: 'Test reason',

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
@@ -95,8 +95,7 @@ describe('CancelledReview', () => {
     expect(tree.getByText('BCSC.CancelledVerification.Label')).toBeTruthy()
   })
 
-  // MainStack and VerifyStack register this screen under distinct route names, so it must
-  // leave via store state (a stack swap), never an in-stack navigation.
+  // Distinct route names per stack mean this screen must leave via store state, not navigation.
   it('re-enters the verify flow via resumeVerification without navigating in-stack', async () => {
     const agentReason = 'Test reason'
     const route = {

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -1,9 +1,6 @@
 import { useLoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
 import { useVerificationReset } from '@/bcsc-theme/hooks/useVerificationReset'
-import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { TOKENS, usePreventDoublePress, useServices } from '@bifold/core'
-import { useNavigation } from '@react-navigation/native'
-import { StackNavigationProp } from '@react-navigation/stack'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SystemModal } from '../../modal/components/SystemModal'
@@ -20,7 +17,6 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
   const { agentReason } = route.params
   const verificationReset = useVerificationReset()
   const { t } = useTranslation()
-  const navigation = useNavigation<StackNavigationProp<BCSCVerifyStackParams>>()
   const { cleanUpVerificationData, goToMethodSelection } = useCancelledReviewViewModel()
   const { preventDoublePress, isPressing } = usePreventDoublePress()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
@@ -46,12 +42,10 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
         try {
           const success = await verificationReset()
           if (success) {
+            // This screen is registered in both MainStack and VerifyStack, and the verify
+            // routes exist only in the latter — so leaving has to go through store state
+            // (RootStack swaps the stack) rather than an in-stack navigation.
             goToMethodSelection()
-            // goToMethodSelection sets store state for the RootStack swap, but on iOS the
-            // VerifyStack may not unmount/remount reliably — navigate explicitly so the user
-            // always leaves this screen. The reset cleared all ID/email/address data, so
-            // IdentitySelection (step 1) is the correct resume point.
-            navigation.reset({ index: 0, routes: [{ name: BCSCScreens.IdentitySelection }] })
           }
         } catch (error) {
           logger.error('CancelledReview: Error during factory reset on account', error as Error)

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -1,6 +1,9 @@
 import { useLoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
 import { useVerificationReset } from '@/bcsc-theme/hooks/useVerificationReset'
+import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { TOKENS, usePreventDoublePress, useServices } from '@bifold/core'
+import { useNavigation } from '@react-navigation/native'
+import { StackNavigationProp } from '@react-navigation/stack'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SystemModal } from '../../modal/components/SystemModal'
@@ -17,6 +20,7 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
   const { agentReason } = route.params
   const verificationReset = useVerificationReset()
   const { t } = useTranslation()
+  const navigation = useNavigation<StackNavigationProp<BCSCVerifyStackParams>>()
   const { cleanUpVerificationData, goToMethodSelection } = useCancelledReviewViewModel()
   const { preventDoublePress, isPressing } = usePreventDoublePress()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
@@ -42,8 +46,12 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
         try {
           const success = await verificationReset()
           if (success) {
-            // goBack() no-ops here: the reset unmounts this screen's stack mid-flight (#4387)
             goToMethodSelection()
+            // goToMethodSelection sets store state for the RootStack swap, but on iOS the
+            // VerifyStack may not unmount/remount reliably — navigate explicitly so the user
+            // always leaves this screen. The reset cleared all ID/email/address data, so
+            // IdentitySelection (step 1) is the correct resume point.
+            navigation.reset({ index: 0, routes: [{ name: BCSCScreens.IdentitySelection }] })
           }
         } catch (error) {
           logger.error('CancelledReview: Error during factory reset on account', error as Error)

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -1,4 +1,7 @@
+import { useLoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
+import { useVerificationReset } from '@/bcsc-theme/hooks/useVerificationReset'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
+import { TOKENS, usePreventDoublePress, useServices } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { useEffect } from 'react'
@@ -15,9 +18,13 @@ interface CancelledReviewProps {
 }
 const CancelledReview = ({ route }: CancelledReviewProps) => {
   const { agentReason } = route.params
+  const verificationReset = useVerificationReset()
   const { t } = useTranslation()
   const navigation = useNavigation<StackNavigationProp<BCSCVerifyStackParams>>()
-  const { cleanUpVerificationData } = useCancelledReviewViewModel()
+  const { cleanUpVerificationData, goToMethodSelection } = useCancelledReviewViewModel()
+  const { preventDoublePress, isPressing } = usePreventDoublePress()
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const loadingScreen = useLoadingScreen()
 
   useEffect(() => {
     cleanUpVerificationData()
@@ -33,10 +40,25 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
         }),
       ]}
       buttonText={t('BCSC.CancelledVerification.Button')}
-      onButtonPress={() => {
-        cleanUpVerificationData()
-        navigation.reset({ index: 0, routes: [{ name: BCSCScreens.VerificationMethodSelection }] })
-      }}
+      buttonDisabled={isPressing}
+      onButtonPress={preventDoublePress(async () => {
+        const stopLoading = loadingScreen.startLoading(t('Alerts.RestartVerification.Loading'))
+        try {
+          const success = await verificationReset()
+          if (success) {
+            goToMethodSelection()
+            // goToMethodSelection sets store state for the RootStack swap, but on iOS the
+            // VerifyStack may not unmount/remount reliably — navigate explicitly so the user
+            // always leaves this screen. The reset cleared all ID/email/address data, so
+            // IdentitySelection (step 1) is the correct resume point.
+            navigation.reset({ index: 0, routes: [{ name: BCSCScreens.IdentitySelection }] })
+          }
+        } catch (error) {
+          logger.error('CancelledReview: Error during factory reset on account', error as Error)
+        } finally {
+          stopLoading()
+        }
+      })}
     />
   )
 }

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -1,7 +1,7 @@
 import { useLoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
 import { useVerificationReset } from '@/bcsc-theme/hooks/useVerificationReset'
-import { TOKENS, useServices } from '@bifold/core'
-import React, { useEffect, useRef, useState } from 'react'
+import { TOKENS, usePreventDoublePress, useServices } from '@bifold/core'
+import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SystemModal } from '../../modal/components/SystemModal'
 import useCancelledReviewViewModel from './CancelledReviewViewModel'
@@ -18,8 +18,7 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
   const verificationReset = useVerificationReset()
   const { t } = useTranslation()
   const { cleanUpVerificationData, goToMethodSelection } = useCancelledReviewViewModel()
-  const [isLoading, setIsLoading] = useState(false)
-  const resettingRef = useRef(false)
+  const { preventDoublePress, isPressing } = usePreventDoublePress()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const loadingScreen = useLoadingScreen()
 
@@ -37,31 +36,21 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
         }),
       ]}
       buttonText={t('BCSC.CancelledVerification.Button')}
-      buttonDisabled={isLoading}
-      onButtonPress={async () => {
-        if (resettingRef.current) {
-          return
-        }
-        resettingRef.current = true
-        setIsLoading(true)
+      buttonDisabled={isPressing}
+      onButtonPress={preventDoublePress(async () => {
         const stopLoading = loadingScreen.startLoading(t('Alerts.RestartVerification.Loading'))
         try {
           const success = await verificationReset()
           if (success) {
             // goBack() no-ops here: the reset unmounts this screen's stack mid-flight (#4387)
             goToMethodSelection()
-            return
           }
-          resettingRef.current = false
-          setIsLoading(false)
         } catch (error) {
           logger.error('CancelledReview: Error during factory reset on account', error as Error)
-          resettingRef.current = false
-          setIsLoading(false)
         } finally {
           stopLoading()
         }
-      }}
+      })}
     />
   )
 }

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -13,13 +13,6 @@ interface CancelledReviewProps {
     }
   }
 }
-/**
- * A SystemModal wrapper that displays a cancellation message when a video verification request is cancelled.
- * This component will also clean up related values (video path, metadata, prompts, etc.) from the store.
- *
- * @param agentReason - A reason provided by the reviewing agent on why the verification request was cancelled
- * @returns
- */
 const CancelledReview = ({ route }: CancelledReviewProps) => {
   const { agentReason } = route.params
   const verificationReset = useVerificationReset()
@@ -30,7 +23,6 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
   const loadingScreen = useLoadingScreen()
 
   useEffect(() => {
-    // This clears up verification request artifacts (images, address data ect.)
     cleanUpVerificationData()
   }, [cleanUpVerificationData])
 
@@ -49,11 +41,9 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
         setIsLoading(true)
         const stopLoading = loadingScreen.startLoading(t('Alerts.RestartVerification.Loading'))
         try {
-          // Clear everything related to verification so it appears as if the user has never started the process before
           const success = await verificationReset()
           if (success) {
-            // goBack() would no-op: clearing verified status unmounts the stack hosting
-            // this screen mid-reset (#4387). Re-enter the verify flow via store state.
+            // goBack() no-ops here: the reset unmounts this screen's stack mid-flight (#4387)
             goToMethodSelection()
             return
           }

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -42,9 +42,11 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
         try {
           const success = await verificationReset()
           if (success) {
-            // This screen is registered in both MainStack and VerifyStack, and the verify
-            // routes exist only in the latter — so leaving has to go through store state
-            // (RootStack swaps the stack) rather than an in-stack navigation.
+            // MainStack and VerifyStack each register this screen under a distinct route name
+            // (MainCancelledReview vs CancelledReview), so leaving has to go through store state
+            // (RootStack swaps the stack) rather than an in-stack navigation: on the swap, the
+            // inherited route no longer matches a name the incoming stack knows, gets dropped,
+            // and the incoming stack falls back to its own initialRouteName.
             goToMethodSelection()
           }
         } catch (error) {

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -1,7 +1,7 @@
 import { useLoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
 import { useVerificationReset } from '@/bcsc-theme/hooks/useVerificationReset'
 import { TOKENS, useServices } from '@bifold/core'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SystemModal } from '../../modal/components/SystemModal'
 import useCancelledReviewViewModel from './CancelledReviewViewModel'
@@ -19,6 +19,7 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
   const { t } = useTranslation()
   const { cleanUpVerificationData, goToMethodSelection } = useCancelledReviewViewModel()
   const [isLoading, setIsLoading] = useState(false)
+  const resettingRef = useRef(false)
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const loadingScreen = useLoadingScreen()
 
@@ -38,6 +39,8 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
       buttonText={t('BCSC.CancelledVerification.Button')}
       buttonDisabled={isLoading}
       onButtonPress={async () => {
+        if (resettingRef.current) return
+        resettingRef.current = true
         setIsLoading(true)
         const stopLoading = loadingScreen.startLoading(t('Alerts.RestartVerification.Loading'))
         try {
@@ -47,9 +50,11 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
             goToMethodSelection()
             return
           }
+          resettingRef.current = false
           setIsLoading(false)
         } catch (error) {
           logger.error('CancelledReview: Error during factory reset on account', error as Error)
+          resettingRef.current = false
           setIsLoading(false)
         } finally {
           stopLoading()

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -39,7 +39,9 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
       buttonText={t('BCSC.CancelledVerification.Button')}
       buttonDisabled={isLoading}
       onButtonPress={async () => {
-        if (resettingRef.current) { return }
+        if (resettingRef.current) {
+          return
+        }
         resettingRef.current = true
         setIsLoading(true)
         const stopLoading = loadingScreen.startLoading(t('Alerts.RestartVerification.Loading'))

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -39,7 +39,7 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
       buttonText={t('BCSC.CancelledVerification.Button')}
       buttonDisabled={isLoading}
       onButtonPress={async () => {
-        if (resettingRef.current) return
+        if (resettingRef.current) { return }
         resettingRef.current = true
         setIsLoading(true)
         const stopLoading = loadingScreen.startLoading(t('Alerts.RestartVerification.Loading'))

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -1,6 +1,6 @@
+import { useLoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
 import { useVerificationReset } from '@/bcsc-theme/hooks/useVerificationReset'
 import { TOKENS, useServices } from '@bifold/core'
-import { useNavigation } from '@react-navigation/native'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SystemModal } from '../../modal/components/SystemModal'
@@ -24,10 +24,10 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
   const { agentReason } = route.params
   const verificationReset = useVerificationReset()
   const { t } = useTranslation()
-  const navigation = useNavigation()
-  const { cleanUpVerificationData } = useCancelledReviewViewModel()
+  const { cleanUpVerificationData, goToMethodSelection } = useCancelledReviewViewModel()
   const [isLoading, setIsLoading] = useState(false)
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const loadingScreen = useLoadingScreen()
 
   useEffect(() => {
     // This clears up verification request artifacts (images, address data ect.)
@@ -46,17 +46,23 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
       buttonText={t('BCSC.CancelledVerification.Button')}
       buttonDisabled={isLoading}
       onButtonPress={async () => {
+        setIsLoading(true)
+        const stopLoading = loadingScreen.startLoading(t('Alerts.RestartVerification.Loading'))
         try {
-          setIsLoading(true)
           // Clear everything related to verification so it appears as if the user has never started the process before
           const success = await verificationReset()
           if (success) {
-            navigation.goBack()
+            // goBack() would no-op: clearing verified status unmounts the stack hosting
+            // this screen mid-reset (#4387). Re-enter the verify flow via store state.
+            goToMethodSelection()
+            return
           }
+          setIsLoading(false)
         } catch (error) {
           logger.error('CancelledReview: Error during factory reset on account', error as Error)
-        } finally {
           setIsLoading(false)
+        } finally {
+          stopLoading()
         }
       }}
     />

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -1,7 +1,4 @@
-import { useLoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
-import { useVerificationReset } from '@/bcsc-theme/hooks/useVerificationReset'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
-import { TOKENS, usePreventDoublePress, useServices } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { useEffect } from 'react'
@@ -18,13 +15,9 @@ interface CancelledReviewProps {
 }
 const CancelledReview = ({ route }: CancelledReviewProps) => {
   const { agentReason } = route.params
-  const verificationReset = useVerificationReset()
   const { t } = useTranslation()
   const navigation = useNavigation<StackNavigationProp<BCSCVerifyStackParams>>()
-  const { cleanUpVerificationData, goToMethodSelection } = useCancelledReviewViewModel()
-  const { preventDoublePress, isPressing } = usePreventDoublePress()
-  const [logger] = useServices([TOKENS.UTIL_LOGGER])
-  const loadingScreen = useLoadingScreen()
+  const { cleanUpVerificationData } = useCancelledReviewViewModel()
 
   useEffect(() => {
     cleanUpVerificationData()
@@ -40,25 +33,10 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
         }),
       ]}
       buttonText={t('BCSC.CancelledVerification.Button')}
-      buttonDisabled={isPressing}
-      onButtonPress={preventDoublePress(async () => {
-        const stopLoading = loadingScreen.startLoading(t('Alerts.RestartVerification.Loading'))
-        try {
-          const success = await verificationReset()
-          if (success) {
-            goToMethodSelection()
-            // goToMethodSelection sets store state for the RootStack swap, but on iOS the
-            // VerifyStack may not unmount/remount reliably — navigate explicitly so the user
-            // always leaves this screen. The reset cleared all ID/email/address data, so
-            // IdentitySelection (step 1) is the correct resume point.
-            navigation.reset({ index: 0, routes: [{ name: BCSCScreens.IdentitySelection }] })
-          }
-        } catch (error) {
-          logger.error('CancelledReview: Error during factory reset on account', error as Error)
-        } finally {
-          stopLoading()
-        }
-      })}
+      onButtonPress={() => {
+        cleanUpVerificationData()
+        navigation.reset({ index: 0, routes: [{ name: BCSCScreens.VerificationMethodSelection }] })
+      }}
     />
   )
 }

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -39,13 +39,11 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
       onButtonPress={preventDoublePress(async () => {
         const stopLoading = loadingScreen.startLoading(t('Alerts.RestartVerification.Loading'))
         try {
-          // Reports failure by returning false (it shows its own factory-reset alert), never by
-          // throwing — so there is nothing here to catch.
+          // Signals failure by returning false (with its own alert), never by throwing.
           const success = await verificationReset()
           if (success) {
-            // Each stack registers this screen under its own route name, so the swap RootStack
-            // performs on this state change drops the inherited route and lands the user on the
-            // incoming stack's initialRouteName. An in-stack navigation cannot do that.
+            // Leaves via store state, not navigation: each stack registers this screen under its
+            // own route name, so the RootStack swap drops it and lands on the new initialRouteName.
             resumeVerification()
           }
         } finally {

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -1,6 +1,6 @@
 import { useLoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
 import { useVerificationReset } from '@/bcsc-theme/hooks/useVerificationReset'
-import { TOKENS, usePreventDoublePress, useServices } from '@bifold/core'
+import { usePreventDoublePress } from '@bifold/core'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SystemModal } from '../../modal/components/SystemModal'
@@ -17,9 +17,8 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
   const { agentReason } = route.params
   const verificationReset = useVerificationReset()
   const { t } = useTranslation()
-  const { cleanUpVerificationData, goToMethodSelection } = useCancelledReviewViewModel()
+  const { cleanUpVerificationData, resumeVerification } = useCancelledReviewViewModel()
   const { preventDoublePress, isPressing } = usePreventDoublePress()
-  const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const loadingScreen = useLoadingScreen()
 
   useEffect(() => {
@@ -40,17 +39,15 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
       onButtonPress={preventDoublePress(async () => {
         const stopLoading = loadingScreen.startLoading(t('Alerts.RestartVerification.Loading'))
         try {
+          // Reports failure by returning false (it shows its own factory-reset alert), never by
+          // throwing — so there is nothing here to catch.
           const success = await verificationReset()
           if (success) {
-            // MainStack and VerifyStack each register this screen under a distinct route name
-            // (MainCancelledReview vs CancelledReview), so leaving has to go through store state
-            // (RootStack swaps the stack) rather than an in-stack navigation: on the swap, the
-            // inherited route no longer matches a name the incoming stack knows, gets dropped,
-            // and the incoming stack falls back to its own initialRouteName.
-            goToMethodSelection()
+            // Each stack registers this screen under its own route name, so the swap RootStack
+            // performs on this state change drops the inherited route and lands the user on the
+            // incoming stack's initialRouteName. An in-stack navigation cannot do that.
+            resumeVerification()
           }
-        } catch (error) {
-          logger.error('CancelledReview: Error during factory reset on account', error as Error)
         } finally {
           stopLoading()
         }

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.test.ts
@@ -95,4 +95,13 @@ describe('useCancelledReviewViewModel', () => {
     })
   })
 
+  describe('goToMethodSelection', () => {
+    it('continues the verification process', () => {
+      const { result } = renderHook(() => useCancelledReviewViewModel())
+
+      result.current.goToMethodSelection()
+
+      expect(mockContinueVerificationProcess).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.test.ts
@@ -95,11 +95,11 @@ describe('useCancelledReviewViewModel', () => {
     })
   })
 
-  describe('goToMethodSelection', () => {
+  describe('resumeVerification', () => {
     it('continues the verification process', () => {
       const { result } = renderHook(() => useCancelledReviewViewModel())
 
-      result.current.goToMethodSelection()
+      result.current.resumeVerification()
 
       expect(mockContinueVerificationProcess).toHaveBeenCalledTimes(1)
     })

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.test.ts
@@ -95,13 +95,4 @@ describe('useCancelledReviewViewModel', () => {
     })
   })
 
-  describe('goToMethodSelection', () => {
-    it('continues the verification process', () => {
-      const { result } = renderHook(() => useCancelledReviewViewModel())
-
-      result.current.goToMethodSelection()
-
-      expect(mockContinueVerificationProcess).toHaveBeenCalledTimes(1)
-    })
-  })
 })

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.ts
@@ -3,13 +3,9 @@ import { BCDispatchAction, BCState } from '@/store'
 import { useStore } from '@bifold/core'
 import { useCallback } from 'react'
 
-/**
- * ViewModel hook for the CancelledReview component that provides
- * the method to clean up verification related data from storage
- */
 const useCancelledReviewViewModel = () => {
   const [, dispatch] = useStore<BCState>()
-  const { updateAccountFlags, updateVerificationRequest, continueVerificationProcess } = useSecureActions()
+  const { updateAccountFlags, updateVerificationRequest } = useSecureActions()
   const cleanUpVerificationData = useCallback(() => {
     updateVerificationRequest(null, null)
     dispatch({ type: BCDispatchAction.RESET_SEND_VIDEO })
@@ -19,10 +15,8 @@ const useCancelledReviewViewModel = () => {
     dispatch({ type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_VIDEO_SUBMITTED_AT, payload: [undefined] })
     updateAccountFlags({ userSubmittedVerificationVideo: false })
   }, [dispatch, updateAccountFlags, updateVerificationRequest])
-  const goToMethodSelection = () => continueVerificationProcess()
   return {
     cleanUpVerificationData,
-    goToMethodSelection,
   }
 }
 

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.ts
@@ -19,10 +19,13 @@ const useCancelledReviewViewModel = () => {
     dispatch({ type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_VIDEO_SUBMITTED_AT, payload: [undefined] })
     updateAccountFlags({ userSubmittedVerificationVideo: false })
   }, [dispatch, updateAccountFlags, updateVerificationRequest])
-  const goToMethodSelection = () => continueVerificationProcess()
+  // Deliberately not named for a screen: this flips verification back to in-progress and lets
+  // VerifyStack pick the landing step via getResumeStepRoute, which resolves to IdentitySelection
+  // after a full reset and moves whenever the resume rules do.
+  const resumeVerification = () => continueVerificationProcess()
   return {
     cleanUpVerificationData,
-    goToMethodSelection,
+    resumeVerification,
   }
 }
 

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.ts
@@ -3,10 +3,7 @@ import { BCDispatchAction, BCState } from '@/store'
 import { useStore } from '@bifold/core'
 import { useCallback } from 'react'
 
-/**
- * ViewModel hook for the CancelledReview component that provides
- * the method to clean up verification related data from storage
- */
+/** ViewModel for CancelledReview: clears verification artifacts and re-enters the verify flow. */
 const useCancelledReviewViewModel = () => {
   const [, dispatch] = useStore<BCState>()
   const { updateAccountFlags, updateVerificationRequest, continueVerificationProcess } = useSecureActions()
@@ -19,9 +16,8 @@ const useCancelledReviewViewModel = () => {
     dispatch({ type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_VIDEO_SUBMITTED_AT, payload: [undefined] })
     updateAccountFlags({ userSubmittedVerificationVideo: false })
   }, [dispatch, updateAccountFlags, updateVerificationRequest])
-  // Deliberately not named for a screen: this flips verification back to in-progress and lets
-  // VerifyStack pick the landing step via getResumeStepRoute, which resolves to IdentitySelection
-  // after a full reset and moves whenever the resume rules do.
+  // Not named for a screen: VerifyStack picks the landing step via getResumeStepRoute
+  // (IdentitySelection after a full reset).
   const resumeVerification = () => continueVerificationProcess()
   return {
     cleanUpVerificationData,

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.ts
@@ -3,9 +3,13 @@ import { BCDispatchAction, BCState } from '@/store'
 import { useStore } from '@bifold/core'
 import { useCallback } from 'react'
 
+/**
+ * ViewModel hook for the CancelledReview component that provides
+ * the method to clean up verification related data from storage
+ */
 const useCancelledReviewViewModel = () => {
   const [, dispatch] = useStore<BCState>()
-  const { updateAccountFlags, updateVerificationRequest } = useSecureActions()
+  const { updateAccountFlags, updateVerificationRequest, continueVerificationProcess } = useSecureActions()
   const cleanUpVerificationData = useCallback(() => {
     updateVerificationRequest(null, null)
     dispatch({ type: BCDispatchAction.RESET_SEND_VIDEO })
@@ -15,8 +19,10 @@ const useCancelledReviewViewModel = () => {
     dispatch({ type: BCDispatchAction.UPDATE_SECURE_VERIFICATION_VIDEO_SUBMITTED_AT, payload: [undefined] })
     updateAccountFlags({ userSubmittedVerificationVideo: false })
   }, [dispatch, updateAccountFlags, updateVerificationRequest])
+  const goToMethodSelection = () => continueVerificationProcess()
   return {
     cleanUpVerificationData,
+    goToMethodSelection,
   }
 }
 

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -476,7 +476,7 @@ const MainStack: React.FC = () => {
             })}
           />
           <Stack.Screen
-            name={BCSCScreens.CancelledReview}
+            name={BCSCScreens.MainCancelledReview}
             component={CancelledReview}
             options={() => ({
               headerShown: true,

--- a/app/src/bcsc-theme/types/navigators.ts
+++ b/app/src/bcsc-theme/types/navigators.ts
@@ -116,6 +116,7 @@ export enum BCSCScreens {
   OnboardingDeveloper = `${BCSCStacks.Onboarding} Developer`,
   VerifyPrompt = `${BCSCStacks.Verify} Verify Prompt`,
   MainVerifyPrompt = `${BCSCStacks.Main} Verify Prompt`,
+  MainCancelledReview = `${BCSCStacks.Main} Cancelled Review`,
   MainLoading = `${BCSCStacks.Main} Loading`,
   MainSettings = `${BCSCStacks.Main} In App Settings`,
   MainWebView = `${BCSCStacks.Main} Web view`,
@@ -309,7 +310,7 @@ export type BCSCMainStackParams = {
   [BCSCScreens.QRCore]: NavigatorScreenParams<BCSCQRCoreTabParams> | undefined
   [BCSCScreens.ConnectionLoading]: { oobRecordId?: string; credentialId?: string; proofId?: string }
   [BCSCScreens.VerificationSuccess]: undefined
-  [BCSCScreens.CancelledReview]: { agentReason?: string }
+  [BCSCScreens.MainCancelledReview]: { agentReason?: string }
   [BCSCScreens.MainVerifyPrompt]: undefined
 
   [BCSCModals.InternetDisconnected]: undefined


### PR DESCRIPTION
## What

Tapping "Retry verification" on the cancelled-verification screen now returns the user to the start of verification. Previously the reset ran but left the user on the same screen, unable to continue.

## Why

The screen is reachable from two parts of the app, and was registered in both under the same internal name. Retrying switches between those parts, and the app carried the screen across the switch instead of dropping it — so the user landed back where they started.

## Decisions

- **Root fix:** register the home-screen copy under its own route name (`BCSCScreens.MainCancelledReview`). React Navigation preserves an inherited route across a stack swap whenever the incoming navigator also registers that name — `StackRouter.getStateForRouteNamesChange` filters inherited routes by name and only falls back to `initialRouteName` when nothing survives the filter. Distinct names make the drop deterministic. This follows the existing `Main*`/`Verify*` convention already used by ~10 dual-hosted screens (`MainSettings`/`VerifySettings`, `MainWebView`/`VerifyWebView`, …); `CancelledReview` was the lone outlier sharing one name.
- The earlier fix (#4165) used `navigation.goBack()`, which failed for the same reason: after the swap this screen was the only route left, so there was nothing behind it to pop to. That is why it looked frozen, and why repeated taps triggered extra account registrations.
- Not iOS-specific despite the original report — the behaviour is identical on both platforms.
- Retry leaves via store state (`resumeVerification()` → `continueVerificationProcess()`) rather than an in-stack navigation, matching `useRestartVerification`, `ReverifyAccountScreen`, and `AccountRenewalFinalWarningScreen`.
- Renamed the view model's `goToMethodSelection` to `resumeVerification`. After a full reset `getResumeStepRoute` resolves to `IdentitySelection`, not `VerificationMethodSelection`, so the old name described a screen it never actually reached. The new name deliberately avoids naming any screen, since the resume rules decide that.
- Removed the `catch` around `verificationReset()`: it signals failure by returning `false` (and raises its own factory-reset alert), never by throwing, so the branch was unreachable. This matches `useRestartVerification`, which is try/finally only.
- Added a loading screen for the duration of the reset, reusing the existing `Alerts.RestartVerification.Loading` copy, for consistency with `useRestartVerification` and to give feedback during a reset that takes a few seconds.
- Replaced the local `isLoading` state with `usePreventDoublePress` for the double-tap guard. Its synchronous ref guard is the only thing that stops a sub-frame double tap — the loading overlay's `pointerEvents: none` only takes effect after a re-render.
- Did not clear `ACCOUNT_SETUP_TYPE` on this path, matching `ReverifyAccountScreen` / `AccountRenewalFinalWarningScreen` rather than `useRestartVerification` (which clears it for a different flow).

## Manual testing

1. Start a new video verification and submit it.
2. In **idcheck**, reject the submission (select "Too low quality video or photo for matching", then "Other").
3. The home screen updates to a "See details" card — tap it.
4. Tap "Retry verification". You should land on the first step of verification, not back on the cancelled screen.

Worth exercising both entry points, since they are hosted by different stacks: the home-screen "See details" card (above), and reaching the cancelled screen from inside the verification flow via "Check status". Verify with a full rebuild rather than a hot reload — route registration changes are baked into the bundle.

## Tests

`CancelledReview.test.tsx` covers: a successful retry re-enters the flow via `resumeVerification` without any in-stack navigation (`goBack`/`reset` are asserted un-called), the loading screen shows and hides around the reset, a second tap while a reset is in flight is ignored, the double-press guard releases once a reset settles, and a failed reset re-enables the button without navigating. `CancelledReviewViewModel.test.ts` covers the view model's two exports.

Typecheck, lint, format and the affected suites pass; the existing `MainStack` snapshot is unchanged.

## Follow-ups (not in this PR)

- `BCSCScreens.VerificationSuccess` is now the only screen still registered in both stacks under a shared name. It does not currently misbehave, but only because the `verified` flip puts `MainStack` into its `isLoadingAccount` branch, which lets the navigator's deferred state cleanup run. That is an incidental timing dependency worth removing with the same rename.
- `useVerificationPendingActions.handleCheckStatus` re-fires after this screen clears `verificationRequestId` and logs `Failed to check status: Verification request ID is missing` at error level (it also causes a duplicate status GET). Its `isCheckingStatus` return value is unused.

Fixes #4387

