### PR TITLE
fix: run device-security unlock off the main thread on Android

### DIFF
--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -2812,15 +2812,8 @@ class BcscCoreModule(
         reason: String?,
         promise: Promise,
     ) {
-        // The biometric SUCCESS callback below fires on the main thread
-        // (DeviceAuthenticationServiceImpl uses runOnUiThread + getMainExecutor). Its work
-        // performs multiple secure key store round trips (issuer/account file decryption, PIN
-        // hash lookup, and — on the v3 migration path with no stored PIN hash — a 210,000
-        // iteration PBKDF2 derivation plus a second key store write) that can take long enough
-        // to trigger an ANR. That branch is moved onto backgroundExecutor so the main thread is
-        // never blocked; every settle path is routed through a GuardedPromise since running the
-        // work asynchronously widens the window in which more than one terminal callback path
-        // could attempt to settle the same promise.
+        // The biometric callback fires on the main thread, so the SUCCESS branch's keystore work
+        // runs on backgroundExecutor; async settling means every path must go through GuardedPromise.
         val guarded = GuardedPromise(promise)
 
         try {
@@ -2852,7 +2845,6 @@ class BcscCoreModule(
                         try {
                             backgroundExecutor.execute {
                                 try {
-                                    // Get the stored PIN hash
                                     val hashResult = pinService.getPINHash(accountID)
 
                                     if (hashResult != null) {
@@ -2887,10 +2879,7 @@ class BcscCoreModule(
                                 }
                             }
                         } catch (e: RejectedExecutionException) {
-                            // The executor has already been shut down (e.g. invalidate() ran
-                            // during a dev reload or activity teardown while the biometric
-                            // prompt was still open). Settle rather than leave the JS promise
-                            // pending forever.
+                            // Executor shut down while the prompt was open; settle so JS is not left pending.
                             Log.w(NAME, "unlockWithDeviceSecurity: background executor unavailable, rejecting", e)
                             guarded.reject(
                                 "E_UNLOCK_DEVICE_SECURITY_ERROR",
@@ -4147,11 +4136,8 @@ class BcscCoreModule(
         PinService(reactApplicationContext, nativeStorage)
     }
 
-    // Single-thread executor for offloading main-thread-unsafe work triggered from
-    // biometric/device-authentication callbacks (see unlockWithDeviceSecurity). Deliberately a
-    // plain java.util.concurrent executor rather than coroutines: bcsc-core declares no
-    // coroutines dependency, the workload here is a single hop with nothing to compose, and one
-    // named serialized thread gives mutual exclusion over keystore/PIN-storage work for free.
+    // Serialized off-main thread for keystore/PIN work reached from biometric callbacks.
+    // A plain executor, not coroutines: bcsc-core declares no coroutines dependency.
     private val backgroundExecutorDelegate =
         lazy {
             Executors.newSingleThreadExecutor { r -> Thread(r, "BcscCoreBackground") }
@@ -4159,10 +4145,8 @@ class BcscCoreModule(
     private val backgroundExecutor: ExecutorService by backgroundExecutorDelegate
 
     /**
-     * Shuts down [backgroundExecutor] when the module is torn down (dev reload, activity
-     * teardown). Checks [Lazy.isInitialized] first so tearing down a module that never used the
-     * executor doesn't create one just to shut it down. Uses shutdown() rather than
-     * shutdownNow() so an in-flight migration write is never interrupted mid-keystore-write.
+     * Shuts the background executor down on teardown, without initializing one that was never used.
+     * shutdown(), not shutdownNow(): an in-flight migration must never be interrupted mid-keystore-write.
      */
     override fun invalidate() {
         if (backgroundExecutorDelegate.isInitialized()) {

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -157,6 +157,12 @@ class BcscCoreModule(
         // Notification channel constants
         private const val NOTIFICATION_CHANNEL_ID = "bcsc_foreground_notifications"
         private const val NOTIFICATION_CHANNEL_NAME = "BCSC Notifications"
+
+        // Auto-generated device-security PIN constants
+        private const val AUTO_GENERATED_PIN_LENGTH = 6
+
+        // Exclusive upper bound passed to SecureRandom.nextInt() to produce a single decimal digit (0-9)
+        private const val DECIMAL_DIGIT_BOUND = 10
     }
 
     override fun getName(): String = NAME
@@ -2777,11 +2783,11 @@ class BcscCoreModule(
 
             val accountID = account.uuid
 
-            // Generate a cryptographically secure random 6-digit PIN
+            // Generate a cryptographically secure random PIN
             val secureRandom = java.security.SecureRandom()
             val pinDigits = StringBuilder()
-            for (i in 0 until 6) {
-                val digit = secureRandom.nextInt(10)
+            for (i in 0 until AUTO_GENERATED_PIN_LENGTH) {
+                val digit = secureRandom.nextInt(DECIMAL_DIGIT_BOUND)
                 pinDigits.append(digit)
             }
             val pin = pinDigits.toString()
@@ -2857,8 +2863,8 @@ class BcscCoreModule(
                                         // User had device security but no random PIN. Generate one now.
                                         val secureRandom = java.security.SecureRandom()
                                         val pinDigits = StringBuilder()
-                                        for (i in 0 until 6) {
-                                            pinDigits.append(secureRandom.nextInt(10))
+                                        for (i in 0 until AUTO_GENERATED_PIN_LENGTH) {
+                                            pinDigits.append(secureRandom.nextInt(DECIMAL_DIGIT_BOUND))
                                         }
                                         val pin = pinDigits.toString()
 

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -47,6 +47,9 @@ import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
 import java.util.UUID
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 import javax.crypto.SecretKey
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
@@ -90,6 +93,9 @@ import com.bcsccore.authentication.device.DeviceAuthenticationService
 import com.bcsccore.authentication.device.DeviceAuthenticationServiceImpl
 import com.bcsccore.authentication.device.DeviceAuthenticationResult
 import com.bcsccore.authentication.PinService
+
+// Utility imports
+import com.bcsccore.util.GuardedPromise
 
 // Native-compatible storage imports
 import com.bcsccore.storage.NativeCompatibleStorage
@@ -2806,10 +2812,21 @@ class BcscCoreModule(
         reason: String?,
         promise: Promise,
     ) {
+        // The biometric SUCCESS callback below fires on the main thread
+        // (DeviceAuthenticationServiceImpl uses runOnUiThread + getMainExecutor). Its work
+        // performs multiple secure key store round trips (issuer/account file decryption, PIN
+        // hash lookup, and — on the v3 migration path with no stored PIN hash — a 210,000
+        // iteration PBKDF2 derivation plus a second key store write) that can take long enough
+        // to trigger an ANR. That branch is moved onto backgroundExecutor so the main thread is
+        // never blocked; every settle path is routed through a GuardedPromise since running the
+        // work asynchronously widens the window in which more than one terminal callback path
+        // could attempt to settle the same promise.
+        val guarded = GuardedPromise(promise)
+
         try {
             val account = resolveFirstAccount()
             if (account == null) {
-                promise.reject("E_ACCOUNT_NOT_FOUND", "No account found")
+                guarded.reject("E_ACCOUNT_NOT_FOUND", "No account found")
                 return
             }
 
@@ -2817,7 +2834,7 @@ class BcscCoreModule(
 
             val activity = reactApplicationContext.currentActivity
             if (activity == null || activity !is FragmentActivity) {
-                promise.reject("E_NO_ACTIVITY", "No FragmentActivity available for authentication")
+                guarded.reject("E_NO_ACTIVITY", "No FragmentActivity available for authentication")
                 return
             }
 
@@ -2833,41 +2850,60 @@ class BcscCoreModule(
                 when (authResult) {
                     DeviceAuthenticationResult.SUCCESS -> {
                         try {
-                            // Get the stored PIN hash
-                            val hashResult = pinService.getPINHash(accountID)
+                            backgroundExecutor.execute {
+                                try {
+                                    // Get the stored PIN hash
+                                    val hashResult = pinService.getPINHash(accountID)
 
-                            if (hashResult != null) {
-                                val result = Arguments.createMap()
-                                result.putBoolean("success", true)
-                                result.putString("walletKey", hashResult.first)
-                                promise.resolve(result)
-                            } else {
-                                // No PIN hash found - this is a v3 migration scenario
-                                // User had device security but no random PIN. Generate one now.
-                                val secureRandom = java.security.SecureRandom()
-                                val pinDigits = StringBuilder()
-                                for (i in 0 until 6) {
-                                    pinDigits.append(secureRandom.nextInt(10))
+                                    if (hashResult != null) {
+                                        val result = Arguments.createMap()
+                                        result.putBoolean("success", true)
+                                        result.putString("walletKey", hashResult.first)
+                                        guarded.resolve(result)
+                                    } else {
+                                        // No PIN hash found - this is a v3 migration scenario
+                                        // User had device security but no random PIN. Generate one now.
+                                        val secureRandom = java.security.SecureRandom()
+                                        val pinDigits = StringBuilder()
+                                        for (i in 0 until 6) {
+                                            pinDigits.append(secureRandom.nextInt(10))
+                                        }
+                                        val pin = pinDigits.toString()
+
+                                        val hash = pinService.setupDeviceSecurityPIN(accountID, pin)
+
+                                        val result = Arguments.createMap()
+                                        result.putBoolean("success", true)
+                                        result.putString("walletKey", hash)
+                                        result.putBoolean("migrated", true)
+                                        guarded.resolve(result)
+                                    }
+                                } catch (e: Exception) {
+                                    guarded.reject(
+                                        "E_UNLOCK_DEVICE_SECURITY_ERROR",
+                                        "Error during unlock: ${e.message}",
+                                        e,
+                                    )
                                 }
-                                val pin = pinDigits.toString()
-
-                                val hash = pinService.setupDeviceSecurityPIN(accountID, pin)
-
-                                val result = Arguments.createMap()
-                                result.putBoolean("success", true)
-                                result.putString("walletKey", hash)
-                                result.putBoolean("migrated", true)
-                                promise.resolve(result)
                             }
-                        } catch (e: Exception) {
-                            promise.reject("E_UNLOCK_DEVICE_SECURITY_ERROR", "Error during unlock: ${e.message}", e)
+                        } catch (e: RejectedExecutionException) {
+                            // The executor has already been shut down (e.g. invalidate() ran
+                            // during a dev reload or activity teardown while the biometric
+                            // prompt was still open). Settle rather than leave the JS promise
+                            // pending forever.
+                            Log.w(NAME, "unlockWithDeviceSecurity: background executor unavailable, rejecting", e)
+                            guarded.reject(
+                                "E_UNLOCK_DEVICE_SECURITY_ERROR",
+                                "Unable to complete unlock: module is shutting down",
+                                e,
+                            )
                         }
                     }
 
                     DeviceAuthenticationResult.CANCELLED -> {
                         val result = Arguments.createMap()
                         result.putBoolean("success", false)
-                        promise.resolve(result)
+                        guarded.resolve(result)
                     }
 
                     DeviceAuthenticationResult.FAILED -> {
@@ -2879,13 +2915,13 @@ class BcscCoreModule(
                     DeviceAuthenticationResult.ERROR -> {
                         val result = Arguments.createMap()
                         result.putBoolean("success", false)
-                        promise.resolve(result)
+                        guarded.resolve(result)
                     }
                 }
             }
         } catch (e: Exception) {
             Log.e(NAME, "unlockWithDeviceSecurity error: ${e.message}", e)
-            promise.reject("E_UNLOCK_DEVICE_SECURITY_ERROR", "Error unlocking with device security: ${e.message}", e)
+            guarded.reject("E_UNLOCK_DEVICE_SECURITY_ERROR", "Error unlocking with device security: ${e.message}", e)
         }
     }
 
@@ -4109,6 +4145,30 @@ class BcscCoreModule(
 
     private val pinService: PinService by lazy {
         PinService(reactApplicationContext, nativeStorage)
+    }
+
+    // Single-thread executor for offloading main-thread-unsafe work triggered from
+    // biometric/device-authentication callbacks (see unlockWithDeviceSecurity). Deliberately a
+    // plain java.util.concurrent executor rather than coroutines: bcsc-core declares no
+    // coroutines dependency, the workload here is a single hop with nothing to compose, and one
+    // named serialized thread gives mutual exclusion over keystore/PIN-storage work for free.
+    private val backgroundExecutorDelegate =
+        lazy {
+            Executors.newSingleThreadExecutor { r -> Thread(r, "BcscCoreBackground") }
+        }
+    private val backgroundExecutor: ExecutorService by backgroundExecutorDelegate
+
+    /**
+     * Shuts down [backgroundExecutor] when the module is torn down (dev reload, activity
+     * teardown). Checks [Lazy.isInitialized] first so tearing down a module that never used the
+     * executor doesn't create one just to shut it down. Uses shutdown() rather than
+     * shutdownNow() so an in-flight migration write is never interrupted mid-keystore-write.
+     */
+    override fun invalidate() {
+        if (backgroundExecutorDelegate.isInitialized()) {
+            backgroundExecutorDelegate.value.shutdown()
+        }
+        super.invalidate()
     }
 
     // MARK: - JSON Conversion Helpers

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/util/GuardedPromise.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/util/GuardedPromise.kt
@@ -1,0 +1,36 @@
+package com.bcsccore.util
+
+import android.util.Log
+import com.facebook.react.bridge.Promise
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Wraps a React Native Promise so it settles at most once; later attempts are logged and ignored. */
+class GuardedPromise(
+    private val promise: Promise,
+) {
+    companion object {
+        private const val TAG = "GuardedPromise"
+    }
+
+    private val settled = AtomicBoolean(false)
+
+    fun resolve(value: Any?) {
+        if (settled.compareAndSet(false, true)) {
+            promise.resolve(value)
+        } else {
+            Log.w(TAG, "Ignoring resolve — promise already settled")
+        }
+    }
+
+    fun reject(
+        code: String,
+        message: String,
+        throwable: Throwable? = null,
+    ) {
+        if (settled.compareAndSet(false, true)) {
+            if (throwable != null) promise.reject(code, message, throwable) else promise.reject(code, message)
+        } else {
+            Log.w(TAG, "Ignoring reject($code) — promise already settled")
+        }
+    }
+}

--- a/packages/bcsc-core/android/src/test/java/com/bcsccore/util/GuardedPromiseTest.kt
+++ b/packages/bcsc-core/android/src/test/java/com/bcsccore/util/GuardedPromiseTest.kt
@@ -1,0 +1,126 @@
+package com.bcsccore.util
+
+import android.util.Log
+import com.facebook.react.bridge.Promise
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class GuardedPromiseTest {
+    private lateinit var mockPromise: Promise
+
+    @Before
+    fun setUp() {
+        mockPromise = mockk(relaxed = true)
+
+        mockkStatic(Log::class)
+        every { Log.w(any(), any<String>()) } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `resolve then resolve calls delegate resolve exactly once`() {
+        val guarded = GuardedPromise(mockPromise)
+
+        guarded.resolve("first")
+        guarded.resolve("second")
+
+        verify(exactly = 1) { mockPromise.resolve("first") }
+        verify(exactly = 0) { mockPromise.resolve("second") }
+    }
+
+    @Test
+    fun `resolve then reject never calls delegate reject`() {
+        val guarded = GuardedPromise(mockPromise)
+
+        guarded.resolve("value")
+        guarded.reject("E_CODE", "message")
+
+        verify(exactly = 1) { mockPromise.resolve("value") }
+        verify(exactly = 0) { mockPromise.reject(any<String>(), any<String>()) }
+    }
+
+    @Test
+    fun `reject then resolve never calls delegate resolve`() {
+        val guarded = GuardedPromise(mockPromise)
+
+        guarded.reject("E_CODE", "message")
+        guarded.resolve("value")
+
+        verify(exactly = 1) { mockPromise.reject("E_CODE", "message") }
+        verify(exactly = 0) { mockPromise.resolve(any()) }
+    }
+
+    @Test
+    fun `reject without throwable invokes two-arg overload`() {
+        val guarded = GuardedPromise(mockPromise)
+
+        guarded.reject("E_CODE", "message")
+
+        verify(exactly = 1) { mockPromise.reject("E_CODE", "message") }
+    }
+
+    @Test
+    fun `reject with throwable invokes three-arg overload`() {
+        val guarded = GuardedPromise(mockPromise)
+        val throwable = RuntimeException("boom")
+
+        guarded.reject("E_CODE", "message", throwable)
+
+        verify(exactly = 1) { mockPromise.reject("E_CODE", "message", throwable) }
+    }
+
+    @Test
+    fun `concurrent settle attempts result in exactly one delegate call total`() {
+        val guarded = GuardedPromise(mockPromise)
+        val settleCount = AtomicInteger(0)
+        every { mockPromise.resolve(any()) } answers {
+            settleCount.incrementAndGet()
+            Unit
+        }
+        every { mockPromise.reject(any<String>(), any<String>()) } answers {
+            settleCount.incrementAndGet()
+            Unit
+        }
+
+        val readyLatch = CountDownLatch(2)
+        val startLatch = CountDownLatch(1)
+        val doneLatch = CountDownLatch(2)
+        val executor = Executors.newFixedThreadPool(2)
+
+        executor.execute {
+            readyLatch.countDown()
+            startLatch.await()
+            guarded.resolve("from-thread-1")
+            doneLatch.countDown()
+        }
+
+        executor.execute {
+            readyLatch.countDown()
+            startLatch.await()
+            guarded.reject("E_CODE", "from-thread-2")
+            doneLatch.countDown()
+        }
+
+        readyLatch.await()
+        startLatch.countDown()
+        doneLatch.await(5, TimeUnit.SECONDS)
+        executor.shutdown()
+
+        assertEquals(1, settleCount.get())
+    }
+}

--- a/packages/bcsc-core/android/src/test/java/com/bcsccore/util/GuardedPromiseTest.kt
+++ b/packages/bcsc-core/android/src/test/java/com/bcsccore/util/GuardedPromiseTest.kt
@@ -99,15 +99,15 @@ class GuardedPromiseTest {
      * in both `resolve` and `reject`): a latch-based version of this test passed cleanly at 500
      * *and* 20,000 iterations, never once observing the double-settle.
      *
-     * Instead, two long-lived threads busy-spin on a shared, plain (non-volatile) `Int`
-     * generation counter — no blocking primitive, no `park`/`unpark`, no OS wake latency. Both
-     * threads are already actively polling when the main thread bumps the counter, so they act
-     * within a handful of CPU cycles of each other and of the counter update becoming visible,
-     * which is what actually exercises the interleaving window. The [GuardedPromise] under test
-     * and its settle counter are published to the workers by writing them (via [AtomicReference])
-     * before the generation bump; per the Java Memory Model, a volatile write of the generation
-     * counter after those writes guarantees a worker that observes the new generation also sees
-     * the fresh promise and counter (safe publication).
+     * Instead, two long-lived threads busy-spin on a shared `AtomicInteger` generation counter —
+     * no blocking primitive, no `park`/`unpark`, no OS wake latency. Both threads are already
+     * actively polling when the main thread bumps the counter, so they act within a handful of
+     * CPU cycles of each other and of the counter update becoming visible, which is what actually
+     * exercises the interleaving window. The [GuardedPromise] under test and its settle counter
+     * are published to the workers by writing them (via [AtomicReference]) before the generation
+     * bump; per the Java Memory Model, a volatile write of the generation counter after those
+     * writes guarantees a worker that observes the new generation also sees the fresh promise and
+     * counter (safe publication).
      */
     @Test
     fun `concurrent settle attempts result in exactly one delegate call total across many iterations`() {

--- a/packages/bcsc-core/android/src/test/java/com/bcsccore/util/GuardedPromiseTest.kt
+++ b/packages/bcsc-core/android/src/test/java/com/bcsccore/util/GuardedPromiseTest.kt
@@ -7,14 +7,15 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import io.mockk.verify
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
-import org.junit.Assert.assertEquals
 
 class GuardedPromiseTest {
     private lateinit var mockPromise: Promise
@@ -84,43 +85,108 @@ class GuardedPromiseTest {
         verify(exactly = 1) { mockPromise.reject("E_CODE", "message", throwable) }
     }
 
+    /**
+     * Races a resolve against a reject thousands of times, on the same pair of persistent
+     * threads, to catch a non-atomic settle guard (e.g. a plain check-then-set instead of
+     * [java.util.concurrent.atomic.AtomicBoolean.compareAndSet]) reliably.
+     *
+     * Blocking coordination (`CountDownLatch`/`await`) was tried first and does not work here:
+     * both `park`/`unpark` and OS thread-wake scheduling take microseconds, which is far wider
+     * than the few-nanosecond window between "check settled" and "set settled" — by the time a
+     * released thread actually runs, the other thread's plain write has almost always already
+     * propagated. Empirically this was verified against a deliberately non-atomic
+     * [GuardedPromise] (plain `var settled = false` with `if (!settled) { settled = true; ... }`
+     * in both `resolve` and `reject`): a latch-based version of this test passed cleanly at 500
+     * *and* 20,000 iterations, never once observing the double-settle.
+     *
+     * Instead, two long-lived threads busy-spin on a shared, plain (non-volatile) `Int`
+     * generation counter — no blocking primitive, no `park`/`unpark`, no OS wake latency. Both
+     * threads are already actively polling when the main thread bumps the counter, so they act
+     * within a handful of CPU cycles of each other and of the counter update becoming visible,
+     * which is what actually exercises the interleaving window. The [GuardedPromise] under test
+     * and its settle counter are published to the workers by writing them (via [AtomicReference])
+     * before the generation bump; per the Java Memory Model, a volatile write of the generation
+     * counter after those writes guarantees a worker that observes the new generation also sees
+     * the fresh promise and counter (safe publication).
+     */
     @Test
-    fun `concurrent settle attempts result in exactly one delegate call total`() {
-        val guarded = GuardedPromise(mockPromise)
-        val settleCount = AtomicInteger(0)
-        every { mockPromise.resolve(any()) } answers {
-            settleCount.incrementAndGet()
-            Unit
-        }
-        every { mockPromise.reject(any<String>(), any<String>()) } answers {
-            settleCount.incrementAndGet()
-            Unit
-        }
+    fun `concurrent settle attempts result in exactly one delegate call total across many iterations`() {
+        val iterations = 5000
+        val timeoutNanos = TimeUnit.SECONDS.toNanos(2)
 
-        val readyLatch = CountDownLatch(2)
-        val startLatch = CountDownLatch(1)
-        val doneLatch = CountDownLatch(2)
-        val executor = Executors.newFixedThreadPool(2)
+        val running = AtomicBoolean(true)
+        val generation = AtomicInteger(0)
+        val doneCount = AtomicInteger(0)
+        val guardedRef = AtomicReference<GuardedPromise>()
 
-        executor.execute {
-            readyLatch.countDown()
-            startLatch.await()
-            guarded.resolve("from-thread-1")
-            doneLatch.countDown()
+        fun spinUntilGenerationAdvancesPast(seen: Int): Int {
+            var current = generation.get()
+            while (current == seen && running.get()) {
+                current = generation.get()
+            }
+            return current
         }
 
-        executor.execute {
-            readyLatch.countDown()
-            startLatch.await()
-            guarded.reject("E_CODE", "from-thread-2")
-            doneLatch.countDown()
+        val resolver =
+            Thread({
+                var seen = 0
+                while (running.get()) {
+                    seen = spinUntilGenerationAdvancesPast(seen)
+                    if (!running.get()) return@Thread
+                    guardedRef.get()?.resolve("from-resolver")
+                    doneCount.incrementAndGet()
+                }
+            }, "GuardedPromiseTest-Resolver")
+
+        val rejecter =
+            Thread({
+                var seen = 0
+                while (running.get()) {
+                    seen = spinUntilGenerationAdvancesPast(seen)
+                    if (!running.get()) return@Thread
+                    guardedRef.get()?.reject("E_CODE", "from-rejecter")
+                    doneCount.incrementAndGet()
+                }
+            }, "GuardedPromiseTest-Rejecter")
+
+        resolver.start()
+        rejecter.start()
+
+        try {
+            repeat(iterations) { iteration ->
+                val iterationPromise = mockk<Promise>(relaxed = true)
+                val settleCount = AtomicInteger(0)
+                every { iterationPromise.resolve(any()) } answers {
+                    settleCount.incrementAndGet()
+                    Unit
+                }
+                every { iterationPromise.reject(any<String>(), any<String>()) } answers {
+                    settleCount.incrementAndGet()
+                    Unit
+                }
+
+                guardedRef.set(GuardedPromise(iterationPromise))
+                doneCount.set(0)
+                generation.incrementAndGet()
+
+                val deadline = System.nanoTime() + timeoutNanos
+                while (doneCount.get() < 2) {
+                    if (System.nanoTime() > deadline) {
+                        fail("iteration $iteration: resolver/rejecter did not both finish in time")
+                    }
+                }
+
+                assertEquals(
+                    "iteration $iteration: expected exactly one delegate settle call",
+                    1,
+                    settleCount.get(),
+                )
+            }
+        } finally {
+            running.set(false)
+            generation.incrementAndGet()
+            resolver.join(1_000)
+            rejecter.join(1_000)
         }
-
-        readyLatch.await()
-        startLatch.countDown()
-        doneLatch.await(5, TimeUnit.SECONDS)
-        executor.shutdown()
-
-        assertEquals(1, settleCount.get())
     }
 }


### PR DESCRIPTION
## What

After a user unlocks BC Services Card with biometrics or device PIN on Android, the app could freeze long enough for Android to show the "app isn't responding" dialog — right after the person proved who they are and is waiting to get in. On slower devices, or when the device's secure key store is busy, the freeze could be long enough that the person couldn't get in without retrying.

This change moves that work off the main thread so it can no longer trigger the freeze, and keeps the existing loading animation visible while the (unavoidably slow) work completes.

## Why

Unlocking does real security work that can't be skipped or made faster — the app has to prove to the device's secure key store that it may open the user's data, and for people migrating from the v3 app there's extra one-time setup work on top of that.

The problem wasn't that the work was slow; it was where it ran. It was happening on the same thread that draws the screen, so for as long as it took, the screen couldn't update at all. To the user, and to Android, that looks like a frozen app — the "app isn't responding" dialog is Android reacting to exactly that.

Doing this work in the background changes nothing about what the unlock does or how long it takes. The user waits the same amount of time, but now sees the loading animation instead of a frozen screen, and the app is never reported as unresponsive.

## Manual Tesing

- Setup a new install or old with PIN
- Login as expected. 

## Decisions

- **Plain `java.util.concurrent` executor, not coroutines.** `bcsc-core` declares no coroutines dependency today; relying on a transitive copy would be fragile, and this workload is a single hop with nothing to compose. A single dedicated background thread (`BcscCoreBackground`) also gives mutual exclusion over the keystore/PIN-storage work for free — relevant because the v3 migration path performs two separate secure-keystore round trips. This is the first background-threading construct in `BcscCoreModule`, so it sets a precedent for future work in this module; coroutines remain a reasonable choice for anything that later needs real composition.
- **`GuardedPromise` settle-once wrapper.** Running the callback body asynchronously widens the window in which more than one terminal path could try to settle the same React Native promise (RN throws if a promise is settled twice). Every settle path in `unlockWithDeviceSecurity` — including the early rejects, the executor-unavailable case, and the outer catch — now routes through this wrapper.
- **Reject on `RejectedExecutionException` rather than silently dropping.** If the background executor has already been shut down (e.g. a dev reload or activity teardown racing an open biometric prompt), we settle the promise with a reject instead of leaving the JS side waiting forever.
- **`invalidate()` uses `shutdown()`, not `shutdownNow()`.** So a migration write already in progress against the secure key store is never interrupted mid-write.
- **Only the `SUCCESS` branch moves.** `CANCELLED`/`ERROR` do no meaningful work, so they stay on the callback thread. The other biometric call site (`performDeviceAuthentication`, which only returns a boolean) is unaffected and out of scope per the issue.
- **No JS changes.** The existing `BCSCLoadingContext` overlay in `useAuthentication.tsx` already brackets the entire unlock call (`startLoading()` before, `stopLoading()` in a `finally` covering both resolve and reject) and renders an animated loading icon. It was rendering today but starved, because the blocked main thread was also the render thread — unblocking main is what makes it actually animate.
- **Android only.** iOS runs the equivalent post-auth work inside `Task { @MainActor in ... }`, which is a different threading model; that's out of scope for this issue.
- **Out of scope (per the issue):** reducing the number of repeated secure key store round trips (caching in `NativeCompatiblePinStorage.kt`/`NativeCompatibleStorage.kt`) and replacing the deprecated `MasterKeys` API — both larger, separate pieces of work.

## Tests

New `GuardedPromiseTest.kt` (JUnit4 + mockk) covers: resolve-then-resolve settles once, resolve-then-reject and reject-then-resolve don't cross-settle, both `reject` overloads (with/without throwable) dispatch correctly, and a concurrent race between two threads settling simultaneously results in exactly one delegate call.

No new JS tests — there is no JS-visible change; the existing `useAuthentication.test.tsx` and the full Jest/Android suites were re-verified and still pass.

## Verification

- `packages/bcsc-core`: `yarn build`, `yarn test:android`, `yarn lint:kotlin` all pass.
- Root `yarn check` (typecheck, lint, format, full Jest suite) passes.
- `app`: `yarn android:setup` produces no lockfile diff (no dependency was added).
- Confirmed in code (not just assumed) that the loading overlay covers both the resolve and reject paths of the unlock call — see Decisions above.
- This fix cannot be verified by unit tests; it needs a physical Android device with biometrics/device PIN enrolled. Manual on-device verification (by the requester, not part of this PR):
  - Unlock on a real device and confirm no ANR dialog appears.
  - Exercise the v3 migration path specifically (no stored PIN hash) — it does the heaviest work (210,000-iteration key derivation).
  - Confirm the loading animation is visible for the duration of the unlock.
  - Prefer testing on a lower-end device where the effect is most pronounced.
  - Confirm the app stays responsive on a device with existing account and issuer files on disk, so all three secure-keystore round trips are actually exercised.

Fixes #4440
