### PR TITLE
fix(bcsc): use dark foreground on the warning banner for WCAG contrast

### DIFF
--- a/app/src/bcsc-theme/components/AppBanner.contrast.test.tsx
+++ b/app/src/bcsc-theme/components/AppBanner.contrast.test.tsx
@@ -1,0 +1,76 @@
+import { testIdWithKey } from '@bifold/core'
+import { render } from '@testing-library/react-native'
+import React from 'react'
+import { StyleSheet } from 'react-native'
+
+import { AppBannerSection, BCSCBanner } from './AppBanner'
+
+// AppBanner reads its colours from useTheme(). Rendered bare, that resolves to
+// Bifold's built-in default theme rather than the theme the app actually ships,
+// which is what let the original contrast bug through: the default theme's
+// `secondaryBackground` happens to be dark, while the app's LightTheme sets it
+// to white. BCSC builds boot on LightTheme (see `defaultThemeName` in App.tsx),
+// so pin the real thing here.
+jest.mock('@bifold/core', () => {
+  const actual = jest.requireActual('@bifold/core')
+
+  // Resolved lazily: '@/theme' pulls in '@bifold/core' itself, so requiring it
+  // in the factory body would deadlock on the partially-initialised module.
+  return { ...actual, useTheme: () => jest.requireActual('@/theme').LightTheme }
+})
+
+/**
+ * WCAG 2.1 relative luminance and contrast ratio.
+ * https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+ */
+const relativeLuminance = (hex: string): number => {
+  const channels = [1, 3, 5].map((offset) => parseInt(hex.slice(offset, offset + 2), 16) / 255)
+  const [r, g, b] = channels.map((c) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)))
+
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+const contrastRatio = (foreground: string, background: string): number => {
+  const [lighter, darker] = [relativeLuminance(foreground), relativeLuminance(background)].sort((a, b) => b - a)
+
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+const colorOf = (element: { props: { style: unknown } }): string =>
+  (StyleSheet.flatten(element.props.style as never) as { color: string }).color
+
+// Matches the `warning` case of AppBanner's bannerColor()
+const WARNING_BACKGROUND = '#F8BB47'
+
+const WCAG_AA_TEXT = 4.5
+const WCAG_AA_NON_TEXT = 3
+
+describe('AppBannerSection contrast', () => {
+  it('meets WCAG AA against the warning banner background', () => {
+    const { getByTestId } = render(
+      <AppBannerSection
+        id={'A' as BCSCBanner}
+        title="Warning title"
+        description="Warning description"
+        type="warning"
+        dismissible={false}
+      />
+    )
+
+    const titleColor = colorOf(getByTestId(testIdWithKey('text-warning')))
+    const descriptionColor = colorOf(getByTestId(testIdWithKey('description-warning')))
+    // The icon carries meaning here, so it needs the 3:1 non-text minimum.
+    const iconColor = colorOf(getByTestId(testIdWithKey('icon-warning')))
+
+    expect(contrastRatio(titleColor, WARNING_BACKGROUND)).toBeGreaterThanOrEqual(WCAG_AA_TEXT)
+    expect(contrastRatio(descriptionColor, WARNING_BACKGROUND)).toBeGreaterThanOrEqual(WCAG_AA_TEXT)
+    expect(contrastRatio(iconColor, WARNING_BACKGROUND)).toBeGreaterThanOrEqual(WCAG_AA_NON_TEXT)
+  })
+
+  it('sanity-checks the contrast helper', () => {
+    expect(contrastRatio('#FFFFFF', '#000000')).toBeCloseTo(21, 1)
+    expect(contrastRatio('#FFFFFF', '#FFFFFF')).toBeCloseTo(1, 1)
+    // The colour the warning banner used to render: white on amber.
+    expect(contrastRatio('#FFFFFF', WARNING_BACKGROUND)).toBeLessThan(WCAG_AA_NON_TEXT)
+  })
+})

--- a/app/src/bcsc-theme/components/AppBanner.tsx
+++ b/app/src/bcsc-theme/components/AppBanner.tsx
@@ -112,6 +112,11 @@ export const AppBannerSection: React.FC<AppBannerSectionProps> = ({
     }
   }
 
+  // The warning banner has a light amber background, so it needs dark text and
+  // icons to stay legible. Every other banner colour is dark enough for white.
+  // Resolved once here so the icon, title and description can't drift apart.
+  const foregroundColor = type === 'warning' ? ColorPalette.grayscale.darkGrey : ColorPalette.grayscale.white
+
   if (!showBanner) {
     return null
   }
@@ -133,7 +138,7 @@ export const AppBannerSection: React.FC<AppBannerSectionProps> = ({
       <Icon
         name={iconName(type)}
         size={24}
-        color={type === 'warning' ? ColorPalette.brand.secondaryBackground : ColorPalette.grayscale.white}
+        color={foregroundColor}
         style={styles.icon}
         testID={testIdWithKey(`icon-${type}`)}
       />
@@ -142,7 +147,7 @@ export const AppBannerSection: React.FC<AppBannerSectionProps> = ({
           <ThemedText
             variant={'bold'}
             style={{
-              color: type === 'warning' ? ColorPalette.brand.secondaryBackground : ColorPalette.grayscale.white,
+              color: foregroundColor,
             }}
             testID={testIdWithKey(`text-${type}`)}
           >
@@ -153,7 +158,7 @@ export const AppBannerSection: React.FC<AppBannerSectionProps> = ({
           <ThemedText
             style={{
               lineHeight: 24,
-              color: type === 'warning' ? ColorPalette.brand.secondaryBackground : ColorPalette.grayscale.white,
+              color: foregroundColor,
             }}
             testID={testIdWithKey(`description-${type}`)}
           >


### PR DESCRIPTION
# Summary of Changes

The warning banner renders white text and icons on its amber `#F8BB47` background. That is a contrast ratio of **1.72:1** — it fails the WCAG 2.1 AA minimum of 4.5:1 for text, and also the 3:1 minimum for the icon, which carries meaning here.

There was already a `type === 'warning'` branch in `AppBanner.tsx` trying to special-case this, but it reached for `ColorPalette.brand.secondaryBackground`, which is theme-dependent:

| Theme | `secondaryBackground` | Contrast on `#F8BB47` |
| --- | --- | --- |
| DarkTheme | `#01264C` | 8.82:1 ✅ |
| **LightTheme** | **`#FFFFFF`** | **1.72:1 ❌** |

BCSC builds boot on LightTheme (`defaultThemeName` in `App.tsx` resolves to `BCThemeNames.Light` when `BUILD_TARGET === Mode.BCSC`), so in the shipped app **both sides of that ternary resolved to white** and the special case silently did nothing. That matches the screenshot on #4200.

This switches the warning foreground to `ColorPalette.grayscale.darkGrey` (`#313132`) — the palette's off-black, and already the light theme's usual body text colour (`foreground`, `textOnWhite`, `onboardingBodyText` all use it). That gives **7.54:1**, clearing AA and AAA. The banner background is a fixed hex rather than a theme token, so this is stable across themes.

The colour is now resolved once into a `foregroundColor` const shared by the icon, title and description, rather than the same ternary repeated three times — this bug is exactly the sort that duplication invites.

This aligns with @knguyenBC's direction on the issue ("the text colour for the warning banner should be an off-black"). I could not open the linked Figma BCSC style guide, so **if the style guide specifies a particular off-black, that value should win over my choice of `darkGrey`** — the swap is a one-line change. Flagging too that the issue carries `needs/ux-wireframe`; happy to hold for UX sign-off if that label is still live.

# Testing Instructions

Automated:

```
cd app
yarn test src/bcsc-theme/components/AppBanner
```

The new `AppBanner.contrast.test.tsx` renders the warning banner and asserts the computed contrast ratio of the title, description and icon against `#F8BB47` clears the WCAG thresholds. It fails on `main` (reports exactly 1.72:1) and passes with this change.

Worth knowing why that test mocks `useTheme`: rendered bare, `AppBannerSection` picks up Bifold's built-in default theme, whose `secondaryBackground` happens to be dark (`#313132`) — so a naive test passes even with the bug present. The test pins the app's real `LightTheme` instead, which is what surfaces the defect.

Manual:

1. Run a BCSC build and trigger a `warning`-type banner (e.g. the Device Management / device limit banner).
2. Confirm the title, description and alert icon render in dark grey on the amber background and are comfortably legible.
3. Confirm `error`, `info` and `success` banners are unchanged (still white on their darker backgrounds).

# Acceptance Criteria

- [x] Warning banner text meets WCAG 2.1 AA (>= 4.5:1) against its background — now 7.54:1
- [x] Warning banner icon meets the non-text minimum (>= 3:1) — now 7.54:1
- [x] `error` / `info` / `success` banners visually unchanged
- [x] Regression test that fails without the fix
- [x] `yarn test src/bcsc-theme` passes (239 suites, 2401 tests), `eslint` and `tsc --noEmit` clean

# Screenshots, videos, or gifs

N/A — I don't have a BCSC device/simulator build available, so I have not captured before/after screenshots of the running app. The change is verified numerically instead (contrast ratios computed from the exact hex values above, asserted in the new test). **A visual check against a real BCSC build is worth doing before merge**, particularly to confirm the dark grey reads well against the amber in situ.

# Related Issues

Fixes #4200