### PR TITLE
fix: prevent crash from missing cached video

### DIFF
--- a/.yarn/patches/react-native-fs-npm-2.20.0-a38fe24051.patch
+++ b/.yarn/patches/react-native-fs-npm-2.20.0-a38fe24051.patch
@@ -2,7 +2,7 @@ diff --git a/RNFSManager.m b/RNFSManager.m
 index 5ddd9417de101a0b18a298434dbc57f46b130f21..7bca62aadd52e2aa1575887965541c6972bcebb1 100755
 --- a/RNFSManager.m
 +++ b/RNFSManager.m
-@@ -294,8 +294,8 @@ RCT_EXPORT_METHOD(readFile:(NSString *)filepath
+@@ -294,8 +294,8 @@ + (BOOL)requiresMainQueueSetup
  }
  
  RCT_EXPORT_METHOD(read:(NSString *)filepath
@@ -13,3 +13,16 @@ index 5ddd9417de101a0b18a298434dbc57f46b130f21..7bca62aadd52e2aa1575887965541c69
                    resolver:(RCTPromiseResolveBlock)resolve
                    rejecter:(RCTPromiseRejectBlock)reject)
  {
+diff --git a/android/src/main/java/com/rnfs/RNFSManager.java b/android/src/main/java/com/rnfs/RNFSManager.java
+index 351ac066dd7936bba7f35627a0730db1dd272b2c..c350ddcc91ab280be7aa772bf1144edb7e746b85 100755
+--- a/android/src/main/java/com/rnfs/RNFSManager.java
++++ b/android/src/main/java/com/rnfs/RNFSManager.java
+@@ -975,7 +975,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
+       return;
+     }
+ 
+-    promise.reject(null, ex.getMessage());
++    promise.reject("RNFS", ex.getMessage());
+   }
+ 
+   private void rejectFileNotFound(Promise promise, String filepath) {

--- a/app/package.json
+++ b/app/package.json
@@ -111,7 +111,7 @@
     "react-native-confirmation-code-field": "~7.3.2",
     "react-native-device-info": "~8.7.1",
     "react-native-drop-shadow": "^1.0.3",
-    "react-native-fs": "~2.20.0",
+    "react-native-fs": "patch:react-native-fs@npm%3A2.20.0#~/.yarn/patches/react-native-fs-npm-2.20.0-a38fe24051.patch",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-get-random-values": "~1.11.0",
     "react-native-gifted-chat": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7816,7 +7816,7 @@ __metadata:
     react-native-confirmation-code-field: "npm:~7.3.2"
     react-native-device-info: "npm:~8.7.1"
     react-native-drop-shadow: "npm:^1.0.3"
-    react-native-fs: "npm:~2.20.0"
+    react-native-fs: "patch:react-native-fs@npm%3A2.20.0#~/.yarn/patches/react-native-fs-npm-2.20.0-a38fe24051.patch"
     react-native-gesture-handler: "npm:~2.28.0"
     react-native-get-random-values: "npm:~1.11.0"
     react-native-gifted-chat: "npm:*"
@@ -16511,7 +16511,7 @@ __metadata:
 
 "react-native-fs@patch:react-native-fs@npm%3A2.20.0#~/.yarn/patches/react-native-fs-npm-2.20.0-a38fe24051.patch":
   version: 2.20.0
-  resolution: "react-native-fs@patch:react-native-fs@npm%3A2.20.0#~/.yarn/patches/react-native-fs-npm-2.20.0-a38fe24051.patch::version=2.20.0&hash=6622c7"
+  resolution: "react-native-fs@patch:react-native-fs@npm%3A2.20.0#~/.yarn/patches/react-native-fs-npm-2.20.0-a38fe24051.patch::version=2.20.0&hash=b1f4bf"
   dependencies:
     base-64: "npm:^0.1.0"
     utf8: "npm:^3.0.0"
@@ -16521,7 +16521,7 @@ __metadata:
   peerDependenciesMeta:
     react-native-windows:
       optional: true
-  checksum: 10c0/bfb84f28551378aa22bac974609e382498ab47ee7e6eb653fd0edae46f49b028a08c3ead5c7d09bc5411eca297d0a6e82b0ab74855ffa0d8b5d51669b768746b
+  checksum: 10c0/69c20222fd7892eba27057023f3c942ed2d07266656fce664ef460f2907d362e6a48bc564931e2f3dbf511883b454547bbe66118ff0391765ba033763251ddab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary of Changes

This PR fixes a bug on Android that caused a fatal crash when the cached video was missing from the device (cache cleared).

# Testing Instructions

1. Record video verification (dont submit / confirm)
2. Android -> settings -> BCSC app -> storage -> clear cache
3. Submit video

# Acceptance Criteria

Error modal renders NOT a fatal crash.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues
issue: https://github.com/orgs/bcgov/projects/108/views/1?pane=issue&itemId=227179045&issue=bcgov%7Cbc-wallet-mobile%7C4439

new: https://github.com/orgs/bcgov/projects/108/views/1?pane=issue&itemId=228953740&issue=bcgov%7Cbc-wallet-mobile%7C4478
