### PR TITLE
feat: e2e onboarding branch sweep

### DIFF
--- a/e2e/src/constants.ts
+++ b/e2e/src/constants.ts
@@ -26,9 +26,8 @@ export enum Timeouts {
   /** First checkpoint of a journey file: the run's FIRST session may also pay simulator/device
    *  boot + WebDriverAgent install + first-ever app launch, all competing for CPU. */
   COLD_START = 60_000,
-  /** A timed lockout expiring on its own. The native schedule's first tier is 1 minute (5 consecutive
-   *  wrong PINs) and the Lockout screen unlocks itself when its countdown reaches zero — this is the
-   *  bound on that unattended wait, with headroom for a slow mount reading the remaining time late. */
+  /** A timed lockout releasing itself. The first native tier is 1 minute (5 wrong PINs); the extra
+   *  headroom covers a slow mount reading the remaining time late. */
   LOCKOUT_AUTO_UNLOCK = 120_000,
   /** Per-test timeout (Mocha) */
   TEST_TIMEOUT = 300_000,
@@ -37,20 +36,17 @@ export enum Timeouts {
 }
 
 /**
- * How long (seconds) the app is held in the background to trip auto-lock's "backgrounded too long"
- * branch — a different code path from the inactivity timer, which is cleared on backgrounding and
- * replaced by an elapsed-time comparison when the app returns to the foreground.
- *
- * Must exceed the auto-lock timeout the caller sets first (the journeys set the 1-minute option; the
- * 5-minute default would cost a 5-minute background). The margin covers the AppState round-trip.
+ * Seconds in the background to trip auto-lock's "backgrounded too long" branch — a different path
+ * from the inactivity timer, which is cleared on backgrounding and replaced by an elapsed-time
+ * check on return. Must exceed the auto-lock timeout the caller sets first (the journeys pick the
+ * 1-minute option; the 5-minute default would cost a 5-minute background).
  */
 export const BACKGROUND_LOCK_SECONDS = 70
 
 /**
- * A background comfortably INSIDE the auto-lock timeout — the control for the background-lock
- * checkpoint. Returning from this must leave the user authenticated, which both pins down the
- * boundary and proves the app is resumed rather than relaunched (a relaunch would land on the unlock
- * screen for the ordinary in-memory `didAuthenticate` reason and make the lock assertion vacuous).
+ * A background well inside the auto-lock timeout — the control for the checkpoint above. Coming back
+ * still authenticated proves the app was resumed, not relaunched (a relaunch reaches the unlock
+ * screen anyway, which would make the lock assertion vacuous).
  */
 export const BACKGROUND_NO_LOCK_SECONDS = 5
 

--- a/e2e/src/constants.ts
+++ b/e2e/src/constants.ts
@@ -8,6 +8,9 @@ export const UPDATED_TEST_PIN = '555555'
 /** A PIN that is always wrong (never used as TEST_PIN/UPDATED_TEST_PIN) — for error/lockout paths. */
 export const WRONG_TEST_PIN = '111111'
 
+/** Fewer than the required 6 digits — trips the PIN forms' "too short" inline validation. */
+export const SHORT_TEST_PIN = '2222'
+
 export enum Timeouts {
   /** Default wait for an element to appear on screen */
   ELEMENT_VISIBLE = 5_000,
@@ -23,11 +26,33 @@ export enum Timeouts {
   /** First checkpoint of a journey file: the run's FIRST session may also pay simulator/device
    *  boot + WebDriverAgent install + first-ever app launch, all competing for CPU. */
   COLD_START = 60_000,
+  /** A timed lockout expiring on its own. The native schedule's first tier is 1 minute (5 consecutive
+   *  wrong PINs) and the Lockout screen unlocks itself when its countdown reaches zero — this is the
+   *  bound on that unattended wait, with headroom for a slow mount reading the remaining time late. */
+  LOCKOUT_AUTO_UNLOCK = 120_000,
   /** Per-test timeout (Mocha) */
   TEST_TIMEOUT = 300_000,
   /** Browser handoff pause (ms) */
   BROWSER_HANDOFF_PAUSE_MS = 1_000,
 }
+
+/**
+ * How long (seconds) the app is held in the background to trip auto-lock's "backgrounded too long"
+ * branch — a different code path from the inactivity timer, which is cleared on backgrounding and
+ * replaced by an elapsed-time comparison when the app returns to the foreground.
+ *
+ * Must exceed the auto-lock timeout the caller sets first (the journeys set the 1-minute option; the
+ * 5-minute default would cost a 5-minute background). The margin covers the AppState round-trip.
+ */
+export const BACKGROUND_LOCK_SECONDS = 70
+
+/**
+ * A background comfortably INSIDE the auto-lock timeout — the control for the background-lock
+ * checkpoint. Returning from this must leave the user authenticated, which both pins down the
+ * boundary and proves the app is resumed rather than relaunched (a relaunch would land on the unlock
+ * screen for the ordinary in-memory `didAuthenticate` reason and make the lock assertion vacuous).
+ */
+export const BACKGROUND_NO_LOCK_SECONDS = 5
 
 export const TestUsers = {
   photo: {

--- a/e2e/src/flows/auth.ts
+++ b/e2e/src/flows/auth.ts
@@ -17,9 +17,11 @@ export async function relaunchApp(): Promise<void> {
 }
 
 /**
- * Background the app for `seconds`, then foreground it — WITHOUT terminating, so in-memory state
- * survives and the app sees a real AppState background → active transition (what auto-lock's
- * backgrounded-too-long branch keys off).
+ * Background the app for `seconds`, then foreground it. Nothing here terminates the app, so it sees a
+ * real AppState background → active transition — what auto-lock's backgrounded-too-long branch keys
+ * off. The OS may still evict a backgrounded app on its own, so in-memory state surviving is likely
+ * but not guaranteed: callers that depend on it must assert their own post-resume marker (see the
+ * short-background control step in `auth-unlock.journey.ts`).
  *
  * The wait is deliberately not the driver's. A POSITIVE `seconds` (or the legacy
  * `driver.background(n)`) blocks that one request for its full duration, and Sauce terminates a
@@ -31,6 +33,8 @@ export async function relaunchApp(): Promise<void> {
 export async function backgroundAppFor(seconds: number): Promise<void> {
   // Resolve while frontmost — `getCurrentAppId` reads the ACTIVE app.
   const appId = await getCurrentAppId()
+  // Cross-platform: XCUITest and UiAutomator2 both register `mobile: backgroundApp` (the latter
+  // already defaults `seconds` to -1). It is NOT an iOS-only extension.
   await driver.execute('mobile: backgroundApp', { seconds: -1 })
   await driver.pause(seconds * 1_000)
   await driver.activateApp(appId)

--- a/e2e/src/flows/auth.ts
+++ b/e2e/src/flows/auth.ts
@@ -17,25 +17,19 @@ export async function relaunchApp(): Promise<void> {
 }
 
 /**
- * Send the app to the background for `seconds`, then bring it back to the foreground — WITHOUT
- * terminating it, so in-memory state survives and the app observes a real AppState background →
- * active transition (which is what auto-lock's backgrounded-too-long branch keys off).
+ * Background the app for `seconds`, then foreground it — WITHOUT terminating, so in-memory state
+ * survives and the app sees a real AppState background → active transition (what auto-lock's
+ * backgrounded-too-long branch keys off).
  *
- * The wait is deliberately NOT the driver's. Asking a driver to hold the app down for N seconds —
- * `mobile: backgroundApp` with a POSITIVE `seconds`, or the legacy `driver.background(n)` — blocks
- * that one request for the whole duration (on iOS it is `POST /wda/deactivateApp {duration}`), and
- * Sauce's gateway terminates a session whose command has not answered within 60s. A 70s background
- * therefore killed the iOS 17 job mid-run: "did not receive any response ... within 60000 ms",
- * immediately followed by "A session is either terminated or not started".
- *
- * A NEGATIVE `seconds` means "leave it in the background" and returns straight away, so the wait
- * becomes a client-side `pause` (wdio implements it as a plain `setTimeout` — no driver traffic at
- * all, bounded by `newCommandTimeout` rather than the gateway), and `activateApp` resumes the still
- * running app. Keep any single driver command well under 60s on Sauce.
+ * The wait is deliberately not the driver's. A POSITIVE `seconds` (or the legacy
+ * `driver.background(n)`) blocks that one request for its full duration, and Sauce terminates a
+ * session whose command hasn't answered within 60s — which is how a 70s background killed the iOS 17
+ * job. A NEGATIVE `seconds` means "leave it there" and returns at once, so the wait becomes a
+ * client-side `pause` (wdio implements it as a plain `setTimeout`). Keep any single driver command
+ * well under 60s on Sauce.
  */
 export async function backgroundAppFor(seconds: number): Promise<void> {
-  // Resolve the id while the app is still frontmost — `getCurrentAppId` reads the ACTIVE app, so
-  // after backgrounding it would report the home screen / launcher instead.
+  // Resolve while frontmost — `getCurrentAppId` reads the ACTIVE app.
   const appId = await getCurrentAppId()
   await driver.execute('mobile: backgroundApp', { seconds: -1 })
   await driver.pause(seconds * 1_000)

--- a/e2e/src/flows/auth.ts
+++ b/e2e/src/flows/auth.ts
@@ -17,6 +17,32 @@ export async function relaunchApp(): Promise<void> {
 }
 
 /**
+ * Send the app to the background for `seconds`, then bring it back to the foreground — WITHOUT
+ * terminating it, so in-memory state survives and the app observes a real AppState background →
+ * active transition (which is what auto-lock's backgrounded-too-long branch keys off).
+ *
+ * The wait is deliberately NOT the driver's. Asking a driver to hold the app down for N seconds —
+ * `mobile: backgroundApp` with a POSITIVE `seconds`, or the legacy `driver.background(n)` — blocks
+ * that one request for the whole duration (on iOS it is `POST /wda/deactivateApp {duration}`), and
+ * Sauce's gateway terminates a session whose command has not answered within 60s. A 70s background
+ * therefore killed the iOS 17 job mid-run: "did not receive any response ... within 60000 ms",
+ * immediately followed by "A session is either terminated or not started".
+ *
+ * A NEGATIVE `seconds` means "leave it in the background" and returns straight away, so the wait
+ * becomes a client-side `pause` (wdio implements it as a plain `setTimeout` — no driver traffic at
+ * all, bounded by `newCommandTimeout` rather than the gateway), and `activateApp` resumes the still
+ * running app. Keep any single driver command well under 60s on Sauce.
+ */
+export async function backgroundAppFor(seconds: number): Promise<void> {
+  // Resolve the id while the app is still frontmost — `getCurrentAppId` reads the ACTIVE app, so
+  // after backgrounding it would report the home screen / launcher instead.
+  const appId = await getCurrentAppId()
+  await driver.execute('mobile: backgroundApp', { seconds: -1 })
+  await driver.pause(seconds * 1_000)
+  await driver.activateApp(appId)
+}
+
+/**
  * Wait for AccountLanding, advancing past the returning-user intro (AuthIntro — the same component
  * as the onboarding intro, shown only when `hasSeenOnboardingIntro` was never recorded) if it
  * appears first. No-op when AccountLanding is already visible.

--- a/e2e/src/flows/onboarding.ts
+++ b/e2e/src/flows/onboarding.ts
@@ -1,4 +1,5 @@
 import { TEST_PIN, Timeouts } from '../constants.js'
+import { acceptSystemAlert, dismissSystemAlert } from '../helpers/alerts.js'
 import { HomeScreen } from '../screens/main.js'
 import {
   OnboardingCreatePINScreen,
@@ -35,6 +36,37 @@ export async function skipNotificationsIfShown(): Promise<void> {
       throw new Error('Neither Notifications nor SecureApp appeared after the analytics opt-in')
     }
   }
+}
+
+/**
+ * Grace period for the OS notification-permission dialog to appear after `EnableNotifications`. The
+ * system permission controller can take several seconds to surface on a loaded real device, well past
+ * the helper's 5s default.
+ */
+const PERMISSION_DIALOG_APPEAR_MS = 15_000
+
+/**
+ * Take the Notifications screen's `EnableNotifications` path and answer the OS permission dialog it
+ * raises, ending on SecureApp (both answers advance).
+ *
+ * The app does not wait for us: on Android its permission request self-resolves after ~2s (a
+ * workaround for a React Native hang, see `PushNotificationsHelper.requestNotificationPermission`),
+ * so it can navigate to SecureApp while the dialog is still up. That only affects what the app
+ * *recorded*; the OS permission itself is decided by this dialog, and every branch that keys off it
+ * (`PermissionDisabled`, the analytics screen's skip-Notifications shortcut) re-reads the live status.
+ * So resolve the dialog first, then assert the destination.
+ */
+export async function answerNotificationPermission(decision: 'allow' | 'deny'): Promise<void> {
+  await OnboardingNotificationsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  await OnboardingNotificationsScreen.tap('primary')
+
+  if (decision === 'allow') {
+    await acceptSystemAlert(PERMISSION_DIALOG_APPEAR_MS)
+  } else {
+    await dismissSystemAlert(PERMISSION_DIALOG_APPEAR_MS)
+  }
+
+  await OnboardingSecureAppScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
 }
 
 /**

--- a/e2e/src/flows/onboarding.ts
+++ b/e2e/src/flows/onboarding.ts
@@ -38,23 +38,17 @@ export async function skipNotificationsIfShown(): Promise<void> {
   }
 }
 
-/**
- * Grace period for the OS notification-permission dialog to appear after `EnableNotifications`. The
- * system permission controller can take several seconds to surface on a loaded real device, well past
- * the helper's 5s default.
- */
+/** The OS permission controller can take several seconds to surface on a loaded real device. */
 const PERMISSION_DIALOG_APPEAR_MS = 15_000
 
 /**
- * Take the Notifications screen's `EnableNotifications` path and answer the OS permission dialog it
- * raises, ending on SecureApp (both answers advance).
+ * Take the Notifications screen's `EnableNotifications` path and answer the OS permission dialog,
+ * ending on SecureApp (both answers advance).
  *
- * The app does not wait for us: on Android its permission request self-resolves after ~2s (a
- * workaround for a React Native hang, see `PushNotificationsHelper.requestNotificationPermission`),
- * so it can navigate to SecureApp while the dialog is still up. That only affects what the app
- * *recorded*; the OS permission itself is decided by this dialog, and every branch that keys off it
- * (`PermissionDisabled`, the analytics screen's skip-Notifications shortcut) re-reads the live status.
- * So resolve the dialog first, then assert the destination.
+ * Resolve the dialog before asserting the destination: on Android the app's permission request
+ * self-resolves after ~2s (an RN hang workaround in `PushNotificationsHelper`), so it can navigate on
+ * while the dialog is still up. Only what the app *recorded* is affected — every branch keying off
+ * the permission re-reads the live OS status.
  */
 export async function answerNotificationPermission(decision: 'allow' | 'deny'): Promise<void> {
   await OnboardingNotificationsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)

--- a/e2e/src/flows/verify.ts
+++ b/e2e/src/flows/verify.ts
@@ -401,6 +401,11 @@ export async function collectNonBcscEvidence(
 /**
  * Fill the ResidentialAddress form (non-BCSC only) and continue → the mandatory email step. Province
  * is a dropdown: tap it to open the modal, then pick British Columbia.
+ *
+ * This screen is why {@link BaseScreen.dismissKeyboard} no longer blind-taps on iOS: the province
+ * dropdown lands under the old tap point once the keyboard-aware scroll has brought the postal-code
+ * field into view, so the "dismiss" opened the province modal instead and left Continue unreachable
+ * behind it (iOS 17 nightlies). Nothing here may dismiss the keyboard positionally.
  */
 export async function fillResidentialAddress(): Promise<void> {
   await ResidentialAddressScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
@@ -411,8 +416,24 @@ export async function fillResidentialAddress(): Promise<void> {
   await ResidentialAddressScreen.link('province')
   await ResidentialAddressScreen.waitFor('provinceBC', Timeouts.SCREEN_TRANSITION)
   await ResidentialAddressScreen.link('provinceBC')
+  await expectProvinceDropdownClosed()
 
   await ResidentialAddressScreen.fill('postalCode', 'V8W 2Y2', { tapFirst: true })
   await engine.dismissKeyboard()
   await ResidentialAddressScreen.tapWhenEnabled('primary') // ResidentialAddressContinue
+}
+
+/**
+ * Wait for the province dropdown's modal to close. The BC option exists ONLY inside that modal, so
+ * its disappearance is the signal. Worth asserting explicitly: with the modal still up, everything
+ * after it fails somewhere unrelated (an "unreachable" postal-code field, then an unreachable
+ * Continue) instead of naming the swallowed option tap.
+ */
+async function expectProvinceDropdownClosed(): Promise<void> {
+  const deadline = Date.now() + Timeouts.SCREEN_TRANSITION
+  do {
+    if (!(await ResidentialAddressScreen.isVisible('provinceBC'))) return
+    await driver.pause(250)
+  } while (Date.now() < deadline)
+  throw new Error('The province dropdown did not close after selecting British Columbia')
 }

--- a/e2e/src/flows/verify.ts
+++ b/e2e/src/flows/verify.ts
@@ -402,10 +402,9 @@ export async function collectNonBcscEvidence(
  * Fill the ResidentialAddress form (non-BCSC only) and continue → the mandatory email step. Province
  * is a dropdown: tap it to open the modal, then pick British Columbia.
  *
- * This screen is why {@link BaseScreen.dismissKeyboard} no longer blind-taps on iOS: the province
- * dropdown lands under the old tap point once the keyboard-aware scroll has brought the postal-code
- * field into view, so the "dismiss" opened the province modal instead and left Continue unreachable
- * behind it (iOS 17 nightlies). Nothing here may dismiss the keyboard positionally.
+ * This screen is why {@link BaseScreen.dismissKeyboard} no longer blind-taps on iOS: once the
+ * postal-code field is focused, the province dropdown sits under the old tap point, so the "dismiss"
+ * opened its modal and left Continue unreachable. Nothing here may dismiss the keyboard positionally.
  */
 export async function fillResidentialAddress(): Promise<void> {
   await ResidentialAddressScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
@@ -424,10 +423,9 @@ export async function fillResidentialAddress(): Promise<void> {
 }
 
 /**
- * Wait for the province dropdown's modal to close. The BC option exists ONLY inside that modal, so
- * its disappearance is the signal. Worth asserting explicitly: with the modal still up, everything
- * after it fails somewhere unrelated (an "unreachable" postal-code field, then an unreachable
- * Continue) instead of naming the swallowed option tap.
+ * Wait for the province dropdown's modal to close — the BC option exists only inside it, so its
+ * disappearance is the signal. Asserted explicitly so a swallowed option tap is named here rather
+ * than surfacing later as an unreachable postal-code field.
  */
 async function expectProvinceDropdownClosed(): Promise<void> {
   const deadline = Date.now() + Timeouts.SCREEN_TRANSITION

--- a/e2e/src/helpers/developer.ts
+++ b/e2e/src/helpers/developer.ts
@@ -3,39 +3,25 @@ import { DeveloperScreen } from '../screens/developer.js'
 import { swipeUpBy } from './gestures.js'
 
 /**
- * Reaching the hidden Developer (IAS) menu.
+ * Reaching the hidden Developer (IAS) menu, by tapping the version line in a Settings footer.
  *
- * The app exposes two triggers and only one of them is drivable:
+ * The app's other trigger — `DeveloperCounter` on the Intro illustration — is unusable: the same
+ * `Pressable` sets `accessibilityElementsHidden` / `importantForAccessibility="no-hide-descendants"`,
+ * so neither driver can see it.
  *
- *  - `DeveloperModeTrigger` (the Intro / AccountSetup illustration) carries testID `DeveloperCounter`,
- *    but the same `Pressable` sets `accessibilityElementsHidden` + `importantForAccessibility=
- *    "no-hide-descendants"`. Both drivers read the accessibility tree, so the node is not in the
- *    snapshot on either platform and no selector can reach it — only a blind coordinate tap could,
- *    which would be a screen-geometry bet, not a test.
- *  - The version line in every Settings footer (`SettingsContent`) is wrapped in a
- *    `TouchableWithoutFeedback`. Its child text nodes ARE in the tree, and a tap on a child is routed
- *    to the parent responder — so it is selectable, scrollable-to, and works identically on both
- *    platforms. That is the route implemented here.
- *
- * Enabling developer mode is a persisted preference change: the `DeveloperMode` settings row appears
- * for the rest of the session, and developer-gated surfaces elsewhere (e.g. the QRCore Display tab)
- * become reachable. Only use this on a journey whose remaining checkpoints tolerate that.
+ * Enabling developer mode persists: the `DeveloperMode` settings row and other dev-gated surfaces
+ * (e.g. the QRCore Display tab) stay available for the rest of the session.
  */
 
 /** bifold's `useDeveloperMode` fires on the tap AFTER its 10-touch threshold — so eleven, not ten. */
 const TAPS_TO_ENABLE_DEVELOPER_MODE = 11
 
-/** Top-up taps allowed if one of the eleven was swallowed mid-scroll. */
+/** Top-up taps allowed if one of the eleven was swallowed. */
 const MAX_EXTRA_TAPS = 4
 
-/** Swipes spent hunting the footer. The pre-auth settings surface often needs none. */
 const MAX_FOOTER_SCROLLS = 8
 
-/**
- * The footer's `Version <version> (<build>)` line. Matched by text prefix because the value is
- * build-dependent, and it is the only "Version …" string on a settings surface. The sibling
- * `BC Services Card` line is deliberately not used — that copy recurs elsewhere in the app.
- */
+/** The footer's `Version <version> (<build>)` line — prefix-matched, since the value is build-dependent. */
 async function versionFooter() {
   return driver.isIOS
     ? $('-ios predicate string:type == "XCUIElementTypeStaticText" AND label BEGINSWITH "Version "')
@@ -43,10 +29,8 @@ async function versionFooter() {
 }
 
 /**
- * Scroll the settings version footer into view.
- *
- * Also positions the `DeveloperMode` row (which sits directly above the footer) on screen, so an
- * absence assertion made after this call means "not rendered" rather than "below the fold".
+ * Scroll the settings version footer into view. Also brings the `DeveloperMode` row (directly above
+ * it) on screen, so an absence assertion after this means "not rendered", not "below the fold".
  */
 export async function scrollToSettingsVersionFooter(): Promise<void> {
   for (let scroll = 0; scroll < MAX_FOOTER_SCROLLS; scroll++) {
@@ -60,22 +44,18 @@ export async function scrollToSettingsVersionFooter(): Promise<void> {
 }
 
 /**
- * Open the Developer menu from the Settings surface currently on screen (works pre-auth on
- * `AuthSettings`/`OnboardingSettings` as well as on `MainSettings`).
- *
- * Leaves the Developer screen on top; the caller asserts and drives it.
+ * Open the Developer menu from whichever Settings surface is on screen (pre-auth `AuthSettings` /
+ * `OnboardingSettings` as well as `MainSettings`), leaving it on top for the caller.
  */
 export async function openDeveloperMenuFromSettings(): Promise<void> {
   await scrollToSettingsVersionFooter()
 
-  // The counter is a `useRef` on the mounted SettingsContent, so every tap has to land on this
-  // instance — no relaunching or re-navigating in between.
+  // The counter is a `useRef` on the mounted SettingsContent — every tap must land on this instance.
   for (let tap = 0; tap < TAPS_TO_ENABLE_DEVELOPER_MODE; tap++) {
     await (await versionFooter()).click()
   }
 
-  // A swallowed tap only under-counts (taps below the threshold do nothing but increment), so top up
-  // until the menu is on top. Once it opens the footer is gone and the loop exits on the check.
+  // A swallowed tap only under-counts, so top up until the menu opens.
   for (let extra = 0; extra < MAX_EXTRA_TAPS; extra++) {
     if (await DeveloperScreen.isPresent(Timeouts.ELEMENT_VISIBLE)) return
     await (await versionFooter()).click()

--- a/e2e/src/helpers/developer.ts
+++ b/e2e/src/helpers/developer.ts
@@ -1,0 +1,85 @@
+import { Timeouts } from '../constants.js'
+import { DeveloperScreen } from '../screens/developer.js'
+import { swipeUpBy } from './gestures.js'
+
+/**
+ * Reaching the hidden Developer (IAS) menu.
+ *
+ * The app exposes two triggers and only one of them is drivable:
+ *
+ *  - `DeveloperModeTrigger` (the Intro / AccountSetup illustration) carries testID `DeveloperCounter`,
+ *    but the same `Pressable` sets `accessibilityElementsHidden` + `importantForAccessibility=
+ *    "no-hide-descendants"`. Both drivers read the accessibility tree, so the node is not in the
+ *    snapshot on either platform and no selector can reach it — only a blind coordinate tap could,
+ *    which would be a screen-geometry bet, not a test.
+ *  - The version line in every Settings footer (`SettingsContent`) is wrapped in a
+ *    `TouchableWithoutFeedback`. Its child text nodes ARE in the tree, and a tap on a child is routed
+ *    to the parent responder — so it is selectable, scrollable-to, and works identically on both
+ *    platforms. That is the route implemented here.
+ *
+ * Enabling developer mode is a persisted preference change: the `DeveloperMode` settings row appears
+ * for the rest of the session, and developer-gated surfaces elsewhere (e.g. the QRCore Display tab)
+ * become reachable. Only use this on a journey whose remaining checkpoints tolerate that.
+ */
+
+/** bifold's `useDeveloperMode` fires on the tap AFTER its 10-touch threshold — so eleven, not ten. */
+const TAPS_TO_ENABLE_DEVELOPER_MODE = 11
+
+/** Top-up taps allowed if one of the eleven was swallowed mid-scroll. */
+const MAX_EXTRA_TAPS = 4
+
+/** Swipes spent hunting the footer. The pre-auth settings surface often needs none. */
+const MAX_FOOTER_SCROLLS = 8
+
+/**
+ * The footer's `Version <version> (<build>)` line. Matched by text prefix because the value is
+ * build-dependent, and it is the only "Version …" string on a settings surface. The sibling
+ * `BC Services Card` line is deliberately not used — that copy recurs elsewhere in the app.
+ */
+async function versionFooter() {
+  return driver.isIOS
+    ? $('-ios predicate string:type == "XCUIElementTypeStaticText" AND label BEGINSWITH "Version "')
+    : $('android=new UiSelector().textStartsWith("Version ")')
+}
+
+/**
+ * Scroll the settings version footer into view.
+ *
+ * Also positions the `DeveloperMode` row (which sits directly above the footer) on screen, so an
+ * absence assertion made after this call means "not rendered" rather than "below the fold".
+ */
+export async function scrollToSettingsVersionFooter(): Promise<void> {
+  for (let scroll = 0; scroll < MAX_FOOTER_SCROLLS; scroll++) {
+    const footer = await versionFooter()
+    if (await footer.isDisplayed().catch(() => false)) return
+    await swipeUpBy(0.4)
+    await driver.pause(150)
+  }
+  const footer = await versionFooter()
+  await footer.waitForDisplayed({ timeout: Timeouts.ELEMENT_VISIBLE })
+}
+
+/**
+ * Open the Developer menu from the Settings surface currently on screen (works pre-auth on
+ * `AuthSettings`/`OnboardingSettings` as well as on `MainSettings`).
+ *
+ * Leaves the Developer screen on top; the caller asserts and drives it.
+ */
+export async function openDeveloperMenuFromSettings(): Promise<void> {
+  await scrollToSettingsVersionFooter()
+
+  // The counter is a `useRef` on the mounted SettingsContent, so every tap has to land on this
+  // instance — no relaunching or re-navigating in between.
+  for (let tap = 0; tap < TAPS_TO_ENABLE_DEVELOPER_MODE; tap++) {
+    await (await versionFooter()).click()
+  }
+
+  // A swallowed tap only under-counts (taps below the threshold do nothing but increment), so top up
+  // until the menu is on top. Once it opens the footer is gone and the loop exits on the check.
+  for (let extra = 0; extra < MAX_EXTRA_TAPS; extra++) {
+    if (await DeveloperScreen.isPresent(Timeouts.ELEMENT_VISIBLE)) return
+    await (await versionFooter()).click()
+  }
+
+  await DeveloperScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+}

--- a/e2e/src/screens/auth.ts
+++ b/e2e/src/screens/auth.ts
@@ -12,10 +12,28 @@ import { bcsc, defineScreen } from './core/index.js'
 
 const auth = TestIds.auth
 
-/** Returning-user landing. `primary` (Unlock) → EnterPIN. */
+/** Returning-user landing. `primary` (Unlock) → EnterPIN · `menu` (header-left) → AuthSettings. */
 export const AccountLandingScreen = defineScreen({
   self: bcsc(auth.accountLanding.unlock),
   primary: bcsc(auth.accountLanding.unlock),
+  menu: bcsc(auth.accountLanding.settings),
+})
+
+/**
+ * Pre-authentication settings (`AuthSettings`, the AccountLanding header-left destination). Wraps the
+ * same `SettingsContent` as Main/Onboarding, but `didAuthenticate` is still false here so the whole
+ * `AuthenticatedSection` (AppSecurity/ChangePIN/AutoLock/…) is ABSENT — the always-rendered Help
+ * section's `ContactUs` row is the arrival marker, as on the onboarding settings surface.
+ *
+ * NB no `back` role: AuthStack sets no `headerBackTestID` (see the note at the foot of this file), so
+ * leave this surface by relaunching rather than by tapping the header.
+ */
+export const AuthSettingsScreen = defineScreen({
+  self: bcsc(TestIds.main.settings.contactUs),
+  links: {
+    // Absent until the footer version line is tapped into developer mode (see `helpers/developer.ts`).
+    developerMode: bcsc(TestIds.main.settings.developerMode),
+  },
 })
 
 /**

--- a/e2e/src/screens/auth.ts
+++ b/e2e/src/screens/auth.ts
@@ -20,13 +20,12 @@ export const AccountLandingScreen = defineScreen({
 })
 
 /**
- * Pre-authentication settings (`AuthSettings`, the AccountLanding header-left destination). Wraps the
- * same `SettingsContent` as Main/Onboarding, but `didAuthenticate` is still false here so the whole
- * `AuthenticatedSection` (AppSecurity/ChangePIN/AutoLock/…) is ABSENT — the always-rendered Help
- * section's `ContactUs` row is the arrival marker, as on the onboarding settings surface.
+ * Pre-authentication settings (`AuthSettings`, the AccountLanding header-left destination). Same
+ * `SettingsContent` as Main/Onboarding, but `didAuthenticate` is still false so the whole
+ * `AuthenticatedSection` is ABSENT; the always-rendered `ContactUs` row is the arrival marker.
  *
- * NB no `back` role: AuthStack sets no `headerBackTestID` (see the note at the foot of this file), so
- * leave this surface by relaunching rather than by tapping the header.
+ * No `back` role — AuthStack sets no `headerBackTestID` (see the note at the foot of this file), so
+ * leave this surface by relaunching.
  */
 export const AuthSettingsScreen = defineScreen({
   self: bcsc(TestIds.main.settings.contactUs),

--- a/e2e/src/screens/core/BaseScreen.ts
+++ b/e2e/src/screens/core/BaseScreen.ts
@@ -17,6 +17,18 @@ const STEADY_POSITION_SAMPLE_MS = 120
 const IOS_KEYBOARD_DISMISS_KEYS = ['done', 'Done', 'return', 'Return', 'go', 'Go', 'next', 'Next', 'search', 'Search']
 
 /**
+ * Escape a value before it is embedded in a quoted iOS predicate / UiSelector string. Both parsers
+ * take the same two escapes, so one helper covers them. Without it a quote or backslash in localized
+ * copy produces an invalid selector rather than a miss. (Mirrors `escapeIosSelectorValue` in
+ * `helpers/alerts.ts`, which escapes alert-button labels for the same reason.)
+ */
+function escapeSelectorValue(value: string): string {
+  const backslash = String.fromCodePoint(0x5c)
+  const doubleQuote = String.fromCodePoint(0x22)
+  return value.replaceAll(backslash, `${backslash}${backslash}`).replaceAll(doubleQuote, `${backslash}${doubleQuote}`)
+}
+
+/**
  * The bit of an element {@link BaseScreen.waitForSteadyPosition} needs — structural so it accepts both a
  * resolved `WebdriverIO.Element` (from `$$`) and the chainable handle `findByTestId` returns.
  */
@@ -145,9 +157,10 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
    * @returns the element
    */
   public async findByText(text: string) {
+    const value = escapeSelectorValue(text)
     const selector = driver.isIOS
-      ? `-ios predicate string:label == "${text}" OR value == "${text}"`
-      : `android=new UiSelector().text("${text}")`
+      ? `-ios predicate string:label == "${value}" OR value == "${value}"`
+      : `android=new UiSelector().text("${value}")`
     return $(selector)
   }
 

--- a/e2e/src/screens/core/BaseScreen.ts
+++ b/e2e/src/screens/core/BaseScreen.ts
@@ -153,6 +153,37 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
     return $(selector)
   }
 
+  /** True if an element with the given visible text is displayed; never throws. */
+  public async isTextDisplayed(text: string): Promise<boolean> {
+    const el = await this.findByText(text)
+    try {
+      return await el.isDisplayed()
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * Wait for an element by its visible TEXT — the counterpart of {@link waitForDisplayed} for the
+   * inline errors, headings and menu titles that carry no testID, scroll-on-miss included.
+   *
+   * The scroll hunt is the point. A bare `findByText(...).waitForDisplayed()` asserts only what is
+   * currently on screen, which is a different claim from "the app rendered this": a keyboard-aware
+   * form scrolls to keep the FOCUSED field clear of the keyboard, so text attached to any other
+   * field can sit above the fold while being perfectly well rendered. That is what broke the
+   * CreatePIN too-short assertion — the error belongs to the first PIN field while the second one
+   * held focus.
+   */
+  public async waitForText(text: string, timeout: number = Timeouts.ELEMENT_VISIBLE): Promise<void> {
+    const el = await this.findByText(text)
+    try {
+      await el.waitForDisplayed({ timeout })
+    } catch {
+      console.warn(`Text "${text}" not visible after ${timeout}ms; scrolling then retrying`)
+      await this.scrollUntilVisible(`Text "${text}"`, () => this.isTextDisplayed(text), 4, 'both')
+    }
+  }
+
   /**
    * Find an element by test ID.
    * @param testId - test ID to find
@@ -427,15 +458,23 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
    * @param directions - `down` scrolls toward content below; `both` tries down then up
    */
   public async scrollToTestId(testId: string, maxScrolls = 8, directions: 'down' | 'both' = 'down') {
-    const isVisible = async () => {
-      const candidate = await this.findByTestId(testId)
-      try {
-        return await candidate.isDisplayed()
-      } catch {
-        return false
-      }
-    }
+    await this.scrollUntilVisible(`Element "${testId}"`, () => this.isTestIdDisplayed(testId), maxScrolls, directions)
+  }
 
+  /**
+   * Swipe until a target becomes visible. Shared by the testID and visible-text hunts, which differ
+   * only in how they locate the target — `isVisible` re-queries on every pass, so a handle
+   * invalidated by the scroll does not poison the search.
+   *
+   * @param description - how the target is named in the failure message
+   * @param isVisible - cheap, non-throwing "is it on screen" probe
+   */
+  private async scrollUntilVisible(
+    description: string,
+    isVisible: () => Promise<boolean>,
+    maxScrolls: number,
+    directions: 'down' | 'both'
+  ): Promise<void> {
     if (await isVisible()) return
 
     // An open keyboard both hides the lower half of the screen and turns the swipes below into
@@ -462,7 +501,7 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
     }
 
     throw new Error(
-      `Element "${testId}" not visible after ${maxScrolls} scroll attempt(s)` +
+      `${description} not visible after ${maxScrolls} scroll attempt(s)` +
         (directions === 'both' ? ' in each direction' : '')
     )
   }

--- a/e2e/src/screens/core/BaseScreen.ts
+++ b/e2e/src/screens/core/BaseScreen.ts
@@ -11,6 +11,14 @@ const STEADY_POSITION_TIMEOUT_MS = 3_000
 const STEADY_POSITION_SAMPLE_MS = 120
 
 /**
+ * Keys XCUITest may press to close the iOS keyboard, tried in order. Case matters — these are the
+ * rendered key labels, and iOS uses lower case on the alphabetic keyboard's return key but title
+ * case on the accessory keys. None of the app's inputs set `onSubmitEditing`, so pressing any of
+ * them only blurs the field.
+ */
+const IOS_KEYBOARD_DISMISS_KEYS = ['done', 'Done', 'return', 'Return', 'go', 'Go', 'next', 'Next', 'search', 'Search']
+
+/**
  * The bit of an element {@link BaseScreen.waitForSteadyPosition} needs — structural so it accepts both a
  * resolved `WebdriverIO.Element` (from `$$`) and the chainable handle `findByTestId` returns.
  */
@@ -286,15 +294,42 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
   }
 
   /**
-   * Dismiss the soft keyboard using platform-native commands (no test IDs needed).
-   * Call before tapping buttons when the keyboard may be covering them.
+   * Dismiss the soft keyboard without ever touching the app's own UI.
+   *
+   * iOS used to do this with a blind tap a quarter of the way down the screen, relying on the form's
+   * scroll view to swallow it (`keyboardShouldPersistTaps: 'handled'` in bifold's `KeyboardView`, so
+   * a tap NOT handled by a child closes the keyboard). That only holds while nothing interactive sits
+   * under the point — and on iOS 17 nightlies it didn't: with the postal-code field focused, the
+   * keyboard-aware scroll puts ResidentialAddress's province dropdown right at that coordinate, so
+   * "dismiss the keyboard" opened the province modal, the tap was handled (so the keyboard stayed),
+   * and the journey stranded with Continue unreachable behind the modal. There is no safe coordinate
+   * to move to either: every `InputWithValidation` carries a 44px hitSlop, so the gaps between fields
+   * are live too. The blind tap had to go, not move.
+   *
+   * What replaces it only ever addresses the keyboard itself: press one of its own dismissal keys.
+   * Number pads (the birthdate and email-confirmation inputs) have no such key, and there the
+   * keyboard is simply left up — which is safe, because every form that calls this renders through
+   * `ScreenWrapper keyboardActive`, laying its controls out ABOVE the keyboard, and `tapWhenEnabled`
+   * scroll-retries if a target still isn't visible.
    */
   async dismissKeyboard() {
-    if (driver.isIOS) {
-      const { width, height } = await driver.getWindowSize()
-      await driver.execute('mobile: tap', { x: Math.round(width / 2), y: Math.round(height / 4) })
-    } else {
-      await driver.hideKeyboard()
+    // A probe failure must not skip the dismissal, so an unreadable state is treated as "shown".
+    if (!(await driver.isKeyboardShown().catch(() => true))) return
+
+    if (driver.isAndroid) {
+      await driver.hideKeyboard().catch(() => undefined)
+      await driver.pause(300) // let the layout settle as the keyboard collapses
+      return
+    }
+
+    try {
+      // Proxies to WDA's /wda/keyboard/dismiss, which taps the first of these keys the keyboard has
+      // and throws when it has none — so a failure here is "no dismissal key", not "command missing".
+      await driver.execute('mobile: hideKeyboard', { keys: IOS_KEYBOARD_DISMISS_KEYS })
+      await driver.pause(300) // let the layout settle as the keyboard collapses
+    } catch {
+      // No dismissal key on this keyboard (number pad). Leaving it open beats tapping the form.
+      console.warn('[keyboard] No iOS dismissal key available; leaving the keyboard open')
     }
   }
 
@@ -304,9 +339,10 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
    * reads the drag as gesture input and TYPES into the still-focused field (observed on a Pixel 7 Pro:
    * a scroll hunt for the next input appended " TY TY TY TY" to the just-filled last-name field).
    *
-   * Android-only by design: iOS has no `hideKeyboard`, its `dismissKeyboard` is a blind tap that could
-   * press a real control if fired speculatively, and its forms keep the focused field clear of the
-   * keyboard on their own. Never throws — a keyboard probe must not fail the caller's real action.
+   * Android-only by design: this exists for the glide-typing hazard above, which is a Gboard
+   * behaviour with no iOS equivalent — iOS forms keep the focused field clear of the keyboard on
+   * their own, and {@link dismissKeyboard} covers the cases that genuinely need it there. Never
+   * throws — a keyboard probe must not fail the caller's real action.
    */
   public async hideAndroidKeyboardIfShown(): Promise<void> {
     if (!driver.isAndroid) return

--- a/e2e/src/screens/core/BaseScreen.ts
+++ b/e2e/src/screens/core/BaseScreen.ts
@@ -11,10 +11,8 @@ const STEADY_POSITION_TIMEOUT_MS = 3_000
 const STEADY_POSITION_SAMPLE_MS = 120
 
 /**
- * Keys XCUITest may press to close the iOS keyboard, tried in order. Case matters — these are the
- * rendered key labels, and iOS uses lower case on the alphabetic keyboard's return key but title
- * case on the accessory keys. None of the app's inputs set `onSubmitEditing`, so pressing any of
- * them only blurs the field.
+ * Keys XCUITest may press to close the iOS keyboard, tried in order — rendered key labels, so case
+ * matters. No app input sets `onSubmitEditing`, so pressing one only blurs the field.
  */
 const IOS_KEYBOARD_DISMISS_KEYS = ['done', 'Done', 'return', 'Return', 'go', 'Go', 'next', 'Next', 'search', 'Search']
 
@@ -167,12 +165,9 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
    * Wait for an element by its visible TEXT — the counterpart of {@link waitForDisplayed} for the
    * inline errors, headings and menu titles that carry no testID, scroll-on-miss included.
    *
-   * The scroll hunt is the point. A bare `findByText(...).waitForDisplayed()` asserts only what is
-   * currently on screen, which is a different claim from "the app rendered this": a keyboard-aware
-   * form scrolls to keep the FOCUSED field clear of the keyboard, so text attached to any other
-   * field can sit above the fold while being perfectly well rendered. That is what broke the
-   * CreatePIN too-short assertion — the error belongs to the first PIN field while the second one
-   * held focus.
+   * The hunt matters: a bare `findByText(...).waitForDisplayed()` only asserts what is currently in
+   * the viewport, and a keyboard-aware form scrolls to keep the FOCUSED field clear — pushing
+   * another field's text above the fold while it is perfectly well rendered.
    */
   public async waitForText(text: string, timeout: number = Timeouts.ELEMENT_VISIBLE): Promise<void> {
     const el = await this.findByText(text)
@@ -325,26 +320,20 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
   }
 
   /**
-   * Dismiss the soft keyboard without ever touching the app's own UI.
+   * Dismiss the soft keyboard without ever touching the app's own UI — press one of the keyboard's
+   * own dismissal keys.
    *
-   * iOS used to do this with a blind tap a quarter of the way down the screen, relying on the form's
-   * scroll view to swallow it (`keyboardShouldPersistTaps: 'handled'` in bifold's `KeyboardView`, so
-   * a tap NOT handled by a child closes the keyboard). That only holds while nothing interactive sits
-   * under the point — and on iOS 17 nightlies it didn't: with the postal-code field focused, the
-   * keyboard-aware scroll puts ResidentialAddress's province dropdown right at that coordinate, so
-   * "dismiss the keyboard" opened the province modal, the tap was handled (so the keyboard stayed),
-   * and the journey stranded with Continue unreachable behind the modal. There is no safe coordinate
-   * to move to either: every `InputWithValidation` carries a 44px hitSlop, so the gaps between fields
-   * are live too. The blind tap had to go, not move.
+   * iOS used to blind-tap a quarter down the screen and let the form's scroll view swallow it. That
+   * only works while nothing interactive sits there: on iOS 17 it landed on ResidentialAddress's
+   * province dropdown, opening the modal and stranding the journey. No coordinate is safe —
+   * `InputWithValidation`'s 44px hitSlop makes the gaps between fields live too.
    *
-   * What replaces it only ever addresses the keyboard itself: press one of its own dismissal keys.
-   * Number pads (the birthdate and email-confirmation inputs) have no such key, and there the
-   * keyboard is simply left up — which is safe, because every form that calls this renders through
-   * `ScreenWrapper keyboardActive`, laying its controls out ABOVE the keyboard, and `tapWhenEnabled`
-   * scroll-retries if a target still isn't visible.
+   * Number pads (birthdate, email code) have no dismissal key, so the keyboard is left up. That is
+   * fine: every form calling this uses `ScreenWrapper keyboardActive`, which lays its controls out
+   * above the keyboard.
    */
   async dismissKeyboard() {
-    // A probe failure must not skip the dismissal, so an unreadable state is treated as "shown".
+    // An unreadable probe counts as "shown" — better to attempt a (now harmless) dismissal.
     if (!(await driver.isKeyboardShown().catch(() => true))) return
 
     if (driver.isAndroid) {
@@ -354,12 +343,10 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
     }
 
     try {
-      // Proxies to WDA's /wda/keyboard/dismiss, which taps the first of these keys the keyboard has
-      // and throws when it has none — so a failure here is "no dismissal key", not "command missing".
+      // Throws when the keyboard has none of these keys — not when the command is missing.
       await driver.execute('mobile: hideKeyboard', { keys: IOS_KEYBOARD_DISMISS_KEYS })
-      await driver.pause(300) // let the layout settle as the keyboard collapses
+      await driver.pause(300)
     } catch {
-      // No dismissal key on this keyboard (number pad). Leaving it open beats tapping the form.
       console.warn('[keyboard] No iOS dismissal key available; leaving the keyboard open')
     }
   }
@@ -370,10 +357,9 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
    * reads the drag as gesture input and TYPES into the still-focused field (observed on a Pixel 7 Pro:
    * a scroll hunt for the next input appended " TY TY TY TY" to the just-filled last-name field).
    *
-   * Android-only by design: this exists for the glide-typing hazard above, which is a Gboard
-   * behaviour with no iOS equivalent — iOS forms keep the focused field clear of the keyboard on
-   * their own, and {@link dismissKeyboard} covers the cases that genuinely need it there. Never
-   * throws — a keyboard probe must not fail the caller's real action.
+   * Android-only: the glide-typing hazard is a Gboard behaviour with no iOS equivalent, and
+   * {@link dismissKeyboard} covers the iOS cases that need it. Never throws — a keyboard probe must
+   * not fail the caller's real action.
    */
   public async hideAndroidKeyboardIfShown(): Promise<void> {
     if (!driver.isAndroid) return
@@ -462,9 +448,8 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
   }
 
   /**
-   * Swipe until a target becomes visible. Shared by the testID and visible-text hunts, which differ
-   * only in how they locate the target — `isVisible` re-queries on every pass, so a handle
-   * invalidated by the scroll does not poison the search.
+   * Swipe until a target becomes visible — shared by the testID and visible-text hunts. `isVisible`
+   * re-queries each pass, so a handle invalidated by the scroll doesn't poison the search.
    *
    * @param description - how the target is named in the failure message
    * @param isVisible - cheap, non-throwing "is it on screen" probe

--- a/e2e/src/screens/developer.ts
+++ b/e2e/src/screens/developer.ts
@@ -3,11 +3,8 @@ import { bcsc, defineScreen } from './core/index.js'
 
 /**
  * The hidden Developer (IAS) menu — one component registered once per stack (`OnboardingDeveloper` /
- * `AuthDeveloper` / `VerifyDeveloper` / `MainDeveloper`), so the same descriptor serves all four.
- *
- * Reached by tapping the version line in a Settings footer (see `helpers/developer.ts`); the app's
- * other trigger — the `DeveloperCounter` wrapping the Intro illustration — is excluded from the
- * accessibility tree and cannot be selected by either driver.
+ * `AuthDeveloper` / `VerifyDeveloper` / `MainDeveloper`), so this descriptor serves all four.
+ * Reached via the Settings version footer (see `helpers/developer.ts`).
  */
 
 const dev = TestIds.developer
@@ -21,12 +18,11 @@ export const DeveloperScreen = defineScreen({
   links: {
     /** Opens the IAS environment modal. Switching environments invalidates the session's account. */
     environment: bcsc(dev.environment),
-    /** Backdates the accepted terms version → the re-acceptance modal on the next MainStack mount. */
+    /** Backdates the accepted terms version → re-acceptance modal on the next MainStack mount. */
     staleTermsOfUse: bcsc(dev.staleTermsOfUse),
     /** Clears `hasSeenOnboardingIntro`; takes effect on the next AuthStack mount, i.e. after a relaunch. */
     resetOnboardingIntro: bcsc(dev.resetOnboardingIntro),
-    /** Deletes the native refresh/registration/access tokens (a verified account then hydrates into
-     *  `sessionRecoveryRequired` — see the SessionRecovery note in the UAT-12 ticket). */
+    /** Deletes the native refresh/registration/access tokens. */
     deleteTokens: bcsc(dev.deleteTokens),
   },
 })

--- a/e2e/src/screens/developer.ts
+++ b/e2e/src/screens/developer.ts
@@ -1,0 +1,32 @@
+import { TestIds } from '../test-ids/registry.js'
+import { bcsc, defineScreen } from './core/index.js'
+
+/**
+ * The hidden Developer (IAS) menu — one component registered once per stack (`OnboardingDeveloper` /
+ * `AuthDeveloper` / `VerifyDeveloper` / `MainDeveloper`), so the same descriptor serves all four.
+ *
+ * Reached by tapping the version line in a Settings footer (see `helpers/developer.ts`); the app's
+ * other trigger — the `DeveloperCounter` wrapping the Intro illustration — is excluded from the
+ * accessibility tree and cannot be selected by either driver.
+ */
+
+const dev = TestIds.developer
+const { common } = TestIds
+
+export const DeveloperScreen = defineScreen({
+  self: bcsc(dev.toggleDeveloper),
+  // Resolves in the Onboarding/Verify/Main stacks, which set `headerBackTestID`. AuthStack does NOT
+  // (its back button renders testID `String(undefined)`) — leave `AuthDeveloper` by relaunching.
+  back: bcsc(common.back),
+  links: {
+    /** Opens the IAS environment modal. Switching environments invalidates the session's account. */
+    environment: bcsc(dev.environment),
+    /** Backdates the accepted terms version → the re-acceptance modal on the next MainStack mount. */
+    staleTermsOfUse: bcsc(dev.staleTermsOfUse),
+    /** Clears `hasSeenOnboardingIntro`; takes effect on the next AuthStack mount, i.e. after a relaunch. */
+    resetOnboardingIntro: bcsc(dev.resetOnboardingIntro),
+    /** Deletes the native refresh/registration/access tokens (a verified account then hydrates into
+     *  `sessionRecoveryRequired` — see the SessionRecovery note in the UAT-12 ticket). */
+    deleteTokens: bcsc(dev.deleteTokens),
+  },
+})

--- a/e2e/src/screens/main.ts
+++ b/e2e/src/screens/main.ts
@@ -122,6 +122,7 @@ export const SettingsScreen = defineScreen({
     profile: bcsc(main.settings.profile), // verified-only → AccountDetails; isVisible spans links, so the unverified absence-assert still holds
     myDevices: bcsc(main.settings.myDevices), // verified-only → in-app WebView (server-rendered device list)
     resetWallet: bcsc(main.settings.resetWallet), // always present → shared DestructiveConfirmationScreen
+    developerMode: bcsc(main.settings.developerMode), // absent until developer mode is enabled
   },
 })
 

--- a/e2e/src/screens/onboarding.ts
+++ b/e2e/src/screens/onboarding.ts
@@ -81,6 +81,27 @@ export const OnboardingNotificationsScreen = defineScreen({
 })
 
 /**
+ * The `PermissionDisabled` variant of the SAME `OnboardingNotifications` route: it replaces the
+ * enable/skip body once the user has been prompted at least once and the live OS status is
+ * denied/blocked. The check runs on mount, so it is reached by leaving the screen after a declined
+ * permission dialog and navigating back to it (SecureApp's header `back`).
+ *
+ * `primary` (OpenSettings) leaves the app for the OS settings — assert it, never tap it in CI.
+ * `secondary` (ContinueWithoutNotifications) is the in-app way forward → SecureApp.
+ */
+export const OnboardingNotificationsDisabledScreen = defineScreen({
+  self: bcsc(ob.notifications.continueWithout),
+  primary: bcsc(ob.notifications.openSettings),
+  secondary: bcsc(ob.notifications.continueWithout),
+  back: bcsc(common.back),
+  help: bcsc(common.help),
+  elements: {
+    openSettings: bcsc(ob.notifications.openSettings),
+    continueWithout: bcsc(ob.notifications.continueWithout),
+  },
+})
+
+/**
  * "Secure your app" selector (`OnboardingSecureApp`, rendered by `SecurityMethodSelector`). The
  * `deviceAuth` link only appears when the device/emulator has biometrics or a passcode configured;
  * `primary` (ChoosePINButton) is always present, so it is the reliable `self`.
@@ -154,4 +175,8 @@ export const OnboardingWebViewScreen = defineScreen({
 export const OnboardingSettingsScreen = defineScreen({
   self: bcsc(TestIds.main.settings.contactUs),
   back: bcsc(common.back),
+  links: {
+    // Absent until the footer version line is tapped into developer mode (see `helpers/developer.ts`).
+    developerMode: bcsc(TestIds.main.settings.developerMode),
+  },
 })

--- a/e2e/src/screens/onboarding.ts
+++ b/e2e/src/screens/onboarding.ts
@@ -81,13 +81,12 @@ export const OnboardingNotificationsScreen = defineScreen({
 })
 
 /**
- * The `PermissionDisabled` variant of the SAME `OnboardingNotifications` route: it replaces the
- * enable/skip body once the user has been prompted at least once and the live OS status is
- * denied/blocked. The check runs on mount, so it is reached by leaving the screen after a declined
- * permission dialog and navigating back to it (SecureApp's header `back`).
+ * The `PermissionDisabled` variant of the SAME `OnboardingNotifications` route — it replaces the
+ * enable/skip body once the user has been prompted and the live OS status is denied/blocked. The
+ * check runs on mount, so it is reached by navigating BACK to the screen after refusing the dialog.
  *
- * `primary` (OpenSettings) leaves the app for the OS settings — assert it, never tap it in CI.
- * `secondary` (ContinueWithoutNotifications) is the in-app way forward → SecureApp.
+ * `primary` (OpenSettings) leaves the app for the OS settings — assert it, never tap it in CI;
+ * `secondary` (ContinueWithoutNotifications) → SecureApp.
  */
 export const OnboardingNotificationsDisabledScreen = defineScreen({
   self: bcsc(ob.notifications.continueWithout),

--- a/e2e/src/test-ids/registry.ts
+++ b/e2e/src/test-ids/registry.ts
@@ -52,9 +52,8 @@ export const TestIds = {
     notifications: {
       enable: 'EnableNotifications',
       skip: 'SkipNotifications',
-      // The same route renders a `PermissionDisabled` variant INSTEAD of the enable/skip pair once
-      // the user has been prompted at least once AND the live OS status is denied/blocked
-      // (`NotificationsScreen.checkPermissions`). Re-entering the screen is what re-runs that check.
+      // The same route renders a `PermissionDisabled` variant INSTEAD of the enable/skip pair once the
+      // user has been prompted and the live OS status is denied/blocked. Re-entering re-runs the check.
       openSettings: 'OpenSettings',
       continueWithout: 'ContinueWithoutNotifications',
     },
@@ -322,8 +321,7 @@ export const TestIds = {
       accessibility: 'Accessibility',
       termsOfUse: 'TermsOfUse',
       privacy: 'Privacy',
-      // Hidden until developer mode is enabled (see the `developer` namespace) — absent by default,
-      // so it doubles as the "the dev menu stays hidden" assertion on any stack's settings surface.
+      // Hidden until developer mode is enabled — so its absence is itself an assertion.
       developerMode: 'DeveloperMode',
       // verified-only (isVerified-gated): absence-assert unverified, presence when verified
       profile: 'Profile',
@@ -441,16 +439,9 @@ export const TestIds = {
 
   /**
    * The hidden Developer (IAS) menu — ONE shared `Developer` screen registered per stack
-   * (`OnboardingDeveloper` / `AuthDeveloper` / `VerifyDeveloper` / `MainDeveloper`).
-   *
-   * Two entry points exist in the app; only the second is addressable from a test:
-   *  - the `DeveloperCounter` tap target wrapping the Intro / AccountSetup illustration — it carries a
-   *    testID but ALSO `accessibilityElementsHidden` / `importantForAccessibility="no-hide-descendants"`,
-   *    so it is absent from both the XCUITest and UiAutomator2 trees and cannot be selected;
-   *  - the version line in the footer of any Settings surface (`SettingsContent`), which is a plain
-   *    text node — see `helpers/developer.ts`.
-   *
-   * The `Testing` section (stale terms / reset intro / delete tokens) renders in BCSC mode only.
+   * (`OnboardingDeveloper` / `AuthDeveloper` / `VerifyDeveloper` / `MainDeveloper`). Reached only via
+   * the Settings version footer (`helpers/developer.ts`); the app's `DeveloperCounter` trigger is
+   * hidden from the accessibility tree and cannot be selected. `Testing` rows are BCSC-mode only.
    */
   developer: {
     /** Always-rendered first row — the reliable "Developer screen mounted" marker. */

--- a/e2e/src/test-ids/registry.ts
+++ b/e2e/src/test-ids/registry.ts
@@ -52,6 +52,11 @@ export const TestIds = {
     notifications: {
       enable: 'EnableNotifications',
       skip: 'SkipNotifications',
+      // The same route renders a `PermissionDisabled` variant INSTEAD of the enable/skip pair once
+      // the user has been prompted at least once AND the live OS status is denied/blocked
+      // (`NotificationsScreen.checkPermissions`). Re-entering the screen is what re-runs that check.
+      openSettings: 'OpenSettings',
+      continueWithout: 'ContinueWithoutNotifications',
     },
     secureApp: {
       choosePin: 'ChoosePINButton',
@@ -74,9 +79,11 @@ export const TestIds = {
   },
 
   auth: {
-    /** Returning-user landing — the unlock entry every cold start of an onboarded user hits. */
+    /** Returning-user landing — the unlock entry every cold start of an onboarded user hits.
+     *  `settings` is its header-left menu button → the PRE-authentication `AuthSettings` surface. */
     accountLanding: {
       unlock: 'Unlock',
+      settings: 'SettingsMenuButton',
     },
     /** Existing-PIN entry (`EnterPIN`). The PIN auto-submits on the 6th digit; Continue is the manual fallback. */
     enterPin: {
@@ -315,6 +322,9 @@ export const TestIds = {
       accessibility: 'Accessibility',
       termsOfUse: 'TermsOfUse',
       privacy: 'Privacy',
+      // Hidden until developer mode is enabled (see the `developer` namespace) — absent by default,
+      // so it doubles as the "the dev menu stays hidden" assertion on any stack's settings surface.
+      developerMode: 'DeveloperMode',
       // verified-only (isVerified-gated): absence-assert unverified, presence when verified
       profile: 'Profile',
       editProfile: 'EditProfile',
@@ -427,6 +437,31 @@ export const TestIds = {
       dateOfBirthField: 'DateOfBirthField',
       emailField: 'EmailAddressField',
     },
+  },
+
+  /**
+   * The hidden Developer (IAS) menu — ONE shared `Developer` screen registered per stack
+   * (`OnboardingDeveloper` / `AuthDeveloper` / `VerifyDeveloper` / `MainDeveloper`).
+   *
+   * Two entry points exist in the app; only the second is addressable from a test:
+   *  - the `DeveloperCounter` tap target wrapping the Intro / AccountSetup illustration — it carries a
+   *    testID but ALSO `accessibilityElementsHidden` / `importantForAccessibility="no-hide-descendants"`,
+   *    so it is absent from both the XCUITest and UiAutomator2 trees and cannot be selected;
+   *  - the version line in the footer of any Settings surface (`SettingsContent`), which is a plain
+   *    text node — see `helpers/developer.ts`.
+   *
+   * The `Testing` section (stale terms / reset intro / delete tokens) renders in BCSC mode only.
+   */
+  developer: {
+    /** Always-rendered first row — the reliable "Developer screen mounted" marker. */
+    toggleDeveloper: 'ToggleDeveloper',
+    /** i18n-DERIVED: `testIdWithKey(t('Developer.Environment').toLowerCase())` — breaks under a locale change. */
+    environment: 'environment',
+    staleTermsOfUse: 'StaleTermsOfUse',
+    /** Clears `hasSeenOnboardingIntro` → the next AuthStack mount opens on the AuthIntro variant. */
+    resetOnboardingIntro: 'ResetOnboardingIntro',
+    /** Deletes the refresh/registration/access tokens from the native keychain. */
+    deleteTokens: 'DeleteTokens',
   },
 
   /** BC Wallet variant — the Preface + onboarding-carousel intro screens (bifold `com.ariesbifold:id/`

--- a/e2e/test/bcsc/auth/auth-intro.journey.ts
+++ b/e2e/test/bcsc/auth/auth-intro.journey.ts
@@ -11,17 +11,14 @@ import { OnboardingIntroScreen } from '../../../src/screens/onboarding.js'
  * Auth journey: the returning-user welcome intro (AuthIntro).
  *
  * AuthStack opens on `AuthIntro` instead of `AccountLanding` when `hasSeenOnboardingIntro` was never
- * recorded — the one-time "the app has changed" gate an already-onboarded user meets on launch. The
- * onboarding walk sets that flag on its very first tap, so the only way to observe the variant is to
- * clear it again: the Developer menu's "Reset Welcome Intro" tool, reached PRE-authentication from
- * AccountLanding's header menu.
+ * recorded. Onboarding sets that flag on its very first tap, so the only way to observe the variant
+ * is the Developer menu's "Reset Welcome Intro", reached PRE-auth from AccountLanding's header menu.
  *
- * It is a separate file from `auth-unlock.journey.ts` on purpose. Getting here depends on the hidden
- * developer-menu trigger (eleven taps on a text node — see `helpers/developer.ts`), and a failure
- * there must not take the core unlock spine down with it.
+ * Separate from `auth-unlock.journey.ts` on purpose: this depends on the hidden developer-menu
+ * trigger, and a failure there must not take the core unlock spine down with it.
  */
 
-/** The dev tools dispatch and persist without awaiting the write; let it flush before terminating. */
+/** The dev tools persist without awaiting the write; let it flush before terminating. */
 const PREFERENCE_WRITE_SETTLE_MS = 1_000
 
 describe('Auth journey: returning-user intro', () => {
@@ -32,8 +29,7 @@ describe('Auth journey: returning-user intro', () => {
   it('opens the pre-authentication settings from AccountLanding', async () => {
     await relaunchApp()
     await selectAccountLandingIfPresent()
-    // Header-left menu → AuthSettings. `didAuthenticate` is still false, so the AuthenticatedSection
-    // rows are absent and ContactUs is the arrival marker.
+    // Header-left menu → AuthSettings (pre-auth, so ContactUs is the arrival marker).
     await AccountLandingScreen.tap('menu')
     await AuthSettingsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })
@@ -43,17 +39,16 @@ describe('Auth journey: returning-user intro', () => {
     await DeveloperScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
     await DeveloperScreen.link('resetOnboardingIntro')
     await driver.pause(PREFERENCE_WRITE_SETTLE_MS)
-    // No assertion on the row's own state readout (it is a split label/value pair with no testID);
-    // the next checkpoint's intro is the observable effect. AuthStack sets no `headerBackTestID`, so
-    // this screen is left by relaunching rather than by tapping Back.
+    // The row's own readout has no testID; the next checkpoint's intro is the observable effect.
+    // AuthStack sets no `headerBackTestID`, so this screen is left by relaunching.
   })
 
   it('shows the welcome intro on the next launch and slides on to AccountLanding', async () => {
-    // AuthStack picks its initial route at mount, so the reset only takes effect on a fresh launch.
+    // AuthStack picks its initial route at mount, so the reset only lands on a fresh launch.
     await relaunchApp()
     await OnboardingIntroScreen.expectVisible(Timeouts.APP_LAUNCH)
-    // The same component as the onboarding intro — what identifies the AuthIntro variant is where
-    // Continue goes: it REPLACES itself with AccountLanding, where onboarding pushes the privacy policy.
+    // Same component as the onboarding intro — what identifies the variant is where Continue goes:
+    // it REPLACES itself with AccountLanding, where onboarding pushes the privacy policy.
     await OnboardingIntroScreen.tap('primary')
     await AccountLandingScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })
@@ -69,8 +64,8 @@ describe('Auth journey: returning-user intro', () => {
   })
 
   it('leaves the developer menu row exposed in settings', async () => {
-    // The counterpart of the onboarding detours journey's "hidden on a default install" assertion:
-    // once enabled the preference is persisted, so the row is now offered on every settings surface.
+    // Counterpart of the detours journey's "hidden on a default install" assertion — the preference
+    // is persisted, so the row is now offered on every settings surface.
     await HomeScreen.tap('menu')
     await SettingsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
     await SettingsScreen.waitFor('developerMode', Timeouts.SCREEN_TRANSITION)

--- a/e2e/test/bcsc/auth/auth-intro.journey.ts
+++ b/e2e/test/bcsc/auth/auth-intro.journey.ts
@@ -1,0 +1,78 @@
+import { TEST_PIN, Timeouts } from '../../../src/constants.js'
+import { relaunchApp, selectAccountLandingIfPresent, unlockWithPin } from '../../../src/flows/auth.js'
+import { skipToHome } from '../../../src/flows/onboarding.js'
+import { openDeveloperMenuFromSettings } from '../../../src/helpers/developer.js'
+import { AccountLandingScreen, AuthSettingsScreen } from '../../../src/screens/auth.js'
+import { DeveloperScreen } from '../../../src/screens/developer.js'
+import { HomeScreen, SettingsScreen } from '../../../src/screens/main.js'
+import { OnboardingIntroScreen } from '../../../src/screens/onboarding.js'
+
+/**
+ * Auth journey: the returning-user welcome intro (AuthIntro).
+ *
+ * AuthStack opens on `AuthIntro` instead of `AccountLanding` when `hasSeenOnboardingIntro` was never
+ * recorded — the one-time "the app has changed" gate an already-onboarded user meets on launch. The
+ * onboarding walk sets that flag on its very first tap, so the only way to observe the variant is to
+ * clear it again: the Developer menu's "Reset Welcome Intro" tool, reached PRE-authentication from
+ * AccountLanding's header menu.
+ *
+ * It is a separate file from `auth-unlock.journey.ts` on purpose. Getting here depends on the hidden
+ * developer-menu trigger (eleven taps on a text node — see `helpers/developer.ts`), and a failure
+ * there must not take the core unlock spine down with it.
+ */
+
+/** The dev tools dispatch and persist without awaiting the write; let it flush before terminating. */
+const PREFERENCE_WRITE_SETTLE_MS = 1_000
+
+describe('Auth journey: returning-user intro', () => {
+  it('onboards and skips to unverified Home', async () => {
+    await skipToHome()
+  })
+
+  it('opens the pre-authentication settings from AccountLanding', async () => {
+    await relaunchApp()
+    await selectAccountLandingIfPresent()
+    // Header-left menu → AuthSettings. `didAuthenticate` is still false, so the AuthenticatedSection
+    // rows are absent and ContactUs is the arrival marker.
+    await AccountLandingScreen.tap('menu')
+    await AuthSettingsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('reveals the developer menu and resets the welcome intro', async () => {
+    await openDeveloperMenuFromSettings()
+    await DeveloperScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    await DeveloperScreen.link('resetOnboardingIntro')
+    await driver.pause(PREFERENCE_WRITE_SETTLE_MS)
+    // No assertion on the row's own state readout (it is a split label/value pair with no testID);
+    // the next checkpoint's intro is the observable effect. AuthStack sets no `headerBackTestID`, so
+    // this screen is left by relaunching rather than by tapping Back.
+  })
+
+  it('shows the welcome intro on the next launch and slides on to AccountLanding', async () => {
+    // AuthStack picks its initial route at mount, so the reset only takes effect on a fresh launch.
+    await relaunchApp()
+    await OnboardingIntroScreen.expectVisible(Timeouts.APP_LAUNCH)
+    // The same component as the onboarding intro — what identifies the AuthIntro variant is where
+    // Continue goes: it REPLACES itself with AccountLanding, where onboarding pushes the privacy policy.
+    await OnboardingIntroScreen.tap('primary')
+    await AccountLandingScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('records the intro as seen so later launches go straight to AccountLanding', async () => {
+    await relaunchApp()
+    await AccountLandingScreen.expectVisible(Timeouts.APP_LAUNCH)
+  })
+
+  it('unlocks to Home', async () => {
+    await unlockWithPin(TEST_PIN)
+    await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('leaves the developer menu row exposed in settings', async () => {
+    // The counterpart of the onboarding detours journey's "hidden on a default install" assertion:
+    // once enabled the preference is persisted, so the row is now offered on every settings surface.
+    await HomeScreen.tap('menu')
+    await SettingsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    await SettingsScreen.waitFor('developerMode', Timeouts.SCREEN_TRANSITION)
+  })
+})

--- a/e2e/test/bcsc/auth/auth-unlock.journey.ts
+++ b/e2e/test/bcsc/auth/auth-unlock.journey.ts
@@ -27,12 +27,11 @@ import { AutoLockScreen, HomeScreen, SettingsScreen } from '../../../src/screens
  * its unattended expiry → the background-timeout lock (TERMINAL: it leaves auto-lock at 1 minute,
  * which would race every checkpoint after it).
  *
- * Two slow, unattended waits live here — the ~1-minute lockout countdown and the 70s background —
- * so this file is the longest of the cheap journeys by design. Both are the assertion, not overhead.
+ * The two unattended waits (~1-minute lockout countdown, 70s background) make this the longest of
+ * the cheap journeys. Both are the assertion, not overhead.
  *
  * SessionRecovery is deliberately absent: `sessionRecoveryRequired` is derived at hydration from a
- * verified account with no refresh token, so it cannot be reached from this unverified session (see
- * the UAT-12 ticket for the verified-journey recipe).
+ * verified account with no refresh token, so it is unreachable from this unverified session.
  */
 
 describe('Auth journey: unlock', () => {
@@ -96,10 +95,9 @@ describe('Auth journey: unlock', () => {
   })
 
   it('auto-unlocks itself when the lockout countdown runs out', async () => {
-    // Nothing is tapped here — the wait IS the assertion. The Lockout screen counts down the native
-    // lock's remaining time and calls `unlockApp()` at zero, which routes a no-longer-locked
-    // PIN account to EnterPIN. `isPresent` polls without the scroll-retry `expectVisible` would
-    // spend on a screen that has nothing to scroll.
+    // Nothing is tapped — the wait IS the assertion. The Lockout screen counts the native lock down
+    // and calls `unlockApp()` at zero, routing a no-longer-locked PIN account to EnterPIN.
+    // `isPresent` polls without the scroll-retry `expectVisible` would waste here.
     assert.ok(
       await EnterPINScreen.isPresent(Timeouts.LOCKOUT_AUTO_UNLOCK),
       'the lockout did not release itself to EnterPIN within the countdown window'
@@ -110,9 +108,8 @@ describe('Auth journey: unlock', () => {
 
   it('shortens auto-lock and survives a background inside the timeout', async () => {
     // Distinct from the inactivity timer the settings journey covers: backgrounding CLEARS that timer
-    // (its handle does not survive suspension) and the foreground handler instead compares elapsed
-    // time against the configured timeout. Shorten the timeout first — the 5-minute default would
-    // need a 5-minute background.
+    // and the foreground handler compares elapsed time instead. Shorten the timeout first — the
+    // 5-minute default would need a 5-minute background.
     await HomeScreen.tap('menu')
     await SettingsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
     await SettingsScreen.link('autoLock')
@@ -123,21 +120,19 @@ describe('Auth journey: unlock', () => {
     await SettingsScreen.back.tap()
     await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
 
-    // The control for the checkpoint below. Landing back on Home proves two things the lock
-    // assertion depends on: a short background does NOT lock, and the app is RESUMED rather than
-    // relaunched — a relaunch would reach the unlock screen for the ordinary in-memory
-    // `didAuthenticate` reason, which would make the next checkpoint pass without proving anything.
+    // The control for the checkpoint below: a short background must NOT lock, and landing back on
+    // Home proves the app was RESUMED rather than relaunched — a relaunch reaches the unlock screen
+    // anyway, which would let the next checkpoint pass without proving anything.
     await backgroundAppFor(BACKGROUND_NO_LOCK_SECONDS)
     await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })
 
   it('locks on return from a long background and re-unlocks with the PIN (terminal)', async () => {
-    // Runs straight after the control so the foreground gap stays seconds long: idle here for a
-    // minute and the inactivity timer would log the user out first, proving the wrong branch.
+    // Straight after the control, so the foreground gap stays seconds long: idle a minute here and
+    // the inactivity timer fires first, proving the wrong branch.
     await backgroundAppFor(BACKGROUND_LOCK_SECONDS)
 
-    // Coming back logs the user out (`didAuthenticate` → false), so RootStack swaps to AuthStack and
-    // the normal unlock spine applies.
+    // Coming back logs the user out, so RootStack swaps to AuthStack and the normal spine applies.
     await unlockWithPin(TEST_PIN)
   })
 })

--- a/e2e/test/bcsc/auth/auth-unlock.journey.ts
+++ b/e2e/test/bcsc/auth/auth-unlock.journey.ts
@@ -1,21 +1,38 @@
-import { TEST_PIN, Timeouts, WRONG_TEST_PIN } from '../../../src/constants.js'
-import { relaunchApp, selectAccountLandingIfPresent, unlockWithPin } from '../../../src/flows/auth.js'
+import assert from 'node:assert/strict'
+import {
+  BACKGROUND_LOCK_SECONDS,
+  BACKGROUND_NO_LOCK_SECONDS,
+  TEST_PIN,
+  Timeouts,
+  WRONG_TEST_PIN,
+} from '../../../src/constants.js'
+import {
+  backgroundAppFor,
+  relaunchApp,
+  selectAccountLandingIfPresent,
+  unlockWithPin,
+} from '../../../src/flows/auth.js'
 import { skipToHome } from '../../../src/flows/onboarding.js'
 import { expectWebViewOpen } from '../../../src/helpers/webview.js'
 import { AccountLandingScreen, EnterPINScreen, LockoutScreen } from '../../../src/screens/auth.js'
-import { HomeScreen } from '../../../src/screens/main.js'
+import { AutoLockScreen, HomeScreen, SettingsScreen } from '../../../src/screens/main.js'
 
 /**
  * Auth/unlock journey.
  *
  * Arrange is UI-driven: onboard + skip to unverified Home, then every relaunch lands on
- * AccountLanding → EnterPIN (`didAuthenticate` is in-memory). Ordered checkpoints, destructive
- * last: unlock happy path → wrong-PIN inline error (single miss; the native attempt counter resets
- * on the subsequent success) → five consecutive misses → the timed Lockout screen (terminal — the
- * app stays locked for 1 minute, so nothing runs after it).
+ * AccountLanding → EnterPIN (`didAuthenticate` is in-memory). Ordered checkpoints, slowest and most
+ * state-changing last: unlock happy path → wrong-PIN inline error (single miss; the native attempt
+ * counter resets on the subsequent success) → five consecutive misses → the timed Lockout screen →
+ * its unattended expiry → the background-timeout lock (TERMINAL: it leaves auto-lock at 1 minute,
+ * which would race every checkpoint after it).
  *
- * SessionRecovery is deliberately absent: `sessionRecoveryRequired` is derived from native secure
- * storage at hydration (verified account with no refresh token) and has no UI-reachable trigger.
+ * Two slow, unattended waits live here — the ~1-minute lockout countdown and the 70s background —
+ * so this file is the longest of the cheap journeys by design. Both are the assertion, not overhead.
+ *
+ * SessionRecovery is deliberately absent: `sessionRecoveryRequired` is derived at hydration from a
+ * verified account with no refresh token, so it cannot be reached from this unverified session (see
+ * the UAT-12 ticket for the verified-journey recipe).
  */
 
 describe('Auth journey: unlock', () => {
@@ -76,5 +93,51 @@ describe('Auth journey: unlock', () => {
       }
     }
     await LockoutScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('auto-unlocks itself when the lockout countdown runs out', async () => {
+    // Nothing is tapped here — the wait IS the assertion. The Lockout screen counts down the native
+    // lock's remaining time and calls `unlockApp()` at zero, which routes a no-longer-locked
+    // PIN account to EnterPIN. `isPresent` polls without the scroll-retry `expectVisible` would
+    // spend on a screen that has nothing to scroll.
+    assert.ok(
+      await EnterPINScreen.isPresent(Timeouts.LOCKOUT_AUTO_UNLOCK),
+      'the lockout did not release itself to EnterPIN within the countdown window'
+    )
+    await EnterPINScreen.fill('pin', TEST_PIN)
+    await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('shortens auto-lock and survives a background inside the timeout', async () => {
+    // Distinct from the inactivity timer the settings journey covers: backgrounding CLEARS that timer
+    // (its handle does not survive suspension) and the foreground handler instead compares elapsed
+    // time against the configured timeout. Shorten the timeout first — the 5-minute default would
+    // need a 5-minute background.
+    await HomeScreen.tap('menu')
+    await SettingsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    await SettingsScreen.link('autoLock')
+    await AutoLockScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    await AutoLockScreen.link('time1') // saved immediately on tap; the activity context re-arms live
+    await AutoLockScreen.back.tap()
+    await SettingsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    await SettingsScreen.back.tap()
+    await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+
+    // The control for the checkpoint below. Landing back on Home proves two things the lock
+    // assertion depends on: a short background does NOT lock, and the app is RESUMED rather than
+    // relaunched — a relaunch would reach the unlock screen for the ordinary in-memory
+    // `didAuthenticate` reason, which would make the next checkpoint pass without proving anything.
+    await backgroundAppFor(BACKGROUND_NO_LOCK_SECONDS)
+    await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('locks on return from a long background and re-unlocks with the PIN (terminal)', async () => {
+    // Runs straight after the control so the foreground gap stays seconds long: idle here for a
+    // minute and the inactivity timer would log the user out first, proving the wrong branch.
+    await backgroundAppFor(BACKGROUND_LOCK_SECONDS)
+
+    // Coming back logs the user out (`didAuthenticate` → false), so RootStack swaps to AuthStack and
+    // the normal unlock spine applies.
+    await unlockWithPin(TEST_PIN)
   })
 })

--- a/e2e/test/bcsc/onboarding/onboarding-detours.journey.ts
+++ b/e2e/test/bcsc/onboarding/onboarding-detours.journey.ts
@@ -1,10 +1,13 @@
-import { TEST_PIN, Timeouts } from '../../../src/constants.js'
-import { skipNotificationsIfShown } from '../../../src/flows/onboarding.js'
+import assert from 'node:assert/strict'
+import { SHORT_TEST_PIN, TEST_PIN, Timeouts, WRONG_TEST_PIN } from '../../../src/constants.js'
+import { answerNotificationPermission } from '../../../src/flows/onboarding.js'
+import { scrollToSettingsVersionFooter } from '../../../src/helpers/developer.js'
 import { tapAtWindowPercent } from '../../../src/helpers/gestures.js'
 import { BaseScreen } from '../../../src/screens/core/BaseScreen.js'
 import {
   OnboardingCreatePINScreen,
   OnboardingIntroScreen,
+  OnboardingNotificationsDisabledScreen,
   OnboardingOptInAnalyticsScreen,
   OnboardingPrivacyPolicyScreen,
   OnboardingSecureAppScreen,
@@ -19,19 +22,59 @@ import {
  *
  * Same fresh-install session as the happy path, but takes every recoverable detour on the way:
  * header back-navigation, the privacy Learn-More webview, the floating help menu, the analytics
- * decline, and the PIN visibility toggles. One checkpoint per detour, so a failure reports exactly
- * which detour broke (mocha bail skips the rest of THIS file; other journey files still run).
+ * decline, the declined-notification-permission branch, and the PIN form's inline validation. One
+ * checkpoint per detour, so a failure reports exactly which detour broke (mocha bail skips the rest
+ * of THIS file; other journey files still run).
+ *
+ * The notification permission is DENIED here — that direction both exercises the `PermissionDisabled`
+ * variant and leaves the device no more permissive than it started. The opposite answer (and the
+ * screen-skipping branch it unlocks) needs its own fresh install: `onboarding-permissions.journey.ts`.
  */
 
-/** Engine handle for the few help-menu elements that expose no testIDs (matched by visible text). */
+/** Engine handle for the elements that expose no testIDs (matched by visible text). */
 const engine = new BaseScreen()
 
+/**
+ * Inline validation copy on the CreatePIN form. `PINInput`'s error line and the checkbox error are
+ * plain `ThemedText` nodes with no testIDs, so they are matched by their rendered string — keys
+ * `BCSC.PIN.PINTooShort` / `PINsDoNotMatch` / `MustCheckBox` in `app/src/localization/en`.
+ */
+const CREATE_PIN_ERRORS = {
+  tooShort: 'PIN must be 6 digits',
+  mismatch: 'PINs do not match',
+  uncheckedBox: 'You must check this box to continue.',
+} as const
+
+/**
+ * Wait for a testID-free inline error to render.
+ *
+ * `waitForText` rather than a bare `findByText`, because these errors are not reliably ON SCREEN
+ * when they appear: the form only drops the keyboard once a field reaches six digits, and while it
+ * is up the keyboard-aware scroll keeps the FOCUSED field clear — which pushes an error belonging to
+ * the other field above the fold. The hunt makes the assertion "the app rendered this" rather than
+ * "this happens to be in the viewport".
+ */
+async function expectInlineError(message: string): Promise<void> {
+  await engine.waitForText(message)
+}
+
 describe('Onboarding journey: detours', () => {
-  it('opens onboarding Settings from the intro header and backs out', async () => {
+  it('opens onboarding Settings from the intro header, with no developer menu, and backs out', async () => {
     await OnboardingIntroScreen.expectVisible(Timeouts.COLD_START) // fresh install lands on the Intro
     await OnboardingIntroScreen.tap('menu') // Intro header Settings button → OnboardingSettings (SettingsContent)
     // Pre-auth, the AuthenticatedSection rows are absent; the always-rendered ContactUs row is the marker.
     await OnboardingSettingsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+
+    // A default install must not expose the developer menu. Scroll to the footer first so the
+    // absence means "not rendered" rather than "below the fold" — the row sits directly above it.
+    // Revealing it is covered where it is actually needed, in `auth/auth-intro.journey.ts`.
+    await scrollToSettingsVersionFooter()
+    assert.equal(
+      await OnboardingSettingsScreen.isVisible('developerMode'),
+      false,
+      'the developer menu row must stay hidden on a default install'
+    )
+
     await OnboardingSettingsScreen.back.tap() // → Intro
     await OnboardingIntroScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })
@@ -78,8 +121,23 @@ describe('Onboarding journey: detours', () => {
     await OnboardingOptInAnalyticsScreen.tap('secondary')
   })
 
-  it('skips notifications when the screen is offered', async () => {
-    await skipNotificationsIfShown()
+  it('declines the OS notification permission and still reaches SecureApp', async () => {
+    // Both answers advance; the app records the refusal and moves on.
+    await answerNotificationPermission('deny')
+  })
+
+  it('re-entering Notifications after the refusal shows the permission-disabled variant', async () => {
+    // The screen re-reads the live OS status on mount, so navigating BACK to it is what swaps the
+    // enable/skip body for PermissionDisabled. OpenSettings hands off to the OS settings app — assert
+    // it, never tap it; ContinueWithoutNotifications is the in-app way forward.
+    await OnboardingSecureAppScreen.back.tap()
+    await OnboardingNotificationsDisabledScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    assert.ok(
+      await OnboardingNotificationsDisabledScreen.isVisible('openSettings'),
+      'PermissionDisabled should offer OpenSettings alongside ContinueWithoutNotifications'
+    )
+    await OnboardingNotificationsDisabledScreen.tap('secondary')
+    await OnboardingSecureAppScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })
 
   it('chooses a PIN to secure the app', async () => {
@@ -87,8 +145,29 @@ describe('Onboarding journey: detours', () => {
     await OnboardingSecureAppScreen.tap('primary')
   })
 
-  it('creates the PIN after exercising the visibility toggles', async () => {
+  it('rejects a short PIN, a mismatched confirmation and an unchecked acknowledgement', async () => {
     await OnboardingCreatePINScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+
+    // Validation runs on submit and stops at the first failing rule, so the three are exercised in
+    // the order the form checks them. Every rejection leaves the user on the form.
+    await OnboardingCreatePINScreen.fill('pin', SHORT_TEST_PIN)
+    await OnboardingCreatePINScreen.fill('confirmPin', SHORT_TEST_PIN)
+    await OnboardingCreatePINScreen.tap('primary')
+    await expectInlineError(CREATE_PIN_ERRORS.tooShort)
+
+    await OnboardingCreatePINScreen.fill('pin', TEST_PIN)
+    await OnboardingCreatePINScreen.fill('confirmPin', WRONG_TEST_PIN)
+    await OnboardingCreatePINScreen.tap('primary')
+    await expectInlineError(CREATE_PIN_ERRORS.mismatch)
+
+    // Matching PINs, acknowledgement still unchecked → the checkbox error, and no PIN is set.
+    await OnboardingCreatePINScreen.fill('confirmPin', TEST_PIN)
+    await OnboardingCreatePINScreen.tap('primary')
+    await expectInlineError(CREATE_PIN_ERRORS.uncheckedBox)
+    await OnboardingCreatePINScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('creates the PIN after exercising the visibility toggles', async () => {
     // Toggle each input on then off so both masked and revealed states render.
     await OnboardingCreatePINScreen.link('pin1Visibility')
     await OnboardingCreatePINScreen.link('pin1Visibility')

--- a/e2e/test/bcsc/onboarding/onboarding-detours.journey.ts
+++ b/e2e/test/bcsc/onboarding/onboarding-detours.journey.ts
@@ -26,18 +26,17 @@ import {
  * checkpoint per detour, so a failure reports exactly which detour broke (mocha bail skips the rest
  * of THIS file; other journey files still run).
  *
- * The notification permission is DENIED here — that direction both exercises the `PermissionDisabled`
- * variant and leaves the device no more permissive than it started. The opposite answer (and the
- * screen-skipping branch it unlocks) needs its own fresh install: `onboarding-permissions.journey.ts`.
+ * The notification permission is DENIED here — that direction exercises the `PermissionDisabled`
+ * variant and leaves the device no more permissive than it started. The opposite answer needs its own
+ * fresh install: `onboarding-permissions.journey.ts`.
  */
 
 /** Engine handle for the elements that expose no testIDs (matched by visible text). */
 const engine = new BaseScreen()
 
 /**
- * Inline validation copy on the CreatePIN form. `PINInput`'s error line and the checkbox error are
- * plain `ThemedText` nodes with no testIDs, so they are matched by their rendered string — keys
- * `BCSC.PIN.PINTooShort` / `PINsDoNotMatch` / `MustCheckBox` in `app/src/localization/en`.
+ * Inline validation copy on the CreatePIN form — plain `ThemedText` with no testIDs, so matched by
+ * their rendered string. Keys `BCSC.PIN.PINTooShort` / `PINsDoNotMatch` / `MustCheckBox`.
  */
 const CREATE_PIN_ERRORS = {
   tooShort: 'PIN must be 6 digits',
@@ -46,13 +45,9 @@ const CREATE_PIN_ERRORS = {
 } as const
 
 /**
- * Wait for a testID-free inline error to render.
- *
- * `waitForText` rather than a bare `findByText`, because these errors are not reliably ON SCREEN
- * when they appear: the form only drops the keyboard once a field reaches six digits, and while it
- * is up the keyboard-aware scroll keeps the FOCUSED field clear — which pushes an error belonging to
- * the other field above the fold. The hunt makes the assertion "the app rendered this" rather than
- * "this happens to be in the viewport".
+ * Wait for a testID-free inline error to render. `waitForText` (which scrolls on a miss) rather than
+ * a bare `findByText`: the form only drops the keyboard at six digits, and while it is up the
+ * keyboard-aware scroll keeps the FOCUSED field clear — pushing the other field's error above the fold.
  */
 async function expectInlineError(message: string): Promise<void> {
   await engine.waitForText(message)
@@ -65,9 +60,8 @@ describe('Onboarding journey: detours', () => {
     // Pre-auth, the AuthenticatedSection rows are absent; the always-rendered ContactUs row is the marker.
     await OnboardingSettingsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
 
-    // A default install must not expose the developer menu. Scroll to the footer first so the
-    // absence means "not rendered" rather than "below the fold" — the row sits directly above it.
-    // Revealing it is covered where it is actually needed, in `auth/auth-intro.journey.ts`.
+    // A default install must not expose the developer menu. Scroll to the footer first so the absence
+    // means "not rendered", not "below the fold". Revealing it lives in `auth/auth-intro.journey.ts`.
     await scrollToSettingsVersionFooter()
     assert.equal(
       await OnboardingSettingsScreen.isVisible('developerMode'),
@@ -127,9 +121,8 @@ describe('Onboarding journey: detours', () => {
   })
 
   it('re-entering Notifications after the refusal shows the permission-disabled variant', async () => {
-    // The screen re-reads the live OS status on mount, so navigating BACK to it is what swaps the
-    // enable/skip body for PermissionDisabled. OpenSettings hands off to the OS settings app — assert
-    // it, never tap it; ContinueWithoutNotifications is the in-app way forward.
+    // The screen re-reads the live OS status on mount, so navigating BACK is what swaps the body.
+    // OpenSettings hands off to the OS settings app — assert it, never tap it.
     await OnboardingSecureAppScreen.back.tap()
     await OnboardingNotificationsDisabledScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
     assert.ok(
@@ -148,8 +141,7 @@ describe('Onboarding journey: detours', () => {
   it('rejects a short PIN, a mismatched confirmation and an unchecked acknowledgement', async () => {
     await OnboardingCreatePINScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
 
-    // Validation runs on submit and stops at the first failing rule, so the three are exercised in
-    // the order the form checks them. Every rejection leaves the user on the form.
+    // Validation stops at the first failing rule, so the three run in the order the form checks them.
     await OnboardingCreatePINScreen.fill('pin', SHORT_TEST_PIN)
     await OnboardingCreatePINScreen.fill('confirmPin', SHORT_TEST_PIN)
     await OnboardingCreatePINScreen.tap('primary')

--- a/e2e/test/bcsc/onboarding/onboarding-permissions.journey.ts
+++ b/e2e/test/bcsc/onboarding/onboarding-permissions.journey.ts
@@ -16,17 +16,14 @@ import {
 /**
  * Onboarding journey: granted notification permission.
  *
- * The one onboarding branch that needs the OS permission to be GRANTED: after the user allows push
- * notifications, the analytics screen stops routing through the Notifications screen at all
- * (`OnboardingOptInAnalyticsScreen.nextScreen` reads the live status and jumps to SecureApp).
+ * The one onboarding branch needing the OS permission GRANTED: once it is, the analytics screen reads
+ * the live status and jumps straight to SecureApp, skipping Notifications entirely.
  *
- * It needs its own fresh install because permission answers are one-way within a session: iOS never
- * re-prompts after a refusal, and Android only re-prompts once. The opposite answer — and the
- * `PermissionDisabled` variant it unlocks — lives in `onboarding-detours.journey.ts`.
+ * Its own fresh install, because permission answers are one-way within a session (iOS never re-prompts
+ * after a refusal). The opposite answer lives in `onboarding-detours.journey.ts`.
  *
- * Assumes Android 13+ (runtime POST_NOTIFICATIONS), i.e. that push permission is NOT granted on a
- * fresh install. On an older Android the first analytics answer would already skip Notifications and
- * the enable checkpoint below would have nothing to drive.
+ * Assumes Android 13+ (runtime POST_NOTIFICATIONS): on older Android the permission is implicit, so
+ * the enable checkpoint would have nothing to drive.
  */
 describe('Onboarding journey: notification permission granted', () => {
   it('walks to the analytics opt-in and accepts it', async () => {
@@ -45,14 +42,13 @@ describe('Onboarding journey: notification permission granted', () => {
   })
 
   it('grants the OS notification permission from the Notifications screen', async () => {
-    // Permission has never been requested at this point, so the screen is offered rather than skipped.
+    // Never requested yet, so the screen is offered rather than skipped.
     await answerNotificationPermission('allow')
   })
 
   it('keeps the normal Notifications body once permission is granted', async () => {
-    // The mirror of the detours journey's refusal branch: `checkPermissions` only swaps in
-    // PermissionDisabled for a denied/blocked status, so a granted user re-entering the screen still
-    // sees the enable/skip pair.
+    // Mirror of the detours journey's refusal branch: `PermissionDisabled` only swaps in for a
+    // denied/blocked status, so a granted user re-entering still sees the enable/skip pair.
     await OnboardingSecureAppScreen.back.tap()
     await OnboardingNotificationsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
     assert.equal(
@@ -67,8 +63,7 @@ describe('Onboarding journey: notification permission granted', () => {
     await OnboardingOptInAnalyticsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
     await OnboardingOptInAnalyticsScreen.tap('primary')
 
-    // The branch under test: with permission already granted the analytics screen navigates straight
-    // to SecureApp. Assert the absence first so a regression fails here rather than in a scroll hunt.
+    // The branch under test. Absence first, so a regression fails here rather than in a scroll hunt.
     assert.equal(
       await OnboardingNotificationsScreen.isPresent(Timeouts.ELEMENT_VISIBLE),
       false,

--- a/e2e/test/bcsc/onboarding/onboarding-permissions.journey.ts
+++ b/e2e/test/bcsc/onboarding/onboarding-permissions.journey.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict'
+import { TEST_PIN, Timeouts } from '../../../src/constants.js'
+import { answerNotificationPermission } from '../../../src/flows/onboarding.js'
+import {
+  OnboardingCreatePINScreen,
+  OnboardingIntroScreen,
+  OnboardingNotificationsDisabledScreen,
+  OnboardingNotificationsScreen,
+  OnboardingOptInAnalyticsScreen,
+  OnboardingPrivacyPolicyScreen,
+  OnboardingSecureAppScreen,
+  OnboardingTermsOfUseScreen,
+  VerifyPromptScreen,
+} from '../../../src/screens/onboarding.js'
+
+/**
+ * Onboarding journey: granted notification permission.
+ *
+ * The one onboarding branch that needs the OS permission to be GRANTED: after the user allows push
+ * notifications, the analytics screen stops routing through the Notifications screen at all
+ * (`OnboardingOptInAnalyticsScreen.nextScreen` reads the live status and jumps to SecureApp).
+ *
+ * It needs its own fresh install because permission answers are one-way within a session: iOS never
+ * re-prompts after a refusal, and Android only re-prompts once. The opposite answer — and the
+ * `PermissionDisabled` variant it unlocks — lives in `onboarding-detours.journey.ts`.
+ *
+ * Assumes Android 13+ (runtime POST_NOTIFICATIONS), i.e. that push permission is NOT granted on a
+ * fresh install. On an older Android the first analytics answer would already skip Notifications and
+ * the enable checkpoint below would have nothing to drive.
+ */
+describe('Onboarding journey: notification permission granted', () => {
+  it('walks to the analytics opt-in and accepts it', async () => {
+    await OnboardingIntroScreen.expectVisible(Timeouts.COLD_START)
+    await OnboardingIntroScreen.tap('primary')
+
+    await OnboardingPrivacyPolicyScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    await OnboardingPrivacyPolicyScreen.tap('primary')
+
+    // The terms body is a fetched WebView; accept stays disabled until it finishes loading.
+    await OnboardingTermsOfUseScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    await OnboardingTermsOfUseScreen.tapWhenEnabled('primary')
+
+    await OnboardingOptInAnalyticsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    await OnboardingOptInAnalyticsScreen.tap('primary')
+  })
+
+  it('grants the OS notification permission from the Notifications screen', async () => {
+    // Permission has never been requested at this point, so the screen is offered rather than skipped.
+    await answerNotificationPermission('allow')
+  })
+
+  it('keeps the normal Notifications body once permission is granted', async () => {
+    // The mirror of the detours journey's refusal branch: `checkPermissions` only swaps in
+    // PermissionDisabled for a denied/blocked status, so a granted user re-entering the screen still
+    // sees the enable/skip pair.
+    await OnboardingSecureAppScreen.back.tap()
+    await OnboardingNotificationsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    assert.equal(
+      await OnboardingNotificationsDisabledScreen.isVisible('openSettings'),
+      false,
+      'PermissionDisabled must not render once the permission is granted'
+    )
+  })
+
+  it('skips the Notifications screen entirely on the next pass', async () => {
+    await OnboardingNotificationsScreen.back.tap()
+    await OnboardingOptInAnalyticsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    await OnboardingOptInAnalyticsScreen.tap('primary')
+
+    // The branch under test: with permission already granted the analytics screen navigates straight
+    // to SecureApp. Assert the absence first so a regression fails here rather than in a scroll hunt.
+    assert.equal(
+      await OnboardingNotificationsScreen.isPresent(Timeouts.ELEMENT_VISIBLE),
+      false,
+      'Notifications must be skipped once push permission is already granted'
+    )
+    await OnboardingSecureAppScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('finishes onboarding on the verify prompt', async () => {
+    await OnboardingSecureAppScreen.tap('primary')
+    await OnboardingCreatePINScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    await OnboardingCreatePINScreen.fill('pin', TEST_PIN)
+    await OnboardingCreatePINScreen.fill('confirmPin', TEST_PIN)
+    await OnboardingCreatePINScreen.link('understand')
+    await OnboardingCreatePINScreen.tapWhenEnabled('primary')
+    await VerifyPromptScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+})


### PR DESCRIPTION
# Summary of Changes

Covers the onboarding and auth branches the screen audit found uncovered, plus three engine fixes those runs surfaced on Sauce iOS 17. E2E-only — no app code touched.

**New coverage** — two new journeys, checkpoints on two existing ones:

- Onboarding: notification permission granted (the analytics screen then skips Notifications entirely) and refused (the `PermissionDisabled` variant); CreatePIN's three inline validation rules; developer menu absent on a default install.
- Auth: lockout releasing itself when its countdown expires; backgrounded-too-long lock; the returning-user `AuthIntro` variant, via the developer menu's "Reset Welcome Intro" — nothing else clears `hasSeenOnboardingIntro`.

**Fixes:**

- **iOS keyboard dismissal tapped app UI.** It blind-tapped a quarter down the screen; on ResidentialAddress that's the province dropdown, so the "dismiss" opened its modal and stranded the non-BCSC journey with Continue unreachable — already failing the nightly. Now presses one of the keyboard's own dismissal keys. Moving the coordinate wouldn't help: `InputWithValidation`'s 44px hitSlop makes the gaps between fields live too.
- **Text assertions had no scroll-on-miss**, unlike testID assertions. Keyboard-aware forms scroll to keep the *focused* field clear, pushing another field's inline error above the fold — a rendered error read as missing. Adds `BaseScreen.waitForText`, sharing one scroll hunt with `scrollToTestId`.
- **A 70s background killed the session.** That blocks one driver command for its full duration and Sauce cuts off at 60s. The wait is now client-side (negative-duration background → `pause` → `activateApp`), with a short-background control step to prove the app resumed rather than relaunched.

# Testing Instructions

1. From `e2e/`: `npm run test:ios:sauce -- --suite onboarding`, then `--suite auth`. Repeat with `test:android:sauce`.
2. `--suite verify` on iOS — the regression check for the keyboard fix; non-BCSC should clear ResidentialAddress instead of stalling on the province dropdown.

# Acceptance Criteria

- [ ] `onboarding` and `auth` suites pass on iOS and Android
- [ ] `verify` still passes — non-BCSC clears ResidentialAddress on iOS 17
- [ ] `auth-unlock.journey.ts` completes both unattended waits without the session being terminated
- [ ] `tsc --noEmit` and eslint clean

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A
