### PR TITLE
fix: evidence navigation bug and correct rule for non-photo

### DIFF
--- a/app/__mocks__/custom/@react-navigation/core.ts
+++ b/app/__mocks__/custom/@react-navigation/core.ts
@@ -2,6 +2,7 @@ const navigate = jest.fn()
 
 const navigation = {
   navigate,
+  push: jest.fn(),
   setOptions: jest.fn(),
   getParent: jest.fn(() => ({
     navigate,

--- a/app/src/bcsc-theme/features/verify/non-photo/AdditionalIdentificationRequiredScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/AdditionalIdentificationRequiredScreen.test.tsx
@@ -1,6 +1,8 @@
+import { BCSCScreens } from '@/bcsc-theme/types/navigators'
+import { testIdWithKey } from '@bifold/core'
 import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
-import { render } from '@testing-library/react-native'
+import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 import AdditionalIdentificationRequiredScreen from './AdditionalIdentificationRequiredScreen'
 
@@ -25,5 +27,23 @@ describe('AdditionalIdentificationRequired', () => {
     )
 
     expect(tree).toMatchSnapshot()
+  })
+
+  it('pushes a fresh photo-filtered evidence list on continue', () => {
+    const { getByTestId } = render(
+      <BasicAppContext>
+        <AdditionalIdentificationRequiredScreen navigation={mockNavigation as never} />
+      </BasicAppContext>
+    )
+
+    fireEvent.press(getByTestId(testIdWithKey('Global.Continue')))
+
+    expect(mockNavigation.push).toHaveBeenCalledWith(
+      BCSCScreens.EvidenceTypeList,
+      expect.objectContaining({ photoFilter: 'photo' })
+    )
+    // navigate would pop back to an existing list (the "Other Options" one), which that screen
+    // treats as back-navigation and uses to release the ID the user just collected.
+    expect(mockNavigation.navigate).not.toHaveBeenCalled()
   })
 })

--- a/app/src/bcsc-theme/features/verify/non-photo/AdditionalIdentificationRequiredScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/AdditionalIdentificationRequiredScreen.tsx
@@ -37,7 +37,7 @@ const AdditionalIdentificationRequiredScreen: React.FC<AdditionalIdentificationR
       primaryAction={{
         label: t('Global.Continue'),
         onPress: () => {
-          navigation.navigate(BCSCScreens.EvidenceTypeList, {
+          navigation.push(BCSCScreens.EvidenceTypeList, {
             // The cardProcess should have been defined prior to reaching this screen.
             // @see EnterBirthdateViewModel.authorizeDevice()
             cardProcess: store.bcscSecure.cardProcess ?? BCSCCardProcess.None,

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.test.tsx
@@ -298,6 +298,151 @@ describe('EvidenceTypeList', () => {
     })
   })
 
+  describe('non-photo BCSC second ID', () => {
+    // Once a non-photo ID has been submitted as the first additional ID, the next list must be the
+    // SECOND-order photo IDs (which is where groups like "OTHER COUNTRIES" live) — not a repeat of
+    // the first-ID list, and without the "Other Options" escape hatch.
+    it('shows SECOND-order photo IDs and hides "Other Options"', () => {
+      const firstPhotoCard = makeEvidenceType({
+        evidence_type: 'BC Drivers Licence',
+        evidence_type_label: 'BC Drivers Licence',
+        collection_order: 'FIRST',
+        has_photo: true,
+      })
+      const secondPhotoCard = makeEvidenceType({
+        evidence_type: 'Foreign Passport',
+        evidence_type_label: 'Foreign Passport',
+        collection_order: 'SECOND',
+        has_photo: true,
+        group: 'OTHER COUNTRIES',
+      })
+      const birthCertificate = makeEvidenceType({
+        evidence_type: 'Birth Certificate',
+        evidence_type_label: 'Birth Certificate',
+        collection_order: 'FIRST',
+        has_photo: false,
+      })
+      const process = BCSCCardProcess.BCSCNonPhoto as string
+
+      const completedBirthCertificate: EvidenceMetadata = {
+        evidenceType: birthCertificate,
+        metadata: [{ uri: 'front.jpg' } as any],
+        documentNumber: 'BC123',
+      }
+
+      mockUseStore.mockReturnValue([
+        {
+          ...initialState,
+          bcscSecure: {
+            ...initialState.bcscSecure,
+            cardProcess: BCSCCardProcess.BCSCNonPhoto,
+            additionalEvidenceData: [completedBirthCertificate],
+          },
+        },
+        jest.fn(),
+      ])
+      mockUseDataLoader.mockReturnValue({
+        data: mockMetadata([firstPhotoCard, secondPhotoCard, birthCertificate], process),
+        load: jest.fn(),
+        isLoading: false,
+      })
+
+      const { getByText, queryByText } = render(
+        <BasicAppContext>
+          <EvidenceTypeListScreen
+            navigation={mockNavigation as never}
+            route={
+              { params: { cardProcess: BCSCCardProcess.BCSCNonPhoto, photoFilter: 'photo' } } as EvidenceTypeListRoute
+            }
+          />
+        </BasicAppContext>
+      )
+
+      expect(getByText('OTHER COUNTRIES')).toBeTruthy()
+      expect(getByText('Foreign Passport')).toBeTruthy()
+      expect(queryByText('BC Drivers Licence')).toBeNull()
+      expect(queryByText('Birth Certificate')).toBeNull()
+      expect(queryByText('BCSC.EvidenceTypeList.ShowMoreOptions')).toBeNull()
+    })
+  })
+
+  describe('non-BCSC second ID', () => {
+    const nonPhotoFirstId = makeEvidenceType({
+      evidence_type: 'Birth Certificate',
+      evidence_type_label: 'Birth Certificate',
+      collection_order: 'FIRST',
+      has_photo: false,
+    })
+    const photoSecondId = makeEvidenceType({
+      evidence_type: 'Foreign Passport',
+      evidence_type_label: 'Foreign Passport',
+      collection_order: 'SECOND',
+      has_photo: true,
+    })
+    const nonPhotoSecondId = makeEvidenceType({
+      evidence_type: 'Marriage Certificate',
+      evidence_type_label: 'Marriage Certificate',
+      collection_order: 'SECOND',
+      has_photo: false,
+    })
+
+    const renderWithFirstId = (firstIdType: EvidenceType) => {
+      const completedFirstId: EvidenceMetadata = {
+        evidenceType: firstIdType,
+        metadata: [{ uri: 'front.jpg' } as any],
+        documentNumber: 'ID123',
+      }
+
+      mockUseStore.mockReturnValue([
+        {
+          ...initialState,
+          bcscSecure: {
+            ...initialState.bcscSecure,
+            cardProcess: BCSCCardProcess.NonBCSC,
+            additionalEvidenceData: [completedFirstId],
+          },
+        },
+        jest.fn(),
+      ])
+      mockUseDataLoader.mockReturnValue({
+        data: mockMetadata([nonPhotoFirstId, photoSecondId, nonPhotoSecondId], BCSCCardProcess.NonBCSC as string),
+        load: jest.fn(),
+        isLoading: false,
+      })
+
+      return render(
+        <BasicAppContext>
+          <EvidenceTypeListScreen
+            navigation={mockNavigation as never}
+            route={{ params: { cardProcess: BCSCCardProcess.NonBCSC } } as EvidenceTypeListRoute}
+          />
+        </BasicAppContext>
+      )
+    }
+
+    // Two IDs are collected and at least one must carry a photo, so a photo-less first ID forces
+    // the second list to photo IDs even though no photoFilter route param is passed.
+    it('restricts the list to photo IDs when the first ID has no photo', () => {
+      const { getByText, queryByText } = renderWithFirstId(nonPhotoFirstId)
+
+      expect(getByText('Foreign Passport')).toBeTruthy()
+      expect(queryByText('Marriage Certificate')).toBeNull()
+    })
+
+    it('allows non-photo IDs when the first ID already has a photo', () => {
+      const photoFirstId = makeEvidenceType({
+        evidence_type: 'BC Drivers Licence',
+        evidence_type_label: 'BC Drivers Licence',
+        collection_order: 'FIRST',
+        has_photo: true,
+      })
+      const { getByText } = renderWithFirstId(photoFirstId)
+
+      expect(getByText('Foreign Passport')).toBeTruthy()
+      expect(getByText('Marriage Certificate')).toBeTruthy()
+    })
+  })
+
   describe('useFocusEffect', () => {
     it('should call removeIncompleteEvidence on mount', () => {
       jest.spyOn(Navigation, 'useFocusEffect').mockImplementation((callback) => {

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.tsx
@@ -38,7 +38,8 @@ interface SectionData {
  *
  * When `photoFilter` is set (non-photo BCSC flow), the list is further restricted
  * to photo-only or non-photo-only IDs, and an "Other Options" escape hatch lets
- * users without a photo ID switch to the non-photo list.
+ * users without a photo ID switch to the non-photo list. The Non-BCSC flow derives
+ * the same photo-only restriction for its second ID when the first one had no photo.
  *
  * On focus, the screen also reconciles the evidence store with the navigation
  * state: incomplete (abandoned) selections are removed on the first visit, and
@@ -150,6 +151,13 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
     [store.bcscSecure.additionalEvidenceData]
   )
 
+  const firstEvidence = store.bcscSecure.additionalEvidenceData[0]
+  const nonBcscSecondIdRequiresPhoto =
+    cardProcess === BCSCCardProcess.NonBCSC &&
+    isCardEvidenceComplete(firstEvidence) &&
+    !firstEvidence.evidenceType?.has_photo
+  const effectivePhotoFilter = nonBcscSecondIdRequiresPhoto ? 'photo' : photoFilter
+
   useEffect(() => {
     if (!data) {
       return
@@ -166,10 +174,10 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
         // first and second runs will show slightly different cards
         p.evidence_types.forEach((e) => {
           // Apply photo filter if specified (used by non-photo BCSC flow)
-          if (photoFilter === 'photo' && !e.has_photo) {
+          if (effectivePhotoFilter === 'photo' && !e.has_photo) {
             return
           }
-          if (photoFilter === 'nonPhoto' && e.has_photo) {
+          if (effectivePhotoFilter === 'nonPhoto' && e.has_photo) {
             return
           }
 
@@ -181,7 +189,7 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
     })
     const mappedData = mapEvidenceToSections(cards)
     setEvidenceSections(mappedData)
-  }, [data, cardProcess, photoFilter, shouldAddEvidence])
+  }, [data, cardProcess, effectivePhotoFilter, shouldAddEvidence])
 
   const mapEvidenceToSections = (cards: Record<string, EvidenceType[]>): SectionData[] => {
     const mappedData: { title: string; data: EvidenceType[] }[] = []


### PR DESCRIPTION
# Summary of Changes

This PR fixes two bugs with evidence collection for non-BCSC and non-photo:
- use navigation.push rather than navigation.navigate so the existing screen instance isn't navigated back to (which caused existing evidence to be cleared)
- filter for photo evidence only in the non-BCSC flow if the first evidence didn't include a photo (matching ias-ios)

# Testing Instructions

Go through non-BCSC and non-photo flows.

# Acceptance Criteria

Works, filters properly, can't use the same evidence twice

# Screenshots, videos, or gifs

N/A

# Related Issues

#4402 