### PR TITLE
chore: read google services config from 1password

### DIFF
--- a/.github/workflows/actions/create-environment-settings/action.yml
+++ b/.github/workflows/actions/create-environment-settings/action.yml
@@ -1,7 +1,6 @@
 name: Create Environment Settings
 description: |
-  Create the .env file with environment settings and write
-  Firebase/Google Services credentials to the file system.
+  Create the .env file with environment settings.
 
 inputs:
   build_target:
@@ -30,12 +29,6 @@ inputs:
     required: true
   indy_vdr_proxy_url:
     description: 'The Indy VDR proxy URL'
-    required: true
-  google_services_credentials_base64:
-    description: 'Base64 encoded Google Services credentials file'
-    required: true
-  platform:
-    description: 'The platform (ios or android)'
     required: true
   snowplow_collector_url:
     description: 'The Snowplow collector URL'
@@ -74,18 +67,3 @@ runs:
         echo "INDY_VDR_PROXY_URL=${INDY_VDR_PROXY_URL}" >>.env
         echo "SNOWPLOW_COLLECTOR_URL=${SNOWPLOW_COLLECTOR_URL}" >>.env
         echo "DEFAULT_ENVIRONMENT=${DEFAULT_ENVIRONMENT}" >>.env
-
-    - name: Write Google Services credentials
-      shell: bash
-      env:
-        GOOGLE_SERVICES_CREDENTIALS_BASE64: ${{ inputs.google_services_credentials_base64 }}
-        PLATFORM: ${{ inputs.platform }}
-      run: |
-        if [ "${PLATFORM}" = "ios" ]; then
-          echo "${GOOGLE_SERVICES_CREDENTIALS_BASE64}" | base64 --decode > app/ios/GoogleService-Info.plist
-        elif [ "${PLATFORM}" = "android" ]; then
-          echo "${GOOGLE_SERVICES_CREDENTIALS_BASE64}" | base64 --decode > app/android/app/google-services.json
-        else
-          echo "error: Unknown platform '${PLATFORM}'"
-          exit 1
-        fi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -674,10 +674,24 @@ jobs:
           ledger_auto_update: ${{ vars.LEDGER_AUTO_UPDATE }}
           remote_logging_url: ${{ secrets.REMOTE_LOGGING_URL }}
           indy_vdr_proxy_url: ${{ vars.INDY_VDR_PROXY_URL }}
-          google_services_credentials_base64: ${{ secrets[env.IOS_GOOGLE_SERVICES_SECRET] }}
-          platform: ios
           snowplow_collector_url: ${{ vars.SNOWPLOW_COLLECTOR_URL }}
           default_environment: ${{ env.DEFAULT_ENVIRONMENT }}
+
+      # Secrets are being consolidated into the bcsc-mobile-app-cd 1Password vault;
+      # OP_SERVICE_ACCOUNT_TOKEN is the single bootstrap secret that stays in GitHub.
+      # These steps are fork-guarded because fork PRs cannot read that secret.
+      - name: Install 1Password CLI
+        if: github.event.pull_request.head.repo.fork != true
+        uses: 1password/install-cli-action@1a3160d5e9de1ae0803eaa08a88746f5ae3daa50 # v4.1.0
+
+      - name: Fetch Google Services config
+        if: github.event.pull_request.head.repo.fork != true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          # `op read` to stdout appends a trailing newline; --out-file writes
+          # the document byte-for-byte instead.
+          op read "op://bcsc-mobile-app-cd/google-services-ios-${{ matrix.variant }}/GoogleService-Info.plist" --out-file app/ios/GoogleService-Info.plist --force
 
       - name: Update APS environment
         run: |
@@ -961,8 +975,6 @@ jobs:
           ledger_auto_update: ${{ vars.LEDGER_AUTO_UPDATE }}
           remote_logging_url: ${{ secrets.REMOTE_LOGGING_URL }}
           indy_vdr_proxy_url: ${{ vars.INDY_VDR_PROXY_URL }}
-          google_services_credentials_base64: ${{ secrets[env.ANDROID_GOOGLE_SERVICES_SECRET] }}
-          platform: android
           snowplow_collector_url: ${{ vars.SNOWPLOW_COLLECTOR_URL }}
           default_environment: ${{ env.DEFAULT_ENVIRONMENT }}
 
@@ -972,6 +984,15 @@ jobs:
       - name: Install 1Password CLI
         if: github.event.pull_request.head.repo.fork != true
         uses: 1password/install-cli-action@1a3160d5e9de1ae0803eaa08a88746f5ae3daa50 # v4.1.0
+
+      - name: Fetch Google Services config
+        if: github.event.pull_request.head.repo.fork != true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          # `op read` to stdout appends a trailing newline; --out-file writes
+          # the document byte-for-byte instead.
+          op read "op://bcsc-mobile-app-cd/google-services-android-${{ matrix.variant }}/google-services.json" --out-file app/android/app/google-services.json --force
 
       # Outputs (not export-env) keep these two values scoped to only the
       # steps that reference them, matching the pre-migration scoping.


### PR DESCRIPTION
## What

Google Services config files (`GoogleService-Info.plist` for iOS, `google-services.json` for Android) now come from the `bcsc-mobile-app-cd` 1Password vault instead of base64-encoded GitHub secrets, for the iOS and Android release build jobs.

## Why

Continuing the migration of build-time secrets into 1Password so they're centrally managed and auditable, rather than scattered across base64-encoded GitHub repo secrets. This is PR 3 in the stack, following the `.env`/quality workflow cleanup (#4449) and the Android signing migration (#4450).

## Decisions

- **Fetch moved out of the composite action, into the workflow directly.** `create-environment-settings/action.yml`'s remaining job is purely writing the `.env` file (still GitHub vars/secrets-sourced — 1Password Environments are explicitly not used here). Fetching the Google Services files in the calling workflow instead of the composite action avoids passing `OP_SERVICE_ACCOUNT_TOKEN` into a composite action, keeping the token's scope as narrow as possible.
- **`op read ... --out-file ... --force`, never a redirect.** `op read` to stdout appends a trailing newline; `--out-file` writes the document byte-for-byte. Same pattern #4450 established for the release keystore.
- **References derive from `matrix.variant`.** Vault item names match matrix variant names exactly (e.g. `google-services-ios-bcsc-dev`), so `op://bcsc-mobile-app-cd/google-services-ios-${{ matrix.variant }}/GoogleService-Info.plist` needs no per-variant mapping.
- **Fork guard added on both new fetch steps** (`if: github.event.pull_request.head.repo.fork != true`), since fork PRs can't read `OP_SERVICE_ACCOUNT_TOKEN`. Verified the actual consumers of these files — iOS `Archive build` and Android `Android release build` — are already fork-guarded, so forks are unaffected either way (previously they'd get an empty plist/JSON from an unguarded base64-decode-of-nothing; now they get no file, which doesn't matter since the build step that would use it never runs on a fork).
- **`distribute-firebase` untouched.** It still reads `IOS_GOOGLE_SERVICES_SECRET` / `ANDROID_GOOGLE_SERVICES_SECRET` from GitHub secrets via `variant.env`, so those variant.env entries stay for now. Both secret sources coexist without conflict; distribute-firebase's migration is the next PR in the stack.
- **iOS job gained its first 1Password CLI install step** (Android already had one from #4450); Android reuses the existing install step and only adds the fetch.

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` — both changed files parse cleanly.
- Repo-wide grep confirms no remaining references to the deleted `google_services_credentials_base64` / `platform` action inputs.
- `actionlint` (installed locally for this check) reports no syntax/semantic issues in the edited regions of `main.yaml`. It does flag every composite `action.yml` under `.github/workflows/actions/*` — including files this PR never touched — as an invalid "workflow" (missing `on:`/`jobs:`); this is a pre-existing actionlint auto-discovery quirk with composite actions nested under `.github/workflows/`, unrelated to this change.
- Success in CI is the `Build iOS - <variant>` and `Build Android - <variant>` matrix jobs completing. Note PRs only build the reduced matrix (`bcwallet-prod`, `bcsc-dev`); the other three variants (`bcsc-qa`, `bcsc-test`, `bcsc-prod`) only build on pushes to `main`.

---

Stacked on #4450 — **retarget to `main` once that merges.**