### PR TITLE
fix: handle already approved evidence response

### DIFF
--- a/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
@@ -13,6 +13,7 @@ import {
   ClientErrorHandlingPolicies,
   digitalServiceCardAccountUnavailableErrorPolicy,
   emailVerificationCodeErrorPolicy,
+  evidenceAlreadyApprovedErrorPolicy,
   failedToRetrieveStringResourceErrorPolicy,
   globalAlertErrorPolicy,
   iasErrorPolicy,
@@ -968,6 +969,81 @@ describe('clientErrorPolicies', () => {
         expect(loggerMock.info).toHaveBeenCalledWith(
           '[AttestationPollingErrorPolicy] 400 or 404 expected during polling — attestation not yet consumed or already consumed'
         )
+      })
+    })
+  })
+
+  describe('evidenceAlreadyApprovedErrorPolicy', () => {
+    const evidenceBase = 'https://idsit.gov.bc.ca/evidence'
+
+    describe('matches', () => {
+      it.each([
+        [`${evidenceBase}/v1/photos`],
+        [`${evidenceBase}/v1/videos`],
+        [`${evidenceBase}/v1/documents`],
+        // The IAS-hosted binary PUT target handed back by the metadata responses
+        ['https://idsit.gov.bc.ca/video/v1/uploads/78be099e-0a51-48bb-8064-547755b6e2c7'],
+      ])('should match 409 on the evidence upload endpoint %s', (endpoint) => {
+        const error = newError('err_209_bad_request')
+        const context = { statusCode: 409, endpoint, apiEndpoints: { evidence: evidenceBase } }
+        expect(evidenceAlreadyApprovedErrorPolicy.matches(error, context as any)).toBeTruthy()
+      })
+
+      it.each([[`${evidenceBase}/v1/verifications/abc-123`], ['https://idsit.gov.bc.ca/device/token']])(
+        'should NOT match 409 on %s, so it keeps the generic modal',
+        (endpoint) => {
+          const error = newError('err_209_bad_request')
+          const context = { statusCode: 409, endpoint, apiEndpoints: { evidence: evidenceBase } }
+          expect(evidenceAlreadyApprovedErrorPolicy.matches(error, context as any)).toBeFalsy()
+        }
+      )
+
+      it('should NOT match other status codes on the evidence uploads', () => {
+        const error = newError('err_209_bad_request')
+        const context = {
+          statusCode: 400,
+          endpoint: `${evidenceBase}/v1/photos`,
+          apiEndpoints: { evidence: evidenceBase },
+        }
+        expect(evidenceAlreadyApprovedErrorPolicy.matches(error, context as any)).toBeFalsy()
+      })
+    })
+
+    describe('handle', () => {
+      it('should log expected info message', () => {
+        const error = newError('err_209_bad_request')
+        const loggerMock = { info: jest.fn() }
+        evidenceAlreadyApprovedErrorPolicy.handle(error, { logger: loggerMock } as any)
+
+        expect(loggerMock.info).toHaveBeenCalledWith(
+          '[EvidenceAlreadyApprovedErrorPolicy] Suppressing global alert — the upload catch block completes the verification'
+        )
+      })
+    })
+
+    describe('ClientErrorHandlingPolicies find', () => {
+      // CONFLICT is mapped to badRequestAlert in the IAS alert map, so this policy must be ordered
+      // ahead of iasErrorPolicy or the modal it exists to suppress would fire anyway.
+      it('should resolve to evidenceAlreadyApprovedErrorPolicy ahead of iasErrorPolicy', () => {
+        const error = newError('conflict')
+        const context = {
+          statusCode: 409,
+          endpoint: `${evidenceBase}/v1/photos`,
+          apiEndpoints: { evidence: evidenceBase },
+        }
+        const policy = ClientErrorHandlingPolicies.find((p) => p.matches(error, context as any))
+        expect(policy).toBe(evidenceAlreadyApprovedErrorPolicy)
+      })
+
+      it('should still resolve a non-evidence 409 to iasErrorPolicy', () => {
+        const error = newError('conflict')
+        const context = {
+          statusCode: 409,
+          endpoint: 'https://idsit.gov.bc.ca/device/token',
+          apiEndpoints: { evidence: evidenceBase },
+        }
+        const policy = ClientErrorHandlingPolicies.find((p) => p.matches(error, context as any))
+        expect(policy).toBe(iasErrorPolicy)
       })
     })
   })

--- a/app/src/bcsc-theme/api/clientErrorPolicies.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.ts
@@ -118,6 +118,7 @@ const _getIasErrorAlertMap = (alerts?: AppAlerts) => {
     [AppEventCode.ERR_210_UNAUTHORIZED, alerts?.unauthorizedAlert],
     [AppEventCode.FORBIDDEN, alerts?.forbiddenAlert],
     [AppEventCode.NOT_FOUND, alerts?.notFoundAlert],
+    [AppEventCode.CONFLICT, alerts?.badRequestAlert],
     [AppEventCode.ERR_211_SERVER_OUTAGE, alerts?.serverOutageAlert],
     [AppEventCode.ERR_212_RETRY_LATER, alerts?.retryLaterAlert],
     [AppEventCode.ERR_213_FAILED_CREATING_CLIENT_REGISTRATION, alerts?.creatingClientRegistrationFailedAlert],
@@ -308,6 +309,24 @@ export const emailVerificationCodeErrorPolicy: ErrorHandlingPolicy = {
   handle: (_error, context) => {
     context.logger.info(
       '[EmailVerificationCodeErrorPolicy] Suppressing global alert — confirmation screen will show inline error for invalid code'
+    )
+  },
+}
+
+// Error policy for the evidence uploads — backend answers 409 when the verification has already been approved,
+// so rather than show and error we should suppress and route to
+// VerificationSuccess
+//
+// V3 reads the same 409s this way (ias-android DocumentUploadViewModel ->
+// CreateSessionAlreadyVerifiedError)
+const EVIDENCE_UPLOAD_PATH_PATTERN = /\/v1\/(photos|videos|documents|uploads)\b/
+export const evidenceAlreadyApprovedErrorPolicy: ErrorHandlingPolicy = {
+  matches: (_, context) => {
+    return context.statusCode === 409 && EVIDENCE_UPLOAD_PATH_PATTERN.test(context.endpoint)
+  },
+  handle: (_error, context) => {
+    context.logger.info(
+      '[EvidenceAlreadyApprovedErrorPolicy] Suppressing global alert — the upload catch block completes the verification'
     )
   },
 }
@@ -609,6 +628,7 @@ export const ClientErrorHandlingPolicies: ErrorHandlingPolicy[] = [
   videoSessionErrorPolicy,
   attestationPollingErrorPolicy,
   emailVerificationCodeErrorPolicy,
+  evidenceAlreadyApprovedErrorPolicy,
   pairingCodeErrorPolicy,
   invalidClientMetadataErrorPolicy,
   iasErrorPolicy,

--- a/app/src/bcsc-theme/features/verify/live-call/hooks/useVideoCallFlow.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/hooks/useVideoCallFlow.tsx
@@ -1,7 +1,9 @@
 import { KEEP_ALIVE_INTERVAL_MS } from '@/constants'
+import { isAxiosAppError } from '@/errors/appError'
 import { Analytics } from '@/utils/analytics/analytics-singleton'
 import useApi from '@bcsc-theme/api/hooks/useApi'
 import { VideoCall, VideoSession } from '@bcsc-theme/api/hooks/useVideoCallApi'
+import useAlreadyVerifiedRecovery from '@bcsc-theme/hooks/useAlreadyVerifiedRecovery'
 import useEvidenceUpload from '@bcsc-theme/hooks/useEvidenceUpload'
 import { TOKENS, useServices } from '@bifold/core'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -25,6 +27,7 @@ import createVideoCallError from '../utils/createVideoCallError'
 // so analytics are consistent across both platforms
 const AnalyticsErrorCodeMap: Record<VideoCallErrorType, string> = {
   [VideoCallErrorType.DOCUMENT_UPLOAD_FAILED]: 'file_upload_error',
+  [VideoCallErrorType.ALREADY_VERIFIED]: 'already_verified',
   [VideoCallErrorType.SESSION_FAILED]: 'server_error',
   [VideoCallErrorType.CONNECTION_FAILED]: 'problem_with_connection',
   [VideoCallErrorType.CALL_FAILED]: 'problem_with_connection',
@@ -64,6 +67,7 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const { video } = useApi()
   const { uploadSelfiePhoto, processAdditionalEvidence, uploadEvidenceBinaries } = useEvidenceUpload()
+  const { recoverFromAlreadyVerified } = useAlreadyVerifiedRecovery()
   const { t } = useTranslation()
 
   // this value is watched to determine which background-related action to take
@@ -222,11 +226,20 @@ const useVideoCallFlow = (leaveCall: () => Promise<void>): VideoCallFlow => {
       const additionalEvidence = await processAdditionalEvidence()
       await uploadEvidenceBinaries(additionalEvidence)
     } catch (error) {
+      // 409 on the evidence endpoints means the registration request is already approved
+      if (isAxiosAppError(error, 409)) {
+        const recovered = await recoverFromAlreadyVerified()
+        if (!recovered) {
+          handleError(VideoCallErrorType.ALREADY_VERIFIED, error as Error)
+        }
+        return false
+      }
+
       handleError(VideoCallErrorType.DOCUMENT_UPLOAD_FAILED, error as Error)
       return false
     }
     return true
-  }, [uploadSelfiePhoto, processAdditionalEvidence, uploadEvidenceBinaries, handleError])
+  }, [uploadSelfiePhoto, processAdditionalEvidence, uploadEvidenceBinaries, handleError, recoverFromAlreadyVerified])
 
   // 1. a session must be created before call can begin
   const createSession = useCallback(async (): Promise<VideoSession | null> => {

--- a/app/src/bcsc-theme/features/verify/live-call/types/live-call.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/types/live-call.ts
@@ -12,6 +12,7 @@ export enum VideoCallErrorType {
   SESSION_FAILED = 'session_failed',
   CALL_FAILED = 'call_failed',
   DOCUMENT_UPLOAD_FAILED = 'document_upload_failed',
+  ALREADY_VERIFIED = 'already_verified',
   NETWORK_ERROR = 'network_error',
   PERMISSION_DENIED = 'permission_denied',
 }

--- a/app/src/bcsc-theme/features/verify/live-call/utils/createVideoCallError.ts
+++ b/app/src/bcsc-theme/features/verify/live-call/utils/createVideoCallError.ts
@@ -27,6 +27,15 @@ export const createVideoCallError = (type: VideoCallErrorType, technicalDetails?
         retryable: true,
         technicalDetails,
       }
+    // Evidence rejected as already received, pending approval
+    case VideoCallErrorType.ALREADY_VERIFIED:
+      return {
+        type,
+        title: 'Problem Checking Status',
+        message: 'We could not confirm your verification status. Please fully close the app and open it again.',
+        retryable: false,
+        technicalDetails,
+      }
     // API call to create call failed
     case VideoCallErrorType.CALL_FAILED:
       return {

--- a/app/src/bcsc-theme/features/verify/send-video/useEvidenceUploadModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/useEvidenceUploadModel.test.ts
@@ -1,10 +1,15 @@
 import useApi from '@/bcsc-theme/api/hooks/useApi'
 import useEvidenceUploadModel from '@/bcsc-theme/features/verify/send-video/useEvidenceUploadModel'
+import { BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { getVideoMetadata, removeFileSafely } from '@/bcsc-theme/utils/file-info'
+import { AppError, ErrorCategory } from '@/errors'
+import { AppEventCode } from '@/events/appEventCode'
 import { BCDispatchAction, BCState } from '@/store'
 import readFileInChunks from '@/utils/read-file'
 import * as Bifold from '@bifold/core'
+import * as Navigation from '@react-navigation/native'
 import { act, renderHook } from '@testing-library/react-native'
+import { AxiosError } from 'axios'
 import RNFS from 'react-native-fs'
 import { VerificationVideoCache } from './VideoReviewScreen'
 
@@ -51,10 +56,20 @@ jest.mock('@/bcsc-theme/hooks/useSecureActions', () => ({
 }))
 
 const mockFileUploadErrorAlert = jest.fn()
+const mockAlreadyVerifiedAlert = jest.fn()
 jest.mock('@/hooks/useAlerts', () => ({
   useAlerts: () => ({
     fileUploadErrorAlert: mockFileUploadErrorAlert,
+    alreadyVerifiedAlert: mockAlreadyVerifiedAlert,
   }),
+}))
+
+// Left unmocked so the real useAlreadyVerifiedRecovery runs and its navigation is asserted here;
+// only the token exchange it depends on is stubbed.
+const mockCheckVerificationStatus = jest.fn()
+jest.mock('@/bcsc-theme/services/hooks/useTokenService', () => ({
+  __esModule: true,
+  useTokenService: () => ({ checkVerificationStatus: mockCheckVerificationStatus }),
 }))
 
 describe('useEvidenceUploadModel', () => {
@@ -481,6 +496,99 @@ describe('useEvidenceUploadModel', () => {
 
       expect(mockFileUploadErrorAlert).toHaveBeenCalled()
       expect(mockEvidenceApi.uploadPhotoEvidenceBinary).not.toHaveBeenCalled()
+    })
+
+    describe('when the evidence endpoint rejects the upload as already approved (409)', () => {
+      // IAS returns 409 "Registration Request already approved" once the registration request behind
+      // the device_code is approved, so the upload is redundant rather than failed.
+      const conflictError = new AppError(
+        'Conflict',
+        { category: ErrorCategory.VERIFICATION, appEvent: AppEventCode.ALREADY_VERIFIED, statusCode: 2410 },
+        {
+          cause: new AxiosError('Conflict', 'ERR_BAD_REQUEST', undefined, undefined, { status: 409 } as any),
+          track: false,
+        }
+      )
+
+      const arrangeReadySend = () => {
+        const bifoldMock = jest.mocked(Bifold)
+        bifoldMock.useStore.mockReturnValue([
+          {
+            ...baseStore,
+            bcsc: {
+              ...baseStore.bcsc,
+              photoPath: '/photo.jpg',
+              videoPath: '/video.mp4',
+              videoDuration: 10,
+              prompts: [{ text: 'smile' }],
+              photoMetadata: plausiblePhotoMetadata,
+            },
+            bcscSecure: {
+              ...baseStore.bcscSecure,
+              verificationRequestId: 'req-123',
+              verificationRequestSha: 'sha-456',
+              deviceCode: 'device-code',
+              userCode: 'user-code',
+              additionalEvidenceData: [],
+            },
+          } as BCState,
+          jest.fn(),
+        ])
+
+        jest.mocked(readFileInChunks).mockResolvedValue(Buffer.from([1, 2, 3]))
+        jest.mocked(VerificationVideoCache.getCache).mockResolvedValue(Buffer.from([4, 5, 6]))
+        jest.mocked(RNFS.stat).mockResolvedValue({ mtime: new Date('2026-01-01') } as any)
+        jest.mocked(getVideoMetadata).mockResolvedValue({ duration: 10 } as any)
+        mockEvidenceApi.uploadVideoEvidenceMetadata.mockResolvedValue({ upload_uri: 'video-uri' })
+        mockEvidenceApi.uploadPhotoEvidenceMetadata.mockRejectedValue(conflictError)
+      }
+
+      it('attempts recovery and returns early without the file upload error modal', async () => {
+        arrangeReadySend()
+        mockCheckVerificationStatus.mockResolvedValue(true)
+
+        const { result } = renderHook(() => useEvidenceUploadModel(mockNavigation))
+
+        await act(async () => {
+          await result.current.handleSend()
+        })
+
+        expect(mockCheckVerificationStatus).toHaveBeenCalledWith('device-code', 'user-code')
+        expect(mockFileUploadErrorAlert).not.toHaveBeenCalled()
+        expect(mockEvidenceApi.uploadPhotoEvidenceBinary).not.toHaveBeenCalled()
+        expect(mockEvidenceApi.sendVerificationRequest).not.toHaveBeenCalled()
+      })
+
+      it('navigates to VerificationSuccess when recovery succeeds', async () => {
+        arrangeReadySend()
+        mockCheckVerificationStatus.mockResolvedValue(true)
+
+        const { result } = renderHook(() => useEvidenceUploadModel(mockNavigation))
+
+        await act(async () => {
+          await result.current.handleSend()
+        })
+
+        expect(Navigation.CommonActions.reset).toHaveBeenCalledWith(
+          expect.objectContaining({ routes: [{ name: BCSCScreens.VerificationSuccess }] })
+        )
+        expect(mockAlreadyVerifiedAlert).not.toHaveBeenCalled()
+      })
+
+      it('emits alreadyVerifiedAlert with the original error when recovery fails', async () => {
+        arrangeReadySend()
+        mockCheckVerificationStatus.mockResolvedValue(false)
+
+        const { result } = renderHook(() => useEvidenceUploadModel(mockNavigation))
+
+        await act(async () => {
+          await result.current.handleSend()
+        })
+
+        expect(mockAlreadyVerifiedAlert).toHaveBeenCalledWith(conflictError)
+        expect(mockFileUploadErrorAlert).not.toHaveBeenCalled()
+        expect(Navigation.CommonActions.reset).not.toHaveBeenCalled()
+      })
     })
 
     it('should emit fileUploadErrorAlert when binary upload fails', async () => {

--- a/app/src/bcsc-theme/features/verify/send-video/useEvidenceUploadModel.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/useEvidenceUploadModel.tsx
@@ -4,6 +4,7 @@ import {
   VerificationPrompt,
   VerificationVideoUploadPayload,
 } from '@/bcsc-theme/api/hooks/useEvidenceApi'
+import useAlreadyVerifiedRecovery from '@/bcsc-theme/hooks/useAlreadyVerifiedRecovery'
 import useEvidenceUpload from '@/bcsc-theme/hooks/useEvidenceUpload'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
@@ -11,6 +12,7 @@ import { withPlausibleCaptureDate } from '@/bcsc-theme/utils/capture-date'
 import { getVideoMetadata, removeFileSafely } from '@/bcsc-theme/utils/file-info'
 import { getResumeStepRoute } from '@/bcsc-theme/utils/resume-step-route'
 import { AppError, ErrorRegistry } from '@/errors'
+import { isAxiosAppError } from '@/errors/appError'
 import { useAlerts } from '@/hooks/useAlerts'
 import { BCDispatchAction, BCState } from '@/store'
 import readFileInChunks from '@/utils/read-file'
@@ -35,7 +37,8 @@ const useEvidenceUploadModel = (
   const [isUploading, setIsUploading] = useState(false)
   const [isCancelling, setIsCancelling] = useState(false)
   const [uploadMessage, setUploadMessage] = useState<string | null>(null)
-  const { fileUploadErrorAlert } = useAlerts(navigation)
+  const { fileUploadErrorAlert, alreadyVerifiedAlert } = useAlerts(navigation)
+  const { recoverFromAlreadyVerified } = useAlreadyVerifiedRecovery()
 
   const { photoPath, videoPath, videoThumbnailPath, videoDuration, prompts, photoMetadata } = store.bcsc
   const { verificationRequestId, verificationRequestSha } = store.bcscSecure
@@ -219,6 +222,16 @@ const useEvidenceUploadModel = (
       if (isCancelledRef.current) {
         return
       }
+
+      // 409 on the evidence endpoints means the registration request is already approved
+      if (isAxiosAppError(error, 409)) {
+        const recovered = await recoverFromAlreadyVerified()
+        if (!recovered) {
+          alreadyVerifiedAlert(error)
+        }
+        return
+      }
+
       /**
        * Dev note: evidence_upload_server_error + evidence_upload_unkown_error are both deprecated in the IAS documentation.
        * So all errors during the upload process will be categorized as FILE_UPLOAD_ERROR.
@@ -231,10 +244,12 @@ const useEvidenceUploadModel = (
       setUploadMessage(null)
     }
   }, [
+    alreadyVerifiedAlert,
     dispatch,
     fileUploadErrorAlert,
     finalizeVerification,
     logger,
+    recoverFromAlreadyVerified,
     navigation,
     photoMetadata,
     photoPath,

--- a/app/src/bcsc-theme/hooks/useAlreadyVerifiedRecovery.test.tsx
+++ b/app/src/bcsc-theme/hooks/useAlreadyVerifiedRecovery.test.tsx
@@ -1,0 +1,86 @@
+import { BCSCScreens } from '@/bcsc-theme/types/navigators'
+import * as Bifold from '@bifold/core'
+import * as Navigation from '@react-navigation/native'
+import { renderHook } from '@testing-library/react-native'
+import useAlreadyVerifiedRecovery from './useAlreadyVerifiedRecovery'
+
+const mockCheckVerificationStatus = jest.fn()
+// Factory mock (not automock) so the real token service — and the store module it pulls in — is
+// never loaded, which the wholesale @bifold/core mock below would break.
+jest.mock('@/bcsc-theme/services/hooks/useTokenService', () => ({
+  __esModule: true,
+  useTokenService: () => ({ checkVerificationStatus: mockCheckVerificationStatus }),
+}))
+jest.mock('@bifold/core', () => ({
+  __esModule: true,
+  TOKENS: { UTIL_LOGGER: 'UTIL_LOGGER' },
+  useServices: jest.fn(),
+  useStore: jest.fn(),
+}))
+jest.mock('@/contexts/NavigationContainerContext', () => ({
+  navigationRef: { isReady: () => false, getCurrentRoute: () => undefined },
+}))
+
+// The repo's manual @react-navigation/native mock exposes CommonActions.reset as a jest.fn, so the
+// navigation intent is asserted there rather than on the shared navigation object's dispatch.
+const mockReset = Navigation.CommonActions.reset as jest.Mock
+
+const mockLogger = { error: jest.fn(), debug: jest.fn(), info: jest.fn(), warn: jest.fn() }
+
+const setStore = (bcscSecure: Record<string, unknown>) => {
+  jest.mocked(Bifold).useStore.mockReturnValue([{ bcscSecure }, jest.fn()] as any)
+}
+
+describe('useAlreadyVerifiedRecovery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.mocked(Bifold).useServices.mockReturnValue([mockLogger] as any)
+    setStore({ deviceCode: 'device-code', userCode: 'user-code' })
+  })
+
+  describe('recoverFromAlreadyVerified', () => {
+    it('fetches tokens and resets to the success screen when the user is verified', async () => {
+      mockCheckVerificationStatus.mockResolvedValue(true)
+
+      const { result } = renderHook(() => useAlreadyVerifiedRecovery())
+      const recovered = await result.current.recoverFromAlreadyVerified()
+
+      expect(mockCheckVerificationStatus).toHaveBeenCalledWith('device-code', 'user-code')
+      expect(recovered).toBe(true)
+      expect(mockReset).toHaveBeenCalledWith(
+        expect.objectContaining({ routes: [{ name: BCSCScreens.VerificationSuccess }] })
+      )
+    })
+
+    it('returns false without navigating when the tokens are not yet issuable', async () => {
+      mockCheckVerificationStatus.mockResolvedValue(false)
+
+      const { result } = renderHook(() => useAlreadyVerifiedRecovery())
+      const recovered = await result.current.recoverFromAlreadyVerified()
+
+      expect(recovered).toBe(false)
+      expect(mockReset).not.toHaveBeenCalled()
+    })
+
+    it('returns false without navigating when the token exchange throws', async () => {
+      mockCheckVerificationStatus.mockRejectedValue(new Error('network'))
+
+      const { result } = renderHook(() => useAlreadyVerifiedRecovery())
+      const recovered = await result.current.recoverFromAlreadyVerified()
+
+      expect(recovered).toBe(false)
+      expect(mockReset).not.toHaveBeenCalled()
+    })
+
+    it('returns false without calling the token endpoint when the device codes are missing', async () => {
+      setStore({})
+
+      const { result } = renderHook(() => useAlreadyVerifiedRecovery())
+      const recovered = await result.current.recoverFromAlreadyVerified()
+
+      expect(recovered).toBe(false)
+      expect(mockCheckVerificationStatus).not.toHaveBeenCalled()
+      expect(mockReset).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/app/src/bcsc-theme/hooks/useAlreadyVerifiedRecovery.tsx
+++ b/app/src/bcsc-theme/hooks/useAlreadyVerifiedRecovery.tsx
@@ -1,0 +1,60 @@
+import { useTokenService } from '@/bcsc-theme/services/hooks/useTokenService'
+import { BCSCScreens } from '@/bcsc-theme/types/navigators'
+import { BCState } from '@/store'
+import { TOKENS, useServices, useStore } from '@bifold/core'
+import { CommonActions, useNavigation } from '@react-navigation/native'
+import { useCallback } from 'react'
+
+/**
+ * Recovery hook for evidence uploads that IAS rejects with 409 "Registration Request already approved".
+ * V3 handles the same 409 this way (ias-android DocumentUploadViewModel ->
+ * CreateSessionAlreadyVerifiedError).
+ */
+export const useAlreadyVerifiedRecovery = () => {
+  const navigation = useNavigation()
+  const [store] = useStore<BCState>()
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const tokenService = useTokenService()
+
+  /**
+   * Exchanges the device code for tokens and sends the user to the success screen.
+   *
+   * Returns false — leaving the caller to surface its own message — when the approval hasn't
+   * propagated to the token endpoint yet, or when the exchange fails outright.
+   *
+   * @returns True if the user was navigated to VerificationSuccess
+   */
+  const recoverFromAlreadyVerified = useCallback(async (): Promise<boolean> => {
+    const { deviceCode, userCode } = store.bcscSecure
+
+    if (!deviceCode || !userCode) {
+      logger.error('[useAlreadyVerifiedRecovery] Cannot complete verification: missing device code or user code')
+      return false
+    }
+
+    try {
+      const isVerified = await tokenService.checkVerificationStatus(deviceCode, userCode)
+
+      if (!isVerified) {
+        logger.warn('[useAlreadyVerifiedRecovery] Evidence already submitted but still pending')
+        return false
+      }
+
+      logger.info('[useAlreadyVerifiedRecovery] Evidence already approved; navigating to verification success')
+      navigation.dispatch(
+        CommonActions.reset({
+          index: 0,
+          routes: [{ name: BCSCScreens.VerificationSuccess }],
+        })
+      )
+      return true
+    } catch (error) {
+      logger.error('[useAlreadyVerifiedRecovery] Failed to complete verification after 409', error as Error)
+      return false
+    }
+  }, [logger, navigation, store.bcscSecure, tokenService])
+
+  return { recoverFromAlreadyVerified }
+}
+
+export default useAlreadyVerifiedRecovery

--- a/app/src/bcsc-theme/utils/axios-error-utils.test.ts
+++ b/app/src/bcsc-theme/utils/axios-error-utils.test.ts
@@ -218,7 +218,7 @@ describe('Error Utils', () => {
       [403, 'forbidden'],
       [404, 'not_found'],
       [429, 'err_212_retry_later'],
-      [409, 'already_verified'], // evidence rejected because the registration request is already approved
+      [409, 'conflict'], // evidence uploads suppress the modal via policy; the code stays generic
       [422, 'err_209_bad_request'], // unmapped 4xx falls back to BAD_REQUEST
     ])('BAD_REQUEST with status %s should resolve to appEvent "%s"', (status, expectedAppEvent) => {
       const errorDefinition = getAxiosErrorDefinition('ERR_BAD_REQUEST', status)

--- a/app/src/bcsc-theme/utils/axios-error-utils.test.ts
+++ b/app/src/bcsc-theme/utils/axios-error-utils.test.ts
@@ -218,7 +218,8 @@ describe('Error Utils', () => {
       [403, 'forbidden'],
       [404, 'not_found'],
       [429, 'err_212_retry_later'],
-      [409, 'err_209_bad_request'], // unmapped 4xx falls back to BAD_REQUEST
+      [409, 'already_verified'], // evidence rejected because the registration request is already approved
+      [422, 'err_209_bad_request'], // unmapped 4xx falls back to BAD_REQUEST
     ])('BAD_REQUEST with status %s should resolve to appEvent "%s"', (status, expectedAppEvent) => {
       const errorDefinition = getAxiosErrorDefinition('ERR_BAD_REQUEST', status)
 

--- a/app/src/bcsc-theme/utils/axios-error-utils.ts
+++ b/app/src/bcsc-theme/utils/axios-error-utils.ts
@@ -198,6 +198,8 @@ const getClientErrorDefinitionFromStatus = (status?: number): ErrorDefinition =>
       return ErrorRegistry.FORBIDDEN
     case 404:
       return ErrorRegistry.NOT_FOUND
+    case 409:
+      return ErrorRegistry.ALREADY_VERIFIED
     case 429:
       return ErrorRegistry.RETRY_LATER
     default:

--- a/app/src/bcsc-theme/utils/axios-error-utils.ts
+++ b/app/src/bcsc-theme/utils/axios-error-utils.ts
@@ -199,7 +199,7 @@ const getClientErrorDefinitionFromStatus = (status?: number): ErrorDefinition =>
     case 404:
       return ErrorRegistry.NOT_FOUND
     case 409:
-      return ErrorRegistry.ALREADY_VERIFIED
+      return ErrorRegistry.CONFLICT
     case 429:
       return ErrorRegistry.RETRY_LATER
     default:

--- a/app/src/errors/errorRegistry.ts
+++ b/app/src/errors/errorRegistry.ts
@@ -514,7 +514,7 @@ export const ErrorRegistry = {
     appEvent: AppEventCode.ALREADY_VERIFIED,
     severity: ErrorSeverity.INFO,
     category: ErrorCategory.VERIFICATION,
-    message: 'Verification request was already completed in a previous session',
+    message: 'Registration request already approved — verification completed outside this session',
   },
   AUTHORIZATION_PENDING: {
     statusCode: 2411,

--- a/app/src/errors/errorRegistry.ts
+++ b/app/src/errors/errorRegistry.ts
@@ -237,6 +237,13 @@ export const ErrorRegistry = {
     category: ErrorCategory.NETWORK,
     message: 'Server returned 404 — requested resource or endpoint was not found',
   },
+  CONFLICT: {
+    statusCode: 2114,
+    appEvent: AppEventCode.CONFLICT,
+    severity: ErrorSeverity.ERROR,
+    category: ErrorCategory.NETWORK,
+    message: 'Server returned 409 — request conflicts with the current state of the resource',
+  },
 
   // ============================================
   // Authentication/Login Errors (2200-2299)

--- a/app/src/events/appEventCode.ts
+++ b/app/src/events/appEventCode.ts
@@ -110,6 +110,7 @@ export enum AppEventCode {
   ERR_210_UNAUTHORIZED = 'err_210_unauthorized',
   FORBIDDEN = 'forbidden',
   NOT_FOUND = 'not_found',
+  CONFLICT = 'conflict',
   ERR_212_RETRY_LATER = 'err_212_retry_later',
   ERR_211_SERVER_OUTAGE = 'err_211_server_outage',
   ERR_213_FAILED_CREATING_CLIENT_REGISTRATION = 'err_213_failed_creating_client_registration',


### PR DESCRIPTION
# Summary of Changes

Fixes a bug where users could get into a state where they were attempting to submit evidence after they had already been approved. The bug is worse in 4.0.2, we've partially addressed it already in main, this addresses the remaining broken paths.

# Testing Instructions

Fresh install, don't enable notifications, do an in-person verification and approve yourself but don't press "Complete", instead navigate back to the "Choose verification method" screen and do a send video. On main, you should get a 409 error, on this branch you should get fast forwarded to approval.

# Acceptance Criteria

No longer get 409

# Screenshots, videos, or gifs

N/A

# Related Issues

#4475 