### PR TITLE
fix: add build number to Need help menu app version

### DIFF
--- a/app/src/bcsc-theme/components/FloatingHelpMenu.test.tsx
+++ b/app/src/bcsc-theme/components/FloatingHelpMenu.test.tsx
@@ -3,10 +3,7 @@ import { render, screen } from '@testing-library/react-native'
 import React from 'react'
 import FloatingHelpMenu from './FloatingHelpMenu'
 
-// The global react-i18next mock (see app/__mocks__/react-i18next.ts) drops interpolation
-// values and returns the raw key, which would hide a regression in the version/build
-// interpolation this test is meant to catch. Override locally with a mock that actually
-// interpolates the `version`/`build` options into the real Version copy.
+// The global react-i18next mock returns raw keys, so interpolate locally to assert version/build.
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, options?: Record<string, string>) => {
@@ -28,8 +25,7 @@ describe('FloatingHelpMenu', () => {
       </BasicAppContext>
     )
 
-    // react-native-device-info mock (__mocks__/react-native-device-info.ts) fixes
-    // getVersion() to '4.0.0' and getBuildNumber() to '142'.
+    // '4.0.0' and '142' come from the react-native-device-info jest mock.
     expect(screen.getByText('App version: 4.0.0 (142)')).toBeTruthy()
   })
 })

--- a/app/src/bcsc-theme/components/FloatingHelpMenu.test.tsx
+++ b/app/src/bcsc-theme/components/FloatingHelpMenu.test.tsx
@@ -1,3 +1,6 @@
+import en from '@/localization/en'
+import fr from '@/localization/fr'
+import ptBr from '@/localization/pt-br'
 import { BasicAppContext } from '@mocks/helpers/app'
 import { render, screen } from '@testing-library/react-native'
 import React from 'react'
@@ -27,5 +30,15 @@ describe('FloatingHelpMenu', () => {
 
     // '4.0.0' and '142' come from the react-native-device-info jest mock.
     expect(screen.getByText('App version: 4.0.0 (142)')).toBeTruthy()
+  })
+
+  // The mock above hardcodes its own template, so it can't catch a regression in the
+  // shipped locale copy itself. Assert directly against the real locale resources so a
+  // dropped `{{ build }}` placeholder in any locale file fails this test.
+  it('keeps the build placeholder in the shipped locale strings', () => {
+    expect(en.BCSC.HelpMenu.Version).toContain('{{ version }}')
+    expect(en.BCSC.HelpMenu.Version).toContain('{{ build }}')
+    expect(fr.BCSC.HelpMenu.Version).toContain('{{ build }}')
+    expect(ptBr.BCSC.HelpMenu.Version).toContain('{{ build }}')
   })
 })

--- a/app/src/bcsc-theme/components/FloatingHelpMenu.test.tsx
+++ b/app/src/bcsc-theme/components/FloatingHelpMenu.test.tsx
@@ -1,0 +1,35 @@
+import { BasicAppContext } from '@mocks/helpers/app'
+import { render, screen } from '@testing-library/react-native'
+import React from 'react'
+import FloatingHelpMenu from './FloatingHelpMenu'
+
+// The global react-i18next mock (see app/__mocks__/react-i18next.ts) drops interpolation
+// values and returns the raw key, which would hide a regression in the version/build
+// interpolation this test is meant to catch. Override locally with a mock that actually
+// interpolates the `version`/`build` options into the real Version copy.
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => {
+      if (key !== 'BCSC.HelpMenu.Version') {
+        return key
+      }
+      return 'App version: {{ version }} ({{ build }})'
+        .replace('{{ version }}', options?.version ?? '')
+        .replace('{{ build }}', options?.build ?? '')
+    },
+  }),
+}))
+
+describe('FloatingHelpMenu', () => {
+  it('renders the app version with the build number', () => {
+    render(
+      <BasicAppContext>
+        <FloatingHelpMenu open onClose={jest.fn()} />
+      </BasicAppContext>
+    )
+
+    // react-native-device-info mock (__mocks__/react-native-device-info.ts) fixes
+    // getVersion() to '4.0.0' and getBuildNumber() to '142'.
+    expect(screen.getByText('App version: 4.0.0 (142)')).toBeTruthy()
+  })
+})

--- a/app/src/bcsc-theme/components/FloatingHelpMenu.test.tsx
+++ b/app/src/bcsc-theme/components/FloatingHelpMenu.test.tsx
@@ -32,9 +32,8 @@ describe('FloatingHelpMenu', () => {
     expect(screen.getByText('App version: 4.0.0 (142)')).toBeTruthy()
   })
 
-  // The mock above hardcodes its own template, so it can't catch a regression in the
-  // shipped locale copy itself. Assert directly against the real locale resources so a
-  // dropped `{{ build }}` placeholder in any locale file fails this test.
+  // The mock above hardcodes its template, so it can't catch a regression in the shipped
+  // locale copy; assert against the real locale resources so a dropped `{{ build }}` fails.
   it('keeps the build placeholder in the shipped locale strings', () => {
     expect(en.BCSC.HelpMenu.Version).toContain('{{ version }}')
     expect(en.BCSC.HelpMenu.Version).toContain('{{ build }}')

--- a/app/src/bcsc-theme/components/FloatingHelpMenu.tsx
+++ b/app/src/bcsc-theme/components/FloatingHelpMenu.tsx
@@ -4,7 +4,7 @@ import { ThemedText, useTheme } from '@bifold/core'
 import { PropsWithChildren, useCallback, useImperativeHandle, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Animated, Easing, Modal, StyleSheet, TouchableWithoutFeedback, useWindowDimensions, View } from 'react-native'
-import { getVersion } from 'react-native-device-info'
+import { getBuildNumber, getVersion } from 'react-native-device-info'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
@@ -148,7 +148,9 @@ const FloatingHelpMenu = (props: FloatingHelpMenuProps) => {
                 </View>
                 <View style={styles.childrenContainer}>{props.children}</View>
                 <View style={styles.versionContainer}>
-                  <ThemedText>{t('BCSC.HelpMenu.Version', { version: getVersion() })}</ThemedText>
+                  <ThemedText>
+                    {t('BCSC.HelpMenu.Version', { version: getVersion(), build: getBuildNumber() })}
+                  </ThemedText>
                 </View>
               </Animated.View>
             </TouchableWithoutFeedback>

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -279,7 +279,7 @@ const translation = {
     "HelpMenu": {
       "Title": "Need help?",
       "AccessibilityLabel": "Help menu",
-      "Version": "App version: {{ version }}",
+      "Version": "App version: {{ version }} ({{ build }})",
       "LearnMore": "Learn more",
       "GiveFeedback": "Give feedback",
       "ReportProblem": "Report a problem",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -279,7 +279,7 @@ const translation = {
     "HelpMenu": {
       "Title": "Need help? (FR)",
       "AccessibilityLabel": "Help menu (FR)",
-      "Version": "App version: {{ version }} (FR)",
+      "Version": "App version: {{ version }} ({{ build }}) (FR)",
       "LearnMore": "Learn more (FR)",
       "GiveFeedback": "Give feedback (FR)",
       "ReportProblem": "Report a problem (FR)",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -279,7 +279,7 @@ const translation = {
     "HelpMenu": {
       "Title": "Need help? (PT-BR)",
       "AccessibilityLabel": "Help menu (PT-BR)",
-      "Version": "App version: {{ version }} (PT-BR)",
+      "Version": "App version: {{ version }} ({{ build }}) (PT-BR)",
       "LearnMore": "Learn more (PT-BR)",
       "GiveFeedback": "Give feedback (PT-BR)",
       "ReportProblem": "Report a problem (PT-BR)",


### PR DESCRIPTION
## What

The app version shown in the "Need help?" floating menu now includes the build number (e.g. `App version: 4.1.0 (7840)`), not just the version number.

## Why

Support sometimes needs the build number to diagnose an issue, and the "Need help?" menu is meant to be reachable even when someone can't get to Settings. Without the build number there, the workaround was digging into Settings — the exact thing the help menu should avoid requiring.

## Decisions

- Reused the existing `getBuildNumber()`/`getVersion()` pattern from `react-native-device-info` already used in Settings, the Developer screen, and `ErrorInfoCard`, rather than introducing a shared version/build utility — this keeps the change minimal and consistent with existing usage elsewhere in the codebase.
- Added a `build` interpolation variable to the existing `BCSC.HelpMenu.Version` i18n string in `en`/`fr`/`pt-br`, matching the `Version X.Y.Z (build)` paren format already shown in Settings.
- Scoped to the `bcsc` build target only — `FloatingHelpMenu` is a BCSC-theme component, not used by `bcwallet`.

## Tests

Added `app/src/bcsc-theme/components/FloatingHelpMenu.test.tsx` with two tests:

1. **Render test** — asserts the help menu renders `App version: 4.0.0 (142)` using the fixed values from the `react-native-device-info` jest mock, confirming the component wires `version`/`build` into the translation call. (The global `react-i18next` mock drops interpolation, so this test uses a local interpolating mock override, matching the pattern in `AgentReadyGate.test.tsx`.)
2. **Locale-string test** — imports the real `en`/`fr`/`pt-br` locale objects and asserts each `BCSC.HelpMenu.Version` string contains the `{{ build }}` placeholder (and `{{ version }}` for `en`). This guards the locale-file half of the change: reverting the locale copy back to version-only now fails the suite.

`yarn check` (typecheck, lint, format, full test suite) passes: 294 suites / 3034 tests / 162 snapshots.

## Verification

1. Open the app with `BUILD_TARGET=bcsc`.
2. From any screen with the floating "Need help?" button, open the help menu.
3. Confirm the version line at the bottom reads `App version: <version> (<build>)`, matching the build number shown in Settings.

Fixes #4429
