### PR TITLE
fix: upgrade react-native-incall-manager to 4.2.2 to fix Android call crash

### DIFF
--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -2836,7 +2836,7 @@ PODS:
     - React-perflogger (= 0.81.5)
     - React-utils (= 0.81.5)
     - SocketRocket
-  - ReactNativeIncallManager (4.2.1):
+  - ReactNativeIncallManager (4.2.2):
     - React-Core
   - RNCAsyncStorage (2.2.0):
     - boost
@@ -3858,7 +3858,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 1bcd3527ac0390a1c898c114f81ff954be35ed79
   ReactCodegen: 6c26f8c25d0b5ae66f86a1cce1777076ac8bcbd8
   ReactCommon: 5f0e5c09a64a2717215dd84380e1a747810406f2
-  ReactNativeIncallManager: dccd3e7499caa3bb73d3acfedf4fb0360f1a87d5
+  ReactNativeIncallManager: c6e08cc005da0f73d5a1ecbd58ad33bc61d5d79f
   RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
   RNCClipboard: 4b58c780f63676367640f23c8e114e9bd0cf86ac
   RNDeviceInfo: d3e91ffb33ee97a7982108476edb68cb3672efa6

--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
@@ -223,11 +223,8 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
   useEffect(() => {
     if (flowState === VideoCallFlowState.IDLE) {
       startVideoCall()
-      // Passing boolean false maps to force-speaker flag -1 (speaker forced OFF,
-      // earpiece as default route) — it does NOT clear the override (a non-boolean
-      // arg / flag 0 does that). We set it before start() so start({ media: 'video' })
-      // does not force audio to the speaker on Android, allowing routing to
-      // Bluetooth/wired headsets.
+      // Boolean false maps to force-speaker flag -1 (force earpiece on Android); it does NOT clear
+      // the override (flag 0 does). start() re-initialises routing, so this does not set the initial route.
       InCallManager.setForceSpeakerphoneOn(false)
       InCallManager.start({ media: 'video', auto: true })
     }

--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
@@ -223,8 +223,7 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
   useEffect(() => {
     if (flowState === VideoCallFlowState.IDLE) {
       startVideoCall()
-      // Boolean false maps to force-speaker flag -1 (force earpiece on Android); it does NOT clear
-      // the override (flag 0 does). start() re-initialises routing, so this does not set the initial route.
+      // No-op: start() re-initialises audio routing immediately after. Removal tracked in #4471.
       InCallManager.setForceSpeakerphoneOn(false)
       InCallManager.start({ media: 'video', auto: true })
     }

--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
@@ -223,9 +223,11 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
   useEffect(() => {
     if (flowState === VideoCallFlowState.IDLE) {
       startVideoCall()
-      // Clear the forced-speaker override before start() so that start()
-      // does not force audio to the speaker on Android. This allows audio
-      // to route to Bluetooth/wired headsets
+      // Passing boolean false maps to force-speaker flag -1 (speaker forced OFF,
+      // earpiece as default route) — it does NOT clear the override (a non-boolean
+      // arg / flag 0 does that). We set it before start() so start({ media: 'video' })
+      // does not force audio to the speaker on Android, allowing routing to
+      // Bluetooth/wired headsets.
       InCallManager.setForceSpeakerphoneOn(false)
       InCallManager.start({ media: 'video', auto: true })
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16583,11 +16583,11 @@ __metadata:
   linkType: hard
 
 "react-native-incall-manager@npm:~4.2.1":
-  version: 4.2.1
-  resolution: "react-native-incall-manager@npm:4.2.1"
+  version: 4.2.2
+  resolution: "react-native-incall-manager@npm:4.2.2"
   peerDependencies:
     react-native: ">=0.40.0"
-  checksum: 10c0/5458621cbab0704e6d57f0e9b9e5e0eef141e6db58f5237fe77f0e6d9f65bc923ec98f54cffa766e394f4e81d5ea26fe01c54e547a1c385a56913f2e58337bcb
+  checksum: 10c0/232e2f4cff8a9840ee70f7ba1b6cef5c5e9e5e5b63ccb145090240db0a0af7fadec28883dfddbe6eefe698280dbb848d080a4547be450a49f8ff2a2ce61cea76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Some Android users hit an app crash the moment the live video verification call screen opened. When it happened, the person lost their in-progress identity verification — camera, microphone and Bluetooth permissions already granted, identity documents already uploaded — and had to restart the app and begin the whole flow again. This change picks up the calling library's official fix for that crash, and corrects a misleading comment in the call screen code.

## Why

The crash came from a defect in `react-native-incall-manager`, the third-party library the video verification call screen uses to manage call audio. Two pieces of audio setup that run back-to-back when the screen opens could collide on the library's internal list of audio devices, occasionally terminating the app. The library's maintainers have published a fix for exactly this defect. Taking it up closes the crash window with no change to our own call logic and no change to how audio behaves for the user.

## Decisions

- **Version bump only — no patch, no source workaround.** Our dependency range (`~4.2.1`) already admits 4.2.2, so this is a lockfile-only re-resolution. No `package.json` change and no `yarn patch` were needed.
- **The fix was confirmed in the resolved artifact**, not just in the version number: the installed `InCallManagerModule.java` uses a thread-safe device set (`ConcurrentHashMap.newKeySet()`) and takes a defensive copy before iterating in `getAudioDeviceStatusMap`. A diff of 4.2.1 against 4.2.2 shows the only Android changes are that thread-safety work plus a guard around ringtone teardown — no change to audio routing behaviour, so there is no regression surface for our usage.
- **iOS `Podfile.lock` regenerated** (`ReactNativeIncallManager` 4.2.1 → 4.2.2) so the pod version tracks the npm package, even though the underlying fix is Android-only.
- **The two `InCallManager` calls and their order are untouched.** Reordering or removing them would narrow but not close the race, and the question of what audio route the call screen *should* use is a separate one, deliberately out of scope here.
- **Comment-only change in `LiveCallScreen.tsx`.** The old comment said `setForceSpeakerphoneOn(false)` "clears the forced-speaker override" and thereby "allows audio to route to Bluetooth/wired headsets". Neither is true: passing boolean `false` maps to flag `-1`, which *forces the earpiece* (flag `0` is what clears the override), and `start()` re-initialises the library's routing state immediately afterwards, so the preceding call does not determine the initial route at all. The comment now describes the verified behaviour.
- **`gradle.lockfile` unchanged**, confirmed by running the Android setup step — 4.2.2 introduces no new Android dependencies.

## Tests

- No new automated tests: the defect is in third-party Android native code that Jest cannot reach, and the only change to our own source is a comment.
- `yarn check` (typecheck, lint, format, full Jest suite — 293 suites / 3031 tests / 162 snapshots) passes clean, with no snapshot changes.
- `yarn why react-native-incall-manager` confirms the resolved version is 4.2.2.

## Verification

Automated verification (typecheck, lint, format, tests, dependency resolution, and confirmation that the fix is present in the installed library) is complete and passing — see Tests above.

**Outstanding — manual testing on a real Android device is still required before merge:**

- Live video verification call in BC Services Card (`BUILD_TARGET=bcsc`) with audio routed through the speaker, a wired headset, and a Bluetooth headset.
- Connecting and disconnecting a Bluetooth headset during an active call.
- A **second** call attempt within the same app session — this is the scenario that originally exposed the crash, since the library's audio device list starts empty on the first call and only fills in after some device activity.
- BC Wallet target (`BUILD_TARGET=bcwallet`) — build-success check only; that target does not use this library at runtime.
- After release: watch Play Store crash reporting for any recurrence of `getAudioDeviceStatusMap`.

## Follow-up

While verifying the comment against the library source, it became clear that `setForceSpeakerphoneOn(false)` before `start()` has no effect on the call's initial audio route — `start()` resets the library's routing state immediately afterwards. Removing that call is tracked separately in #4471. It is kept out of this PR deliberately: the library's iOS and JavaScript sources are byte-identical between 4.2.1 and 4.2.2, so this change needs only an Android device pass, whereas touching the routing call would add a full iOS pass on top.

Fixes #4438
