### PR TITLE
chore: read android signing material from 1password

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -966,26 +966,42 @@ jobs:
           snowplow_collector_url: ${{ vars.SNOWPLOW_COLLECTOR_URL }}
           default_environment: ${{ env.DEFAULT_ENVIRONMENT }}
 
+      # Secrets are being consolidated into the bcsc-mobile-app-cd 1Password vault;
+      # OP_SERVICE_ACCOUNT_TOKEN is the single bootstrap secret that stays in GitHub.
+      # This step will not work in a `fork` because it will not have access
+      # to org and repo secrets.
+      - name: Install 1Password CLI
+        if: github.event.pull_request.head.repo.fork != true
+        uses: 1password/install-cli-action@1a3160d5e9de1ae0803eaa08a88746f5ae3daa50 # v4.1.0
+
+      - name: Load Android signing secrets from 1Password
+        if: github.event.pull_request.head.repo.fork != true
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          PLAY_STORE_JKS_ALIAS: op://bcsc-mobile-app-cd/android-signing-${{ matrix.variant }}/key-alias
+          PLAY_STORE_JKS_PASSWD: op://bcsc-mobile-app-cd/android-signing-${{ matrix.variant }}/store-password
+
       - name: Create release keystore
         # This step will not work in a `fork` because it will not have access
         # to org and repo secrets.
         if: github.event.pull_request.head.repo.fork != true
         working-directory: app/android/app
         env:
-          PLAY_STORE_JKS_BASE64: ${{ secrets[env.ANDROID_JKS_BASE64_SECRET] }}
-          PLAY_STORE_JKS_ALIAS: ${{ secrets[env.ANDROID_JKS_ALIAS_SECRET] }}
-          PLAY_STORE_JKS_PASSWD: ${{ secrets[env.ANDROID_JKS_PASSWD_SECRET] }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
-          echo "${PLAY_STORE_JKS_BASE64}" | base64 -d >release.keystore && \
-          keytool -list -v -keystore release.keystore -alias ${PLAY_STORE_JKS_ALIAS} -storepass:env PLAY_STORE_JKS_PASSWD | \
+          # `op read` to stdout appends a trailing newline, which would corrupt
+          # this binary keystore. --out-file writes the bytes as-is.
+          op read "op://bcsc-mobile-app-cd/android-signing-${{ matrix.variant }}/release.keystore" --out-file release.keystore --force
+          keytool -list -v -keystore release.keystore -alias "${PLAY_STORE_JKS_ALIAS}" -storepass:env PLAY_STORE_JKS_PASSWD | \
           grep "SHA1"
 
       - name: Android release build
         if: github.event.pull_request.head.repo.fork != true
         working-directory: app/android
         env:
-          PLAY_STORE_JKS_ALIAS: ${{ secrets[env.ANDROID_JKS_ALIAS_SECRET] }}
-          PLAY_STORE_JKS_PASSWD: ${{ secrets[env.ANDROID_JKS_PASSWD_SECRET] }}
           VERSION_CODE: ${{ env.APP_BUILD_NUMBER }}
           VERSION_NAME: ${{ env.APP_VERSION }}
           # Skip Metro bundling: use the pre-built JS bundle from the

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -973,11 +973,12 @@ jobs:
         if: github.event.pull_request.head.repo.fork != true
         uses: 1password/install-cli-action@1a3160d5e9de1ae0803eaa08a88746f5ae3daa50 # v4.1.0
 
+      # Outputs (not export-env) keep these two values scoped to only the
+      # steps that reference them, matching the pre-migration scoping.
       - name: Load Android signing secrets from 1Password
+        id: op_android_signing
         if: github.event.pull_request.head.repo.fork != true
         uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
-        with:
-          export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           PLAY_STORE_JKS_ALIAS: op://bcsc-mobile-app-cd/android-signing-${{ matrix.variant }}/key-alias
@@ -990,6 +991,8 @@ jobs:
         working-directory: app/android/app
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          PLAY_STORE_JKS_ALIAS: ${{ steps.op_android_signing.outputs.PLAY_STORE_JKS_ALIAS }}
+          PLAY_STORE_JKS_PASSWD: ${{ steps.op_android_signing.outputs.PLAY_STORE_JKS_PASSWD }}
         run: |
           # `op read` to stdout appends a trailing newline, which would corrupt
           # this binary keystore. --out-file writes the bytes as-is.
@@ -1001,6 +1004,8 @@ jobs:
         if: github.event.pull_request.head.repo.fork != true
         working-directory: app/android
         env:
+          PLAY_STORE_JKS_ALIAS: ${{ steps.op_android_signing.outputs.PLAY_STORE_JKS_ALIAS }}
+          PLAY_STORE_JKS_PASSWD: ${{ steps.op_android_signing.outputs.PLAY_STORE_JKS_PASSWD }}
           VERSION_CODE: ${{ env.APP_BUILD_NUMBER }}
           VERSION_NAME: ${{ env.APP_VERSION }}
           # Skip Metro bundling: use the pre-built JS bundle from the

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -968,8 +968,7 @@ jobs:
 
       # Secrets are being consolidated into the bcsc-mobile-app-cd 1Password vault;
       # OP_SERVICE_ACCOUNT_TOKEN is the single bootstrap secret that stays in GitHub.
-      # This step will not work in a `fork` because it will not have access
-      # to org and repo secrets.
+      # These steps are fork-guarded because fork PRs cannot read that secret.
       - name: Install 1Password CLI
         if: github.event.pull_request.head.repo.fork != true
         uses: 1password/install-cli-action@1a3160d5e9de1ae0803eaa08a88746f5ae3daa50 # v4.1.0


### PR DESCRIPTION
## What

Android release builds now fetch their signing keystore, key alias, and store password from the 1Password vault `bcsc-mobile-app-cd` instead of GitHub Actions secrets. This is PR 1 of a stack migrating the repo's CI secrets into 1Password.

## Why

Consolidating build secrets into 1Password gives us a single, auditable source of truth with a read-only service account, instead of scattering them across GitHub org/repo secrets. This PR moves the Android signing material as the first, self-contained slice of that migration.

## Decisions

- **Why the `op` CLI is needed at all**: `1password/load-secrets-action` can only export text values as environment variables — it cannot write files. The release keystore is a binary document (not a text field), so it has to be fetched separately with the `op` CLI's `op read --out-file`.
- **Why `--out-file` and not a shell redirect**: `op read <ref>` printed to stdout appends a trailing newline. Redirecting that into a file (`op read ... > release.keystore`) would silently corrupt the binary keystore by one byte. `--out-file` writes the bytes verbatim, so it's the only safe option here — called out with an inline comment in the workflow since it's the single most important operational detail of this change.
- **Vault item names match variant names exactly**: `bcwallet-prod`, `bcsc-dev`, `bcsc-qa`, `bcsc-test`, `bcsc-prod`. References are built directly from `${{ matrix.variant }}` (e.g. `op://bcsc-mobile-app-cd/android-signing-${{ matrix.variant }}/...`), which removes the need for the old `secrets[env.ANDROID_JKS_*_SECRET]` indirection.
- **Fork guard carried onto the new steps**: fork PRs don't have access to `OP_SERVICE_ACCOUNT_TOKEN` (or any repo secret), so the existing `if: github.event.pull_request.head.repo.fork != true` guard is applied to the new "Install 1Password CLI" and "Load Android signing secrets from 1Password" steps as well, matching the existing "Create release keystore" / "Android release build" steps.
- **`keytool -list -v ... | grep SHA1` is deliberately preserved**: it's a cheap, free verification that the fetched keystore contains the expected alias and prints its SHA1 fingerprint, which can be diffed against previous CI runs to confirm the same signing key landed.
- **Action versions are SHA-pinned** (`1password/install-cli-action@1a3160d...` / `1password/load-secrets-action@e544b78...`) per this repo's SonarCloud full-SHA-pinning requirement, matching the style already established in `.github/workflows/quality.yml` (#4449).

**Known follow-ups (deliberately out of scope for this PR):**
- `ANDROID_JKS_BASE64_SECRET`, `ANDROID_JKS_ALIAS_SECRET`, `ANDROID_JKS_PASSWD_SECRET` keys in `variants/*/variant.env` are now unused but left in place; removing them is a follow-up cleanup.
- The `check-secrets` job still validates the old `PLAY_STORE_JKS_*` GitHub secrets exist; left as-is for now.
- The old GitHub secrets themselves are untouched, so this change has a trivial revert path.

## Testing

- Validated the workflow YAML parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/main.yaml'))"`.
- `actionlint` is not available in this environment, so it was not run — noting this rather than claiming a pass.
- No unit tests exist for this workflow file; none were added.

Success criteria on this PR: all five `Build Android - <variant>` matrix jobs sign successfully, and the printed SHA1 fingerprints match previous CI runs, confirming the same signing keys are still in use.
