### PR TITLE
chore: read codecov token from 1password

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -54,7 +54,7 @@ jobs:
       # Secrets are being consolidated into the bcsc-mobile-app-cd 1Password vault;
       # OP_SERVICE_ACCOUNT_TOKEN is the single bootstrap secret that stays in GitHub.
       - name: Load secrets from 1Password
-        uses: 1password/load-secrets-action@v5
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         with:
           export-env: true
         env:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -51,9 +51,20 @@ jobs:
       - name: Run tests and generate coverage report
         run: yarn coverage
 
+      # Secrets are being consolidated into the bcsc-mobile-app-cd 1Password vault;
+      # OP_SERVICE_ACCOUNT_TOKEN is the single bootstrap secret that stays in GitHub.
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@v5
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          CODECOV_TOKEN: op://bcsc-mobile-app-cd/codecov/credential
+        if: always() && !startsWith(github.base_ref, 'release/') && !startsWith(github.ref_name, 'release/')
+
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # (v7.0.0) pinning for SonarQube
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
         if: always() && !startsWith(github.base_ref, 'release/') && !startsWith(github.ref_name, 'release/')


### PR DESCRIPTION
## What

The Codecov upload token used in our CI quality workflow now comes from 1Password instead of a GitHub Actions secret. This is the first, smallest change to prove that our new 1Password service account works in CI before we migrate any other secrets.

## Why

We're consolidating CI secrets into a single 1Password vault (`bcsc-mobile-app-cd`) so they're managed and rotated in one place instead of scattered across GitHub repo secrets. The Codecov token is a low-risk, self-contained secret to migrate first — if this works, we have confidence to move the rest.

## Decisions

- Added a "Load secrets from 1Password" step immediately before the `codecov/codecov-action` step in the `typecheck-test` job of `.github/workflows/quality.yml`, using `1password/load-secrets-action@v5`.
- The new step reads `op://bcsc-mobile-app-cd/codecov/credential` into `CODECOV_TOKEN`, authenticating with `OP_SERVICE_ACCOUNT_TOKEN` (an existing GitHub secret, added 2026-08-12). `OP_SERVICE_ACCOUNT_TOKEN` is the one secret that necessarily remains in GitHub — it's the bootstrap credential 1Password needs before it can hand out anything else.
- `export-env: true` is set so the token is exported as a masked environment variable — masking matters here because the codecov step has `verbose: true`, and we don't want the token showing up in verbose log output.
- The codecov step now reads `token: ${{ env.CODECOV_TOKEN }}` explicitly. The codecov-action would likely pick up `CODECOV_TOKEN` from the environment implicitly even without the `token:` input, but it's passed explicitly for clarity and to keep the intent obvious to future readers.
- The new step has the exact same `if:` condition as the codecov step (skip on release branches), kept in sync so it doesn't run when the codecov upload itself is skipped.
- The pinned codecov-action SHA, its explanatory comment, `fail_ci_if_error`, and `verbose` are untouched.
- The existing `CODECOV_TOKEN` GitHub secret is left in place, untouched, as a fallback — this PR only changes where the value comes from at runtime, not the secret's existence.
- No other workflow (`main.yaml` etc.) is touched.

## Testing

There are no unit tests for a workflow-only change. Verification so far: `.github/workflows/quality.yml` still parses as valid YAML (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/quality.yml'))"`).

A branch push alone will **not** trigger this workflow — `quality.yml` only runs on `push` for `main` and on `pull_request` against `main`/`release/**`. This draft PR against `main` is what actually exercises the change. Success looks like the `Build, Typecheck, Test & Coverage` job passing with the Codecov upload succeeding using the token loaded from 1Password. If anything goes wrong, the old `CODECOV_TOKEN` secret is untouched, so reverting this change is trivial.


#4057