### PR TITLE
feat: e2e verify branch sweep

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -517,12 +517,15 @@ e2e/
 │       │
 │       ├── onboarding/                      # one file = one app session = one ordered journey
 │       │   ├── onboarding.journey.ts        # happy-path onboarding → VerifyPrompt
-│       │   └── onboarding-detours.journey.ts # back-nav, webviews, help menu, onboarding settings, analytics decline
+│       │   ├── onboarding-detours.journey.ts # back-nav, webviews, help menu, onboarding settings, analytics decline
+│       │   └── onboarding-permissions.journey.ts # notifications granted → enable path + skip-notifications branch
 │       ├── auth/
-│       │   └── auth-unlock.journey.ts       # unlock, Get Help, wrong-PIN retry, lockout
+│       │   ├── auth-unlock.journey.ts       # unlock, Get Help, wrong-PIN retry, lockout, background lock
+│       │   └── auth-intro.journey.ts        # AuthIntro variant via the developer menu's Reset Welcome Intro
 │       ├── verify/
 │       │   ├── verify-entry.journey.ts      # entry spine (stops short of authorize)
-│       │   ├── verify-entry-detours.journey.ts # transfer/scan/OtherID detours + mismatched-serial error
+│       │   ├── verify-entry-detours.journey.ts # transfer/scan/OtherID detours, refused-camera fallback, serial errors, mismatched-serial
+│       │   ├── verify-resume.journey.ts     # leave/relaunch → resume routing, restart verification
 │       │   ├── verified-photo.journey.ts    # photo card + send-video/live-call detours
 │       │   ├── verified-non-photo.journey.ts # non-photo card (+ additional photo ID)
 │       │   ├── verified-combined.journey.ts # combined card + login/deep-link/transfer/contacts/account

--- a/e2e/scripts/login.mjs
+++ b/e2e/scripts/login.mjs
@@ -16,6 +16,18 @@ const VALIDATE_CARDHOLDER_URL = 'https://idsit.gov.bc.ca/idcheck/protected/valid
 const VERIFY_NON_BCSC_URL = 'https://idsit.gov.bc.ca/idcheck/protected/counterNonBcscRequest/verifyIdentity'
 
 /**
+ * Wall-clock at the previous {@link logStep}, so each line can report how long its request took.
+ * Reset at the top of {@link approveInPersonLogin}.
+ *
+ * Worth the module-level state: the whole SM chain runs under ONE client-side abort budget, so when
+ * that budget expires the error names whichever request was in flight — structurally the last one —
+ * and says nothing about which step actually ate the time. These timings are the difference between
+ * "the budget was thin" and "that endpoint hung". Safe as module state because each wdio worker is
+ * its own process and runs one journey at a time.
+ */
+let previousStepAt = 0
+
+/**
  * Logs a compact summary line for a response and throws on non-2xx status.
  * Returns the response body text so callers that need it can use the return value.
  *
@@ -26,9 +38,12 @@ const VERIFY_NON_BCSC_URL = 'https://idsit.gov.bc.ca/idcheck/protected/counterNo
  */
 async function logStep(step, response, bodyText) {
   const body = bodyText ?? (await response.text())
+  const now = Date.now()
+  const elapsedSeconds = previousStepAt ? ((now - previousStepAt) / 1000).toFixed(1) : '?'
+  previousStepAt = now
   const pathname = new URL(response.url).pathname
   const icon = response.ok ? '+' : '!'
-  console.log(`[sm-login] [${icon}] ${step}: ${response.status} ${pathname}`)
+  console.log(`[sm-login] [${icon}] ${step}: ${response.status} ${pathname} (${elapsedSeconds}s)`)
 
   if (!response.ok) {
     const errorDetail = extractErrorMessage(body)
@@ -40,6 +55,13 @@ async function logStep(step, response, bodyText) {
     try {
       const parsed = JSON.parse(body)
       console.log(`  body: ${JSON.stringify(parsed).slice(0, 300)}`)
+      // The transaction's device list falls outside that 300-char slice, and it is the one thing in
+      // this response that reflects what EARLIER runs left on the account — the same test cards are
+      // shared by every platform's suite, and nothing here deregisters them afterwards.
+      if (Array.isArray(parsed.devices)) {
+        const names = parsed.devices.map((device) => device?.applicationName ?? '(unnamed)').join(', ')
+        console.log(`  devices (${parsed.devices.length}): ${names}`)
+      }
     } catch {
       console.log(`  body: ${body.slice(0, 300)}`)
     }
@@ -176,6 +198,7 @@ function buildUsercodeBody(csrfToken, input) {
  */
 export async function approveInPersonLogin(input, options = {}) {
   const { signal } = options
+  previousStepAt = Date.now()
 
   const cookieJar = new CookieJar()
   const fetchWithCookies = makeFetchCookie(fetch, cookieJar)

--- a/e2e/scripts/login.mjs
+++ b/e2e/scripts/login.mjs
@@ -16,14 +16,9 @@ const VALIDATE_CARDHOLDER_URL = 'https://idsit.gov.bc.ca/idcheck/protected/valid
 const VERIFY_NON_BCSC_URL = 'https://idsit.gov.bc.ca/idcheck/protected/counterNonBcscRequest/verifyIdentity'
 
 /**
- * Wall-clock at the previous {@link logStep}, so each line can report how long its request took.
- * Reset at the top of {@link approveInPersonLogin}.
- *
- * Worth the module-level state: the whole SM chain runs under ONE client-side abort budget, so when
- * that budget expires the error names whichever request was in flight — structurally the last one —
- * and says nothing about which step actually ate the time. These timings are the difference between
- * "the budget was thin" and "that endpoint hung". Safe as module state because each wdio worker is
- * its own process and runs one journey at a time.
+ * Wall-clock at the previous {@link logStep}, so each line reports how long its request took. The whole
+ * chain shares ONE abort budget, so a timeout names the request in flight — structurally the last one —
+ * not the slow one; these timings tell them apart. Module state is safe: one wdio worker, one journey.
  */
 let previousStepAt = 0
 
@@ -55,9 +50,8 @@ async function logStep(step, response, bodyText) {
     try {
       const parsed = JSON.parse(body)
       console.log(`  body: ${JSON.stringify(parsed).slice(0, 300)}`)
-      // The transaction's device list falls outside that 300-char slice, and it is the one thing in
-      // this response that reflects what EARLIER runs left on the account — the same test cards are
-      // shared by every platform's suite, and nothing here deregisters them afterwards.
+      // The device list falls outside that 300-char slice, and it is the only thing here that shows what
+      // EARLIER runs left on the shared test cards — nothing deregisters them afterwards.
       if (Array.isArray(parsed.devices)) {
         const names = parsed.devices.map((device) => device?.applicationName ?? '(unnamed)').join(', ')
         console.log(`  devices (${parsed.devices.length}): ${names}`)

--- a/e2e/src/flows/verify.ts
+++ b/e2e/src/flows/verify.ts
@@ -40,23 +40,16 @@ import {
 } from '../screens/verify.js'
 
 /**
- * Verify-stack arranges: the entry spine plus the post-authorize step arranges that mirror the app's
- * `getResumeStepRoute` (id → address → email → verify). Reaching a given step is composed from
- * `reachVerificationMethod()` + the explicit per-step arranges (`collectNonBcscEvidence`,
- * `fillResidentialAddress`, `verifyEmailWithTempInbox`, `addAdditionalPhotoId`) rather than a single
- * parameterized `reachVerifyStep`. `completeVerification(user)` then drives the
- * in-person approval to VerificationSuccess.
+ * Verify-stack arranges: the entry spine plus the per-step arranges that mirror the app's
+ * `getResumeStepRoute` (id → address → email → verify), composed with `reachVerificationMethod()`.
  *
- * Reminder: the VerifyPrompt exists only in the session that completed onboarding — run
- * `completeOnboarding()` first and never relaunch in between.
+ * VerifyPrompt exists only in the session that completed onboarding — run `completeOnboarding()` first
+ * and never relaunch in between.
  */
 
 const engine = new BaseScreen()
 
-/**
- * The confirming action on EnterEmail's skip alert (`BCSC.EnterEmail.EmailSkipButton2`) — copy-matched,
- * as the alert's buttons carry no testIDs. Its sibling action keeps the user on the form.
- */
+/** Confirming action on EnterEmail's skip alert — copy-matched, as its buttons carry no testIDs. */
 const EMAIL_SKIP_CONFIRM = 'Skip'
 
 /** VerifyPrompt `Continue` → the AccountSetup add-or-transfer choice. */
@@ -74,12 +67,8 @@ export async function chooseAddAccount(): Promise<void> {
 }
 
 /**
- * Leave an in-progress verification for Home via the header help menu's "Back to home", KEEPING
- * progress (`useLeaveVerification` only moves the verification status out of IN_PROGRESS, which makes
- * RootStack render the MainStack; nothing is cleared).
- *
- * Available on every verify screen except the initial VerifyPrompt and the two transfer screens, which
- * override `headerRight` with the default help menu.
+ * Help menu → "Back to home", KEEPING progress (the app only moves the status out of IN_PROGRESS).
+ * Available on every verify screen except VerifyPrompt and the two transfer screens.
  */
 export async function leaveVerificationToHome(): Promise<void> {
   await openHelpMenu()
@@ -88,10 +77,9 @@ export async function leaveVerificationToHome(): Promise<void> {
 }
 
 /**
- * Re-enter an interrupted verification from Home by tapping the Start/Continue-verification card —
- * the app's ONLY route back in, since the in-progress flag is in-memory and every relaunch recomputes
- * it as unverified. The VerifyStack then mounts at `getResumeStepRoute`; WHICH screen that is, is the
- * caller's assertion (that mapping is the thing under test).
+ * Re-enter an interrupted verification from Home's verification card — the only route back in, since
+ * the in-progress flag is in-memory. The stack mounts at `getResumeStepRoute`; which screen that is,
+ * is the caller's assertion.
  */
 export async function resumeVerification(): Promise<void> {
   await HomeNotificationCard.expectVisible(Timeouts.SCREEN_TRANSITION)
@@ -99,12 +87,10 @@ export async function resumeVerification(): Promise<void> {
 }
 
 /**
- * Open the help menu's "Restart verification process" and answer its confirmation alert.
+ * Help menu → "Restart verification process", answering its confirmation alert.
  *
- * `confirm` wipes all verification progress and re-registers the device with IAS (a backend round trip
- * behind a loading screen), then clears the recorded setup type — so the flow reopens on AccountSetup,
- * NOT IdentitySelection. `cancel` leaves the menu open, so it is closed here to return the caller to
- * the screen they started on.
+ * `confirm` wipes progress and re-registers the device with IAS, reopening on AccountSetup — NOT
+ * IdentitySelection. `cancel` leaves the menu open, so it is closed here.
  */
 export async function restartVerification(answer: 'confirm' | 'cancel'): Promise<void> {
   await openHelpMenu()
@@ -118,10 +104,9 @@ export async function restartVerification(answer: 'confirm' | 'cancel'): Promise
 }
 
 /**
- * The CI-default serial path — no live camera: IdentitySelection `Scan` → ScanSerial (accepting the
- * OS camera dialog whenever it appears; no-op when permission is already granted) → `EnterManually` →
- * ManualSerial → serial typed → EnterBirthdate. Card type is derived later, by `authorizeDevice`
- * at the birthdate submit.
+ * The CI-default serial path, no live camera: `Scan` → ScanSerial (accepting the OS camera dialog if it
+ * appears) → `EnterManually` → serial typed → EnterBirthdate. Card type is derived later, by
+ * `authorizeDevice` at the birthdate submit.
  */
 export async function enterSerialManually(user: TestUser): Promise<void> {
   await IdentitySelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
@@ -136,10 +121,9 @@ export async function enterSerialManually(user: TestUser): Promise<void> {
 }
 
 /**
- * Fill and SUBMIT the birthdate — the submit fires the backend `authorizeDevice(serial, dob)` that
- * derives the card type and resumes the flow. Callers assert the post-authorize screen themselves
- * (it differs per card type). For a no-network fill (e.g. the entry-spine journey), use
- * `EnterBirthdateScreen.fill(...)` directly instead.
+ * Fill and SUBMIT the birthdate — the submit fires `authorizeDevice(serial, dob)`, which derives the
+ * card type. Callers assert the post-authorize screen themselves (it differs per card type); for a
+ * no-network fill, use `EnterBirthdateScreen.fill(...)` directly.
  */
 export async function enterBirthdate(user: TestUser): Promise<void> {
   await EnterBirthdateScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
@@ -148,11 +132,7 @@ export async function enterBirthdate(user: TestUser): Promise<void> {
   await EnterBirthdateScreen.tapWhenEnabled('primary')
 }
 
-/**
- * Build the SiteMinder in-person approval payload from a TestUser's flow — card-tap flows pass the
- * serial + birthdate, document flows pass the typed document number(s). Mirrors the per-flow inputs
- * `approveInPersonRequest` expects.
- */
+/** The SiteMinder approval payload for a user's flow: serial + birthdate, typed document numbers, or both. */
 function approvalInputForUser(user: TestUser): ApproveInPersonInput {
   if (user.flow === 'non-bcsc') {
     return {
@@ -175,11 +155,9 @@ function approvalInputForUser(user: TestUser): ApproveInPersonInput {
 }
 
 /**
- * From the post-authorize state (birthdate submitted), reach VerificationMethodSelection. For a
- * card-tap flow the address step is auto-satisfied once the device is authorized; the email step only
- * appears when the card supplied no verified email — detect it by its SkipEmail button (a stable
- * testID via the EnterEmail descriptor; the input marker is less reliable) and skip it (BCSC cards
- * allow skipping). On an unexpected screen the error reports what is actually on screen.
+ * From the post-authorize state, reach VerificationMethodSelection. The address step is auto-satisfied
+ * once the device is authorized; the email step only appears when the card supplied no verified email —
+ * detect it by its SkipEmail button and skip it (BCSC cards allow skipping).
  */
 export async function reachVerificationMethod(): Promise<void> {
   const deadline = Date.now() + Timeouts.APP_LAUNCH
@@ -189,10 +167,8 @@ export async function reachVerificationMethod(): Promise<void> {
     }
     if (await EnterEmailScreen.isVisible('skip')) {
       await EnterEmailScreen.tap('secondary') // SkipEmail (BCSC flow) → confirmation alert
-      // Skipping is confirm-gated: the tap only raises an `Alert.alert`, and the skip is recorded by
-      // its second action. Unanswered, that alert blocks the screen — so this branch cannot be a bare
-      // tap. It is currently unexercised (every SIT BCSC card carries a verified email, so the email
-      // step never renders), which is exactly why the alert had gone unnoticed.
+      // Confirm-gated: the tap only raises the alert, which blocks the screen until answered. Unexercised
+      // today, as every SIT BCSC card carries a verified email.
       await tapAlertButton(EMAIL_SKIP_CONFIRM)
       await VerificationMethodSelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
       return
@@ -202,23 +178,17 @@ export async function reachVerificationMethod(): Promise<void> {
         `reachVerificationMethod: neither VerificationMethodSelection nor EnterEmail appeared. On screen: ${await describeCurrentScreen()}`
       )
     }
-    // VerificationMethodSelection anchors on the Hours-of-Service heading, which sits at the BOTTOM of
-    // the screen and can be below the fold on a short viewport — where isPresent() (which never scrolls)
-    // reads a genuine arrival as a miss. Nudge the content up to reveal the anchor before the next
-    // probe. Safe on the email screen (its Skip button is caught above, before we ever swipe) and a
-    // no-op while the post-authorize transition is still settling.
+    // VerificationMethodSelection anchors on the Hours-of-Service heading, which can sit below the fold
+    // where isPresent() (which never scrolls) reads an arrival as a miss. Nudge it into view.
     await swipeUpBy()
   }
 }
 
 /**
- * Complete verification via the IN-PERSON method — the CI default: no in-app camera, approved by the
- * real SiteMinder/IDcheck SIT flow (`approveInPersonRequest`; needs `SM_USER`/`SM_PASSWORD` and an
- * allowlisted runner IP). Assumes VerificationMethodSelection is showing. Reads the on-screen
- * confirmation code, drives the approval, then Complete → VerificationSuccess → Home (verified).
- *
- * In-person is the only CI-completable method (hence no `method` parameter); the send-video /
- * live-call methods enter camera screens and are exercised in the manual suite.
+ * Complete verification via the IN-PERSON method — the only CI-completable one (send-video and
+ * live-call open camera screens). From VerificationMethodSelection: read the confirmation code, drive
+ * the real SiteMinder SIT approval (needs `SM_USER`/`SM_PASSWORD` and an allowlisted runner IP), then
+ * Complete → VerificationSuccess → Home.
  */
 export async function completeVerification(user: TestUser): Promise<void> {
   await VerificationMethodSelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
@@ -236,12 +206,11 @@ export async function completeVerification(user: TestUser): Promise<void> {
 }
 
 /**
- * Start the email step against a throwaway inbox: enter a temp address and continue to
- * EmailConfirmation. Returns the inbox token the code is later read with.
+ * Start the email step against a throwaway inbox, continuing to EmailConfirmation. Returns the inbox
+ * token the code is later read with.
  *
- * The email step is MANDATORY in the non-BCSC flow (Skip is hidden there and a non-BCSC user has no
- * card-provided email), so this belongs to the non-bcsc journey. BCSC photo/combined cards carry a
- * verified email and never see the step — those use `reachVerificationMethod` instead.
+ * Non-BCSC only: the step is mandatory there (Skip is hidden), while BCSC cards carry a verified email
+ * and never see it — those use `reachVerificationMethod` instead.
  */
 export async function startEmailVerification(): Promise<string> {
   const { email, token } = await getTempEmailAddress()
@@ -256,10 +225,8 @@ export async function startEmailVerification(): Promise<string> {
 }
 
 /**
- * Type a code into EmailConfirmation and press Continue. Deliberately asserts NOTHING about what
- * follows: a correct code resets the stack to EmailVerified, while a wrong one keeps the screen and
- * adds an inline error (plus, for a rejected-by-the-server code, an alert). The caller decides which
- * it expected.
+ * Type a code into EmailConfirmation and Continue. Asserts NOTHING about what follows — a correct code
+ * resets the stack to EmailVerified, a wrong one stays put with an inline error — so the caller decides.
  */
 export async function submitEmailCode(code: string): Promise<void> {
   await EmailConfirmationScreen.fill('code', code, { tapFirst: true })
@@ -270,25 +237,21 @@ export async function submitEmailCode(code: string): Promise<void> {
 /**
  * Tap "Send a new code" and return the code from the message that arrives AFTER it.
  *
- * Waiting for a NEW message is the assertion — the resend's only other feedback is a toast that
- * auto-hides in 1.5s, which a polling client cannot observe reliably. It also has to be a new message:
- * the resend mints a fresh `email_address_id`, so the code already in the inbox is dead from that
- * moment and submitting it would fail as a mismatch.
+ * The new message IS the assertion: the resend's only other feedback is a 1.5s toast, and it mints a
+ * fresh `email_address_id`, retiring the code already in the inbox.
  */
 export async function resendEmailCode(token: string): Promise<string> {
-  // Waits for the FIRST code to land before resending: taking the baseline from a still-empty inbox
-  // would let the wait below return that first message, whose code the resend has just retired.
+  // Wait for the first code before resending — a baseline taken from a still-empty inbox would let the
+  // wait below return that first, now-retired message.
   const alreadyReceived = await getLatestMailId(token)
   await tapResendCodeLink()
   return getEmailConfirmationCode(token, { afterMailId: alreadyReceived })
 }
 
 /**
- * Tap "Send a new code". Its testID sits on a `ThemedText` nested INSIDE another `ThemedText`, and RN
- * flattens nested text into the parent paragraph — the same shape that turned out to be unaddressable
- * for the Contacts inline link. It may still surface as its own element here, because this one also
- * carries `accessibilityRole="link"` and a label, so both handles are tried before giving up; the
- * failure names the cause rather than reporting a missing element.
+ * Tap "Send a new code". Its testID sits on a `ThemedText` nested inside another, which RN flattens into
+ * the parent paragraph — so the accessibility label is tried too, and the failure names that cause
+ * rather than reporting a missing element.
  */
 async function tapResendCodeLink(): Promise<void> {
   if (await EmailConfirmationScreen.isVisible('resendCode')) {
@@ -314,8 +277,8 @@ async function tapResendCodeLink(): Promise<void> {
 }
 
 /**
- * Finish the email step after a code was accepted: EmailVerified → VerificationMethodSelection.
- * EmailVerified's only testID is the shared Continue, so arrival is confirmed by its title copy.
+ * EmailVerified → VerificationMethodSelection. EmailVerified's only testID is the shared Continue, so
+ * arrival is confirmed by its title copy.
  */
 export async function completeEmailVerification(): Promise<void> {
   const verifiedTitle = await engine.findByText('Your email has been verified')
@@ -325,10 +288,7 @@ export async function completeEmailVerification(): Promise<void> {
   await VerificationMethodSelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
 }
 
-/**
- * Every EvidenceTypeList row on screen, paired with its testID. The list has no container testID and
- * its rows are keyed by the SERVER's `evidence_type`, so the ids are discovered rather than declared.
- */
+/** Every EvidenceTypeList row with its testID — discovered, not declared: the ids embed the server's `evidence_type`. */
 async function evidenceTypeRows(): Promise<{ id: string; element: WebdriverIO.Element }[]> {
   const rowsSelector = driver.isIOS
     ? '-ios predicate string:name CONTAINS "EvidenceTypeListItem"'
@@ -345,24 +305,20 @@ async function evidenceTypeRows(): Promise<{ id: string; element: WebdriverIO.El
 }
 
 /**
- * The testIDs of the rows the list is currently offering — for asserting what it does NOT offer (an
- * ID already used, or one that belongs to the other collection slot). The ids embed the server's
- * `evidence_type`, so match them as substrings, and put the whole list in the failure message: it is
- * the only record of what the backend actually served.
+ * The testIDs the list is currently offering — for asserting what it does NOT offer. Match as
+ * substrings, and print the whole list on failure: it is the only record of what the backend served.
  */
 export async function listEvidenceTypeRowIds(): Promise<string[]> {
   return (await evidenceTypeRows()).map((row) => row.id)
 }
 
 /**
- * Tap an EvidenceTypeList row. Rows carry testID `EvidenceTypeListItem-<evidence_type>` where the
- * evidence_type suffix is SERVER-PROVIDED — so match it as a case-insensitive substring of the row's
- * testID (`match`, e.g. `'Passport'`) rather than a guessed exact label. Requires exactly one match;
- * on zero or multiple it throws WITH the list of row testIDs found, so a mismatch is self-diagnosing
- * (the next run's error reveals the real evidence_type values to pin).
+ * Tap the one EvidenceTypeList row whose testID contains `match` (case-insensitive; the
+ * `EvidenceTypeListItem-<evidence_type>` suffix is server-provided, so never guess an exact label).
+ * Zero or multiple matches throw with the row ids found, making a mismatch self-diagnosing.
  *
- * Selecting a row PERSISTS the choice and pushes IDPhotoInformation — so a caller that stops here has
- * left an evidence entry with no photos, which is the app's "capture interrupted" state.
+ * Selecting PERSISTS the choice and pushes IDPhotoInformation — stopping here leaves an evidence entry
+ * with no photos, the app's "capture interrupted" state.
  */
 export async function selectEvidenceType(match: string): Promise<void> {
   const rows = await evidenceTypeRows()
@@ -378,8 +334,8 @@ export async function selectEvidenceType(match: string): Promise<void> {
   }
 
   if (count === 1 && target) {
-    // The list arrives on a push animation, so settle the row before tapping — a tap dispatched against
-    // bounds the view has already moved past is silently dropped, and the flow blames the NEXT screen.
+    // The list arrives on a push animation — settle the row first, or the tap lands on stale bounds,
+    // is silently dropped, and the flow blames the NEXT screen.
     await engine.waitForSteadyPosition(target)
     await target.click()
     return
@@ -392,13 +348,9 @@ export async function selectEvidenceType(match: string): Promise<void> {
 }
 
 /**
- * Wait for EvidenceCapture's shutter, and on failure say WHICH of the two very different causes it was.
- *
- * The screen's `self` is the shutter, which renders last: the MaskedCamera container mounts as soon as
- * the permission request settles, but the shutter waits on `useCameraDevice` resolving a device. So a
- * missing shutter means either the push never landed (container absent) or the camera never came up
- * (container present) — indistinguishable from the timeout alone, and the ambiguity is what makes this
- * failure expensive to read off a CI log.
+ * Wait for EvidenceCapture's shutter, naming which of two causes a timeout was. The shutter renders only
+ * once `useCameraDevice` resolves, so a miss means either the push never landed (container absent) or no
+ * camera came up (container present) — indistinguishable from the timeout alone.
  */
 async function reachEvidenceCamera(): Promise<void> {
   try {
@@ -418,22 +370,16 @@ async function reachEvidenceCamera(): Promise<void> {
 }
 
 /**
- * Capture a document's photo(s). CAMERA-ONLY: on Sauce the supplied image is injected before the
- * shutter (RN camera feeds are unreliable — see `helpers/camera`); on a local real device the physical
- * camera captures whatever it sees (`injectPhoto` throws off-Sauce). Shutter → accept in PhotoReview,
- * repeating per side (1 for a passport, 2 for a licence — backend-driven) until the typed
- * EvidenceIDCollection form appears.
+ * Capture a document's photo(s), repeating per side (1 for a passport, 2 for a licence — backend-driven)
+ * until the typed EvidenceIDCollection form appears. CAMERA-ONLY: on Sauce the image is injected before
+ * the shutter; on a local device the physical camera captures whatever it sees.
  *
- * `barcodeMasks` MUST cover any decodable barcode on the injected image: the document camera runs a
- * live code scanner behind the shutter, and on Android the injected frames feed it. An unmasked SIT
- * combo barcode gets "scanned", and in the non-BCSC flow the app then verifies it with the backend on
- * UsePhoto and — on a match — quietly resets the flow into card setup (observed: sees the template's
- * serial C26444539, authorizes THAT card, resumes at IDPhotoInformation, journey dead). iOS injection
- * never produces barcode scans, which is why this only ever broke Android.
+ * `barcodeMasks` MUST cover any decodable barcode on the image: the camera runs a live code scanner
+ * behind the shutter that Android's injected frames feed. An unmasked SIT combo barcode gets scanned,
+ * and in the non-BCSC flow the app then authorizes THAT card and resets into card setup mid-capture.
  *
- * `retakeFirstSide` exercises PhotoReview's Retake before accepting: it pops back to the camera for the
- * SAME side, so the side is simply shot again. Nothing about the resulting evidence differs — the point
- * is that the discard-and-return path works — so it is an option here rather than a separate flow.
+ * `retakeFirstSide` exercises PhotoReview's Retake — it re-shoots the same side, so only the
+ * discard-and-return path differs.
  */
 async function capturePhotoIdDocument(
   image: string,
@@ -441,10 +387,8 @@ async function capturePhotoIdDocument(
   options: { retakeFirstSide?: boolean } = {}
 ): Promise<void> {
   await IDPhotoInformationScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
-  // The primer's CTA pushes EvidenceCapture — confirm the push actually landed rather than assuming it.
-  // A tap dispatched while the screen is still transitioning gets swallowed on Android, and because the
-  // element WAS found the tap reports success; the flow then waits out its whole timeout on the shutter
-  // of a camera screen that was never opened, and blames the camera.
+  // Confirm the push landed: a tap dispatched mid-transition is swallowed on Android yet still reports
+  // success, and the flow then waits out its timeout on a camera screen that never opened.
   await IDPhotoInformationScreen.tapToNavigate('primary')
 
   for (let side = 0; side < 2; side++) {
@@ -463,10 +407,9 @@ async function capturePhotoIdDocument(
 
 /** One trip through the document camera: reach it, inject, fire the shutter, land on PhotoReview. */
 async function shootDocumentSide(image: string, barcodeMasks: readonly ImageMaskRegion[]): Promise<void> {
-  // The document camera requests camera permission on first entry — accept it whenever it appears,
-  // otherwise EvidenceCapture renders the PermissionDisabled fallback and MaskedCamera never mounts.
-  // On later entries permission is long granted, but the capture session still has to restart — so
-  // every entry gets the camera budget rather than a screen-transition one.
+  // Camera permission is requested on first entry — accepted whenever it appears, or EvidenceCapture
+  // renders the PermissionDisabled fallback. Later entries still restart the capture session, so every
+  // entry gets the camera budget rather than a screen-transition one.
   await reachEvidenceCamera()
   if (isSauceLabs()) {
     await injectPhoto(image, {}, barcodeMasks) // padding may need tuning to the document mask
@@ -476,14 +419,13 @@ async function shootDocumentSide(image: string, barcodeMasks: readonly ImageMask
 }
 
 /**
- * Non-photo BCSC "additional ID", step one: from AdditionalIdentificationRequired, open the photo-ID
- * list. Separate from the capture because the list is where the non-photo escape hatch lives, and
- * because backing out of that hatch lands here again — so this is re-callable.
+ * Non-photo BCSC "additional ID", step one: open the photo-ID list from AdditionalIdentificationRequired.
+ * Separate from the capture, and re-callable, because backing out of the list's non-photo escape hatch
+ * lands here again.
  */
 export async function reachAdditionalPhotoIdList(): Promise<void> {
-  // AdditionalIdentificationRequired's only testID is the generic `Continue` (shared by ~10 screens),
-  // so wait for its UNIQUE heading to settle before tapping — otherwise a lingering `Continue` from the
-  // previous screen can be tapped mid-transition and the flow never advances.
+  // This screen's only testID is the generic `Continue` (shared by ~10 screens), so wait for its unique
+  // heading — otherwise a lingering `Continue` from the previous screen gets tapped mid-transition.
   const headingSelector = driver.isIOS
     ? '-ios predicate string:label CONTAINS "provide additional ID"'
     : 'android=new UiSelector().textContains("provide additional ID")'
@@ -492,11 +434,10 @@ export async function reachAdditionalPhotoIdList(): Promise<void> {
 }
 
 /**
- * Non-photo BCSC "additional ID", step two: pick the ID type and capture its photo(s), stopping ON the
- * typed EvidenceIDCollection form (its document number is submitted separately, by
- * {@link submitEvidenceIdCollection} — the gap between capture and number is itself a resumable state).
- * `evidenceMatch` is a case-insensitive substring of the target row's testID (server-provided; e.g.
- * `'Passport'`). Camera-only via {@link capturePhotoIdDocument}.
+ * Non-photo BCSC "additional ID", step two: pick the ID type and capture it, stopping ON the typed
+ * EvidenceIDCollection form — the number is submitted separately by {@link submitEvidenceIdCollection},
+ * and that gap is itself a resumable state. `evidenceMatch` is a case-insensitive substring of the
+ * target row's testID (e.g. `'Passport'`). Camera-only via {@link capturePhotoIdDocument}.
  */
 export async function captureAdditionalPhotoId(
   user: TestUser,
@@ -504,18 +445,14 @@ export async function captureAdditionalPhotoId(
   options: { retakeFirstSide?: boolean } = {}
 ): Promise<void> {
   await selectEvidenceType(evidenceMatch)
-  // The card-back template carries the SIT combo barcode. The reroute-on-scan has only been observed
-  // in the non-BCSC flow, but the code scanner runs behind every document capture — mask on principle.
+  // The card-back template carries the SIT combo barcode; the scanner runs behind every capture, so mask
+  // it even though the reroute has only been observed in the non-BCSC flow.
   await capturePhotoIdDocument(user.cardScanImage, COMBO_CARD_BARCODE_MASKS, options)
 }
 
 /**
- * Fill an EvidenceIDCollection form — the typed document number, plus (first non-BCSC ID only) the
- * name + birthdate personal-info fields — then Continue.
- *
- * Every field is re-typed from scratch, so calling this again after a rejected submit replaces the
- * offending value rather than appending to it (the engine clears before typing, and the form clears a
- * field's error as soon as it changes).
+ * Fill an EvidenceIDCollection form — document number, plus (first non-BCSC ID only) name + birthdate —
+ * then Continue. Every field is re-typed from scratch, so this is re-callable after a rejected submit.
  */
 export async function submitEvidenceIdCollection(
   documentNumber: string,
@@ -533,12 +470,10 @@ export async function submitEvidenceIdCollection(
 }
 
 /**
- * Enter the non-BCSC branch: IdentitySelection `OtherID` → DualIdentificationRequired → the first-ID
- * EvidenceTypeList. Choosing OtherID sets the non-BCSC card process and discards any serial already
- * entered, so this is a one-way turn off the BCSC path.
+ * Enter the non-BCSC branch: `OtherID` → DualIdentificationRequired → the first-ID EvidenceTypeList.
+ * OtherID discards any serial already entered, so this is a one-way turn off the BCSC path.
  *
- * Stops AT the list — no camera and no document is committed — so it is also the cheap way to reach
- * the evidence screens on a session that never verifies.
+ * Stops AT the list, committing no document — the cheap way to reach the evidence screens.
  */
 export async function chooseOtherIdPath(): Promise<void> {
   await IdentitySelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
@@ -549,19 +484,17 @@ export async function chooseOtherIdPath(): Promise<void> {
     ? '-ios predicate string:label CONTAINS "two government"'
     : 'android=new UiSelector().textContains("two government")'
   await $(dualHeadingSelector).waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
-  // Safe to confirm-and-retry on the generic `Continue` here: EvidenceTypeList renders no Continue of
-  // its own, so the button going away really does mean the push landed.
+  // Confirm-and-retry is safe on the generic `Continue` here: EvidenceTypeList renders no Continue of
+  // its own, so the button going away means the push landed.
   await DualIdentificationRequiredScreen.tapToNavigate('primary') // Continue → EvidenceTypeList (first ID)
 }
 
 /**
- * Non-BCSC path, first of the two required IDs: OtherID → the first-ID list → pick → capture, stopping
- * ON the typed form (which for this document also collects name + birthdate). `docMatch` is a
- * case-insensitive substring of the target row's testID. Camera-only via {@link capturePhotoIdDocument}.
+ * Non-BCSC first ID: OtherID → list → pick → capture, stopping ON the typed form (which also collects
+ * name + birthdate). `docMatch` is a case-insensitive substring of the target row's testID.
  *
- * The card-back image carries the SIT combo barcode, and this is the flow where the app verifies a
- * scanned barcode with the backend on UsePhoto and reroutes on a match — so the barcode regions must be
- * masked out of the injection.
+ * The card-back image carries the SIT combo barcode, and this is the flow that reroutes on a scan — so
+ * those regions are masked out of the injection.
  */
 export async function captureFirstNonBcscDocument(user: TestUser, docMatch: string): Promise<void> {
   if (user.flow !== 'non-bcsc') {
@@ -573,11 +506,9 @@ export async function captureFirstNonBcscDocument(user: TestUser, docMatch: stri
 }
 
 /**
- * Non-BCSC path, second ID: pick → capture, stopping ON its typed form. Submitting that form (number
- * only — the personal info was collected with the first document) resumes to ResidentialAddress.
- *
- * The list this picks from is a DIFFERENT list from the first document's: the screen filters by
- * `collection_order` and hides anything already chosen, so the two slots genuinely offer different rows.
+ * Non-BCSC second ID: pick → capture, stopping ON its typed form. Submitting that form (number only)
+ * resumes to ResidentialAddress. The list differs from the first document's — the screen filters by
+ * `collection_order` and hides what was already chosen.
  */
 export async function captureSecondNonBcscDocument(user: TestUser, docMatch: string): Promise<void> {
   await selectEvidenceType(docMatch)
@@ -585,12 +516,11 @@ export async function captureSecondNonBcscDocument(user: TestUser, docMatch: str
 }
 
 /**
- * Fill the ResidentialAddress form (non-BCSC only) and continue → the mandatory email step. Province
- * is a dropdown: tap it to open the modal, then pick British Columbia.
+ * Fill the ResidentialAddress form (non-BCSC only) → the mandatory email step. Province is a dropdown:
+ * tap to open the modal, then pick British Columbia.
  *
- * This screen is why {@link BaseScreen.dismissKeyboard} no longer blind-taps on iOS: once the
- * postal-code field is focused, the province dropdown sits under the old tap point, so the "dismiss"
- * opened its modal and left Continue unreachable. Nothing here may dismiss the keyboard positionally.
+ * Nothing here may dismiss the keyboard positionally — the province dropdown sits under the old blind
+ * tap point, which is why {@link BaseScreen.dismissKeyboard} no longer uses one on iOS.
  */
 export async function fillResidentialAddress(): Promise<void> {
   await ResidentialAddressScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
@@ -609,9 +539,8 @@ export async function fillResidentialAddress(): Promise<void> {
 }
 
 /**
- * Wait for the province dropdown's modal to close — the BC option exists only inside it, so its
- * disappearance is the signal. Asserted explicitly so a swallowed option tap is named here rather
- * than surfacing later as an unreachable postal-code field.
+ * Wait for the province modal to close — the BC option only exists inside it. Asserted explicitly so a
+ * swallowed option tap is named here, not later as an unreachable postal-code field.
  */
 async function expectProvinceDropdownClosed(): Promise<void> {
   const deadline = Date.now() + Timeouts.SCREEN_TRANSITION

--- a/e2e/src/flows/verify.ts
+++ b/e2e/src/flows/verify.ts
@@ -1,14 +1,22 @@
 import type { TestUser } from '../constants.js'
 import { COMBO_CARD_BARCODE_MASKS, Timeouts } from '../constants.js'
+import { tapAlertButton } from '../helpers/alerts.js'
 import { ApproveInPersonInput, approveInPersonRequest } from '../helpers/approval.js'
 import type { ImageMaskRegion } from '../helpers/camera.js'
 import { injectPhoto } from '../helpers/camera.js'
-import { getEmailConfirmationCode, getTempEmailAddress } from '../helpers/email.js'
+import { getEmailConfirmationCode, getLatestMailId, getTempEmailAddress } from '../helpers/email.js'
 import { swipeUpBy } from '../helpers/gestures.js'
+import {
+  closeHelpMenu,
+  HelpMenuRows,
+  openHelpMenu,
+  RestartVerificationAlert,
+  tapHelpMenuRow,
+} from '../helpers/help-menu.js'
 import { isSauceLabs } from '../helpers/sauce.js'
 import { describeCurrentScreen, reachCameraScreen } from '../helpers/screens.js'
 import { BaseScreen } from '../screens/core/BaseScreen.js'
-import { HomeScreen } from '../screens/main.js'
+import { HomeNotificationCard, HomeScreen } from '../screens/main.js'
 import { VerifyPromptScreen } from '../screens/onboarding.js'
 import {
   AccountSetupScreen,
@@ -45,6 +53,12 @@ import {
 
 const engine = new BaseScreen()
 
+/**
+ * The confirming action on EnterEmail's skip alert (`BCSC.EnterEmail.EmailSkipButton2`) — copy-matched,
+ * as the alert's buttons carry no testIDs. Its sibling action keeps the user on the form.
+ */
+const EMAIL_SKIP_CONFIRM = 'Skip'
+
 /** VerifyPrompt `Continue` → the AccountSetup add-or-transfer choice. */
 export async function startVerification(): Promise<void> {
   await VerifyPromptScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
@@ -57,6 +71,50 @@ export async function chooseAddAccount(): Promise<void> {
   await AccountSetupScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   await AccountSetupScreen.tap('primary')
   await IdentitySelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+}
+
+/**
+ * Leave an in-progress verification for Home via the header help menu's "Back to home", KEEPING
+ * progress (`useLeaveVerification` only moves the verification status out of IN_PROGRESS, which makes
+ * RootStack render the MainStack; nothing is cleared).
+ *
+ * Available on every verify screen except the initial VerifyPrompt and the two transfer screens, which
+ * override `headerRight` with the default help menu.
+ */
+export async function leaveVerificationToHome(): Promise<void> {
+  await openHelpMenu()
+  await tapHelpMenuRow(HelpMenuRows.backToHome)
+  await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+}
+
+/**
+ * Re-enter an interrupted verification from Home by tapping the Start/Continue-verification card —
+ * the app's ONLY route back in, since the in-progress flag is in-memory and every relaunch recomputes
+ * it as unverified. The VerifyStack then mounts at `getResumeStepRoute`; WHICH screen that is, is the
+ * caller's assertion (that mapping is the thing under test).
+ */
+export async function resumeVerification(): Promise<void> {
+  await HomeNotificationCard.expectVisible(Timeouts.SCREEN_TRANSITION)
+  await HomeNotificationCard.tapToNavigate('primary')
+}
+
+/**
+ * Open the help menu's "Restart verification process" and answer its confirmation alert.
+ *
+ * `confirm` wipes all verification progress and re-registers the device with IAS (a backend round trip
+ * behind a loading screen), then clears the recorded setup type — so the flow reopens on AccountSetup,
+ * NOT IdentitySelection. `cancel` leaves the menu open, so it is closed here to return the caller to
+ * the screen they started on.
+ */
+export async function restartVerification(answer: 'confirm' | 'cancel'): Promise<void> {
+  await openHelpMenu()
+  await tapHelpMenuRow(HelpMenuRows.restartVerification)
+  if (answer === 'cancel') {
+    await tapAlertButton(RestartVerificationAlert.cancel)
+    await closeHelpMenu()
+    return
+  }
+  await tapAlertButton(RestartVerificationAlert.confirm)
 }
 
 /**
@@ -130,7 +188,12 @@ export async function reachVerificationMethod(): Promise<void> {
       return
     }
     if (await EnterEmailScreen.isVisible('skip')) {
-      await EnterEmailScreen.tap('secondary') // SkipEmail (BCSC flow)
+      await EnterEmailScreen.tap('secondary') // SkipEmail (BCSC flow) → confirmation alert
+      // Skipping is confirm-gated: the tap only raises an `Alert.alert`, and the skip is recorded by
+      // its second action. Unanswered, that alert blocks the screen — so this branch cannot be a bare
+      // tap. It is currently unexercised (every SIT BCSC card carries a verified email, so the email
+      // step never renders), which is exactly why the alert had gone unnoticed.
+      await tapAlertButton(EMAIL_SKIP_CONFIRM)
       await VerificationMethodSelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
       return
     }
@@ -173,13 +236,14 @@ export async function completeVerification(user: TestUser): Promise<void> {
 }
 
 /**
- * Drive the full email-verification step with a throwaway inbox: enter a temp address, read the
- * emailed 6-digit code, confirm it, and continue past EmailVerified to VerificationMethodSelection.
+ * Start the email step against a throwaway inbox: enter a temp address and continue to
+ * EmailConfirmation. Returns the inbox token the code is later read with.
+ *
  * The email step is MANDATORY in the non-BCSC flow (Skip is hidden there and a non-BCSC user has no
  * card-provided email), so this belongs to the non-bcsc journey. BCSC photo/combined cards carry a
- * verified email and skip the step — those use `reachVerificationMethod` instead.
+ * verified email and never see the step — those use `reachVerificationMethod` instead.
  */
-export async function verifyEmailWithTempInbox(): Promise<void> {
+export async function startEmailVerification(): Promise<string> {
   const { email, token } = await getTempEmailAddress()
 
   await EnterEmailScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
@@ -188,18 +252,106 @@ export async function verifyEmailWithTempInbox(): Promise<void> {
   await EnterEmailScreen.tapWhenEnabled('primary') // Continue → createEmailVerification → EmailConfirmation
 
   await EmailConfirmationScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
-  const code = await getEmailConfirmationCode(token)
+  return token
+}
+
+/**
+ * Type a code into EmailConfirmation and press Continue. Deliberately asserts NOTHING about what
+ * follows: a correct code resets the stack to EmailVerified, while a wrong one keeps the screen and
+ * adds an inline error (plus, for a rejected-by-the-server code, an alert). The caller decides which
+ * it expected.
+ */
+export async function submitEmailCode(code: string): Promise<void> {
   await EmailConfirmationScreen.fill('code', code, { tapFirst: true })
   await engine.dismissKeyboard()
-  await EmailConfirmationScreen.tapWhenEnabled('primary') // Continue → sendCode → RESET to EmailVerified
+  await EmailConfirmationScreen.tapWhenEnabled('primary') // Continue → sendCode
+}
 
-  // EmailVerified's only testID is the shared Continue, so confirm arrival by its title copy before
-  // tapping through — its Continue RESETS to VerificationMethodSelection.
+/**
+ * Tap "Send a new code" and return the code from the message that arrives AFTER it.
+ *
+ * Waiting for a NEW message is the assertion — the resend's only other feedback is a toast that
+ * auto-hides in 1.5s, which a polling client cannot observe reliably. It also has to be a new message:
+ * the resend mints a fresh `email_address_id`, so the code already in the inbox is dead from that
+ * moment and submitting it would fail as a mismatch.
+ */
+export async function resendEmailCode(token: string): Promise<string> {
+  // Waits for the FIRST code to land before resending: taking the baseline from a still-empty inbox
+  // would let the wait below return that first message, whose code the resend has just retired.
+  const alreadyReceived = await getLatestMailId(token)
+  await tapResendCodeLink()
+  return getEmailConfirmationCode(token, { afterMailId: alreadyReceived })
+}
+
+/**
+ * Tap "Send a new code". Its testID sits on a `ThemedText` nested INSIDE another `ThemedText`, and RN
+ * flattens nested text into the parent paragraph — the same shape that turned out to be unaddressable
+ * for the Contacts inline link. It may still surface as its own element here, because this one also
+ * carries `accessibilityRole="link"` and a label, so both handles are tried before giving up; the
+ * failure names the cause rather than reporting a missing element.
+ */
+async function tapResendCodeLink(): Promise<void> {
+  if (await EmailConfirmationScreen.isVisible('resendCode')) {
+    await EmailConfirmationScreen.link('resendCode')
+    return
+  }
+
+  const label = 'Send a new code' // BCSC.EmailConfirmation.SendNewCode
+  const selector = driver.isIOS
+    ? `-ios predicate string:label == "${label}" OR name == "${label}"`
+    : `android=new UiSelector().description("${label}")`
+  const link = $(selector)
+  if (await link.isDisplayed().catch(() => false)) {
+    await link.click()
+    return
+  }
+
+  throw new Error(
+    'EmailConfirmation\'s "Send a new code" link is not addressable by testID or accessibility label: ' +
+      'it is a Text nested inside another Text, which RN flattens into the paragraph. Covering the resend ' +
+      'branch would need the link moved onto a real pressable in the app.'
+  )
+}
+
+/**
+ * Finish the email step after a code was accepted: EmailVerified → VerificationMethodSelection.
+ * EmailVerified's only testID is the shared Continue, so arrival is confirmed by its title copy.
+ */
+export async function completeEmailVerification(): Promise<void> {
   const verifiedTitle = await engine.findByText('Your email has been verified')
   await verifiedTitle.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
-  await EmailVerifiedScreen.tap('primary')
+  await EmailVerifiedScreen.tap('primary') // RESETS to VerificationMethodSelection
 
   await VerificationMethodSelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+}
+
+/**
+ * Every EvidenceTypeList row on screen, paired with its testID. The list has no container testID and
+ * its rows are keyed by the SERVER's `evidence_type`, so the ids are discovered rather than declared.
+ */
+async function evidenceTypeRows(): Promise<{ id: string; element: WebdriverIO.Element }[]> {
+  const rowsSelector = driver.isIOS
+    ? '-ios predicate string:name CONTAINS "EvidenceTypeListItem"'
+    : 'android=new UiSelector().resourceIdMatches(".*EvidenceTypeListItem.*")'
+  await $(rowsSelector).waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
+
+  const attr = driver.isIOS ? 'name' : 'resource-id'
+  const rows = await $$(rowsSelector)
+  const found: { id: string; element: WebdriverIO.Element }[] = []
+  for (const element of rows) {
+    found.push({ id: (await element.getAttribute(attr).catch(() => null)) ?? '', element })
+  }
+  return found
+}
+
+/**
+ * The testIDs of the rows the list is currently offering — for asserting what it does NOT offer (an
+ * ID already used, or one that belongs to the other collection slot). The ids embed the server's
+ * `evidence_type`, so match them as substrings, and put the whole list in the failure message: it is
+ * the only record of what the backend actually served.
+ */
+export async function listEvidenceTypeRowIds(): Promise<string[]> {
+  return (await evidenceTypeRows()).map((row) => row.id)
 }
 
 /**
@@ -208,25 +360,20 @@ export async function verifyEmailWithTempInbox(): Promise<void> {
  * testID (`match`, e.g. `'Passport'`) rather than a guessed exact label. Requires exactly one match;
  * on zero or multiple it throws WITH the list of row testIDs found, so a mismatch is self-diagnosing
  * (the next run's error reveals the real evidence_type values to pin).
+ *
+ * Selecting a row PERSISTS the choice and pushes IDPhotoInformation — so a caller that stops here has
+ * left an evidence entry with no photos, which is the app's "capture interrupted" state.
  */
-async function selectEvidenceType(match: string): Promise<void> {
-  const rowsSelector = driver.isIOS
-    ? '-ios predicate string:name CONTAINS "EvidenceTypeListItem"'
-    : 'android=new UiSelector().resourceIdMatches(".*EvidenceTypeListItem.*")'
-  await $(rowsSelector).waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
-
-  const attr = driver.isIOS ? 'name' : 'resource-id'
-  const rows = await $$(rowsSelector)
+export async function selectEvidenceType(match: string): Promise<void> {
+  const rows = await evidenceTypeRows()
   const needle = match.toLowerCase()
-  const ids: string[] = []
+  const ids = rows.map((row) => row.id)
   let target: WebdriverIO.Element | null = null
   let count = 0
-  for (const el of rows) {
-    const id = (await el.getAttribute(attr).catch(() => null)) ?? ''
-    ids.push(id)
-    if (id.toLowerCase().includes(needle)) {
+  for (const row of rows) {
+    if (row.id.toLowerCase().includes(needle)) {
       count += 1
-      target = el
+      target = row.element
     }
   }
 
@@ -283,8 +430,16 @@ async function reachEvidenceCamera(): Promise<void> {
  * UsePhoto and — on a match — quietly resets the flow into card setup (observed: sees the template's
  * serial C26444539, authorizes THAT card, resumes at IDPhotoInformation, journey dead). iOS injection
  * never produces barcode scans, which is why this only ever broke Android.
+ *
+ * `retakeFirstSide` exercises PhotoReview's Retake before accepting: it pops back to the camera for the
+ * SAME side, so the side is simply shot again. Nothing about the resulting evidence differs — the point
+ * is that the discard-and-return path works — so it is an option here rather than a separate flow.
  */
-async function capturePhotoIdDocument(image: string, barcodeMasks: readonly ImageMaskRegion[] = []): Promise<void> {
+async function capturePhotoIdDocument(
+  image: string,
+  barcodeMasks: readonly ImageMaskRegion[] = [],
+  options: { retakeFirstSide?: boolean } = {}
+): Promise<void> {
   await IDPhotoInformationScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   // The primer's CTA pushes EvidenceCapture — confirm the push actually landed rather than assuming it.
   // A tap dispatched while the screen is still transitioning gets swallowed on Android, and because the
@@ -293,16 +448,11 @@ async function capturePhotoIdDocument(image: string, barcodeMasks: readonly Imag
   await IDPhotoInformationScreen.tapToNavigate('primary')
 
   for (let side = 0; side < 2; side++) {
-    // The document camera requests camera permission on first entry — accept it whenever it appears,
-    // otherwise EvidenceCapture renders the PermissionDisabled fallback and MaskedCamera never mounts.
-    // On the second side permission is long granted, but the capture session still has to restart — so
-    // both sides get the camera budget rather than a screen-transition one.
-    await reachEvidenceCamera()
-    if (isSauceLabs()) {
-      await injectPhoto(image, {}, barcodeMasks) // padding may need tuning to the document mask
+    await shootDocumentSide(image, barcodeMasks)
+    if (side === 0 && options.retakeFirstSide) {
+      await PhotoReviewScreen.tapToNavigate('secondary') // Retake → back to the camera, same side
+      await shootDocumentSide(image, barcodeMasks)
     }
-    await EvidenceCaptureScreen.tap('primary') // MaskedCamera shutter — NOT tapToNavigate (not idempotent)
-    await PhotoReviewScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
     await PhotoReviewScreen.tapToNavigate('primary') // UsePhoto → next side or the typed form
     if (await EvidenceIDCollectionScreen.isPresent(Timeouts.SCREEN_TRANSITION)) {
       return
@@ -311,14 +461,26 @@ async function capturePhotoIdDocument(image: string, barcodeMasks: readonly Imag
   await EvidenceIDCollectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
 }
 
+/** One trip through the document camera: reach it, inject, fire the shutter, land on PhotoReview. */
+async function shootDocumentSide(image: string, barcodeMasks: readonly ImageMaskRegion[]): Promise<void> {
+  // The document camera requests camera permission on first entry — accept it whenever it appears,
+  // otherwise EvidenceCapture renders the PermissionDisabled fallback and MaskedCamera never mounts.
+  // On later entries permission is long granted, but the capture session still has to restart — so
+  // every entry gets the camera budget rather than a screen-transition one.
+  await reachEvidenceCamera()
+  if (isSauceLabs()) {
+    await injectPhoto(image, {}, barcodeMasks) // padding may need tuning to the document mask
+  }
+  await EvidenceCaptureScreen.tap('primary') // MaskedCamera shutter — NOT tapToNavigate (not idempotent)
+  await PhotoReviewScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+}
+
 /**
- * Non-photo BCSC "additional ID": from AdditionalIdentificationRequired, add one extra photo ID — pick
- * its type, capture its photo, and type its document number — landing on the post-document resume
- * (EnterEmail, skippable for a BCSC card). `evidenceMatch` is a case-insensitive substring of the
- * target EvidenceTypeList row testID (server-provided; e.g. `'Passport'`). Camera-only via
- * {@link capturePhotoIdDocument}.
+ * Non-photo BCSC "additional ID", step one: from AdditionalIdentificationRequired, open the photo-ID
+ * list. Separate from the capture because the list is where the non-photo escape hatch lives, and
+ * because backing out of that hatch lands here again — so this is re-callable.
  */
-export async function addAdditionalPhotoId(user: TestUser, evidenceMatch: string): Promise<void> {
+export async function reachAdditionalPhotoIdList(): Promise<void> {
   // AdditionalIdentificationRequired's only testID is the generic `Continue` (shared by ~10 screens),
   // so wait for its UNIQUE heading to settle before tapping — otherwise a lingering `Continue` from the
   // previous screen can be tapped mid-transition and the flow never advances.
@@ -327,20 +489,35 @@ export async function addAdditionalPhotoId(user: TestUser, evidenceMatch: string
     : 'android=new UiSelector().textContains("provide additional ID")'
   await $(headingSelector).waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
   await AdditionalIdentificationRequiredScreen.tapToNavigate('primary') // Continue → EvidenceTypeList
+}
+
+/**
+ * Non-photo BCSC "additional ID", step two: pick the ID type and capture its photo(s), stopping ON the
+ * typed EvidenceIDCollection form (its document number is submitted separately, by
+ * {@link submitEvidenceIdCollection} — the gap between capture and number is itself a resumable state).
+ * `evidenceMatch` is a case-insensitive substring of the target row's testID (server-provided; e.g.
+ * `'Passport'`). Camera-only via {@link capturePhotoIdDocument}.
+ */
+export async function captureAdditionalPhotoId(
+  user: TestUser,
+  evidenceMatch: string,
+  options: { retakeFirstSide?: boolean } = {}
+): Promise<void> {
   await selectEvidenceType(evidenceMatch)
   // The card-back template carries the SIT combo barcode. The reroute-on-scan has only been observed
   // in the non-BCSC flow, but the code scanner runs behind every document capture — mask on principle.
-  await capturePhotoIdDocument(user.cardScanImage, COMBO_CARD_BARCODE_MASKS)
-  await EvidenceIDCollectionScreen.fill('documentNumber', user.documentNumber, { tapFirst: true })
-  await engine.dismissKeyboard()
-  await EvidenceIDCollectionScreen.tapWhenEnabled('primary') // EvidenceIDCollectionContinue
+  await capturePhotoIdDocument(user.cardScanImage, COMBO_CARD_BARCODE_MASKS, options)
 }
 
 /**
  * Fill an EvidenceIDCollection form — the typed document number, plus (first non-BCSC ID only) the
  * name + birthdate personal-info fields — then Continue.
+ *
+ * Every field is re-typed from scratch, so calling this again after a rejected submit replaces the
+ * offending value rather than appending to it (the engine clears before typing, and the form clears a
+ * field's error as soon as it changes).
  */
-async function fillEvidenceIdCollection(
+export async function submitEvidenceIdCollection(
   documentNumber: string,
   personalInfo?: { lastName: string; firstName: string; dob: string }
 ): Promise<void> {
@@ -356,19 +533,14 @@ async function fillEvidenceIdCollection(
 }
 
 /**
- * Non-BCSC path: from IdentitySelection, choose OtherID and provide TWO government IDs (each captured
- * then typed), landing on ResidentialAddress. `firstDocMatch`/`secondDocMatch` are case-insensitive
- * substrings of the two EvidenceTypeList row testIDs; the first document also collects name +
- * birthdate. Camera-only via {@link capturePhotoIdDocument}.
+ * Enter the non-BCSC branch: IdentitySelection `OtherID` → DualIdentificationRequired → the first-ID
+ * EvidenceTypeList. Choosing OtherID sets the non-BCSC card process and discards any serial already
+ * entered, so this is a one-way turn off the BCSC path.
+ *
+ * Stops AT the list — no camera and no document is committed — so it is also the cheap way to reach
+ * the evidence screens on a session that never verifies.
  */
-export async function collectNonBcscEvidence(
-  user: TestUser,
-  firstDocMatch: string,
-  secondDocMatch: string
-): Promise<void> {
-  if (user.flow !== 'non-bcsc') {
-    throw new Error(`collectNonBcscEvidence requires a non-bcsc TestUser (got '${user.flow}')`)
-  }
+export async function chooseOtherIdPath(): Promise<void> {
   await IdentitySelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   await IdentitySelectionScreen.tapToNavigate('secondary') // OtherID → DualIdentificationRequired
 
@@ -380,22 +552,36 @@ export async function collectNonBcscEvidence(
   // Safe to confirm-and-retry on the generic `Continue` here: EvidenceTypeList renders no Continue of
   // its own, so the button going away really does mean the push landed.
   await DualIdentificationRequiredScreen.tapToNavigate('primary') // Continue → EvidenceTypeList (first ID)
+}
 
-  // First ID — captured + typed WITH name/birthdate. The card-back image carries the SIT combo
-  // barcode, and this is the flow where the app verifies a scanned barcode with the backend on
-  // UsePhoto and reroutes on a match — so the barcode regions must be masked out of the injection.
-  await selectEvidenceType(firstDocMatch)
+/**
+ * Non-BCSC path, first of the two required IDs: OtherID → the first-ID list → pick → capture, stopping
+ * ON the typed form (which for this document also collects name + birthdate). `docMatch` is a
+ * case-insensitive substring of the target row's testID. Camera-only via {@link capturePhotoIdDocument}.
+ *
+ * The card-back image carries the SIT combo barcode, and this is the flow where the app verifies a
+ * scanned barcode with the backend on UsePhoto and reroutes on a match — so the barcode regions must be
+ * masked out of the injection.
+ */
+export async function captureFirstNonBcscDocument(user: TestUser, docMatch: string): Promise<void> {
+  if (user.flow !== 'non-bcsc') {
+    throw new Error(`captureFirstNonBcscDocument requires a non-bcsc TestUser (got '${user.flow}')`)
+  }
+  await chooseOtherIdPath()
+  await selectEvidenceType(docMatch)
   await capturePhotoIdDocument(user.cardScanImage, COMBO_CARD_BARCODE_MASKS)
-  await fillEvidenceIdCollection(user.primaryDocumentNumber, {
-    lastName: user.lastName,
-    firstName: user.firstName,
-    dob: user.dob,
-  })
+}
 
-  // Second ID — captured + typed (number only); its save resumes to ResidentialAddress.
-  await selectEvidenceType(secondDocMatch)
+/**
+ * Non-BCSC path, second ID: pick → capture, stopping ON its typed form. Submitting that form (number
+ * only — the personal info was collected with the first document) resumes to ResidentialAddress.
+ *
+ * The list this picks from is a DIFFERENT list from the first document's: the screen filters by
+ * `collection_order` and hides anything already chosen, so the two slots genuinely offer different rows.
+ */
+export async function captureSecondNonBcscDocument(user: TestUser, docMatch: string): Promise<void> {
+  await selectEvidenceType(docMatch)
   await capturePhotoIdDocument(user.selfieImage)
-  await fillEvidenceIdCollection(user.documentNumber)
 }
 
 /**

--- a/e2e/src/helpers/alerts.ts
+++ b/e2e/src/helpers/alerts.ts
@@ -6,10 +6,8 @@ const DEFAULT_DISMISS_TIMEOUT_MS = 3_000
 
 // 'Open' accepts the iOS "Open in <app>?" confirmation raised when a deep link resolves to the app.
 const IOS_APPROVE_ALERT_BUTTON_LABELS = ['Allow', 'Allow While Using App', 'Allow Once', 'OK', 'Trust', 'Continue', 'Open']
-// iOS types the apostrophe in "Don't Allow" as U+2019, not U+0027 — observed on iOS 17, where matching
-// only the straight form dropped the deny through to the label-blind `mobile: alert dismiss` fallback.
-// Both are listed (rather than swapped) because the rendered form is an OS-version detail, not a
-// contract, and the escape keeps the two visually indistinguishable characters apart in source.
+// iOS renders the apostrophe in "Don't Allow" as U+2019 — matching only the straight form let the deny
+// fall through to the label-blind dismiss fallback. Both are listed; the rendered form is OS-dependent.
 const IOS_DECLINE_ALERT_BUTTON_LABELS = ["Don't Allow", 'Don\u2019t Allow', 'Deny', 'Cancel', 'Not Now']
 
 const ANDROID_PERM_ALLOW_REGEX = '.*:id/permission_allow.*'
@@ -279,22 +277,18 @@ export async function tapResetAppConfirm(appearTimeoutMs = DEFAULT_APPEAR_TIMEOU
 }
 
 /**
- * Tap a NAMED button on an app-owned `Alert.alert` — the two-action confirmations the verify flow
- * raises (restart verification, skip email), where cancel and confirm must be told apart.
+ * Tap a NAMED button on an app-owned `Alert.alert` — the verify flow's two-action confirmations, where
+ * cancel and confirm must be told apart. `acceptSystemAlert`/`acceptAppAlert` cannot: they take whichever
+ * button the platform calls the accept action, which for such a pair is the choice under test.
  *
- * `acceptSystemAlert` / `acceptAppAlert` cannot do this: they take whichever button the platform
- * considers the accept action, which for a cancel/destructive pair is exactly the choice under test.
- *
- * iOS goes through WDA's `buttonLabel` (it reaches the alert even when it is presented over a modal,
- * as the help menu's are), falling back to a direct tap inside the alert. Android matches the button's
- * visible label case-insensitively — the AppCompat dialog theme may upper-case it for display — and
- * never consults the popup probes, which on that platform only recognize the OS permission dialog.
+ * iOS uses WDA's `buttonLabel` (it reaches alerts presented over a modal, as the help menu's are), then
+ * falls back to a direct tap. Android matches the visible label case-insensitively — AppCompat may
+ * upper-case it.
  */
 export async function tapAlertButton(label: string, appearTimeoutMs = DEFAULT_APPEAR_TIMEOUT_MS): Promise<void> {
   if (driver.isAndroid) {
-    // The presence probes above only know the OS permission controller, so an app dialog is waited on
-    // through the button itself (as `tapResetAppConfirm` / `acceptAppAlert` do). The reverse wait is
-    // what proves the tap landed — the dialog is gone, not merely tapped at.
+    // The popup probes above only know the OS permission controller, so an app dialog is waited on
+    // through the button itself; the reverse wait is what proves the tap landed.
     const escaped = label.replaceAll(/[.*+?^${}()|[\]\\]/g, (match) => `\\${match}`)
     const button = $(`android=new UiSelector().textMatches("(?i)^${escaped}$")`)
     await button.waitForDisplayed({ timeout: appearTimeoutMs })
@@ -307,8 +301,7 @@ export async function tapAlertButton(label: string, appearTimeoutMs = DEFAULT_AP
   if (!(await waitForPopup(appearTimeoutMs))) {
     throw new Error(`[alerts] No alert appeared within ${appearTimeoutMs}ms to tap "${label}" on`)
   }
-  // WDA's accept-by-name taps the button it is given, whichever role it plays — so this is how the
-  // cancel action is chosen too, not just the confirming one.
+  // WDA's accept-by-name taps whichever button it is given, whatever role it plays — cancel included.
   const tappedByLabel = await quietly(() =>
     driver
       .execute('mobile: alert', { action: 'accept', buttonLabel: label })

--- a/e2e/src/helpers/alerts.ts
+++ b/e2e/src/helpers/alerts.ts
@@ -6,7 +6,11 @@ const DEFAULT_DISMISS_TIMEOUT_MS = 3_000
 
 // 'Open' accepts the iOS "Open in <app>?" confirmation raised when a deep link resolves to the app.
 const IOS_APPROVE_ALERT_BUTTON_LABELS = ['Allow', 'Allow While Using App', 'Allow Once', 'OK', 'Trust', 'Continue', 'Open']
-const IOS_DECLINE_ALERT_BUTTON_LABELS = ["Don't Allow", 'Deny', 'Cancel', 'Not Now']
+// iOS types the apostrophe in "Don't Allow" as U+2019, not U+0027 — observed on iOS 17, where matching
+// only the straight form dropped the deny through to the label-blind `mobile: alert dismiss` fallback.
+// Both are listed (rather than swapped) because the rendered form is an OS-version detail, not a
+// contract, and the escape keeps the two visually indistinguishable characters apart in source.
+const IOS_DECLINE_ALERT_BUTTON_LABELS = ["Don't Allow", 'Don\u2019t Allow', 'Deny', 'Cancel', 'Not Now']
 
 const ANDROID_PERM_ALLOW_REGEX = '.*:id/permission_allow.*'
 const ANDROID_PERM_DENY_REGEX = '.*:id/permission_deny.*'
@@ -272,6 +276,52 @@ export async function tapResetAppConfirm(appearTimeoutMs = DEFAULT_APPEAR_TIMEOU
   } catch {
     // autoAcceptAlerts already handled it
   }
+}
+
+/**
+ * Tap a NAMED button on an app-owned `Alert.alert` — the two-action confirmations the verify flow
+ * raises (restart verification, skip email), where cancel and confirm must be told apart.
+ *
+ * `acceptSystemAlert` / `acceptAppAlert` cannot do this: they take whichever button the platform
+ * considers the accept action, which for a cancel/destructive pair is exactly the choice under test.
+ *
+ * iOS goes through WDA's `buttonLabel` (it reaches the alert even when it is presented over a modal,
+ * as the help menu's are), falling back to a direct tap inside the alert. Android matches the button's
+ * visible label case-insensitively — the AppCompat dialog theme may upper-case it for display — and
+ * never consults the popup probes, which on that platform only recognize the OS permission dialog.
+ */
+export async function tapAlertButton(label: string, appearTimeoutMs = DEFAULT_APPEAR_TIMEOUT_MS): Promise<void> {
+  if (driver.isAndroid) {
+    // The presence probes above only know the OS permission controller, so an app dialog is waited on
+    // through the button itself (as `tapResetAppConfirm` / `acceptAppAlert` do). The reverse wait is
+    // what proves the tap landed — the dialog is gone, not merely tapped at.
+    const escaped = label.replaceAll(/[.*+?^${}()|[\]\\]/g, (match) => `\\${match}`)
+    const button = $(`android=new UiSelector().textMatches("(?i)^${escaped}$")`)
+    await button.waitForDisplayed({ timeout: appearTimeoutMs })
+    await button.click()
+    await button.waitForDisplayed({ timeout: DEFAULT_DISMISS_TIMEOUT_MS, reverse: true })
+    console.log(`[alerts] Tapped "${label}" on the app alert`)
+    return
+  }
+
+  if (!(await waitForPopup(appearTimeoutMs))) {
+    throw new Error(`[alerts] No alert appeared within ${appearTimeoutMs}ms to tap "${label}" on`)
+  }
+  // WDA's accept-by-name taps the button it is given, whichever role it plays — so this is how the
+  // cancel action is chosen too, not just the confirming one.
+  const tappedByLabel = await quietly(() =>
+    driver
+      .execute('mobile: alert', { action: 'accept', buttonLabel: label })
+      .then(() => true)
+      .catch(() => false)
+  )
+  if (!tappedByLabel && !(await tapIosButtonInsideAlert([label]))) {
+    throw new Error(`[alerts] Alert is showing but has no button labelled "${label}"`)
+  }
+  if (!(await waitForDismissal(DEFAULT_DISMISS_TIMEOUT_MS))) {
+    throw new Error(`[alerts] Tapped "${label}" but the alert did not dismiss`)
+  }
+  console.log(`[alerts] Tapped "${label}" on the app alert`)
 }
 
 /**

--- a/e2e/src/helpers/approval.ts
+++ b/e2e/src/helpers/approval.ts
@@ -84,13 +84,12 @@ export async function approveInPersonRequest(
     await approveInPersonLogin(loginInput, { signal: controller.signal })
   } catch (error: unknown) {
     const elapsedMs = Date.now() - startedAt
+    const message = error instanceof Error ? error.message : String(error)
     // Our own abort surfaces from undici as a bare "This operation was aborted" — name it as OUR budget
     // so it is never mistaken for an SM rejection.
     const detail = controller.signal.aborted
       ? `the ${timeoutMs}ms budget for the whole SM chain ran out (see the per-step [sm-login] timings for where it went)`
-      : error instanceof Error
-        ? error.message
-        : String(error)
+      : message
     throw new Error(`In-person approval failed after ${elapsedMs}ms (flow=${input.flow}, code="${code}"): ${detail}`)
   } finally {
     clearTimeout(timeoutId)

--- a/e2e/src/helpers/approval.ts
+++ b/e2e/src/helpers/approval.ts
@@ -52,12 +52,15 @@ type ApproveInPersonLoginInput = ApproveInPersonInput extends infer T
  *
  * @param formattedCode - The confirmation code as displayed in the app (XXXX-XXXX)
  * @param input - Flow selector + per-flow inputs
- * @param timeoutMs - Max time to wait for the approval flow (default 30s)
+ * @param timeoutMs - Budget for the WHOLE chain, not per request. That chain is ~10 sequential round
+ *   trips to SIT, so a thin budget expires on whichever one is in flight — structurally the last,
+ *   `POST /deviceCredential/approve` — which reads as "approve is broken" no matter what was slow.
+ *   The per-step timings `login.mjs` logs are what tells the two apart.
  */
 export async function approveInPersonRequest(
   formattedCode: string,
   input: ApproveInPersonInput,
-  timeoutMs = 30_000
+  timeoutMs = 60_000
 ): Promise<void> {
   const code = formattedCode.replaceAll(/[\s-]/g, '')
   if (!/^[A-Za-z0-9]{8}$/.test(code)) {
@@ -76,12 +79,20 @@ export async function approveInPersonRequest(
 
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  const startedAt = Date.now()
 
   try {
     await approveInPersonLogin(loginInput, { signal: controller.signal })
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error)
-    throw new Error(`In-person approval failed (flow=${input.flow}, code="${code}"): ${message}`)
+    const elapsedMs = Date.now() - startedAt
+    // Our own abort surfaces from undici as a bare "This operation was aborted" against whichever
+    // request it interrupted. Name it as OUR budget so it is never mistaken for an SM rejection.
+    const detail = controller.signal.aborted
+      ? `the ${timeoutMs}ms budget for the whole SM chain ran out (see the per-step [sm-login] timings for where it went)`
+      : error instanceof Error
+        ? error.message
+        : String(error)
+    throw new Error(`In-person approval failed after ${elapsedMs}ms (flow=${input.flow}, code="${code}"): ${detail}`)
   } finally {
     clearTimeout(timeoutId)
   }

--- a/e2e/src/helpers/approval.ts
+++ b/e2e/src/helpers/approval.ts
@@ -52,10 +52,9 @@ type ApproveInPersonLoginInput = ApproveInPersonInput extends infer T
  *
  * @param formattedCode - The confirmation code as displayed in the app (XXXX-XXXX)
  * @param input - Flow selector + per-flow inputs
- * @param timeoutMs - Budget for the WHOLE chain, not per request. That chain is ~10 sequential round
- *   trips to SIT, so a thin budget expires on whichever one is in flight — structurally the last,
- *   `POST /deviceCredential/approve` — which reads as "approve is broken" no matter what was slow.
- *   The per-step timings `login.mjs` logs are what tells the two apart.
+ * @param timeoutMs - Budget for the WHOLE chain (~10 sequential SIT round trips), not per request — so a
+ *   thin budget always expires on the last one, `approve`, whatever was actually slow. The per-step
+ *   `[sm-login]` timings tell them apart.
  */
 export async function approveInPersonRequest(
   formattedCode: string,
@@ -85,8 +84,8 @@ export async function approveInPersonRequest(
     await approveInPersonLogin(loginInput, { signal: controller.signal })
   } catch (error: unknown) {
     const elapsedMs = Date.now() - startedAt
-    // Our own abort surfaces from undici as a bare "This operation was aborted" against whichever
-    // request it interrupted. Name it as OUR budget so it is never mistaken for an SM rejection.
+    // Our own abort surfaces from undici as a bare "This operation was aborted" — name it as OUR budget
+    // so it is never mistaken for an SM rejection.
     const detail = controller.signal.aborted
       ? `the ${timeoutMs}ms budget for the whole SM chain ran out (see the per-step [sm-login] timings for where it went)`
       : error instanceof Error

--- a/e2e/src/helpers/email.ts
+++ b/e2e/src/helpers/email.ts
@@ -20,10 +20,9 @@ export async function getTempEmailAddress(): Promise<{ email: string; token: str
 
     return { email: email_addr, token: sid_token }
   } catch (error) {
-    // This request comes from the RUNNER, not the device, so it is the runner's network that has to
-    // reach a disposable-email service — and those are a standard corporate-filtering target. A TLS
-    // error here is that block, not a broken test: say so, because `fetch failed` alone sends the
-    // next person hunting through the app.
+    // This runs on the RUNNER's network, and disposable-email services are a standard filtering target,
+    // so a TLS error here is that block rather than a broken test — say so, or `fetch failed` alone
+    // sends the next person hunting through the app.
     const cause = (error as { cause?: { code?: string } }).cause?.code
     const blocked = cause === 'SELF_SIGNED_CERT_IN_CHAIN' || cause === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
     console.error('Error fetching temporary email address:', error)
@@ -57,10 +56,9 @@ function mailId(email: Email): number {
 /**
  * The highest message id in the inbox, waiting until there is at least one message.
  *
- * Take this BEFORE an action that should send another email, then pass it as `afterMailId` so the wait
- * for that email cannot be satisfied by one already in flight. The waiting is the point: a baseline of
- * 0 taken from an inbox whose first message simply has not arrived yet would let the NEXT wait return
- * that first message — the very one the action being tested has just superseded.
+ * Take this BEFORE an action that should send another email, then pass it as `afterMailId` so that
+ * wait cannot be satisfied by a message already in flight. Waiting is the point: a 0 baseline from a
+ * not-yet-delivered inbox would let the next wait return that first, now-superseded message.
  */
 export async function getLatestMailId(
   token: string,
@@ -84,13 +82,12 @@ export async function getLatestMailId(
 /**
  * Retrieves the confirmation code from the email inbox.
  *
- * Always reads the NEWEST message (highest `mail_id`), not the first in the listing: a resend leaves
- * two codes in the inbox and only the latest one still matches the verification the screen is now
- * pointing at — the resend mints a new `email_address_id`, which retires the previous code.
+ * Always reads the NEWEST message (highest `mail_id`), not the first in the listing: a resend leaves two
+ * codes in the inbox, and it mints a new `email_address_id`, so only the latest one still works.
  *
  * @param token - The token associated with the temporary email address, used to check for incoming emails.
- * @param options - Timeout/polling, plus `afterMailId`: ignore anything already in the inbox and wait
- *   for a message newer than that id (see {@link getLatestMailId}).
+ * @param options - Timeout/polling, plus `afterMailId`: wait for a message newer than that id, ignoring
+ *   anything already in the inbox (see {@link getLatestMailId}).
  * @returns The 6-digit confirmation code extracted from the email body.
  */
 export async function getEmailConfirmationCode(

--- a/e2e/src/helpers/email.ts
+++ b/e2e/src/helpers/email.ts
@@ -25,9 +25,11 @@ export async function getTempEmailAddress(): Promise<{ email: string; token: str
     // sends the next person hunting through the app.
     const cause = (error as { cause?: { code?: string } }).cause?.code
     const blocked = cause === 'SELF_SIGNED_CERT_IN_CHAIN' || cause === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
+    const host = new URL(TEMP_EMAIL_API).host
+    const causeDetail = cause ? `: ${cause}` : ''
     console.error('Error fetching temporary email address:', error)
     throw new Error(
-      `Could not reach the temporary-inbox provider (${new URL(TEMP_EMAIL_API).host})${cause ? `: ${cause}` : ''}. ` +
+      `Could not reach the temporary-inbox provider (${host})${causeDetail}. ` +
         (blocked
           ? 'The TLS chain was replaced, which is what a network filtering disposable-email services looks like — ' +
             'run this journey from a network that allows it (CI does).'
@@ -97,7 +99,8 @@ export async function getEmailConfirmationCode(
   const { timeout = 60_000, interval = 10_000, afterMailId = 0 } = options
   const deadline = Date.now() + timeout
 
-  console.log(`Waiting for email confirmation code${afterMailId ? ` newer than mail ${afterMailId}` : ''}...`)
+  const newerThan = afterMailId ? ` newer than mail ${afterMailId}` : ''
+  console.log(`Waiting for email confirmation code${newerThan}...`)
   while (Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, interval))
 

--- a/e2e/src/helpers/email.ts
+++ b/e2e/src/helpers/email.ts
@@ -111,7 +111,7 @@ export async function getEmailConfirmationCode(
     if (!candidates.length) {
       continue
     }
-    const email = candidates.reduce((newest, next) => (mailId(next) > mailId(newest) ? next : newest))
+    const email = candidates.reduce((newest, next) => (mailId(next) > mailId(newest) ? next : newest), candidates[0])
     console.log(`Received email ${mailId(email)} from: ${email.mail_from}`)
 
     const emailResponse = await fetch(`${TEMP_EMAIL_API}?f=fetch_email&email_id=${email.mail_id}&sid_token=${token}`)

--- a/e2e/src/helpers/email.ts
+++ b/e2e/src/helpers/email.ts
@@ -20,44 +20,102 @@ export async function getTempEmailAddress(): Promise<{ email: string; token: str
 
     return { email: email_addr, token: sid_token }
   } catch (error) {
+    // This request comes from the RUNNER, not the device, so it is the runner's network that has to
+    // reach a disposable-email service — and those are a standard corporate-filtering target. A TLS
+    // error here is that block, not a broken test: say so, because `fetch failed` alone sends the
+    // next person hunting through the app.
+    const cause = (error as { cause?: { code?: string } }).cause?.code
+    const blocked = cause === 'SELF_SIGNED_CERT_IN_CHAIN' || cause === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
     console.error('Error fetching temporary email address:', error)
-    throw error
+    throw new Error(
+      `Could not reach the temporary-inbox provider (${new URL(TEMP_EMAIL_API).host})${cause ? `: ${cause}` : ''}. ` +
+        (blocked
+          ? 'The TLS chain was replaced, which is what a network filtering disposable-email services looks like — ' +
+            'run this journey from a network that allows it (CI does).'
+          : 'The email step cannot run without it.')
+    )
+  }
+}
+
+/** Fetch the inbox listing, or null on a transient failure (the caller retries). */
+async function fetchInbox(token: string): Promise<Email[] | null> {
+  try {
+    const response = await fetch(`${TEMP_EMAIL_API}?f=check_email&seq=1&sid_token=${token}`)
+    const inbox = (await response.json()) as { list?: Email[] }
+    return inbox.list ?? []
+  } catch (error) {
+    console.warn('Transient error checking email inbox, retrying...', error)
+    return null
+  }
+}
+
+/** `mail_id` comes back as a string on some responses — compare it as a number, always. */
+function mailId(email: Email): number {
+  return Number(email.mail_id)
+}
+
+/**
+ * The highest message id in the inbox, waiting until there is at least one message.
+ *
+ * Take this BEFORE an action that should send another email, then pass it as `afterMailId` so the wait
+ * for that email cannot be satisfied by one already in flight. The waiting is the point: a baseline of
+ * 0 taken from an inbox whose first message simply has not arrived yet would let the NEXT wait return
+ * that first message — the very one the action being tested has just superseded.
+ */
+export async function getLatestMailId(
+  token: string,
+  options: { timeout?: number; interval?: number } = {}
+): Promise<number> {
+  const { timeout = 60_000, interval = 10_000 } = options
+  const deadline = Date.now() + timeout
+
+  for (;;) {
+    const list = await fetchInbox(token)
+    if (list?.length) {
+      return Math.max(...list.map(mailId))
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`No email arrived within ${timeout}ms, so there is no baseline message id to take`)
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval))
   }
 }
 
 /**
  * Retrieves the confirmation code from the email inbox.
  *
+ * Always reads the NEWEST message (highest `mail_id`), not the first in the listing: a resend leaves
+ * two codes in the inbox and only the latest one still matches the verification the screen is now
+ * pointing at — the resend mints a new `email_address_id`, which retires the previous code.
+ *
  * @param token - The token associated with the temporary email address, used to check for incoming emails.
- * @param options - Optional configuration for timeout and polling interval.
+ * @param options - Timeout/polling, plus `afterMailId`: ignore anything already in the inbox and wait
+ *   for a message newer than that id (see {@link getLatestMailId}).
  * @returns The 6-digit confirmation code extracted from the email body.
  */
 export async function getEmailConfirmationCode(
   token: string,
-  options = { timeout: 60_000, interval: 10_000 }
+  options: { timeout?: number; interval?: number; afterMailId?: number } = {}
 ): Promise<string> {
-  const deadline = Date.now() + options.timeout
+  const { timeout = 60_000, interval = 10_000, afterMailId = 0 } = options
+  const deadline = Date.now() + timeout
 
-  console.log(`Waiting for email confirmation code...`)
+  console.log(`Waiting for email confirmation code${afterMailId ? ` newer than mail ${afterMailId}` : ''}...`)
   while (Date.now() < deadline) {
-    await new Promise((resolve) => setTimeout(resolve, options.interval))
+    await new Promise((resolve) => setTimeout(resolve, interval))
 
-    let inbox: { list: Email[] }
-    try {
-      console.log('Checking inbox for confirmation code email...')
-      const inboxResponse = await fetch(`${TEMP_EMAIL_API}?f=check_email&seq=1&sid_token=${token}`)
-      inbox = (await inboxResponse.json()) as { list: Email[] }
-    } catch (error) {
-      console.warn('Transient error checking email inbox, retrying...', error)
+    console.log('Checking inbox for confirmation code email...')
+    const list = await fetchInbox(token)
+    if (!list?.length) {
       continue
     }
 
-    if (!inbox.list.length) {
+    const candidates = list.filter((email) => mailId(email) > afterMailId)
+    if (!candidates.length) {
       continue
     }
-
-    const email = inbox.list[0]
-    console.log(`Received email from: ${email.mail_from}`)
+    const email = candidates.reduce((newest, next) => (mailId(next) > mailId(newest) ? next : newest))
+    console.log(`Received email ${mailId(email)} from: ${email.mail_from}`)
 
     const emailResponse = await fetch(`${TEMP_EMAIL_API}?f=fetch_email&email_id=${email.mail_id}&sid_token=${token}`)
     const emailContent = (await emailResponse.json()) as { mail_body: string }

--- a/e2e/src/helpers/help-menu.ts
+++ b/e2e/src/helpers/help-menu.ts
@@ -1,0 +1,99 @@
+import { Timeouts } from '../constants.js'
+import { BaseScreen } from '../screens/core/BaseScreen.js'
+import { bcsc } from '../screens/core/index.js'
+import { TestIds } from '../test-ids/registry.js'
+
+/**
+ * The floating help menu (`FloatingHelpMenu`) — the header `HelpMenu` button every onboarding/verify
+ * screen carries, and the only route to "Back to home" and "Restart verification process".
+ *
+ * Its rows have NO testIDs: `ListButton` only sets one when the caller passes it, and the verify
+ * menu's rows don't. They are therefore matched by COPY — a localization edit to these strings breaks
+ * these helpers, which is the accepted cost (the alternative, testIDs on the rows, is app work this
+ * epic does not do). The app renders each row's accessibility label through `a11yLabel`, which joins
+ * words with non-breaking spaces, so the visible text and the a11y label differ by whitespace only —
+ * hence the candidate-selector hunt below rather than a single matcher.
+ *
+ * No escaping is applied to the labels: they are fixed English UI copy with no quotes or backslashes.
+ */
+
+/** Verify-flow menu rows (`BCSC.HelpMenu.*`). Copy-matched — see the module note. */
+export const HelpMenuRows = {
+  /** Leaves the flow for Home, KEEPING progress (`useLeaveVerification`). */
+  backToHome: 'Back to home',
+  /** Confirm-then-wipe (`useRestartVerification`); hidden on the initial verify prompt. */
+  restartVerification: 'Restart verification process',
+} as const
+
+/** The restart confirmation's buttons (`Alerts.RestartVerification.*` / `Global.Cancel`). */
+export const RestartVerificationAlert = {
+  cancel: 'Cancel',
+  confirm: 'Restart Verification',
+} as const
+
+/** The menu's own close (X) control — `Global.Close`, passed directly so it is NOT nbsp-joined. */
+const CLOSE_LABEL = 'Close'
+
+const engine = new BaseScreen()
+
+/**
+ * Non-breaking-space form of a label — how the app's `a11yLabel` renders every derived row label.
+ * Written as an escape, never as a literal: a raw U+00A0 in source is indistinguishable from a plain
+ * space on screen, so a reformat or a copy-paste could silently turn every selector below into a miss.
+ */
+function nonBreaking(label: string): string {
+  return label.replaceAll(' ', '\u00A0')
+}
+
+/**
+ * Selectors that could match a menu row, most to least specific: the row Pressable's a11y label
+ * (nbsp-joined, the form the app actually sets), the same label with plain spaces (in case a row
+ * passes its own label), and the visible text of the row's inner `ThemedText` (Android only —
+ * on iOS the `accessible` Pressable merges its children out of the tree).
+ */
+function rowSelectors(label: string): string[] {
+  const nbsp = nonBreaking(label)
+  if (driver.isIOS) {
+    return [
+      `-ios predicate string:label == "${nbsp}" OR name == "${nbsp}"`,
+      `-ios predicate string:label == "${label}" OR name == "${label}"`,
+    ]
+  }
+  return [
+    `android=new UiSelector().description("${nbsp}")`,
+    `android=new UiSelector().description("${label}")`,
+    `android=new UiSelector().text("${label}")`,
+  ]
+}
+
+/** Open the floating help menu from whichever screen is showing. */
+export async function openHelpMenu(): Promise<void> {
+  await engine.tapByTestId(bcsc(TestIds.common.help))
+}
+
+/**
+ * Tap a help-menu row by its copy, waiting out the menu's slide-in first. The menu is a `Modal`
+ * animating in over the screen, so a tap dispatched at the old coordinates is silently swallowed on
+ * Android (see {@link BaseScreen.waitForSteadyPosition}).
+ */
+export async function tapHelpMenuRow(label: string, timeout: number = Timeouts.SCREEN_TRANSITION): Promise<void> {
+  const deadline = Date.now() + timeout
+  do {
+    for (const selector of rowSelectors(label)) {
+      const row = $(selector)
+      if (await row.isDisplayed().catch(() => false)) {
+        await engine.waitForSteadyPosition(row)
+        await row.click()
+        return
+      }
+    }
+    await driver.pause(250)
+  } while (Date.now() < deadline)
+
+  throw new Error(`Help-menu row "${label}" did not appear within ${timeout}ms — is the menu open?`)
+}
+
+/** Close the help menu via its X. Needed after a row that leaves the menu up (e.g. a cancelled alert). */
+export async function closeHelpMenu(): Promise<void> {
+  await tapHelpMenuRow(CLOSE_LABEL)
+}

--- a/e2e/src/helpers/help-menu.ts
+++ b/e2e/src/helpers/help-menu.ts
@@ -7,14 +7,10 @@ import { TestIds } from '../test-ids/registry.js'
  * The floating help menu (`FloatingHelpMenu`) — the header `HelpMenu` button every onboarding/verify
  * screen carries, and the only route to "Back to home" and "Restart verification process".
  *
- * Its rows have NO testIDs: `ListButton` only sets one when the caller passes it, and the verify
- * menu's rows don't. They are therefore matched by COPY — a localization edit to these strings breaks
- * these helpers, which is the accepted cost (the alternative, testIDs on the rows, is app work this
- * epic does not do). The app renders each row's accessibility label through `a11yLabel`, which joins
- * words with non-breaking spaces, so the visible text and the a11y label differ by whitespace only —
- * hence the candidate-selector hunt below rather than a single matcher.
- *
- * No escaping is applied to the labels: they are fixed English UI copy with no quotes or backslashes.
+ * Its rows have no testIDs, so they are matched by COPY — a localization edit to these strings breaks
+ * these helpers, which is the accepted cost of not touching the app. The app also renders row labels
+ * through `a11yLabel`, which joins words with non-breaking spaces, hence the candidate-selector hunt
+ * below rather than a single matcher. Labels are fixed English copy, so nothing needs escaping.
  */
 
 /** Verify-flow menu rows (`BCSC.HelpMenu.*`). Copy-matched — see the module note. */
@@ -37,19 +33,18 @@ const CLOSE_LABEL = 'Close'
 const engine = new BaseScreen()
 
 /**
- * Non-breaking-space form of a label — how the app's `a11yLabel` renders every derived row label.
- * Written as an escape, never as a literal: a raw U+00A0 in source is indistinguishable from a plain
- * space on screen, so a reformat or a copy-paste could silently turn every selector below into a miss.
+ * Non-breaking-space form of a label — how `a11yLabel` renders every derived row label. Kept as an
+ * escape: a literal U+00A0 is indistinguishable from a space in source, so a reformat could silently
+ * turn every selector below into a miss.
  */
 function nonBreaking(label: string): string {
   return label.replaceAll(' ', '\u00A0')
 }
 
 /**
- * Selectors that could match a menu row, most to least specific: the row Pressable's a11y label
- * (nbsp-joined, the form the app actually sets), the same label with plain spaces (in case a row
- * passes its own label), and the visible text of the row's inner `ThemedText` (Android only —
- * on iOS the `accessible` Pressable merges its children out of the tree).
+ * Selectors that could match a menu row, most to least specific: the a11y label the app sets
+ * (nbsp-joined), the same with plain spaces, and the inner `ThemedText` (Android only — iOS merges the
+ * Pressable's children out of the tree).
  */
 function rowSelectors(label: string): string[] {
   const nbsp = nonBreaking(label)
@@ -72,9 +67,8 @@ export async function openHelpMenu(): Promise<void> {
 }
 
 /**
- * Tap a help-menu row by its copy, waiting out the menu's slide-in first. The menu is a `Modal`
- * animating in over the screen, so a tap dispatched at the old coordinates is silently swallowed on
- * Android (see {@link BaseScreen.waitForSteadyPosition}).
+ * Tap a help-menu row by its copy, waiting out the modal's slide-in first — a tap dispatched at the old
+ * coordinates is silently swallowed on Android (see {@link BaseScreen.waitForSteadyPosition}).
  */
 export async function tapHelpMenuRow(label: string, timeout: number = Timeouts.SCREEN_TRANSITION): Promise<void> {
   const deadline = Date.now() + timeout

--- a/e2e/src/screens/core/BaseScreen.ts
+++ b/e2e/src/screens/core/BaseScreen.ts
@@ -17,6 +17,26 @@ const STEADY_POSITION_SAMPLE_MS = 120
 const IOS_KEYBOARD_DISMISS_KEYS = ['done', 'Done', 'return', 'Return', 'go', 'Go', 'next', 'Next', 'search', 'Search']
 
 /**
+ * Does the on-screen keyboard carry any of {@link IOS_KEYBOARD_DISMISS_KEYS}? Built from that list so
+ * the two cannot drift, and it mirrors the test WebDriverAgent runs inside `mobile: hideKeyboard` —
+ * identifier or label, over every key and button under the keyboard — so a hit here means that
+ * command has something to press.
+ *
+ * Asking first is what makes number pads cheap. WDA has no answer for a keyboard carrying no
+ * dismissal key: it falls through to a hard-coded 3s re-check of keyboard visibility and only then
+ * throws. This probe is one query, and it turns that 3s failure into a decision not to try.
+ */
+const IOS_KEYBOARD_DISMISS_KEY_SELECTOR = `-ios class chain:**/XCUIElementTypeKeyboard/**/*[\`${IOS_KEYBOARD_DISMISS_KEYS.map(
+  (key) => `name == "${key}" OR label == "${key}"`
+).join(' OR ')}\`]`
+
+/** How long to keep asking whether a keyboard we pressed or blurred has actually retracted. */
+const KEYBOARD_RETRACT_TIMEOUT_MS = 1_500
+
+/** Pause once a keyboard is down, letting the layout it was covering settle before we tap into it. */
+const KEYBOARD_SETTLE_MS = 300
+
+/**
  * Escape a value before it is embedded in a quoted iOS predicate / UiSelector string. Both parsers
  * take the same two escapes, so one helper covers them. Without it a quote or backslash in localized
  * copy produces an invalid selector rather than a miss. (Mirrors `escapeIosSelectorValue` in
@@ -341,27 +361,113 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
    * province dropdown, opening the modal and stranding the journey. No coordinate is safe —
    * `InputWithValidation`'s 44px hitSlop makes the gaps between fields live too.
    *
-   * Number pads (birthdate, email code) have no dismissal key, so the keyboard is left up. That is
-   * fine: every form calling this uses `ScreenWrapper keyboardActive`, which lays its controls out
-   * above the keyboard.
+   * Number pads (birthdate, email code, PIN) carry digits and a delete key only, so on iOS nothing on
+   * the keyboard itself can close them — we detect that up front and leave the keyboard up instead of
+   * paying WDA's 3s failure for it. That is fine by default: every form calling this uses
+   * `ScreenWrapper keyboardActive`, which lays its controls out above the keyboard. For the screens
+   * where it is not fine, pass `tapToDismiss`.
+   *
+   * @param options.tapToDismiss - testID of an INERT element on the current screen (a heading, say)
+   *   to tap when the keyboard carries no dismissal key of its own. `ScreenWrapper`'s scroll view
+   *   sets `keyboardShouldPersistTaps: 'handled'`, so a tap no child handles blurs the focused input.
+   *   Named, never positional — see the coordinate hazard above.
+   * @returns whether the keyboard is down by the time this returns
    */
-  async dismissKeyboard() {
+  async dismissKeyboard(options?: { tapToDismiss?: string }): Promise<boolean> {
     // An unreadable probe counts as "shown" — better to attempt a (now harmless) dismissal.
-    if (!(await driver.isKeyboardShown().catch(() => true))) return
+    if (!(await driver.isKeyboardShown().catch(() => true))) return true
 
-    if (driver.isAndroid) {
-      await driver.hideKeyboard().catch(() => undefined)
-      await driver.pause(300) // let the layout settle as the keyboard collapses
-      return
+    if (driver.isAndroid) return await this.hideAndroidKeyboard()
+
+    const hasDismissKey = await this.hasIosKeyboardDismissKey()
+    if (hasDismissKey) {
+      try {
+        // Presses the first matching key. Throws when the keyboard has none of them — not when the
+        // command is missing — which the probe above has already ruled out in the common case.
+        await driver.execute('mobile: hideKeyboard', { keys: IOS_KEYBOARD_DISMISS_KEYS })
+        if (await this.waitForKeyboardHidden()) return true
+      } catch {
+        // Still up — fall through to the caller's tap target, if it gave us one.
+      }
     }
 
+    if (options?.tapToDismiss) {
+      try {
+        const el = await this.findByTestId(options.tapToDismiss)
+        await el.click()
+        if (await this.waitForKeyboardHidden()) return true
+      } catch {
+        console.warn(`[keyboard] Could not tap "${options.tapToDismiss}" to dismiss the keyboard`)
+      }
+    }
+
+    console.warn(
+      hasDismissKey
+        ? '[keyboard] iOS dismissal key would not close the keyboard; leaving it up'
+        : '[keyboard] iOS keyboard carries no dismissal key (number pad); leaving it up'
+    )
+    return false
+  }
+
+  /**
+   * Does the current iOS keyboard have a key that closes it? Number pads do not; the alphabetic and
+   * email keyboards carry a `return`.
+   *
+   * An unanswerable probe returns true: attempting the command anyway is the older behaviour and no
+   * worse than it was.
+   */
+  private async hasIosKeyboardDismissKey(): Promise<boolean> {
     try {
-      // Throws when the keyboard has none of these keys — not when the command is missing.
-      await driver.execute('mobile: hideKeyboard', { keys: IOS_KEYBOARD_DISMISS_KEYS })
-      await driver.pause(300)
+      return await $(IOS_KEYBOARD_DISMISS_KEY_SELECTOR).isExisting()
     } catch {
-      console.warn('[keyboard] No iOS dismissal key available; leaving the keyboard open')
+      return true
     }
+  }
+
+  /**
+   * Close the Android soft keyboard, verified. `driver.hideKeyboard()` is adb underneath: ESC, then
+   * BACK, each polled against `dumpsys input_method`. It throws when neither lands — notably when the
+   * IME reports `mIsInputViewShown=false`, where adb sends no key at all and only waits.
+   *
+   * The IME's own "done" editor action is a second, independent way in: it blurs the focused field
+   * through the input connection instead of pressing a system key. Kept as the fallback rather than
+   * the first move because Appium implements it by swapping the device IME to its own, sending the
+   * action, then swapping back — worth it only once the cheap route has already failed. No app input
+   * sets `onSubmitEditing`, so the action blurs and nothing else fires.
+   *
+   * Never throws — a keyboard probe must not fail the caller's real action.
+   */
+  private async hideAndroidKeyboard(): Promise<boolean> {
+    await driver.hideKeyboard().catch(() => undefined)
+    if (await this.waitForKeyboardHidden()) return true
+
+    await driver.execute('mobile: performEditorAction', { action: 'done' }).catch(() => undefined)
+    if (await this.waitForKeyboardHidden()) return true
+
+    console.warn('[keyboard] Android keyboard would not close; continuing with it up')
+    return false
+  }
+
+  /**
+   * Poll until the keyboard is actually gone, then let the layout it was covering settle. Both
+   * platforms' dismissal commands already block until the keyboard reports hidden, so on the happy
+   * path this costs one probe; it earns its keep when one of them reports success over a keyboard
+   * that is still up.
+   *
+   * An unreadable probe counts as "gone" — like every other keyboard probe here, when we cannot tell,
+   * take the cheap branch and let the caller's real action be the thing that fails.
+   */
+  private async waitForKeyboardHidden(timeout: number = KEYBOARD_RETRACT_TIMEOUT_MS): Promise<boolean> {
+    try {
+      await driver.waitUntil(async () => !(await driver.isKeyboardShown().catch(() => false)), {
+        timeout,
+        interval: 150,
+      })
+    } catch {
+      return false
+    }
+    await driver.pause(KEYBOARD_SETTLE_MS)
+    return true
   }
 
   /**
@@ -378,8 +484,7 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
     if (!driver.isAndroid) return
     const shown = await driver.isKeyboardShown().catch(() => false)
     if (!shown) return
-    await driver.hideKeyboard().catch(() => undefined)
-    await driver.pause(300) // let the layout settle as the keyboard collapses
+    await this.hideAndroidKeyboard()
   }
 
   /**

--- a/e2e/src/screens/core/BaseScreen.ts
+++ b/e2e/src/screens/core/BaseScreen.ts
@@ -17,14 +17,10 @@ const STEADY_POSITION_SAMPLE_MS = 120
 const IOS_KEYBOARD_DISMISS_KEYS = ['done', 'Done', 'return', 'Return', 'go', 'Go', 'next', 'Next', 'search', 'Search']
 
 /**
- * Does the on-screen keyboard carry any of {@link IOS_KEYBOARD_DISMISS_KEYS}? Built from that list so
- * the two cannot drift, and it mirrors the test WebDriverAgent runs inside `mobile: hideKeyboard` —
- * identifier or label, over every key and button under the keyboard — so a hit here means that
- * command has something to press.
- *
- * Asking first is what makes number pads cheap. WDA has no answer for a keyboard carrying no
- * dismissal key: it falls through to a hard-coded 3s re-check of keyboard visibility and only then
- * throws. This probe is one query, and it turns that 3s failure into a decision not to try.
+ * Does the on-screen keyboard carry any of {@link IOS_KEYBOARD_DISMISS_KEYS}? Built from that list so the
+ * two cannot drift, and it mirrors the test WDA runs inside `mobile: hideKeyboard` — so a hit means that
+ * command has something to press. Asking first is what makes number pads cheap: with no dismissal key
+ * WDA falls through to a hard-coded 3s re-check before throwing, and this probe is one query.
  */
 const IOS_KEYBOARD_DISMISS_KEY_SELECTOR = `-ios class chain:**/XCUIElementTypeKeyboard/**/*[\`${IOS_KEYBOARD_DISMISS_KEYS.map(
   (key) => `name == "${key}" OR label == "${key}"`
@@ -361,16 +357,14 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
    * province dropdown, opening the modal and stranding the journey. No coordinate is safe —
    * `InputWithValidation`'s 44px hitSlop makes the gaps between fields live too.
    *
-   * Number pads (birthdate, email code, PIN) carry digits and a delete key only, so on iOS nothing on
-   * the keyboard itself can close them — we detect that up front and leave the keyboard up instead of
-   * paying WDA's 3s failure for it. That is fine by default: every form calling this uses
-   * `ScreenWrapper keyboardActive`, which lays its controls out above the keyboard. For the screens
-   * where it is not fine, pass `tapToDismiss`.
+   * On iOS, number pads (birthdate, email code, PIN) carry no key that can close them — detected up
+   * front, so the keyboard is left up rather than pay WDA's 3s failure. Usually fine: the forms calling
+   * this use `ScreenWrapper keyboardActive`, which lays controls out above the keyboard. Where it is
+   * not, pass `tapToDismiss`.
    *
-   * @param options.tapToDismiss - testID of an INERT element on the current screen (a heading, say)
-   *   to tap when the keyboard carries no dismissal key of its own. `ScreenWrapper`'s scroll view
-   *   sets `keyboardShouldPersistTaps: 'handled'`, so a tap no child handles blurs the focused input.
-   *   Named, never positional — see the coordinate hazard above.
+   * @param options.tapToDismiss - testID of an INERT element (a heading, say) to tap when the keyboard
+   *   has no dismissal key. `ScreenWrapper` sets `keyboardShouldPersistTaps: 'handled'`, so a tap no
+   *   child handles blurs the focused input. Named, never positional — see the coordinate hazard above.
    * @returns whether the keyboard is down by the time this returns
    */
   async dismissKeyboard(options?: { tapToDismiss?: string }): Promise<boolean> {
@@ -382,8 +376,8 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
     const hasDismissKey = await this.hasIosKeyboardDismissKey()
     if (hasDismissKey) {
       try {
-        // Presses the first matching key. Throws when the keyboard has none of them — not when the
-        // command is missing — which the probe above has already ruled out in the common case.
+        // Presses the first matching key; throws when the keyboard has none — which the probe above has
+        // already ruled out in the common case.
         await driver.execute('mobile: hideKeyboard', { keys: IOS_KEYBOARD_DISMISS_KEYS })
         if (await this.waitForKeyboardHidden()) return true
       } catch {
@@ -410,11 +404,9 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
   }
 
   /**
-   * Does the current iOS keyboard have a key that closes it? Number pads do not; the alphabetic and
-   * email keyboards carry a `return`.
-   *
-   * An unanswerable probe returns true: attempting the command anyway is the older behaviour and no
-   * worse than it was.
+   * Does the current iOS keyboard have a key that closes it? Number pads do not; alphabetic and email
+   * keyboards carry a `return`. An unanswerable probe returns true — attempting the command anyway is
+   * the older behaviour.
    */
   private async hasIosKeyboardDismissKey(): Promise<boolean> {
     try {
@@ -425,17 +417,13 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
   }
 
   /**
-   * Close the Android soft keyboard, verified. `driver.hideKeyboard()` is adb underneath: ESC, then
-   * BACK, each polled against `dumpsys input_method`. It throws when neither lands — notably when the
-   * IME reports `mIsInputViewShown=false`, where adb sends no key at all and only waits.
+   * Close the Android soft keyboard, verified. `driver.hideKeyboard()` is adb underneath (ESC, then
+   * BACK) and throws when neither lands — notably when the IME reports `mIsInputViewShown=false`.
    *
-   * The IME's own "done" editor action is a second, independent way in: it blurs the focused field
-   * through the input connection instead of pressing a system key. Kept as the fallback rather than
-   * the first move because Appium implements it by swapping the device IME to its own, sending the
-   * action, then swapping back — worth it only once the cheap route has already failed. No app input
-   * sets `onSubmitEditing`, so the action blurs and nothing else fires.
-   *
-   * Never throws — a keyboard probe must not fail the caller's real action.
+   * The IME's "done" editor action is an independent way in: it blurs through the input connection
+   * rather than a system key. Second because Appium implements it by swapping the device IME and back.
+   * No app input sets `onSubmitEditing`, so it only blurs. Never throws — a keyboard probe must not
+   * fail the caller's real action.
    */
   private async hideAndroidKeyboard(): Promise<boolean> {
     await driver.hideKeyboard().catch(() => undefined)
@@ -449,13 +437,10 @@ export class BaseScreen<T extends Record<string, string> = Record<string, string
   }
 
   /**
-   * Poll until the keyboard is actually gone, then let the layout it was covering settle. Both
-   * platforms' dismissal commands already block until the keyboard reports hidden, so on the happy
-   * path this costs one probe; it earns its keep when one of them reports success over a keyboard
-   * that is still up.
-   *
-   * An unreadable probe counts as "gone" — like every other keyboard probe here, when we cannot tell,
-   * take the cheap branch and let the caller's real action be the thing that fails.
+   * Poll until the keyboard is actually gone, then let the layout settle. Both platforms' dismissal
+   * commands already block until it reports hidden, so this costs one probe on the happy path; it earns
+   * its keep when one of them reports success over a keyboard that is still up. An unreadable probe
+   * counts as "gone" — let the caller's real action be the thing that fails.
    */
   private async waitForKeyboardHidden(timeout: number = KEYBOARD_RETRACT_TIMEOUT_MS): Promise<boolean> {
     try {

--- a/e2e/src/screens/core/BaseScreen.ts
+++ b/e2e/src/screens/core/BaseScreen.ts
@@ -22,9 +22,11 @@ const IOS_KEYBOARD_DISMISS_KEYS = ['done', 'Done', 'return', 'Return', 'go', 'Go
  * command has something to press. Asking first is what makes number pads cheap: with no dismissal key
  * WDA falls through to a hard-coded 3s re-check before throwing, and this probe is one query.
  */
-const IOS_KEYBOARD_DISMISS_KEY_SELECTOR = `-ios class chain:**/XCUIElementTypeKeyboard/**/*[\`${IOS_KEYBOARD_DISMISS_KEYS.map(
+const IOS_KEYBOARD_DISMISS_KEY_MATCHES = IOS_KEYBOARD_DISMISS_KEYS.map(
   (key) => `name == "${key}" OR label == "${key}"`
-).join(' OR ')}\`]`
+).join(' OR ')
+
+const IOS_KEYBOARD_DISMISS_KEY_SELECTOR = `-ios class chain:**/XCUIElementTypeKeyboard/**/*[\`${IOS_KEYBOARD_DISMISS_KEY_MATCHES}\`]`
 
 /** How long to keep asking whether a keyboard we pressed or blurred has actually retracted. */
 const KEYBOARD_RETRACT_TIMEOUT_MS = 1_500

--- a/e2e/src/screens/main.ts
+++ b/e2e/src/screens/main.ts
@@ -37,14 +37,12 @@ export const HomeScreen = defineScreen({
 })
 
 /**
- * The notification card in Home's list. An unverified account renders the Start- (no id progress) or
- * Continue-verification (id step done) variant here; both cards are the same component with the same
- * testIDs, and both re-enter the verify stack at `getResumeStepRoute` — so tell them apart by
- * `title`/`body` copy, not by testID, and treat either as "the way back in" (see `resumeVerification`).
+ * The notification card in Home's list. An unverified account renders the Start- or
+ * Continue-verification variant here; both are the same component with the same testIDs and both
+ * re-enter at `getResumeStepRoute`, so tell them apart by `title`/`body` copy.
  *
- * `primary` (its CTA) is the ONLY in-app route back into an interrupted verification: leaving the flow
- * (help menu → Back to home) and every relaunch land here, because the verification-in-progress flag is
- * in-memory and hydration recomputes it from the credential.
+ * `primary` is the ONLY in-app route back into an interrupted verification — the in-progress flag is
+ * in-memory, so leaving the flow and every relaunch land here (see `resumeVerification`).
  */
 export const HomeNotificationCard = defineScreen({
   self: bcsc(main.notification.item),

--- a/e2e/src/screens/main.ts
+++ b/e2e/src/screens/main.ts
@@ -37,6 +37,25 @@ export const HomeScreen = defineScreen({
 })
 
 /**
+ * The notification card in Home's list. An unverified account renders the Start- (no id progress) or
+ * Continue-verification (id step done) variant here; both cards are the same component with the same
+ * testIDs, and both re-enter the verify stack at `getResumeStepRoute` — so tell them apart by
+ * `title`/`body` copy, not by testID, and treat either as "the way back in" (see `resumeVerification`).
+ *
+ * `primary` (its CTA) is the ONLY in-app route back into an interrupted verification: leaving the flow
+ * (help menu → Back to home) and every relaunch land here, because the verification-in-progress flag is
+ * in-memory and hydration recomputes it from the credential.
+ */
+export const HomeNotificationCard = defineScreen({
+  self: bcsc(main.notification.item),
+  primary: bcsc(main.notification.view),
+  elements: {
+    title: bcsc(main.notification.headerText),
+    body: bcsc(main.notification.bodyText),
+  },
+})
+
+/**
  * The no-skip verify prompt (`MainVerifyPrompt`) — where the tab listeners send unverified users
  * who tap Services (TabStack) or PairingCode (QRCoreStack). Continue is its only body testID;
  * the screen is otherwise distinguished by its "Verify your account" title copy. `back` (header)

--- a/e2e/src/screens/verify.ts
+++ b/e2e/src/screens/verify.ts
@@ -48,9 +48,8 @@ export const IdentitySelectionScreen = defineScreen({
  * the PermissionDisabled fallback renders the SAME testID as its secondary action, so the flow reaches
  * manual entry whether permission was granted or refused — only the loading view lacks it.
  *
- * Which of the two bodies rendered is therefore NOT knowable from `self`: `openSettings` is the
- * permission-refused marker (it exists only in the fallback). It is asserted, never tapped — it hands
- * the session off to the OS settings app.
+ * Which body rendered is therefore NOT knowable from `self`: `openSettings` exists only in the fallback,
+ * so it is the permission-refused marker. Asserted, never tapped — it exits to the OS settings app.
  */
 export const ScanSerialScreen = defineScreen({
   self: bcsc(v.scanSerial.enterManually),
@@ -62,12 +61,10 @@ export const ScanSerialScreen = defineScreen({
 })
 
 /**
- * Manual serial form (`ManualSerial`). Continue is always enabled — validation runs on press, against
- * a schema that rejects an empty value ("Required") and anything outside 3–15 alphanumerics ("Enter a
- * valid card serial number"). The input itself caps at 15 characters, so the over-long case is not
- * typeable. iOS types into the pressable wrapper, Android into the inner input (the
- * `InputWithValidation` pattern); `error` is that component's shared subtext slot, present only while
- * a validation message is showing.
+ * Manual serial form (`ManualSerial`). Continue is always enabled — validation runs on press, rejecting
+ * empty ("Required") and anything outside 3–15 alphanumerics; the input caps at 15 chars, so over-long
+ * is not typeable. iOS types the pressable wrapper, Android the inner input (`InputWithValidation`);
+ * `error` is that component's shared subtext slot, present only while a message is showing.
  */
 export const ManualSerialScreen = defineScreen({
   self: { ios: bcsc(v.manualSerial.serialPressable), android: bcsc(v.manualSerial.serialInput) },
@@ -209,12 +206,12 @@ export const EmailConfirmationScreen = defineScreen({
     code: bcsc(v.emailConfirmation.codeInput),
   },
   links: {
-    // BARE testID — written without `testIdWithKey`, so it carries no prefix and is NOT `bcsc()`-wrapped.
+    // BARE testID — no `testIdWithKey` prefix, so it is NOT `bcsc()`-wrapped.
     resendCode: v.emailConfirmationBare.resendCode,
   },
   elements: {
-    // Rendered only while the code is rejected; its text distinguishes "not six digits" (client-side)
-    // from "does not match" (the 404, which also raises an alert).
+    // Rendered only while the code is rejected; its text separates "not six digits" (client-side) from
+    // "does not match" (the 404, which also raises an alert).
     codeError: bcsc(v.emailConfirmation.codeError),
   },
 })
@@ -299,20 +296,19 @@ export const EvidenceIDCollectionScreen = defineScreen({
     birthdate: bcsc(v.evidenceIdCollection.birthdate),
   },
   elements: {
-    // ALWAYS present: the birthdate field ships a static subtext and its errors share that node, so
-    // this reads as the hint until a rule fails and as the message afterwards. Compare the text.
+    // ALWAYS present: the static hint and the validation errors share this node, so compare its text
+    // rather than asserting presence.
     birthdateSubtext: bcsc(v.evidenceIdCollection.birthdateSubtext),
   },
 })
 
 /**
- * `EvidenceTypeList` — the document-type picker. It has no container testID and its rows are
- * server-keyed (`EvidenceTypeListItem-<evidence_type>`), so rows are selected through
- * `selectEvidenceType` rather than this descriptor; what IS stable is the non-photo escape hatch.
+ * `EvidenceTypeList` — the document-type picker. Its rows are server-keyed with no container testID, so
+ * they go through `selectEvidenceType` rather than this descriptor; the non-photo escape hatch is what
+ * IS stable.
  *
- * `otherOptions` renders ONLY on the non-photo BCSC path's first list (`photoFilter === 'photo'` with
- * nothing collected yet) and REPLACES the list with the non-photo one — so there is no back to the
- * photo list, only back out to AdditionalIdentificationRequired.
+ * `otherOptions` renders only on the non-photo BCSC path's first list and REPLACES it with the non-photo
+ * list — there is no way back to the photo list, only out to AdditionalIdentificationRequired.
  */
 export const EvidenceTypeListScreen = defineScreen({
   self: bcsc(v.evidenceTypeList.otherOptions),

--- a/e2e/src/screens/verify.ts
+++ b/e2e/src/screens/verify.ts
@@ -47,17 +47,27 @@ export const IdentitySelectionScreen = defineScreen({
  * `primary` (EnterManually) is the CI path around the live camera, and it is a deliberately good anchor:
  * the PermissionDisabled fallback renders the SAME testID as its secondary action, so the flow reaches
  * manual entry whether permission was granted or refused — only the loading view lacks it.
+ *
+ * Which of the two bodies rendered is therefore NOT knowable from `self`: `openSettings` is the
+ * permission-refused marker (it exists only in the fallback). It is asserted, never tapped — it hands
+ * the session off to the OS settings app.
  */
 export const ScanSerialScreen = defineScreen({
   self: bcsc(v.scanSerial.enterManually),
   primary: bcsc(v.scanSerial.enterManually),
   back: bcsc(common.back),
+  elements: {
+    openSettings: bcsc(v.scanSerial.openSettings),
+  },
 })
 
 /**
- * Manual serial form (`ManualSerial`). Continue is always enabled — validation runs on press
- * (empty-serial error); the input caps at 15 chars. iOS types into the pressable wrapper,
- * Android into the inner input (the `InputWithValidation` pattern).
+ * Manual serial form (`ManualSerial`). Continue is always enabled — validation runs on press, against
+ * a schema that rejects an empty value ("Required") and anything outside 3–15 alphanumerics ("Enter a
+ * valid card serial number"). The input itself caps at 15 characters, so the over-long case is not
+ * typeable. iOS types into the pressable wrapper, Android into the inner input (the
+ * `InputWithValidation` pattern); `error` is that component's shared subtext slot, present only while
+ * a validation message is showing.
  */
 export const ManualSerialScreen = defineScreen({
   self: { ios: bcsc(v.manualSerial.serialPressable), android: bcsc(v.manualSerial.serialInput) },
@@ -65,6 +75,9 @@ export const ManualSerialScreen = defineScreen({
   back: bcsc(common.back),
   inputs: {
     serial: { ios: bcsc(v.manualSerial.serialPressable), android: bcsc(v.manualSerial.serialInput) },
+  },
+  elements: {
+    error: bcsc(v.manualSerial.serialSubtext),
   },
 })
 
@@ -195,6 +208,15 @@ export const EmailConfirmationScreen = defineScreen({
   inputs: {
     code: bcsc(v.emailConfirmation.codeInput),
   },
+  links: {
+    // BARE testID — written without `testIdWithKey`, so it carries no prefix and is NOT `bcsc()`-wrapped.
+    resendCode: v.emailConfirmationBare.resendCode,
+  },
+  elements: {
+    // Rendered only while the code is rejected; its text distinguishes "not six digits" (client-side)
+    // from "does not match" (the 404, which also raises an alert).
+    codeError: bcsc(v.emailConfirmation.codeError),
+  },
 })
 
 /**
@@ -275,6 +297,28 @@ export const EvidenceIDCollectionScreen = defineScreen({
     firstName: bcsc(v.evidenceIdCollection.firstName),
     middleNames: bcsc(v.evidenceIdCollection.middleNames),
     birthdate: bcsc(v.evidenceIdCollection.birthdate),
+  },
+  elements: {
+    // ALWAYS present: the birthdate field ships a static subtext and its errors share that node, so
+    // this reads as the hint until a rule fails and as the message afterwards. Compare the text.
+    birthdateSubtext: bcsc(v.evidenceIdCollection.birthdateSubtext),
+  },
+})
+
+/**
+ * `EvidenceTypeList` — the document-type picker. It has no container testID and its rows are
+ * server-keyed (`EvidenceTypeListItem-<evidence_type>`), so rows are selected through
+ * `selectEvidenceType` rather than this descriptor; what IS stable is the non-photo escape hatch.
+ *
+ * `otherOptions` renders ONLY on the non-photo BCSC path's first list (`photoFilter === 'photo'` with
+ * nothing collected yet) and REPLACES the list with the non-photo one — so there is no back to the
+ * photo list, only back out to AdditionalIdentificationRequired.
+ */
+export const EvidenceTypeListScreen = defineScreen({
+  self: bcsc(v.evidenceTypeList.otherOptions),
+  back: bcsc(common.back),
+  links: {
+    otherOptions: bcsc(v.evidenceTypeList.otherOptions),
   },
 })
 

--- a/e2e/src/support/context.ts
+++ b/e2e/src/support/context.ts
@@ -22,10 +22,9 @@ export function getTestUser(): TestUser {
 }
 
 /**
- * The journey's TestUser, narrowed to the non-BCSC persona — the only one carrying the SECOND set of
- * document fields (`primaryDocumentNumber` / `primaryDocumentTypeId`), because it is the only flow that
- * collects two documents. Use it where those fields are read; `getTestUser()` returns the union, on
- * which they do not exist.
+ * The journey's TestUser, narrowed to the non-BCSC persona — the only flow that collects two documents,
+ * so the only one carrying `primaryDocumentNumber` / `primaryDocumentTypeId`. `getTestUser()` returns
+ * the union, on which those fields do not exist.
  */
 export function getNonBcscTestUser(): Extract<TestUser, { flow: 'non-bcsc' }> {
   const user = getTestUser()

--- a/e2e/src/support/context.ts
+++ b/e2e/src/support/context.ts
@@ -21,6 +21,20 @@ export function getTestUser(): TestUser {
   return currentUser
 }
 
+/**
+ * The journey's TestUser, narrowed to the non-BCSC persona — the only one carrying the SECOND set of
+ * document fields (`primaryDocumentNumber` / `primaryDocumentTypeId`), because it is the only flow that
+ * collects two documents. Use it where those fields are read; `getTestUser()` returns the union, on
+ * which they do not exist.
+ */
+export function getNonBcscTestUser(): Extract<TestUser, { flow: 'non-bcsc' }> {
+  const user = getTestUser()
+  if (user.flow !== 'non-bcsc') {
+    throw new Error(`This journey drives a '${user.flow}' user; it needs the non-bcsc persona`)
+  }
+  return user
+}
+
 /** Clear the context — defensive reset for suites that run multiple journeys in one worker. */
 export function clearTestUser(): void {
   currentUser = undefined

--- a/e2e/src/test-ids/registry.ts
+++ b/e2e/src/test-ids/registry.ts
@@ -197,8 +197,8 @@ export const TestIds = {
      *  them.) */
     emailConfirmation: {
       codeInput: 'EmailConfirmationCodeInput',
-      // `CodeInput` renders its error as `<input testID>-subtext`, so the app has already prefixed this
-      // one — do NOT wrap it in `bcsc()` again.
+      // `CodeInput` appends `-subtext` to the input's already-prefixed testID, which puts the suffix at
+      // the END — so this stays a normal key and IS `bcsc()`-wrapped, unlike the bare ids below.
       codeError: 'EmailConfirmationCodeInput-subtext',
       continue: 'Continue',
     },

--- a/e2e/src/test-ids/registry.ts
+++ b/e2e/src/test-ids/registry.ts
@@ -114,17 +114,16 @@ export const TestIds = {
       scan: 'Scan',
       otherId: 'OtherID',
     },
-    /** Camera scan screen; `EnterManually` is the CI path around the live camera. When the camera
-     *  permission is refused the screen renders the shared `PermissionDisabled` body INSTEAD of the
-     *  camera — `openSettings` is that fallback's marker (it hands off to the OS settings app, so it
-     *  is asserted, never tapped), while `enterManually` renders in BOTH bodies as the way out. */
+    /** Camera scan screen; `EnterManually` is the CI path around the live camera and renders in BOTH
+     *  bodies. `openSettings` marks the refused-permission `PermissionDisabled` fallback — asserted,
+     *  never tapped (it exits to the OS settings app). */
     scanSerial: {
       enterManually: 'EnterManually',
       openSettings: 'OpenSettings',
     },
-    /** Manual serial form (`InputWithValidation id='serial'` → derived input/pressable/subtext ids).
-     *  `serialSubtext` is the shared error slot: this screen passes no static subtext, so the element
-     *  exists ONLY while an inline validation error is showing, and its text is which rule failed. */
+    /** Manual serial form (`InputWithValidation id='serial'` → derived ids). `serialSubtext` is the
+     *  shared error slot: no static subtext here, so it exists only while a validation error shows,
+     *  and its text is which rule failed. */
     manualSerial: {
       serialPressable: 'serial-pressable',
       serialInput: 'serial-input',
@@ -198,13 +197,13 @@ export const TestIds = {
      *  them.) */
     emailConfirmation: {
       codeInput: 'EmailConfirmationCodeInput',
-      // `CodeInput` renders its error as `<the input's testID>-subtext`, so this one is already
-      // prefixed by the app — it is NOT wrapped by `bcsc()` a second time.
+      // `CodeInput` renders its error as `<input testID>-subtext`, so the app has already prefixed this
+      // one — do NOT wrap it in `bcsc()` again.
       codeError: 'EmailConfirmationCodeInput-subtext',
       continue: 'Continue',
     },
-    /** BARE testIDs on EmailConfirmation — written without `testIdWithKey`, so they carry NO prefix.
-     *  Pass them to a descriptor as raw strings; `bcsc()` would produce an id that does not exist. */
+    /** BARE testIDs on EmailConfirmation — no `testIdWithKey`, so no prefix. Pass them as raw strings;
+     *  `bcsc()` would produce an id that does not exist. */
     emailConfirmationBare: {
       resendCode: 'ResendCodeLink',
       goToMyEmail: 'GoToMyEmailLink',
@@ -263,9 +262,8 @@ export const TestIds = {
       firstName: 'firstName-input',
       middleNames: 'middleNames-input',
       birthdate: 'birthDate-input',
-      // The birthdate field carries a STATIC subtext as well as its validation errors, and
-      // `InputWithValidation` renders both through the same node — so this element is always present
-      // and only its TEXT says whether the value was rejected. Compare it; never assert presence.
+      // The static subtext and the validation errors share this node, so it is always present and only
+      // its TEXT says whether the value was rejected. Compare the text; never assert presence.
       birthdateSubtext: 'birthDate-subtext',
     },
     /** `ResidentialAddress` ('Address Entry') — non-BCSC only, after both documents. Text fields are
@@ -301,11 +299,10 @@ export const TestIds = {
     header: {
       settings: 'SettingsMenuButton',
     },
-    /** Home's notification list card (`NotificationActionCard`). For an unverified account with
-     *  verification progress this is the Start/Continue-verification card, whose `view` button
-     *  re-enters the verify stack at `getResumeStepRoute` — the app's ONLY route back into an
-     *  interrupted verification. All four keys are shared by every action card, so which card is
-     *  showing is told apart by `headerText`/`bodyText` copy, not by testID. */
+    /** Home's notification list card (`NotificationActionCard`). For an unverified account this is the
+     *  Start/Continue-verification card, whose `view` re-enters the verify stack at `getResumeStepRoute`
+     *  — the ONLY route back into an interrupted verification. All four keys are shared by every action
+     *  card, so tell cards apart by `headerText`/`bodyText` copy, not by testID. */
     notification: {
       item: 'NotificationListItem',
       headerText: 'HeaderText',

--- a/e2e/src/test-ids/registry.ts
+++ b/e2e/src/test-ids/registry.ts
@@ -114,14 +114,21 @@ export const TestIds = {
       scan: 'Scan',
       otherId: 'OtherID',
     },
-    /** Camera scan screen; `EnterManually` is the CI path around the live camera. */
+    /** Camera scan screen; `EnterManually` is the CI path around the live camera. When the camera
+     *  permission is refused the screen renders the shared `PermissionDisabled` body INSTEAD of the
+     *  camera — `openSettings` is that fallback's marker (it hands off to the OS settings app, so it
+     *  is asserted, never tapped), while `enterManually` renders in BOTH bodies as the way out. */
     scanSerial: {
       enterManually: 'EnterManually',
+      openSettings: 'OpenSettings',
     },
-    /** Manual serial form (`InputWithValidation id='serial'` → derived input/pressable ids). */
+    /** Manual serial form (`InputWithValidation id='serial'` → derived input/pressable/subtext ids).
+     *  `serialSubtext` is the shared error slot: this screen passes no static subtext, so the element
+     *  exists ONLY while an inline validation error is showing, and its text is which rule failed. */
     manualSerial: {
       serialPressable: 'serial-pressable',
       serialInput: 'serial-input',
+      serialSubtext: 'serial-subtext',
       continue: 'Continue',
     },
     /** Birthdate form (`DateInput id='birthDate'`, digits progressive-format to YYYY/MM/DD).
@@ -191,7 +198,16 @@ export const TestIds = {
      *  them.) */
     emailConfirmation: {
       codeInput: 'EmailConfirmationCodeInput',
+      // `CodeInput` renders its error as `<the input's testID>-subtext`, so this one is already
+      // prefixed by the app — it is NOT wrapped by `bcsc()` a second time.
+      codeError: 'EmailConfirmationCodeInput-subtext',
       continue: 'Continue',
+    },
+    /** BARE testIDs on EmailConfirmation — written without `testIdWithKey`, so they carry NO prefix.
+     *  Pass them to a descriptor as raw strings; `bcsc()` would produce an id that does not exist. */
+    emailConfirmationBare: {
+      resendCode: 'ResendCodeLink',
+      goToMyEmail: 'GoToMyEmailLink',
     },
     /** Email verified (`'Email Verified'`, no header) — success interstitial. Its only testID is the
      *  shared `continue`, so the screen is identified by its title copy ("Your email has been
@@ -247,6 +263,10 @@ export const TestIds = {
       firstName: 'firstName-input',
       middleNames: 'middleNames-input',
       birthdate: 'birthDate-input',
+      // The birthdate field carries a STATIC subtext as well as its validation errors, and
+      // `InputWithValidation` renders both through the same node — so this element is always present
+      // and only its TEXT says whether the value was rejected. Compare it; never assert presence.
+      birthdateSubtext: 'birthDate-subtext',
     },
     /** `ResidentialAddress` ('Address Entry') — non-BCSC only, after both documents. Text fields are
      *  InputWithValidation (iOS types the pressable wrapper); `province` is a DropdownWithValidation —
@@ -280,6 +300,17 @@ export const TestIds = {
     /** Header settings (menu) button on the Home/Services tab headers. */
     header: {
       settings: 'SettingsMenuButton',
+    },
+    /** Home's notification list card (`NotificationActionCard`). For an unverified account with
+     *  verification progress this is the Start/Continue-verification card, whose `view` button
+     *  re-enters the verify stack at `getResumeStepRoute` — the app's ONLY route back into an
+     *  interrupted verification. All four keys are shared by every action card, so which card is
+     *  showing is told apart by `headerText`/`bodyText` copy, not by testID. */
+    notification: {
+      item: 'NotificationListItem',
+      headerText: 'HeaderText',
+      bodyText: 'BodyText',
+      view: 'ViewNotification',
     },
     /** Floating scan FAB (rendered on the Home + Wallet tabs, not verification-gated) → QRCore. */
     scan: {

--- a/e2e/test/bcsc/verify/verified-non-bcsc.journey.ts
+++ b/e2e/test/bcsc/verify/verified-non-bcsc.journey.ts
@@ -55,10 +55,9 @@ const EMAIL_ALERT_OK = 'OK'
  * selectEvidenceType lists the real ones on a miss), the ResidentialAddress province dropdown
  * (`province-option-BC`), and the mandatory email step all resolve.
  *
- * Because this is the only journey that reaches them, it also carries the branch-sweep riders that need
- * this state: the under-12 birthdate rejection on the first document's form, the second slot's filtered
- * ID list, the wrong-code/resend email detours, and the two resume steps (address, email) that cannot be
- * reached without paying for two captured documents.
+ * Being the only journey that reaches them, it also carries the riders that need this state: the under-12
+ * birthdate rejection, the second slot's filtered ID list, the wrong-code/resend email detours, and the
+ * two resume steps (address, email) that cost two captured documents.
  *
  * Ordered session: onboard → OtherID → two documents → residential address → email (temp inbox) →
  * method selection → in-person → verified Home
@@ -77,14 +76,12 @@ describe('Verified journey: non-bcsc card', () => {
     await chooseAddAccount()
     await captureFirstNonBcscDocument(getTestUser(), FIRST_DOC_MATCH)
 
-    // The age rule is client-side and lives ONLY here — there is no under-12 card process, so this
-    // inline rejection is the whole of the app's under-12 behaviour. Submit an under-age date first,
-    // then the real one; the form re-types every field, so the second submit replaces it cleanly.
+    // The age rule is client-side and lives ONLY here — there is no under-12 card process. Submit an
+    // under-age date, then the real one; the form re-types every field, so the second submit is clean.
     const user = getNonBcscTestUser()
     const personalInfo = { lastName: user.lastName, firstName: user.firstName, dob: UNDER_AGE_DOB }
     await submitEvidenceIdCollection(user.primaryDocumentNumber, personalInfo)
-    // The birthdate field always renders this node (it doubles as the field's static hint), so the
-    // assertion is on its TEXT, not its presence. `waitFor` scroll-hunts it into view first.
+    // This node doubles as the field's static hint, so assert its TEXT, not its presence.
     await EvidenceIDCollectionScreen.waitFor('birthdateSubtext', Timeouts.SCREEN_TRANSITION)
     assert.equal(await EvidenceIDCollectionScreen.read('birthdateSubtext'), UNDER_AGE_ERROR)
 
@@ -92,8 +89,8 @@ describe('Verified journey: non-bcsc card', () => {
   })
 
   it('offers a different ID list for the second slot, without the one already used', async () => {
-    // The list filters by `collection_order` AND hides anything already chosen, so the two slots are
-    // genuinely different lists — the second must not offer the licence just collected.
+    // The list filters by `collection_order` and hides what is already chosen, so the second slot must
+    // not offer the licence just collected.
     const rows = await listEvidenceTypeRowIds()
     assert.ok(
       !rows.some((id) => id.toLowerCase().includes(FIRST_DOC_MATCH.toLowerCase())),
@@ -112,8 +109,7 @@ describe('Verified journey: non-bcsc card', () => {
   })
 
   it('resumes onto the address step after leaving verification', async () => {
-    // Both documents are complete but the device is not yet authorized, so the address step is what
-    // the app owes the user — the resume row that cannot be reached without paying for two captures.
+    // Both documents are complete but the device is not yet authorized, so address is the owed step.
     await leaveVerificationToHome()
     await resumeVerification()
     await ResidentialAddressScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
@@ -133,15 +129,15 @@ describe('Verified journey: non-bcsc card', () => {
   it('rejects a wrong email code, then verifies with a resent one', async () => {
     const token = await startEmailVerification()
 
-    // Six digits, so this is the SERVER's rejection (404) rather than the client-side length rule:
-    // it renders the message inline and raises an alert carrying the same copy.
+    // Six digits, so this is the SERVER's 404 rather than the client-side length rule: it renders the
+    // message inline and raises an alert carrying the same copy.
     await submitEmailCode(WRONG_EMAIL_CODE)
     await tapAlertButton(EMAIL_ALERT_OK)
     await EmailConfirmationScreen.waitFor('codeError', Timeouts.SCREEN_TRANSITION)
     assert.equal(await EmailConfirmationScreen.read('codeError'), CODE_DOES_NOT_MATCH)
 
-    // Resending mints a new verification, retiring the code already sent — so the only code that can
-    // work from here is the one the resend produces. That it arrives is the resend's assertion.
+    // The resend retires the code already sent, so only the new one can work — and that it arrives at
+    // all is the resend's assertion.
     await submitEmailCode(await resendEmailCode(token))
     await completeEmailVerification()
     await VerificationMethodSelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)

--- a/e2e/test/bcsc/verify/verified-non-bcsc.journey.ts
+++ b/e2e/test/bcsc/verify/verified-non-bcsc.journey.ts
@@ -2,16 +2,47 @@ import assert from 'node:assert/strict'
 import { TestUsers, Timeouts } from '../../../src/constants.js'
 import { completeOnboarding } from '../../../src/flows/onboarding.js'
 import {
+  captureFirstNonBcscDocument,
+  captureSecondNonBcscDocument,
   chooseAddAccount,
-  collectNonBcscEvidence,
+  completeEmailVerification,
   completeVerification,
   fillResidentialAddress,
+  leaveVerificationToHome,
+  listEvidenceTypeRowIds,
+  resendEmailCode,
+  resumeVerification,
+  startEmailVerification,
   startVerification,
-  verifyEmailWithTempInbox,
+  submitEmailCode,
+  submitEvidenceIdCollection,
 } from '../../../src/flows/verify.js'
+import { tapAlertButton } from '../../../src/helpers/alerts.js'
 import { HomeScreen, SettingsScreen } from '../../../src/screens/main.js'
-import { VerificationMethodSelectionScreen } from '../../../src/screens/verify.js'
-import { getTestUser, setTestUser } from '../../../src/support/context.js'
+import {
+  EmailConfirmationScreen,
+  EnterEmailScreen,
+  EvidenceIDCollectionScreen,
+  ResidentialAddressScreen,
+  VerificationMethodSelectionScreen,
+} from '../../../src/screens/verify.js'
+import { getNonBcscTestUser, getTestUser, setTestUser } from '../../../src/support/context.js'
+
+/** The two documents, in slot order. Case-insensitive substrings of the server-keyed row testIDs. */
+const FIRST_DOC_MATCH = 'BC Drivers Licence'
+const SECOND_DOC_MATCH = 'Canadian Passport'
+
+/** Under the app's 12-year minimum until 2032, and a valid past date — so it fails ONLY the age rule. */
+const UNDER_AGE_DOB = '20200101'
+/** `BCSC.EvidenceIDCollection.BirthDateAgeError` with `MINIMUM_VERIFICATION_AGE` interpolated. */
+const UNDER_AGE_ERROR = 'You must be 12 years or older to set up a mobile card'
+
+/** Six digits, so the server (not the client-side length rule) is what rejects it. */
+const WRONG_EMAIL_CODE = '000000'
+/** `BCSC.EmailConfirmation.CodeDoesNotMatch` — shown inline AND in an alert on the 404. */
+const CODE_DOES_NOT_MATCH = 'The code you entered does not match. Try again.'
+/** The 404 alert's only action (`Global.OK`). */
+const EMAIL_ALERT_OK = 'OK'
 
 /**
  * Verified journey: non-BCSC card — the heaviest path. The user has no BC Services Card, so instead of
@@ -23,6 +54,11 @@ import { getTestUser, setTestUser } from '../../../src/support/context.js'
  * Sauce: the per-slot EvidenceTypeList row substrings ('BC Drivers Licence' / 'Canadian Passport';
  * selectEvidenceType lists the real ones on a miss), the ResidentialAddress province dropdown
  * (`province-option-BC`), and the mandatory email step all resolve.
+ *
+ * Because this is the only journey that reaches them, it also carries the branch-sweep riders that need
+ * this state: the under-12 birthdate rejection on the first document's form, the second slot's filtered
+ * ID list, the wrong-code/resend email detours, and the two resume steps (address, email) that cannot be
+ * reached without paying for two captured documents.
  *
  * Ordered session: onboard → OtherID → two documents → residential address → email (temp inbox) →
  * method selection → in-person → verified Home
@@ -36,21 +72,78 @@ describe('Verified journey: non-bcsc card', () => {
     await completeOnboarding()
   })
 
-  it('chooses Other ID and provides two government documents', async () => {
+  it('captures the first ID and rejects an under-12 birthdate on its form', async () => {
     await startVerification()
     await chooseAddAccount()
-    // The options DIFFER per slot: the first document's list offers 'BC Drivers Licence', the second
-    // uses 'Canadian Drivers Licence'. Each substring must uniquely match its slot's list and map to
-    // fred's document types (18 / 12) for the SM approval — so the specific document matters.
-    await collectNonBcscEvidence(getTestUser(), 'BC Drivers Licence', 'Canadian Passport')
+    await captureFirstNonBcscDocument(getTestUser(), FIRST_DOC_MATCH)
+
+    // The age rule is client-side and lives ONLY here — there is no under-12 card process, so this
+    // inline rejection is the whole of the app's under-12 behaviour. Submit an under-age date first,
+    // then the real one; the form re-types every field, so the second submit replaces it cleanly.
+    const user = getNonBcscTestUser()
+    const personalInfo = { lastName: user.lastName, firstName: user.firstName, dob: UNDER_AGE_DOB }
+    await submitEvidenceIdCollection(user.primaryDocumentNumber, personalInfo)
+    // The birthdate field always renders this node (it doubles as the field's static hint), so the
+    // assertion is on its TEXT, not its presence. `waitFor` scroll-hunts it into view first.
+    await EvidenceIDCollectionScreen.waitFor('birthdateSubtext', Timeouts.SCREEN_TRANSITION)
+    assert.equal(await EvidenceIDCollectionScreen.read('birthdateSubtext'), UNDER_AGE_ERROR)
+
+    await submitEvidenceIdCollection(user.primaryDocumentNumber, { ...personalInfo, dob: user.dob })
+  })
+
+  it('offers a different ID list for the second slot, without the one already used', async () => {
+    // The list filters by `collection_order` AND hides anything already chosen, so the two slots are
+    // genuinely different lists — the second must not offer the licence just collected.
+    const rows = await listEvidenceTypeRowIds()
+    assert.ok(
+      !rows.some((id) => id.toLowerCase().includes(FIRST_DOC_MATCH.toLowerCase())),
+      `"${FIRST_DOC_MATCH}" is already collected and should not be selectable again. Rows: ${JSON.stringify(rows)}`
+    )
+    assert.ok(
+      rows.some((id) => id.toLowerCase().includes(SECOND_DOC_MATCH.toLowerCase())),
+      `"${SECOND_DOC_MATCH}" should be offered for the second ID. Rows: ${JSON.stringify(rows)}`
+    )
+  })
+
+  it('captures the second ID and reaches the address step', async () => {
+    await captureSecondNonBcscDocument(getTestUser(), SECOND_DOC_MATCH)
+    await submitEvidenceIdCollection(getTestUser().documentNumber)
+    await ResidentialAddressScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('resumes onto the address step after leaving verification', async () => {
+    // Both documents are complete but the device is not yet authorized, so the address step is what
+    // the app owes the user — the resume row that cannot be reached without paying for two captures.
+    await leaveVerificationToHome()
+    await resumeVerification()
+    await ResidentialAddressScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })
 
   it('fills the residential address', async () => {
     await fillResidentialAddress()
   })
 
-  it('verifies the mandatory email via a temporary inbox', async () => {
-    await verifyEmailWithTempInbox()
+  it('resumes onto the email step after leaving verification', async () => {
+    // The address submit authorizes the device, which moves the owed step from address to email.
+    await leaveVerificationToHome()
+    await resumeVerification()
+    await EnterEmailScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('rejects a wrong email code, then verifies with a resent one', async () => {
+    const token = await startEmailVerification()
+
+    // Six digits, so this is the SERVER's rejection (404) rather than the client-side length rule:
+    // it renders the message inline and raises an alert carrying the same copy.
+    await submitEmailCode(WRONG_EMAIL_CODE)
+    await tapAlertButton(EMAIL_ALERT_OK)
+    await EmailConfirmationScreen.waitFor('codeError', Timeouts.SCREEN_TRANSITION)
+    assert.equal(await EmailConfirmationScreen.read('codeError'), CODE_DOES_NOT_MATCH)
+
+    // Resending mints a new verification, retiring the code already sent — so the only code that can
+    // work from here is the one the resend produces. That it arrives is the resend's assertion.
+    await submitEmailCode(await resendEmailCode(token))
+    await completeEmailVerification()
     await VerificationMethodSelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })
 

--- a/e2e/test/bcsc/verify/verified-non-photo.journey.ts
+++ b/e2e/test/bcsc/verify/verified-non-photo.journey.ts
@@ -1,18 +1,33 @@
 import assert from 'node:assert/strict'
-import { TestUsers, Timeouts } from '../../../src/constants.js'
+import { TEST_PIN, TestUsers, Timeouts } from '../../../src/constants.js'
+import { unlockWithPin } from '../../../src/flows/auth.js'
 import { completeOnboarding } from '../../../src/flows/onboarding.js'
 import {
-  addAdditionalPhotoId,
+  captureAdditionalPhotoId,
   chooseAddAccount,
   completeVerification,
   enterBirthdate,
   enterSerialManually,
+  reachAdditionalPhotoIdList,
   reachVerificationMethod,
+  resumeVerification,
   startVerification,
+  submitEvidenceIdCollection,
 } from '../../../src/flows/verify.js'
+import { BaseScreen } from '../../../src/screens/core/BaseScreen.js'
 import { HomeScreen, SettingsScreen } from '../../../src/screens/main.js'
-import { VerificationMethodSelectionScreen } from '../../../src/screens/verify.js'
+import {
+  EvidenceIDCollectionScreen,
+  EvidenceTypeListScreen,
+  VerificationMethodSelectionScreen,
+} from '../../../src/screens/verify.js'
 import { getTestUser, setTestUser } from '../../../src/support/context.js'
+
+/** Engine handle for the one screen anchored on visible copy (EvidenceTypeList has no container testID). */
+const engine = new BaseScreen()
+
+/** `BCSC.EvidenceTypeList.OtherIDOptionsHeading` — proves the list swapped to the non-photo filter. */
+const OTHER_ID_OPTIONS_HEADING = 'Other ID options'
 
 /**
  * Verified journey: non-photo card. A non-photo BC Services Card has no photo, so after the serial is
@@ -22,6 +37,11 @@ import { getTestUser, setTestUser } from '../../../src/support/context.js'
  *
  * CAMERA-DEPENDENT — the document capture uses Sauce image injection (`injectPhoto` throws off-Sauce)
  * or a physical camera; validated on Sauce.
+ *
+ * This is the only journey whose evidence list is photo-FILTERED, so it also carries the branch-sweep
+ * riders that live there: the "Show more options" escape hatch (which exists only on this path),
+ * PhotoReview's Retake, and the resume step for a document captured but not yet numbered — the one
+ * mid-capture state that survives a relaunch, so it is asserted across one.
  *
  * One ordered session: onboard → Continue → Scan serial → birthdate (authorizeDevice, non-photo) →
  * additional photo ID (pick → capture → typed number) → method selection → in-person → verified Home.
@@ -42,10 +62,36 @@ describe('Verified journey: non-photo card', () => {
     await enterBirthdate(getTestUser())
   })
 
-  it('adds the required additional photo ID (passport) via capture + typed number', async () => {
-    // Matches the EvidenceTypeList row whose testID contains 'Passport' (server-provided evidence_type).
-    // If it throws listing the rows, pin the exact substring for daphne's document type (id 12).
-    await addAdditionalPhotoId(getTestUser(), 'Passport')
+  it('browses the non-photo ID options and returns to the photo list', async () => {
+    await reachAdditionalPhotoIdList()
+    // The escape hatch renders ONLY here — photo-filtered list, nothing collected yet — and is how a
+    // user without any photo ID proceeds. It REPLACES the list rather than pushing, so there is no
+    // back to the photo list: the way out is back to the primer and in again.
+    await EvidenceTypeListScreen.waitFor('otherOptions', Timeouts.SCREEN_TRANSITION)
+    await EvidenceTypeListScreen.link('otherOptions')
+    await engine.waitForText(OTHER_ID_OPTIONS_HEADING, Timeouts.SCREEN_TRANSITION)
+    await EvidenceTypeListScreen.back.tap()
+    await reachAdditionalPhotoIdList()
+  })
+
+  it('captures the passport, retaking the first photo before accepting it', async () => {
+    // Retake discards the shot and returns to the camera for the SAME side; the resulting evidence is
+    // identical, so what this proves is that the discard-and-return path works at all.
+    await captureAdditionalPhotoId(getTestUser(), 'Passport', { retakeFirstSide: true })
+    await EvidenceIDCollectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('resumes onto the document-number form after a relaunch', async () => {
+    // A document with all its photos but no number is the ONE mid-capture state hydration preserves
+    // (an evidence with no photos at all is dropped as abandoned), so the captured photos must survive
+    // the relaunch and the app must resume here rather than at the start of the ID step.
+    await unlockWithPin(TEST_PIN, { relaunch: true })
+    await resumeVerification()
+    await EvidenceIDCollectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('types the captured document number', async () => {
+    await submitEvidenceIdCollection(getTestUser().documentNumber)
   })
 
   it('resumes to the verification method selection after the document', async () => {

--- a/e2e/test/bcsc/verify/verified-non-photo.journey.ts
+++ b/e2e/test/bcsc/verify/verified-non-photo.journey.ts
@@ -38,10 +38,9 @@ const OTHER_ID_OPTIONS_HEADING = 'Other ID options'
  * CAMERA-DEPENDENT — the document capture uses Sauce image injection (`injectPhoto` throws off-Sauce)
  * or a physical camera; validated on Sauce.
  *
- * This is the only journey whose evidence list is photo-FILTERED, so it also carries the branch-sweep
- * riders that live there: the "Show more options" escape hatch (which exists only on this path),
- * PhotoReview's Retake, and the resume step for a document captured but not yet numbered — the one
- * mid-capture state that survives a relaunch, so it is asserted across one.
+ * This is the only journey whose evidence list is photo-FILTERED, so it also carries the riders that live
+ * there: the "Show more options" escape hatch, PhotoReview's Retake, and the resume step for a document
+ * captured but not yet numbered — the one mid-capture state that survives a relaunch.
  *
  * One ordered session: onboard → Continue → Scan serial → birthdate (authorizeDevice, non-photo) →
  * additional photo ID (pick → capture → typed number) → method selection → in-person → verified Home.
@@ -64,9 +63,8 @@ describe('Verified journey: non-photo card', () => {
 
   it('browses the non-photo ID options and returns to the photo list', async () => {
     await reachAdditionalPhotoIdList()
-    // The escape hatch renders ONLY here — photo-filtered list, nothing collected yet — and is how a
-    // user without any photo ID proceeds. It REPLACES the list rather than pushing, so there is no
-    // back to the photo list: the way out is back to the primer and in again.
+    // The escape hatch renders ONLY here — photo-filtered list, nothing collected yet — and REPLACES the
+    // list rather than pushing, so the way out is back to the primer and in again.
     await EvidenceTypeListScreen.waitFor('otherOptions', Timeouts.SCREEN_TRANSITION)
     await EvidenceTypeListScreen.link('otherOptions')
     await engine.waitForText(OTHER_ID_OPTIONS_HEADING, Timeouts.SCREEN_TRANSITION)
@@ -75,16 +73,14 @@ describe('Verified journey: non-photo card', () => {
   })
 
   it('captures the passport, retaking the first photo before accepting it', async () => {
-    // Retake discards the shot and returns to the camera for the SAME side; the resulting evidence is
-    // identical, so what this proves is that the discard-and-return path works at all.
+    // Retake returns to the camera for the SAME side, so what this proves is the discard-and-return path.
     await captureAdditionalPhotoId(getTestUser(), 'Passport', { retakeFirstSide: true })
     await EvidenceIDCollectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })
 
   it('resumes onto the document-number form after a relaunch', async () => {
-    // A document with all its photos but no number is the ONE mid-capture state hydration preserves
-    // (an evidence with no photos at all is dropped as abandoned), so the captured photos must survive
-    // the relaunch and the app must resume here rather than at the start of the ID step.
+    // Photos-but-no-number is the ONE mid-capture state hydration preserves (an evidence with no photos
+    // is dropped), so the photos must survive the relaunch and the app must resume here.
     await unlockWithPin(TEST_PIN, { relaunch: true })
     await resumeVerification()
     await EvidenceIDCollectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)

--- a/e2e/test/bcsc/verify/verified-photo.journey.ts
+++ b/e2e/test/bcsc/verify/verified-photo.journey.ts
@@ -53,9 +53,8 @@ describe('Verified journey: photo card', () => {
   })
 
   it('resumes onto the method selection after leaving verification', async () => {
-    // The last resume step: everything before the method choice is done, so an authorized-but-
-    // unverified user must come back to the choice itself. This is the cheapest journey that reaches
-    // that state, which is why the row is asserted here rather than on one of the document journeys.
+    // The last resume row: everything before the method choice is done, so an authorized-but-unverified
+    // user comes back to the choice itself. Asserted here as the cheapest journey reaching that state.
     await leaveVerificationToHome()
     await resumeVerification()
     await VerificationMethodSelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)

--- a/e2e/test/bcsc/verify/verified-photo.journey.ts
+++ b/e2e/test/bcsc/verify/verified-photo.journey.ts
@@ -6,7 +6,9 @@ import {
   completeVerification,
   enterBirthdate,
   enterSerialManually,
+  leaveVerificationToHome,
   reachVerificationMethod,
+  resumeVerification,
   startVerification,
 } from '../../../src/flows/verify.js'
 import { HomeScreen, SettingsScreen } from '../../../src/screens/main.js'
@@ -47,6 +49,15 @@ describe('Verified journey: photo card', () => {
 
   it('resumes to the verification method selection after authorizing', async () => {
     await reachVerificationMethod()
+    await VerificationMethodSelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('resumes onto the method selection after leaving verification', async () => {
+    // The last resume step: everything before the method choice is done, so an authorized-but-
+    // unverified user must come back to the choice itself. This is the cheapest journey that reaches
+    // that state, which is why the row is asserted here rather than on one of the document journeys.
+    await leaveVerificationToHome()
+    await resumeVerification()
     await VerificationMethodSelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })
 

--- a/e2e/test/bcsc/verify/verify-entry-detours.journey.ts
+++ b/e2e/test/bcsc/verify/verify-entry-detours.journey.ts
@@ -23,8 +23,7 @@ const engine = new BaseScreen()
 const MISMATCH_DOB = '19800101'
 /** Shorter than the serial schema's 3-character minimum, so it trips the format rule rather than the empty one. */
 const TOO_SHORT_SERIAL = 'AB'
-/** ManualSerial's two reachable inline errors (`BCSC.ManualSerial.EmptySerialError` / `FormatError`).
- *  Asserted verbatim: only the message tells the two validation rules apart. */
+/** ManualSerial's two reachable inline errors — asserted verbatim, as only the message tells them apart. */
 const EMPTY_SERIAL_ERROR = 'Required'
 const SERIAL_FORMAT_ERROR = 'Enter a valid card serial number'
 
@@ -40,12 +39,10 @@ const SERIAL_FORMAT_ERROR = 'Enter a valid card serial number'
  * the serial branch backs out through its push stack (ManualSerial → ScanSerial → IdentitySelection);
  * the Other-ID branch chains FORWARD (DualId webview → EvidenceTypeList) with no deep back-out.
  *
- * The camera permission is REFUSED at the first ScanSerial, which is why that checkpoint comes before
- * everything else on the serial branch: the answer is one-way within a session (iOS never re-prompts),
- * so a grant anywhere earlier would make the refused body unreachable. It costs the later checkpoints
- * nothing — `EnterManually` is rendered by both the camera body and the permission fallback, so the
- * CI path around the camera works either way (which is also why this now runs on both platforms
- * rather than iOS only: nothing here depends on a live camera coming up).
+ * The camera permission is REFUSED at the first ScanSerial, which is why that checkpoint comes first on
+ * the serial branch: the answer is one-way within a session (iOS never re-prompts), so a grant earlier
+ * would make the refused body unreachable. It costs the later checkpoints nothing — `EnterManually`
+ * renders in both bodies — which is also why this now runs on both platforms rather than iOS only.
  *
  * Anchors + navigation verified against app source (main): AccountSetup Add/Transfer
  * (AddAccount/TransferAccount → TransferAccountInstructions), TransferInstructions `ScanQRCode`,
@@ -86,12 +83,11 @@ describe('Verify journey: entry detours', () => {
 
   it('offers manual entry when the camera permission is refused', async () => {
     await IdentitySelectionScreen.tapToNavigate('primary') // Scan → ScanSerial (auto-requests the camera)
-    // REFUSING is a one-way door for the session (iOS never re-prompts), so it has to be the first
-    // thing the camera screen is asked, before any checkpoint grants it.
+    // Refusing is a one-way door for the session (iOS never re-prompts), so it must be the first thing
+    // the camera screen is asked.
     await dismissSystemAlert(Timeouts.SCREEN_TRANSITION)
-    // `self` cannot tell the two bodies apart — EnterManually renders in both, which is what keeps the
-    // CI path working either way. `openSettings` exists only in the refused one. It is never tapped:
-    // it hands the session off to the OS settings app.
+    // `self` cannot tell the two bodies apart — EnterManually renders in both — while `openSettings`
+    // exists only in the refused one. Never tapped: it exits to the OS settings app.
     await ScanSerialScreen.waitFor('openSettings', Timeouts.SCREEN_TRANSITION)
     await ScanSerialScreen.tapToNavigate('primary') // EnterManually (pushes ManualSerial)
     await ManualSerialScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
@@ -106,8 +102,7 @@ describe('Verify journey: entry detours', () => {
     await engine.dismissKeyboard()
     await ManualSerialScreen.tapWhenEnabled('primary')
     assert.equal(await ManualSerialScreen.read('error'), SERIAL_FORMAT_ERROR)
-    // The third rule the schema carries — over 15 characters — is unreachable from the UI: the input
-    // sets maxLength 15, so those keystrokes never arrive.
+    // The schema's third rule — over 15 characters — is unreachable: the input sets maxLength 15.
   })
 
   it('backs out of the serial branch to identity selection', async () => {

--- a/e2e/test/bcsc/verify/verify-entry-detours.journey.ts
+++ b/e2e/test/bcsc/verify/verify-entry-detours.journey.ts
@@ -1,7 +1,8 @@
+import assert from 'node:assert/strict'
 import { TestUsers, Timeouts } from '../../../src/constants.js'
 import { completeOnboarding } from '../../../src/flows/onboarding.js'
 import { chooseAddAccount, enterSerialManually, startVerification } from '../../../src/flows/verify.js'
-import { acceptSystemAlert } from '../../../src/helpers/alerts.js'
+import { dismissSystemAlert } from '../../../src/helpers/alerts.js'
 import { BaseScreen } from '../../../src/screens/core/BaseScreen.js'
 import {
   AccountSetupScreen,
@@ -20,6 +21,12 @@ import { getTestUser, setTestUser } from '../../../src/support/context.js'
 const engine = new BaseScreen()
 /** A valid-format birthdate that does NOT match the photo card, to force the CSN/birthdate mismatch. */
 const MISMATCH_DOB = '19800101'
+/** Shorter than the serial schema's 3-character minimum, so it trips the format rule rather than the empty one. */
+const TOO_SHORT_SERIAL = 'AB'
+/** ManualSerial's two reachable inline errors (`BCSC.ManualSerial.EmptySerialError` / `FormatError`).
+ *  Asserted verbatim: only the message tells the two validation rules apart. */
+const EMPTY_SERIAL_ERROR = 'Required'
+const SERIAL_FORMAT_ERROR = 'Enter a valid card serial number'
 
 /**
  * Verify journey: entry detours — the cheap, no-verification-completed browse of the verify entry
@@ -32,6 +39,13 @@ const MISMATCH_DOB = '19800101'
  * Structure avoids ambiguous back-navigation: the AccountSetup detour is a self-contained round-trip;
  * the serial branch backs out through its push stack (ManualSerial → ScanSerial → IdentitySelection);
  * the Other-ID branch chains FORWARD (DualId webview → EvidenceTypeList) with no deep back-out.
+ *
+ * The camera permission is REFUSED at the first ScanSerial, which is why that checkpoint comes before
+ * everything else on the serial branch: the answer is one-way within a session (iOS never re-prompts),
+ * so a grant anywhere earlier would make the refused body unreachable. It costs the later checkpoints
+ * nothing — `EnterManually` is rendered by both the camera body and the permission fallback, so the
+ * CI path around the camera works either way (which is also why this now runs on both platforms
+ * rather than iOS only: nothing here depends on a live camera coming up).
  *
  * Anchors + navigation verified against app source (main): AccountSetup Add/Transfer
  * (AddAccount/TransferAccount → TransferAccountInstructions), TransferInstructions `ScanQRCode`,
@@ -70,20 +84,39 @@ describe('Verify journey: entry detours', () => {
     await IdentitySelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })
 
-  if (driver.isIOS) {
-    it('reveals manual serial entry behind the Scan camera gate and backs out', async () => {
-      await IdentitySelectionScreen.tap('primary') // Scan → ScanSerial (auto-requests camera permission)
-      await acceptSystemAlert()
-      await ScanSerialScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
-      await ScanSerialScreen.tap('primary') // EnterManually (pushes ManualSerial)
-      await ManualSerialScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
-      // Both hops are pushes, so back out twice: ManualSerial → ScanSerial → IdentitySelection.
-      await ManualSerialScreen.back.tap()
-      await ScanSerialScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
-      await ScanSerialScreen.back.tap()
-      await IdentitySelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
-    })
-  }
+  it('offers manual entry when the camera permission is refused', async () => {
+    await IdentitySelectionScreen.tapToNavigate('primary') // Scan → ScanSerial (auto-requests the camera)
+    // REFUSING is a one-way door for the session (iOS never re-prompts), so it has to be the first
+    // thing the camera screen is asked, before any checkpoint grants it.
+    await dismissSystemAlert(Timeouts.SCREEN_TRANSITION)
+    // `self` cannot tell the two bodies apart — EnterManually renders in both, which is what keeps the
+    // CI path working either way. `openSettings` exists only in the refused one. It is never tapped:
+    // it hands the session off to the OS settings app.
+    await ScanSerialScreen.waitFor('openSettings', Timeouts.SCREEN_TRANSITION)
+    await ScanSerialScreen.tapToNavigate('primary') // EnterManually (pushes ManualSerial)
+    await ManualSerialScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('rejects an empty and a malformed serial with inline errors', async () => {
+    // Continue is always enabled here — validation runs on press, so both cases are a press away.
+    await ManualSerialScreen.tapWhenEnabled('primary') // empty field
+    assert.equal(await ManualSerialScreen.read('error'), EMPTY_SERIAL_ERROR)
+
+    await ManualSerialScreen.fill('serial', TOO_SHORT_SERIAL, { tapFirst: true })
+    await engine.dismissKeyboard()
+    await ManualSerialScreen.tapWhenEnabled('primary')
+    assert.equal(await ManualSerialScreen.read('error'), SERIAL_FORMAT_ERROR)
+    // The third rule the schema carries — over 15 characters — is unreachable from the UI: the input
+    // sets maxLength 15, so those keystrokes never arrive.
+  })
+
+  it('backs out of the serial branch to identity selection', async () => {
+    // Both hops were pushes, so back out twice: ManualSerial → ScanSerial → IdentitySelection.
+    await ManualSerialScreen.back.tap()
+    await ScanSerialScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    await ScanSerialScreen.back.tap()
+    await IdentitySelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
 
   it('rejects a mismatched serial + birthdate and offers Try Another', async () => {
     // The one backend authorize on this journey: a REAL card serial + a deliberately WRONG birthdate.

--- a/e2e/test/bcsc/verify/verify-resume.journey.ts
+++ b/e2e/test/bcsc/verify/verify-resume.journey.ts
@@ -1,0 +1,122 @@
+import { TEST_PIN, TestUsers, Timeouts } from '../../../src/constants.js'
+import { unlockWithPin } from '../../../src/flows/auth.js'
+import { completeOnboarding } from '../../../src/flows/onboarding.js'
+import {
+  chooseAddAccount,
+  chooseOtherIdPath,
+  enterSerialManually,
+  leaveVerificationToHome,
+  restartVerification,
+  resumeVerification,
+  selectEvidenceType,
+  startVerification,
+} from '../../../src/flows/verify.js'
+import { HomeNotificationCard, HomeScreen } from '../../../src/screens/main.js'
+import { AccountSetupScreen, EnterBirthdateScreen, IDPhotoInformationScreen } from '../../../src/screens/verify.js'
+import { getTestUser, setTestUser } from '../../../src/support/context.js'
+
+/** The first-ID list row to select but never capture — the same slot the non-BCSC journey proves. */
+const INTERRUPTED_EVIDENCE_MATCH = 'BC Drivers Licence'
+
+/**
+ * Verify journey: resume routing — what `getResumeStepRoute` puts on screen when a user comes BACK to
+ * an unfinished verification. That mapping drives the verify stack's initial route and every
+ * step-completion navigation, and none of it was covered.
+ *
+ * The route back in is always the same and is worth stating, because it is not the obvious one: the
+ * verification-in-progress flag is in-memory and hydration recomputes it from the credential, so
+ * leaving the flow AND every relaunch land on Home, where the Start/Continue-verification notification
+ * card is the only way back into the stack. Each checkpoint therefore leaves, returns, and asserts
+ * which step the app chose.
+ *
+ * Deliberately cheap: no verification is completed and no camera is used. The serial is saved but never
+ * submitted (no `authorizeDevice`), and the interrupted-capture state is reached by selecting an ID and
+ * stopping — the app persists that selection with zero photos, which is exactly its "capture was
+ * interrupted" state. Backend traffic is the terms fetch, the evidence-type list, and the IAS
+ * re-registration that Restart performs.
+ *
+ * Two rows of the resume matrix are NOT here because they cost a full verification: the captured-but-
+ * unnumbered document (→ EvidenceIDCollection) and the post-authorize steps (→ ResidentialAddress /
+ * EnterEmail / VerificationMethodSelection). They belong on the journeys that already pay for that
+ * state. The video-submitted row (→ PendingReview) needs a submitted video, which CI cannot produce.
+ *
+ * ORDER MATTERS: the serial and the interrupted capture are mutually exclusive resume states (a serial
+ * only routes to EnterBirthdate while no card process is set, and choosing Other ID sets one), so the
+ * serial rows run first and Restart is what clears them for the evidence rows.
+ */
+describe('Verify journey: resume routing', () => {
+  before(() => {
+    setTestUser(TestUsers.photo)
+  })
+
+  it('onboards to the verify prompt', async () => {
+    await completeOnboarding()
+  })
+
+  it('saves a card serial and stops on the birthdate step', async () => {
+    await startVerification()
+    await chooseAddAccount()
+    // Stops at EnterBirthdate WITHOUT submitting: the serial is persisted, the card is not authorized.
+    await enterSerialManually(getTestUser())
+    await EnterBirthdateScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('leaves verification for home and offers a way back in', async () => {
+    await leaveVerificationToHome()
+    // Progress is kept, so Home offers the verification card. Which variant it is (Start vs Continue)
+    // depends on whether the ID step is complete — it is not here — and both re-enter the same way.
+    await HomeNotificationCard.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('resumes onto the birthdate step, since a serial is saved', async () => {
+    await resumeVerification()
+    await EnterBirthdateScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('leaves again via the resumed step back button, which has nothing to pop', async () => {
+    // Resuming makes EnterBirthdate the stack's INITIAL route, so its back button has no destination.
+    // Rather than being dead it leaves the flow (VerifyResumeHeaderBackButton) — the same exit as the
+    // help menu, and the reason those screens carry a custom header-left at all.
+    await EnterBirthdateScreen.back.tap()
+    await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('still resumes onto the birthdate step after a relaunch', async () => {
+    // A relaunch is the case the in-memory flag cannot cover: the serial has to survive in native
+    // storage AND hydration has to recompute the step. Landing on Home (not the verify stack) is part
+    // of the assertion — `unlockWithPin` requires it.
+    await unlockWithPin(TEST_PIN, { relaunch: true })
+    await resumeVerification()
+    await EnterBirthdateScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('stays on the birthdate step when the restart confirmation is cancelled', async () => {
+    await restartVerification('cancel')
+    await EnterBirthdateScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('wipes progress when the restart is confirmed, reopening on the setup question', async () => {
+    await restartVerification('confirm')
+    // Restart clears the recorded setup type as well as the verification data, so the flow reopens on
+    // the add-or-transfer question — NOT on IdentitySelection, which is where the serial branch began.
+    // The wait is generous: the reset deletes and recreates the IAS registration behind a loading screen.
+    await AccountSetupScreen.expectVisible(Timeouts.APP_LAUNCH)
+  })
+
+  it('selects an ID and stops before capturing it', async () => {
+    await chooseAddAccount()
+    await chooseOtherIdPath()
+    await selectEvidenceType(INTERRUPTED_EVIDENCE_MATCH)
+    await IDPhotoInformationScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('resumes an interrupted capture onto the photo primer', async () => {
+    await leaveVerificationToHome()
+    await resumeVerification()
+    // A selected ID with no photos resumes to the primer so capture restarts from the first side,
+    // rather than dropping the user on the document-number form or back at the start of the ID step.
+    // Nothing else could produce this route here: Restart wiped the serial, and choosing Other ID set
+    // the non-BCSC card process, so the interrupted capture is the only progress left to resume.
+    await IDPhotoInformationScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+})

--- a/e2e/test/bcsc/verify/verify-resume.journey.ts
+++ b/e2e/test/bcsc/verify/verify-resume.journey.ts
@@ -19,30 +19,24 @@ import { getTestUser, setTestUser } from '../../../src/support/context.js'
 const INTERRUPTED_EVIDENCE_MATCH = 'BC Drivers Licence'
 
 /**
- * Verify journey: resume routing — what `getResumeStepRoute` puts on screen when a user comes BACK to
- * an unfinished verification. That mapping drives the verify stack's initial route and every
- * step-completion navigation, and none of it was covered.
+ * Verify journey: resume routing — what `getResumeStepRoute` puts on screen when a user comes BACK to an
+ * unfinished verification. That mapping drives the verify stack's initial route and every step-completion
+ * navigation, and none of it was covered.
  *
- * The route back in is always the same and is worth stating, because it is not the obvious one: the
- * verification-in-progress flag is in-memory and hydration recomputes it from the credential, so
- * leaving the flow AND every relaunch land on Home, where the Start/Continue-verification notification
- * card is the only way back into the stack. Each checkpoint therefore leaves, returns, and asserts
- * which step the app chose.
+ * The route back in is always Home's verification card: the in-progress flag is in-memory and hydration
+ * recomputes it, so leaving the flow AND every relaunch land there. Each checkpoint leaves, returns, and
+ * asserts which step the app chose.
  *
- * Deliberately cheap: no verification is completed and no camera is used. The serial is saved but never
- * submitted (no `authorizeDevice`), and the interrupted-capture state is reached by selecting an ID and
- * stopping — the app persists that selection with zero photos, which is exactly its "capture was
- * interrupted" state. Backend traffic is the terms fetch, the evidence-type list, and the IAS
- * re-registration that Restart performs.
+ * Deliberately cheap — nothing is verified and no camera is used. The serial is saved but never submitted
+ * (no `authorizeDevice`), and the interrupted capture is a selected ID with zero photos, which the app
+ * persists as exactly that state.
  *
- * Two rows of the resume matrix are NOT here because they cost a full verification: the captured-but-
- * unnumbered document (→ EvidenceIDCollection) and the post-authorize steps (→ ResidentialAddress /
- * EnterEmail / VerificationMethodSelection). They belong on the journeys that already pay for that
- * state. The video-submitted row (→ PendingReview) needs a submitted video, which CI cannot produce.
+ * The rows costing a full verification (captured-but-unnumbered document, the post-authorize steps) live
+ * on the journeys already paying for that state; the video-submitted row needs a video CI cannot produce.
  *
- * ORDER MATTERS: the serial and the interrupted capture are mutually exclusive resume states (a serial
- * only routes to EnterBirthdate while no card process is set, and choosing Other ID sets one), so the
- * serial rows run first and Restart is what clears them for the evidence rows.
+ * ORDER MATTERS: a saved serial and an interrupted capture are mutually exclusive resume states (choosing
+ * Other ID sets a card process, which retires the serial route), so the serial rows run first and Restart
+ * is what clears them for the evidence rows.
  */
 describe('Verify journey: resume routing', () => {
   before(() => {
@@ -63,8 +57,7 @@ describe('Verify journey: resume routing', () => {
 
   it('leaves verification for home and offers a way back in', async () => {
     await leaveVerificationToHome()
-    // Progress is kept, so Home offers the verification card. Which variant it is (Start vs Continue)
-    // depends on whether the ID step is complete — it is not here — and both re-enter the same way.
+    // Progress is kept, so Home offers the verification card; both variants re-enter the same way.
     await HomeNotificationCard.expectVisible(Timeouts.SCREEN_TRANSITION)
   })
 
@@ -74,17 +67,15 @@ describe('Verify journey: resume routing', () => {
   })
 
   it('leaves again via the resumed step back button, which has nothing to pop', async () => {
-    // Resuming makes EnterBirthdate the stack's INITIAL route, so its back button has no destination.
-    // Rather than being dead it leaves the flow (VerifyResumeHeaderBackButton) — the same exit as the
-    // help menu, and the reason those screens carry a custom header-left at all.
+    // Resuming makes EnterBirthdate the stack's INITIAL route, so its back button has nothing to pop —
+    // it leaves the flow instead (`VerifyResumeHeaderBackButton`), the same exit as the help menu.
     await EnterBirthdateScreen.back.tap()
     await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })
 
   it('still resumes onto the birthdate step after a relaunch', async () => {
-    // A relaunch is the case the in-memory flag cannot cover: the serial has to survive in native
-    // storage AND hydration has to recompute the step. Landing on Home (not the verify stack) is part
-    // of the assertion — `unlockWithPin` requires it.
+    // A relaunch is what the in-memory flag cannot cover: the serial must survive in native storage and
+    // hydration must recompute the step. Landing on Home is part of it — `unlockWithPin` requires it.
     await unlockWithPin(TEST_PIN, { relaunch: true })
     await resumeVerification()
     await EnterBirthdateScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
@@ -97,9 +88,8 @@ describe('Verify journey: resume routing', () => {
 
   it('wipes progress when the restart is confirmed, reopening on the setup question', async () => {
     await restartVerification('confirm')
-    // Restart clears the recorded setup type as well as the verification data, so the flow reopens on
-    // the add-or-transfer question — NOT on IdentitySelection, which is where the serial branch began.
-    // The wait is generous: the reset deletes and recreates the IAS registration behind a loading screen.
+    // Restart clears the recorded setup type too, so the flow reopens on the add-or-transfer question,
+    // NOT IdentitySelection. The generous wait covers the IAS re-registration behind its loading screen.
     await AccountSetupScreen.expectVisible(Timeouts.APP_LAUNCH)
   })
 
@@ -113,10 +103,8 @@ describe('Verify journey: resume routing', () => {
   it('resumes an interrupted capture onto the photo primer', async () => {
     await leaveVerificationToHome()
     await resumeVerification()
-    // A selected ID with no photos resumes to the primer so capture restarts from the first side,
-    // rather than dropping the user on the document-number form or back at the start of the ID step.
-    // Nothing else could produce this route here: Restart wiped the serial, and choosing Other ID set
-    // the non-BCSC card process, so the interrupted capture is the only progress left to resume.
+    // A selected ID with no photos resumes to the primer, so capture restarts from the first side rather
+    // than dropping the user on the number form or back at the start of the ID step.
     await IDPhotoInformationScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })
 })


### PR DESCRIPTION
# Summary of Changes

Extends verify-stack e2e coverage to the branches the screen audit left uncovered — resume routing, inline validation errors, the refused-camera fallback, and the email detours — and splits the verify flow helpers into per-step arranges so journeys can stop between steps. E2E-only, no app code touched.

- New `verify-resume.journey.ts` — the `getResumeStepRoute` mapping after leaving the flow or relaunching, plus restart-verification cancel and confirm.
- `verify-entry-detours` — refused-camera `PermissionDisabled` fallback and both ManualSerial validation errors; the serial block now runs on Android too (was iOS-only).
- `verified-non-bcsc` — under-12 birthdate rejection, second-slot ID list filtering, wrong-code then resend email path, and the address/email resume steps.
- `verified-non-photo` — the non-photo escape hatch, PhotoReview retake, and resume onto the document-number form across a relaunch.
- Verify helpers split per step (capture, typed number and email are now separate calls), plus new help-menu, resume and evidence-list helpers with their testIDs.
- Fixes: iOS keyboard dismissal detects a number pad up front, falls back to the Android editor action, and verifies the keyboard retracted; in-person approval budget 30s → 60s, with per-step `[sm-login]` timings.

Also condenses the inline comments added across this branch, and catches the README test tree up to the journeys already on main.

# Testing Instructions

1. From `e2e/`: `npm run test:ios:sauce -- --suite verify`, then `npm run test:android:sauce -- --suite verify`.
2. `verified-non-photo` and `verified-non-bcsc` capture documents via Sauce image injection — run those on Sauce, not locally.

# Acceptance Criteria

- [ ] `verify` suite passes on iOS and Android
- [ ] `verify-resume` lands on the expected step after each leave and relaunch
- [ ] Non-BCSC and non-photo journeys still complete through to verified Home
- [ ] `tsc --noEmit` and eslint clean

# Screenshots, videos, or gifs

N/A

# Related Issues

N/A
