### PR TITLE
fix: incorrect flag preventing full deactivated / expiry detection

### DIFF
--- a/app/src/bcsc-theme/hooks/useCardStatus.test.ts
+++ b/app/src/bcsc-theme/hooks/useCardStatus.test.ts
@@ -1,0 +1,84 @@
+import { BCSCReason } from '@/bcsc-theme/utils/id-token'
+import * as Bifold from '@bifold/core'
+import { renderHook } from '@testing-library/react-native'
+import { useAccount } from '../contexts/BCSCAccountContext'
+import { useCardStatus } from './useCardStatus'
+
+jest.mock('@bifold/core')
+jest.mock('../contexts/BCSCAccountContext', () => ({ useAccount: jest.fn() }))
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const futureExpiry = new Date(Date.now() + 365 * DAY_MS)
+const pastExpiry = new Date(Date.now() - 30 * DAY_MS)
+
+const mockStore = (opts: { verified?: boolean; bcscReason?: BCSCReason }) => {
+  jest.mocked(Bifold.useStore).mockReturnValue([
+    {
+      bcscSecure: { verified: opts.verified ?? true },
+      bcsc: { credentialMetadata: { bcscReason: opts.bcscReason ?? BCSCReason.ApprovedByAgent } },
+    } as any,
+    jest.fn(),
+  ])
+}
+
+const mockAccount = (expiry: Date | null) => {
+  jest.mocked(useAccount).mockReturnValue({ account: expiry ? { account_expiration_date: expiry } : null } as any)
+}
+
+describe('useCardStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('is actively verified when the card is verified and the expiry date has not passed', () => {
+    mockStore({})
+    mockAccount(futureExpiry)
+
+    const { result } = renderHook(() => useCardStatus())
+
+    expect(result.current.isExpired).toBe(false)
+    expect(result.current.isActivelyVerified).toBe(true)
+  })
+
+  it('is expired once the expiry date has passed', () => {
+    mockStore({})
+    mockAccount(pastExpiry)
+
+    const { result } = renderHook(() => useCardStatus())
+
+    expect(result.current.isExpired).toBe(true)
+    expect(result.current.isActivelyVerified).toBe(false)
+  })
+
+  // IAS can expire an account server-side before its printed expiry date. Previously this reason
+  // was read as an "emergency mode" that bypassed the expiry check, leaving a deactivated user
+  // with Services, pairing, and the verified home still open to them.
+  it('is expired when IAS reports ExpiredBySystem, even if the expiry date is in the future', () => {
+    mockStore({ bcscReason: BCSCReason.ExpiredBySystem })
+    mockAccount(futureExpiry)
+
+    const { result } = renderHook(() => useCardStatus())
+
+    expect(result.current.isExpired).toBe(true)
+    expect(result.current.isActivelyVerified).toBe(false)
+  })
+
+  it('is not expired when the user is not verified, so they are routed to verify rather than renew', () => {
+    mockStore({ verified: false, bcscReason: BCSCReason.ExpiredBySystem })
+    mockAccount(pastExpiry)
+
+    const { result } = renderHook(() => useCardStatus())
+
+    expect(result.current.isExpired).toBe(false)
+    expect(result.current.isActivelyVerified).toBe(false)
+  })
+
+  it('is not expired when no account has loaded yet', () => {
+    mockStore({})
+    mockAccount(null)
+
+    const { result } = renderHook(() => useCardStatus())
+
+    expect(result.current.isExpired).toBe(false)
+  })
+})

--- a/app/src/bcsc-theme/hooks/useCardStatus.ts
+++ b/app/src/bcsc-theme/hooks/useCardStatus.ts
@@ -10,8 +10,8 @@ import { useVerificationStatus } from './useVerificationStatus'
  * Extends useVerificationStatus with card expiry awareness.
  *
  * - `isActivelyVerified` — true when the user is verified AND their card has not expired; use this for feature gating
- * - `isExpired` — true when the user has a verified card that has passed its expiry date
- * - Emergency mode (`bcscReason === ExpiredBySystem`) bypasses the date-based expiry check.
+ * - `isExpired` — true when the user has a verified card that IAS has expired server-side, or whose
+ *   expiry date has passed
  *
  * Must be used within BCSCAccountProvider.
  */
@@ -21,16 +21,14 @@ export const useCardStatus = () => {
   const [store] = useStore<BCState>()
 
   return useMemo(() => {
-    const isEmergencyMode = store.bcsc.credentialMetadata?.bcscReason === BCSCReason.ExpiredBySystem
-    const isExpired =
-      !isEmergencyMode && verificationStatus.isVerified && account != null
-        ? isAccountExpired(account.account_expiration_date)
-        : false
+    const isExpiredByServer = store.bcsc.credentialMetadata?.bcscReason === BCSCReason.ExpiredBySystem
+    const isExpired = verificationStatus.isVerified
+      ? isExpiredByServer || (account != null && isAccountExpired(account.account_expiration_date))
+      : false
 
     return {
       ...verificationStatus,
       isExpired,
-      isEmergencyMode,
       isActivelyVerified: verificationStatus.isVerified && !isExpired,
     }
   }, [verificationStatus, account, store.bcsc.credentialMetadata?.bcscReason])

--- a/app/src/bcsc-theme/navigators/RootStack.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.tsx
@@ -7,16 +7,16 @@ import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useInitializeAccountStatus } from '../api/hooks/useInitializeAccountStatus'
 import useThirdPartyKeyboardWarning from '../api/hooks/useThirdPartyKeyboardWarning'
-import { BCSCAccountProvider, useAccount } from '../contexts/BCSCAccountContext'
+import { BCSCAccountProvider } from '../contexts/BCSCAccountContext'
 import { BCSCActivityProvider } from '../contexts/BCSCActivityContext'
 import { BCSCIdTokenProvider } from '../contexts/BCSCIdTokenContext'
 import { LoadingScreen } from '../contexts/BCSCLoadingContext'
 import BCSCAgentProvider from '../features/agent/BCSCAgentProvider'
 import { useFcmService } from '../features/fcm'
 import { useBCSCApiClientState } from '../hooks/useBCSCApiClient'
+import { useCardStatus } from '../hooks/useCardStatus'
 import { SystemCheckScope, useSystemChecks } from '../hooks/useSystemChecks'
 import { useVerificationStatus } from '../hooks/useVerificationStatus'
-import { isAccountExpired } from '../utils/datetime-utils'
 import { toAppError } from '../utils/native-error-map'
 import AuthStack from './AuthStack'
 import BCSCMainStack from './MainStack'
@@ -26,13 +26,12 @@ import VerifyStack from './VerifyStack'
 // Keeps FcmViewModel in sync with card expiry so it can drop challenges for expired users.
 // Must live inside BCSCAccountProvider.
 const FcmCardExpirySync: React.FC = () => {
-  const { account } = useAccount()
+  const { isExpired } = useCardStatus()
   const fcmService = useFcmService()
 
   useEffect(() => {
-    const isExpired = account != null ? isAccountExpired(account.account_expiration_date) : false
     fcmService.viewModel.setCardExpired(isExpired)
-  }, [account, fcmService.viewModel])
+  }, [isExpired, fcmService.viewModel])
 
   return null
 }

--- a/app/src/services/system-checks/EventReasonAlertsSystemCheck.test.ts
+++ b/app/src/services/system-checks/EventReasonAlertsSystemCheck.test.ts
@@ -1,9 +1,9 @@
 import { tokenToCredentialMetadata } from '@/bcsc-theme/contexts/BCSCIdTokenContext'
 import { BCSCEvent, BCSCReason, IdToken } from '@/bcsc-theme/utils/id-token'
 import { AppEventCode } from '@/events/appEventCode'
-import { BCDispatchAction, VerificationStatus } from '@/store'
 import { EventReasonAlertsSystemCheck } from '@/services/system-checks/EventReasonAlertsSystemCheck'
 import { SystemCheckNavigation, SystemCheckUtils } from '@/services/system-checks/system-checks'
+import { BCDispatchAction, VerificationStatus } from '@/store'
 
 describe('EventReasonAlertsSystemCheck', () => {
   let mockUtils: SystemCheckUtils

--- a/app/src/services/system-checks/EventReasonAlertsSystemCheck.test.ts
+++ b/app/src/services/system-checks/EventReasonAlertsSystemCheck.test.ts
@@ -1,6 +1,7 @@
 import { tokenToCredentialMetadata } from '@/bcsc-theme/contexts/BCSCIdTokenContext'
 import { BCSCEvent, BCSCReason, IdToken } from '@/bcsc-theme/utils/id-token'
 import { AppEventCode } from '@/events/appEventCode'
+import { BCDispatchAction, VerificationStatus } from '@/store'
 import { EventReasonAlertsSystemCheck } from '@/services/system-checks/EventReasonAlertsSystemCheck'
 import { SystemCheckNavigation, SystemCheckUtils } from '@/services/system-checks/system-checks'
 
@@ -203,6 +204,30 @@ describe('EventReasonAlertsSystemCheck', () => {
         })
       )
     })
+    it('should mark the credential deactivated without alerting when the event is Expire', async () => {
+      const mockIdToken = createMockIdToken({
+        bcsc_event: BCSCEvent.Expire,
+        bcsc_reason: BCSCReason.ExpiredBySystem,
+      })
+      const getIdToken = jest.fn().mockResolvedValue(mockIdToken)
+      const check = new EventReasonAlertsSystemCheck(getIdToken, emitAlert, undefined, mockUtils, mockNavigation)
+      await check.runCheck()
+      check.onFail()
+
+      // The reason is persisted so useCardStatus can gate login, pairing, and Services on it.
+      expect(mockUtils.dispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_CREDENTIAL_METADATA,
+        payload: [expect.objectContaining({ bcscReason: BCSCReason.ExpiredBySystem })],
+      })
+      expect(mockUtils.dispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_SECURE_VERIFIED_STATUS,
+        payload: [VerificationStatus.DEACTIVATED],
+      })
+      // ias-ios suppresses the expiry alert deliberately (IASP-12489); v4 matches it.
+      expect(emitAlert).not.toHaveBeenCalled()
+      expect(mockNavigation.navigate).not.toHaveBeenCalled()
+    })
+
     it('should render an alert with CARD_TYPE_CHANGED event when reason Replace', async () => {
       const mockIdToken = createMockIdToken({
         bcsc_event: BCSCEvent.Replace,

--- a/app/src/services/system-checks/EventReasonAlertsSystemCheck.ts
+++ b/app/src/services/system-checks/EventReasonAlertsSystemCheck.ts
@@ -3,7 +3,7 @@ import { BCSCModals } from '@/bcsc-theme/types/navigators'
 import { BCSCEvent, BCSCReason, IdToken } from '@/bcsc-theme/utils/id-token'
 import { AlertOptions } from '@/contexts/ErrorAlertContext'
 import { AppEventCode } from '@/events/appEventCode'
-import { BCDispatchAction, CredentialMetadata } from '@/store'
+import { BCDispatchAction, CredentialMetadata, VerificationStatus } from '@/store'
 import { SystemCheckNavigation, SystemCheckStrategy, SystemCheckUtils } from './system-checks'
 
 /**
@@ -11,6 +11,10 @@ import { SystemCheckNavigation, SystemCheckStrategy, SystemCheckUtils } from './
  * Reasons:
  * Cancel
  *  - displays a modal instructing user to reset their app
+ *
+ * Expire:
+ *  - marks the credential deactivated; no alert (see IASP-12489)
+ *
  * Renew:
  *  - emits an alert informing the user their information has been updated
  *
@@ -73,6 +77,13 @@ export class EventReasonAlertsSystemCheck implements SystemCheckStrategy {
     switch (this.event) {
       case BCSCEvent.Cancel:
         this.navigation.navigate(BCSCModals.DeviceInvalidated, { invalidationReason: this.reason })
+        break
+      case BCSCEvent.Expire:
+        // Login, pairing, and Services, will only be usable in emergency mode, but don't force reverification
+        this.utils.dispatch({
+          type: BCDispatchAction.UPDATE_SECURE_VERIFIED_STATUS,
+          payload: [VerificationStatus.DEACTIVATED],
+        })
         break
       case BCSCEvent.Renewal:
         this.alertBuilder(AppEventCode.CARD_STATUS_UPDATED)


### PR DESCRIPTION
# Summary of Changes

This PR prevents an incorrect `isEmergencyMode` flag from preventing expiry / deactivation from being detected. It also adds a handler for the expiry case

# Testing Instructions

Temporarily change `store.bcsc.credentialMetadata?.bcscReason === BCSCReason.ExpiredBySystem` to `true` in useCardStatus and expire your account via MC or JZ, ensure the apps recognizes the expiry.

# Acceptance Criteria

Works

# Screenshots, videos, or gifs

N/A

# Related Issues

#4410 