### PR TITLE
chore: read remote logging and mediator urls from 1password

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -617,7 +617,7 @@ jobs:
         uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          REMOTE_LOGGING_URL: op://bcsc-mobile-app-cd/remote-logging-url-prod/prod
+          REMOTE_LOGGING_URL: op://bcsc-mobile-app-cd/remote-logging-url/prod
           MEDIATOR_URL: op://bcsc-mobile-app-cd/mediator-url-prod/prod
 
         # Actual environment variables are not being picked up
@@ -930,7 +930,7 @@ jobs:
         uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          REMOTE_LOGGING_URL: op://bcsc-mobile-app-cd/remote-logging-url-prod/prod
+          REMOTE_LOGGING_URL: op://bcsc-mobile-app-cd/remote-logging-url/prod
           MEDIATOR_URL: op://bcsc-mobile-app-cd/mediator-url-prod/prod
 
       # Actual environment variables are not being picked up

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -608,6 +608,20 @@ jobs:
 
         # Actual environment variables are not being picked up
         # by the build so they're put into an .env file.
+
+      # Secrets are being consolidated into the bcsc-mobile-app-cd 1Password vault;
+      # OP_SERVICE_ACCOUNT_TOKEN is the single bootstrap secret that stays in GitHub.
+      # This step is fork-guarded because fork PRs cannot read that secret; when
+      # skipped, the output is empty, so REMOTE_LOGGING_URL in .env comes out
+      # empty on forks too — same as before this value moved to 1Password.
+      - name: Load remote logging URL from 1Password
+        id: op_remote_logging
+        if: github.event.pull_request.head.repo.fork != true
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          REMOTE_LOGGING_URL: op://bcsc-mobile-app-cd/remote-logging-url-prod/prod
+
       - name: Create environment settings
         uses: ./.github/workflows/actions/create-environment-settings
         with:
@@ -617,7 +631,7 @@ jobs:
           oca_url: ${{ vars.OCA_URL }}
           proof_template_url: ${{ vars.PROOF_TEMPLATE_URL }}
           ledger_auto_update: ${{ vars.LEDGER_AUTO_UPDATE }}
-          remote_logging_url: ${{ secrets.REMOTE_LOGGING_URL }}
+          remote_logging_url: ${{ steps.op_remote_logging.outputs.REMOTE_LOGGING_URL }}
           indy_vdr_proxy_url: ${{ vars.INDY_VDR_PROXY_URL }}
           snowplow_collector_url: ${{ vars.SNOWPLOW_COLLECTOR_URL }}
           default_environment: ${{ env.DEFAULT_ENVIRONMENT }}
@@ -907,6 +921,20 @@ jobs:
 
       # Actual environment variables are not being picked up
       # by the build so they're put into an .env file.
+
+      # Secrets are being consolidated into the bcsc-mobile-app-cd 1Password vault;
+      # OP_SERVICE_ACCOUNT_TOKEN is the single bootstrap secret that stays in GitHub.
+      # This step is fork-guarded because fork PRs cannot read that secret; when
+      # skipped, the output is empty, so REMOTE_LOGGING_URL in .env comes out
+      # empty on forks too — same as before this value moved to 1Password.
+      - name: Load remote logging URL from 1Password
+        id: op_remote_logging
+        if: github.event.pull_request.head.repo.fork != true
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          REMOTE_LOGGING_URL: op://bcsc-mobile-app-cd/remote-logging-url-prod/prod
+
       - name: Create environment settings
         uses: ./.github/workflows/actions/create-environment-settings
         with:
@@ -916,7 +944,7 @@ jobs:
           oca_url: ${{ vars.OCA_URL }}
           proof_template_url: ${{ vars.PROOF_TEMPLATE_URL }}
           ledger_auto_update: ${{ vars.LEDGER_AUTO_UPDATE }}
-          remote_logging_url: ${{ secrets.REMOTE_LOGGING_URL }}
+          remote_logging_url: ${{ steps.op_remote_logging.outputs.REMOTE_LOGGING_URL }}
           indy_vdr_proxy_url: ${{ vars.INDY_VDR_PROXY_URL }}
           snowplow_collector_url: ${{ vars.SNOWPLOW_COLLECTOR_URL }}
           default_environment: ${{ env.DEFAULT_ENVIRONMENT }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -609,15 +609,16 @@ jobs:
       # Secrets are being consolidated into the bcsc-mobile-app-cd 1Password vault;
       # OP_SERVICE_ACCOUNT_TOKEN is the single bootstrap secret that stays in GitHub.
       # This step is fork-guarded because fork PRs cannot read that secret; when
-      # skipped, the output is empty, so REMOTE_LOGGING_URL in .env comes out
-      # empty on forks too — same as before this value moved to 1Password.
-      - name: Load remote logging URL from 1Password
+      # skipped, both outputs are empty, so .env gets the same empty values on
+      # forks as it did before these moved to 1Password.
+      - name: Load .env secrets from 1Password
         id: op_remote_logging
         if: github.event.pull_request.head.repo.fork != true
         uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           REMOTE_LOGGING_URL: op://bcsc-mobile-app-cd/remote-logging-url-prod/prod
+          MEDIATOR_URL: op://bcsc-mobile-app-cd/mediator-url-prod/prod
 
         # Actual environment variables are not being picked up
         # by the build so they're put into an .env file.
@@ -626,7 +627,7 @@ jobs:
         with:
           build_target: ${{ env.BUILD_TARGET }}
           mediator_use_push_notifications: ${{ vars.MEDIATOR_USE_PUSH_NOTIFICATIONS }}
-          mediator_url: ${{ secrets.MEDIATOR_URL }}
+          mediator_url: ${{ steps.op_remote_logging.outputs.MEDIATOR_URL }}
           oca_url: ${{ vars.OCA_URL }}
           proof_template_url: ${{ vars.PROOF_TEMPLATE_URL }}
           ledger_auto_update: ${{ vars.LEDGER_AUTO_UPDATE }}
@@ -921,15 +922,16 @@ jobs:
       # Secrets are being consolidated into the bcsc-mobile-app-cd 1Password vault;
       # OP_SERVICE_ACCOUNT_TOKEN is the single bootstrap secret that stays in GitHub.
       # This step is fork-guarded because fork PRs cannot read that secret; when
-      # skipped, the output is empty, so REMOTE_LOGGING_URL in .env comes out
-      # empty on forks too — same as before this value moved to 1Password.
-      - name: Load remote logging URL from 1Password
+      # skipped, both outputs are empty, so .env gets the same empty values on
+      # forks as it did before these moved to 1Password.
+      - name: Load .env secrets from 1Password
         id: op_remote_logging
         if: github.event.pull_request.head.repo.fork != true
         uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           REMOTE_LOGGING_URL: op://bcsc-mobile-app-cd/remote-logging-url-prod/prod
+          MEDIATOR_URL: op://bcsc-mobile-app-cd/mediator-url-prod/prod
 
       # Actual environment variables are not being picked up
       # by the build so they're put into an .env file.
@@ -938,7 +940,7 @@ jobs:
         with:
           build_target: ${{ env.BUILD_TARGET }}
           mediator_use_push_notifications: ${{ vars.MEDIATOR_USE_PUSH_NOTIFICATIONS }}
-          mediator_url: ${{ secrets.MEDIATOR_URL }}
+          mediator_url: ${{ steps.op_remote_logging.outputs.MEDIATOR_URL }}
           oca_url: ${{ vars.OCA_URL }}
           proof_template_url: ${{ vars.PROOF_TEMPLATE_URL }}
           ledger_auto_update: ${{ vars.LEDGER_AUTO_UPDATE }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -618,7 +618,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           REMOTE_LOGGING_URL: op://bcsc-mobile-app-cd/remote-logging-url/prod
-          MEDIATOR_URL: op://bcsc-mobile-app-cd/mediator-url-prod/prod
+          MEDIATOR_URL: op://bcsc-mobile-app-cd/mediator-url/prod
 
         # Actual environment variables are not being picked up
         # by the build so they're put into an .env file.
@@ -931,7 +931,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           REMOTE_LOGGING_URL: op://bcsc-mobile-app-cd/remote-logging-url/prod
-          MEDIATOR_URL: op://bcsc-mobile-app-cd/mediator-url-prod/prod
+          MEDIATOR_URL: op://bcsc-mobile-app-cd/mediator-url/prod
 
       # Actual environment variables are not being picked up
       # by the build so they're put into an .env file.

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -606,9 +606,6 @@ jobs:
           agvtool new-version ${CURRENT_PROJECT_VERSION} && \
           agvtool new-marketing-version ${MARKETING_VERSION}
 
-        # Actual environment variables are not being picked up
-        # by the build so they're put into an .env file.
-
       # Secrets are being consolidated into the bcsc-mobile-app-cd 1Password vault;
       # OP_SERVICE_ACCOUNT_TOKEN is the single bootstrap secret that stays in GitHub.
       # This step is fork-guarded because fork PRs cannot read that secret; when
@@ -622,6 +619,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           REMOTE_LOGGING_URL: op://bcsc-mobile-app-cd/remote-logging-url-prod/prod
 
+        # Actual environment variables are not being picked up
+        # by the build so they're put into an .env file.
       - name: Create environment settings
         uses: ./.github/workflows/actions/create-environment-settings
         with:
@@ -919,9 +918,6 @@ jobs:
       - name: Apply variant configuration
         run: node scripts/apply-variant.mjs ${{ matrix.variant }}
 
-      # Actual environment variables are not being picked up
-      # by the build so they're put into an .env file.
-
       # Secrets are being consolidated into the bcsc-mobile-app-cd 1Password vault;
       # OP_SERVICE_ACCOUNT_TOKEN is the single bootstrap secret that stays in GitHub.
       # This step is fork-guarded because fork PRs cannot read that secret; when
@@ -935,6 +931,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           REMOTE_LOGGING_URL: op://bcsc-mobile-app-cd/remote-logging-url-prod/prod
 
+      # Actual environment variables are not being picked up
+      # by the build so they're put into an .env file.
       - name: Create environment settings
         uses: ./.github/workflows/actions/create-environment-settings
         with:


### PR DESCRIPTION
## What

The remote logging URL and the mediator URL used to build the app are now pulled from our 1Password vault instead of GitHub Actions secrets, for both the iOS and Android build jobs. Nothing about how the app behaves changes — this only changes where the values come from during the build.

## Why

We're consolidating build-time secrets into 1Password so they're managed in one place with proper access control and rotation, rather than scattered across GitHub repo secrets. This is a small follow-on to the CI secrets migration already completed in #4057, closing out two more `.env` values that weren't yet moved as part of the original iOS/Android build jobs. The `REMOTE_LOGGING_URL` and `MEDIATOR_URL` GitHub secrets themselves are left in place for now as a rollback path.

## Decisions

- **`load-secrets-action` only, no `install-cli-action`.** Both vault references (`op://bcsc-mobile-app-cd/remote-logging-url/prod` and `op://bcsc-mobile-app-cd/mediator-url/prod`) are plain fields, not documents, so `load-secrets-action` can inject them directly as step outputs. `install-cli-action` (which provides the `op` CLI for raw `op read` calls) is only needed for document/file fetches elsewhere in this workflow (e.g. GoogleService-Info.plist, provisioning profiles) and isn't needed here.
- **Step outputs, not `export-env`.** Following the convention already established in this file (see the `op_android_signing` step), the load step uses `id: op_remote_logging` with vault references in its `env:` block and is consumed via `${{ steps.op_remote_logging.outputs.<NAME> }}`. This came out of a Copilot finding on an earlier PR in the migration: `export-env` leaks secrets into the whole job's environment, whereas step outputs scope them to only the step that consumes them.
- **Both values loaded by a single step**, not one step each. Both `REMOTE_LOGGING_URL` and `MEDIATOR_URL` feed the same `Create environment settings` call, so a second step would duplicate the fork guard and the `OP_SERVICE_ACCOUNT_TOKEN` wiring for no benefit. The step was renamed from `Load remote logging URL from 1Password` to `Load .env secrets from 1Password` to stay accurate now that it loads two values. Its `id: op_remote_logging` was left unchanged — renaming it would churn both existing call sites for no benefit, and the id isn't user-facing.
- **New step placed immediately before `Create environment settings`, not merged into the existing 1Password block further down.** In both jobs, `Create environment settings` runs *before* the existing `Install 1Password CLI` / `Fetch Google Services config` / etc. steps — it needs these values before that later block even starts. So the new step had to be inserted earlier in the job, as its own small 1Password step, rather than reusing the later block.
- **Fork guard, and why fork behaviour is unchanged.** `Create environment settings` itself has no fork guard and does run on fork PRs. Fork PRs can't read `OP_SERVICE_ACCOUNT_TOKEN`, so the load step is fork-guarded (`if: github.event.pull_request.head.repo.fork != true`). When it's skipped, both `steps.op_remote_logging.outputs.*` values evaluate to empty strings, so `.env` gets empty entries for both on fork PRs — which is exactly what happens today, since `secrets.REMOTE_LOGGING_URL` and `secrets.MEDIATOR_URL` are also empty on forks. Fork PR `.env` output is unchanged by this PR.

## Testing

No unit tests apply — this is CI workflow configuration only. Verified locally:
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/main.yaml'))"` — parses cleanly.
- Confirmed neither `secrets.REMOTE_LOGGING_URL` nor `secrets.MEDIATOR_URL` appears anywhere under `.github/`.
- Confirmed the load step precedes `Create environment settings` in both `build-ios` and `build-android` jobs.
- `actionlint` on the changed file — no new findings on the changed lines (pre-existing shellcheck notes elsewhere in the file are unrelated; actionlint also flags every composite `action.yml` under `.github/workflows/actions/*` as an invalid standalone workflow, which is a known pre-existing auto-discovery quirk, not a real finding).
- `yarn check` (typecheck, lint, format, full test suite) passes.

The `Build iOS` / `Build Android` jobs on this PR completing is the practical signal that the wiring is correct — note PRs only build the reduced `bcwallet-prod` and `bcsc-dev` variants (not the full matrix from `compute-variants`). A green build only proves both 1Password references resolved and were wired through correctly, not that either value is actually correct at runtime: `MEDIATOR_URL` only matters when the wallet provisions mediation, and `REMOTE_LOGGING_URL` only when logs are shipped. Whether they're right shows up in whether mediation and remote logging actually work from a real build using these values.

Related to #4057
Related to #4461 — two of the `.env` values it tracks (`REMOTE_LOGGING_URL`, `MEDIATOR_URL`) are now sourced from 1Password by this PR; the remaining `vars.*` inputs (`OCA_URL`, `PROOF_TEMPLATE_URL`, `INDY_VDR_PROXY_URL`, `SNOWPLOW_COLLECTOR_URL`, `MEDIATOR_USE_PUSH_NOTIFICATIONS`, `LEDGER_AUTO_UPDATE`) are still tracked there.


