### PR TITLE
fix: prevent hang during ledger cache lookup

### DIFF
--- a/app/src/bcsc-theme/features/agent/services/agent-service.test.ts
+++ b/app/src/bcsc-theme/features/agent/services/agent-service.test.ts
@@ -1,3 +1,4 @@
+import { CACHED_LEDGER_READ_TIMEOUT_MS } from '@/constants'
 import { AppError } from '@/errors'
 import { AppEventCode } from '@/events/appEventCode'
 import { PersistentStorage } from '@bifold/core'
@@ -98,6 +99,18 @@ beforeEach(() => {
 })
 
 describe('loadCachedLedgers', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('reads the cached genesis transactions key', async () => {
+    mockFetchValueForKey.mockResolvedValue(undefined)
+
+    await loadCachedLedgers()
+
+    expect(mockFetchValueForKey).toHaveBeenCalledWith('GenesisTransactions')
+  })
+
   it('returns undefined when no cache exists', async () => {
     mockFetchValueForKey.mockResolvedValue(undefined)
 
@@ -127,6 +140,42 @@ describe('loadCachedLedgers', () => {
     const result = await loadCachedLedgers()
 
     expect(result).toBeUndefined()
+  })
+
+  it('returns undefined when the storage read never settles', async () => {
+    jest.useFakeTimers()
+    mockFetchValueForKey.mockReturnValue(new Promise(() => {}))
+
+    const resultPromise = loadCachedLedgers()
+    await jest.advanceTimersByTimeAsync(CACHED_LEDGER_READ_TIMEOUT_MS)
+
+    await expect(resultPromise).resolves.toBeUndefined()
+  })
+
+  it('does not time out a read that settles before the threshold', async () => {
+    jest.useFakeTimers()
+    const transactions = [{ id: 'ledger-1' }]
+    let resolveRead: (value: unknown) => void = () => {}
+    mockFetchValueForKey.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRead = resolve
+      })
+    )
+
+    const resultPromise = loadCachedLedgers()
+    await jest.advanceTimersByTimeAsync(CACHED_LEDGER_READ_TIMEOUT_MS - 1)
+    resolveRead({ timestamp: moment().toISOString(), transactions })
+
+    await expect(resultPromise).resolves.toEqual(transactions)
+  })
+
+  it('clears the timeout once the read settles', async () => {
+    jest.useFakeTimers()
+    mockFetchValueForKey.mockResolvedValue(undefined)
+
+    await loadCachedLedgers()
+
+    expect(jest.getTimerCount()).toBe(0)
   })
 })
 

--- a/app/src/bcsc-theme/features/agent/services/agent-service.ts
+++ b/app/src/bcsc-theme/features/agent/services/agent-service.ts
@@ -1,4 +1,4 @@
-import { CACHED_LEDGERS_TTL_DAYS } from '@/constants'
+import { CACHED_LEDGER_READ_TIMEOUT_MS, CACHED_LEDGERS_TTL_DAYS } from '@/constants'
 import { AppError, ErrorRegistry } from '@/errors'
 import { BCLocalStorageKeys } from '@/store'
 import { getBCAgentModules } from '@/utils/bc-agent-modules'
@@ -67,16 +67,25 @@ const enqueueWalletOp = <T>(op: () => Promise<T>): Promise<T> => {
  * Loads previously cached pool genesis transactions from persistent storage.
  *
  * Used to skip live ledger discovery on subsequent agent inits. Returns `undefined`
- * if no cache exists or if the cache is older than `CACHED_LEDGERS_TTL_DAYS`,
- * signalling that callers should fall back to the configured ledgers and refresh
- * the cache.
+ * if no cache exists, if the read times out, or if the cache is older than
+ * `CACHED_LEDGERS_TTL_DAYS`, signalling that callers should fall back to the
+ * configured ledgers and refresh the cache.
+ *
+ * The read is bounded because `AsyncStorage.getItem` never settles when the
+ * native callback is dropped
  *
  * @returns Cached ledger configs if fresh, otherwise `undefined`.
  */
 export const loadCachedLedgers = async (): Promise<IndyVdrPoolConfig[] | undefined> => {
-  const cached = await PersistentStorage.fetchValueForKey<CachedGenesisTransactions>(
-    BCLocalStorageKeys.GenesisTransactions
-  )
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const cached = await Promise.race([
+    PersistentStorage.fetchValueForKey<CachedGenesisTransactions>(BCLocalStorageKeys.GenesisTransactions),
+    new Promise<undefined>((resolve) => {
+      timeoutId = setTimeout(() => resolve(undefined), CACHED_LEDGER_READ_TIMEOUT_MS)
+    }),
+  ])
+  clearTimeout(timeoutId)
+
   if (!cached) {
     return undefined
   }

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -191,6 +191,7 @@ export const DEVICE_COUNT_BANNER_COOLDOWN_MS_PROD = 30 * 24 * 60 * 60 * 1000 // 
 // Agent constants
 export const WALLET_ID = 'bc-wallet-bcsc'
 export const CACHED_LEDGERS_TTL_DAYS = 1
+export const CACHED_LEDGER_READ_TIMEOUT_MS = 3000
 
 // Shadow constants
 export const SHADOW_CASTER_HEIGHT = 1

--- a/app/src/hooks/useBCAgentSetup.test.tsx
+++ b/app/src/hooks/useBCAgentSetup.test.tsx
@@ -26,6 +26,7 @@ import {
 import { act, renderHook } from '@testing-library/react-native'
 import useBCAgentSetup from './useBCAgentSetup'
 
+import { CACHED_LEDGER_READ_TIMEOUT_MS } from '@/constants'
 import { PersistentStorage, useServices, useStore as useStoreBifold } from '@bifold/core'
 import moment from 'moment'
 
@@ -234,6 +235,26 @@ describe('useBCAgentSetup', () => {
         key: 'wallet-key',
         salt: 'wallet-salt',
       })
+    })
+
+    expect(Agent).toHaveBeenCalled()
+    expect(result.current.agent).toBeTruthy()
+  })
+
+  it('should still create an agent when the cached ledger read never settles', async () => {
+    jest.useFakeTimers()
+    jest.spyOn(PersistentStorage, 'fetchValueForKey').mockReturnValue(new Promise(() => {}))
+
+    const { result } = renderHook(() => useBCAgentSetup())
+
+    await act(async () => {
+      const initializePromise = result.current.initializeAgent({
+        id: 'wallet-id',
+        key: 'wallet-key',
+        salt: 'wallet-salt',
+      })
+      await jest.advanceTimersByTimeAsync(CACHED_LEDGER_READ_TIMEOUT_MS)
+      await initializePromise
     })
 
     expect(Agent).toHaveBeenCalled()

--- a/app/src/hooks/useBCAgentSetup.ts
+++ b/app/src/hooks/useBCAgentSetup.ts
@@ -1,4 +1,5 @@
 import { ledgerResolver } from '@/configs/ledgers/indy/ledgerResolver'
+import { CACHED_LEDGER_READ_TIMEOUT_MS } from '@/constants'
 import { BCLocalStorageKeys, BCState } from '@/store'
 import { activate } from '@/utils/PushNotificationsHelper'
 import { getBCAgentModules } from '@/utils/bc-agent-modules'
@@ -34,9 +35,19 @@ import { CachesDirectoryPath } from 'react-native-fs'
 const DEFAULT_MEDIATION_EXPIRED_THRESHOLD_DAYS = '90'
 const CONNECTION_COMPLETION_TIMEOUT_MS = 10000
 
+// AsyncStorage.getItem never settles if the native callback is dropped so time it
+// out and fall through to a full refresh
 const loadCachedLedgers = async (): Promise<IndyVdrPoolConfig[] | undefined> => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const cachedTransactions = await PersistentStorage.fetchValueForKey<any>(BCLocalStorageKeys.GenesisTransactions)
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const cachedTransactions = await Promise.race([
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    PersistentStorage.fetchValueForKey<any>(BCLocalStorageKeys.GenesisTransactions),
+    new Promise<undefined>((resolve) => {
+      timeoutId = setTimeout(() => resolve(undefined), CACHED_LEDGER_READ_TIMEOUT_MS)
+    }),
+  ])
+  clearTimeout(timeoutId)
+
   if (cachedTransactions) {
     const { timestamp, transactions } = cachedTransactions
     return moment().diff(moment(timestamp), 'days') >= 1 ? undefined : transactions


### PR DESCRIPTION
# Summary of Changes

See related issue

# Testing Instructions

Open app, see agent initializes as usual

# Acceptance Criteria

N/A

# Screenshots, videos, or gifs

N/A

# Related Issues

#4406 