### PR TITLE
fix: 2113 error upgrading from V4.0.2 -> V4.1.0

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useEvidenceApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useEvidenceApi.tsx
@@ -9,6 +9,10 @@ import { createPreVerificationJWT, EvidenceType } from 'react-native-bcsc-core'
 import BCSCApiClient from '../client'
 import { withAccount } from './withAccountGuard'
 
+export interface EvidenceApiOptions {
+  skipOnErrorHandler?: boolean
+}
+
 export interface VerificationPrompt {
   id: number
   prompt: string
@@ -265,8 +269,15 @@ const useEvidenceApi = (apiClient: BCSCApiClient) => {
     [_getDeviceCode, apiClient]
   )
 
+  /**
+   * Fetches the status of a verification request by its ID and handles errors appropriately.
+   * TODO (MD): deprecate `options` once all callsites use `useEvidenceService` instead of `useEvidenceApi`.
+   * @param verificationRequestId - The ID of the verification request to check.
+   * @param options - Optional configuration for the API call.
+   * @returns Promise resolving to the verification status response data.
+   */
   const getVerificationRequestStatus = useCallback(
-    async (verificationRequestId: string): Promise<VerificationStatusResponseData> => {
+    async (verificationRequestId: string, options?: EvidenceApiOptions): Promise<VerificationStatusResponseData> => {
       return withAccount(async (account) => {
         const token = await createPreVerificationJWT(_getDeviceCode(), account.clientID)
         const { data } = await apiClient.get<VerificationStatusResponseData>(
@@ -276,6 +287,7 @@ const useEvidenceApi = (apiClient: BCSCApiClient) => {
               Authorization: `Bearer ${token}`,
             },
             skipBearerAuth: true,
+            skipOnErrorHandler: options?.skipOnErrorHandler,
           }
         )
         await cancelRemindersOnTerminalStatus(data)

--- a/app/src/bcsc-theme/features/verification-response/useVerificationResponseListener.test.tsx
+++ b/app/src/bcsc-theme/features/verification-response/useVerificationResponseListener.test.tsx
@@ -55,12 +55,15 @@ const mockCheckDeviceCodeStatus = jest.fn().mockResolvedValue({
 jest.mock('@/bcsc-theme/api/hooks/useApi', () => ({
   __esModule: true,
   default: () => ({
-    evidence: {
-      getVerificationRequestStatus: mockGetVerificationRequestStatus,
-    },
     token: {
       checkDeviceCodeStatus: mockCheckDeviceCodeStatus,
     },
+  }),
+}))
+
+jest.mock('@/bcsc-theme/services/hooks/useEvidenceService', () => ({
+  useEvidenceService: () => ({
+    getVerificationRequestStatus: mockGetVerificationRequestStatus,
   }),
 }))
 

--- a/app/src/bcsc-theme/features/verification-response/useVerificationResponseListener.tsx
+++ b/app/src/bcsc-theme/features/verification-response/useVerificationResponseListener.tsx
@@ -3,6 +3,7 @@ import {
   useVerificationResponseService,
   VerificationResponseNavigationEvent,
 } from '@/bcsc-theme/features/verification-response'
+import { useEvidenceService } from '@/bcsc-theme/services/hooks/useEvidenceService'
 import { BCDispatchAction, BCState } from '@/store'
 import { TOKENS, useServices, useStore } from '@bifold/core'
 import { useCallback, useEffect } from 'react'
@@ -28,7 +29,8 @@ import { useCallback, useEffect } from 'react'
 export const useVerificationResponseListener = () => {
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const [store, dispatch] = useStore<BCState>()
-  const { evidence, token } = useApi()
+  const { token } = useApi()
+  const evidenceService = useEvidenceService()
   const verificationResponseService = useVerificationResponseService()
 
   /**
@@ -52,7 +54,7 @@ export const useVerificationResponseListener = () => {
 
       // Check the verification request status (same as Check Status button)
       logger.info('[useVerificationResponseListener] Checking verification request status')
-      const { status, status_message } = await evidence.getVerificationRequestStatus(verificationRequestId)
+      const { status, status_message } = await evidenceService.getVerificationRequestStatus(verificationRequestId)
       logger.info(`[useVerificationResponseListener] Verification request status: ${status}`)
 
       if (status === 'verified') {
@@ -84,7 +86,7 @@ export const useVerificationResponseListener = () => {
       const message = error instanceof Error ? error.message : String(error)
       logger.error(`[useVerificationResponseListener] Failed to handle request reviewed: ${message}`)
     }
-  }, [logger, store.bcscSecure, evidence, token, dispatch])
+  }, [logger, store.bcscSecure, evidenceService, token, dispatch])
 
   /**
    * Route the event to the appropriate handler based on event type.

--- a/app/src/bcsc-theme/hooks/useCreateSystemChecks.test.tsx
+++ b/app/src/bcsc-theme/hooks/useCreateSystemChecks.test.tsx
@@ -14,7 +14,7 @@ export const mockUseBCSCApiClientState = jest.fn()
 export const mockUseTokenApi = jest.fn()
 export const mockUseConfigApi = jest.fn()
 export const mockUseRegistrationApi = jest.fn()
-export const mockUseEvidenceApi = jest.fn()
+export const mockUseEvidenceService = jest.fn()
 export const mockUseNavigation = jest.fn()
 export const mockUseNavigationContainer = jest.fn()
 export const mockGetBundleId = jest.fn()
@@ -37,7 +37,9 @@ jest.mock('@/bcsc-theme/hooks/useBCSCApiClient', () => ({
 jest.mock('@/bcsc-theme/api/hooks/useTokens', () => () => mockUseTokenApi())
 jest.mock('../api/hooks/useConfigApi', () => () => mockUseConfigApi())
 jest.mock('../api/hooks/useRegistrationApi', () => () => mockUseRegistrationApi())
-jest.mock('../api/hooks/useEvidenceApi', () => () => mockUseEvidenceApi())
+jest.mock('../services/hooks/useEvidenceService', () => ({
+  useEvidenceService: () => mockUseEvidenceService(),
+}))
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -444,7 +446,7 @@ describe('useGetSystemChecks', () => {
       it('is not added when there is no verificationRequestId', async () => {
         mockStoreWith({ verificationRequestId: undefined })
         mockUseTokenApi.mockReturnValue({ getCachedIdTokenMetadata: jest.fn() })
-        mockUseEvidenceApi.mockReturnValue({ getVerificationRequestStatus: jest.fn() })
+        mockUseEvidenceService.mockReturnValue({ getVerificationRequestStatus: jest.fn() })
 
         const { result } = renderHook(() => useCreateSystemChecks())
         const systemChecks = await result.current[SystemCheckScope.MAIN_STACK].getSystemChecks()
@@ -455,7 +457,7 @@ describe('useGetSystemChecks', () => {
       it('is not added once the user is verified, even with a verificationRequestId', async () => {
         mockStoreWith({ verified: true, verificationRequestId: 'req-1' })
         mockUseTokenApi.mockReturnValue({ getCachedIdTokenMetadata: jest.fn() })
-        mockUseEvidenceApi.mockReturnValue({ getVerificationRequestStatus: jest.fn() })
+        mockUseEvidenceService.mockReturnValue({ getVerificationRequestStatus: jest.fn() })
 
         const { result } = renderHook(() => useCreateSystemChecks())
         const systemChecks = await result.current[SystemCheckScope.MAIN_STACK].getSystemChecks()
@@ -466,7 +468,7 @@ describe('useGetSystemChecks', () => {
       it('is added when unverified with a pending verificationRequestId', async () => {
         mockStoreWith({ verificationRequestId: 'req-1', deviceCode: 'device-1', userCode: 'user-1' })
         mockUseTokenApi.mockReturnValue({ getCachedIdTokenMetadata: jest.fn(), checkDeviceCodeStatus: jest.fn() })
-        mockUseEvidenceApi.mockReturnValue({ getVerificationRequestStatus: jest.fn() })
+        mockUseEvidenceService.mockReturnValue({ getVerificationRequestStatus: jest.fn() })
 
         const { result } = renderHook(() => useCreateSystemChecks())
         const systemChecks = await result.current[SystemCheckScope.MAIN_STACK].getSystemChecks()
@@ -478,7 +480,7 @@ describe('useGetSystemChecks', () => {
         mockStoreWith({ verificationRequestId: 'req-1', deviceCode: 'device-1', userCode: 'user-1' })
         mockUseTokenApi.mockReturnValue({ getCachedIdTokenMetadata: jest.fn(), checkDeviceCodeStatus: jest.fn() })
         const getVerificationRequestStatus = jest.fn().mockResolvedValue({ status: 'pending' })
-        mockUseEvidenceApi.mockReturnValue({ getVerificationRequestStatus })
+        mockUseEvidenceService.mockReturnValue({ getVerificationRequestStatus })
 
         const { result } = renderHook(() => useCreateSystemChecks())
         const systemChecks = await result.current[SystemCheckScope.MAIN_STACK].getSystemChecks()
@@ -493,7 +495,7 @@ describe('useGetSystemChecks', () => {
         mockStoreWith({ verificationRequestId: 'req-1', deviceCode: undefined, userCode: undefined })
         const checkDeviceCodeStatus = jest.fn()
         mockUseTokenApi.mockReturnValue({ getCachedIdTokenMetadata: jest.fn(), checkDeviceCodeStatus })
-        mockUseEvidenceApi.mockReturnValue({ getVerificationRequestStatus: jest.fn() })
+        mockUseEvidenceService.mockReturnValue({ getVerificationRequestStatus: jest.fn() })
 
         const { result } = renderHook(() => useCreateSystemChecks())
         const systemChecks = await result.current[SystemCheckScope.MAIN_STACK].getSystemChecks()
@@ -509,7 +511,7 @@ describe('useGetSystemChecks', () => {
         mockStoreWith({ verificationRequestId: 'req-1', deviceCode: 'device-1', userCode: 'user-1' })
         const checkDeviceCodeStatus = jest.fn().mockResolvedValue(undefined)
         mockUseTokenApi.mockReturnValue({ getCachedIdTokenMetadata: jest.fn(), checkDeviceCodeStatus })
-        mockUseEvidenceApi.mockReturnValue({ getVerificationRequestStatus: jest.fn() })
+        mockUseEvidenceService.mockReturnValue({ getVerificationRequestStatus: jest.fn() })
 
         const { result } = renderHook(() => useCreateSystemChecks())
         const systemChecks = await result.current[SystemCheckScope.MAIN_STACK].getSystemChecks()
@@ -529,7 +531,7 @@ describe('useGetSystemChecks', () => {
         })
         const checkDeviceCodeStatus = jest.fn()
         mockUseTokenApi.mockReturnValue({ getCachedIdTokenMetadata: jest.fn(), checkDeviceCodeStatus })
-        mockUseEvidenceApi.mockReturnValue({ getVerificationRequestStatus: jest.fn() })
+        mockUseEvidenceService.mockReturnValue({ getVerificationRequestStatus: jest.fn() })
 
         const { result } = renderHook(() => useCreateSystemChecks())
         const systemChecks = await result.current[SystemCheckScope.MAIN_STACK].getSystemChecks()
@@ -559,7 +561,7 @@ describe('useGetSystemChecks', () => {
         jest.spyOn(React, 'useContext').mockReturnValue({ account: null })
         mockUseConfigApi.mockReturnValue({ getTermsOfUse: jest.fn() })
         mockUseRegistrationApi.mockReturnValue({})
-        mockUseEvidenceApi.mockReturnValue({ getVerificationRequestStatus: jest.fn() })
+        mockUseEvidenceService.mockReturnValue({ getVerificationRequestStatus: jest.fn() })
       }
 
       it('is not added when there is no pending deviceCode/userCode', async () => {

--- a/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
+++ b/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
@@ -30,9 +30,9 @@ import { getMaxDevicesBannerLastDisplayedDate } from 'react-native-bcsc-core'
 import { getBundleId } from 'react-native-device-info'
 import { SystemCheckStrategy } from '../../services/system-checks/system-checks'
 import useConfigApi from '../api/hooks/useConfigApi'
-import useEvidenceApi from '../api/hooks/useEvidenceApi'
 import useTokenApi from '../api/hooks/useTokens'
 import { BCSCAccountContext } from '../contexts/BCSCAccountContext'
+import { useEvidenceService } from '../services/hooks/useEvidenceService'
 import { useRegistrationService } from '../services/hooks/useRegistrationService'
 import { useTokenService } from '../services/hooks/useTokenService'
 import { SystemCheckScope } from './useSystemChecks'
@@ -66,7 +66,7 @@ export const useCreateSystemChecks = (): UseGetSystemChecksReturn => {
   const [store, dispatch] = useStore<BCState>()
   const { client, isClientReady } = useBCSCApiClientState()
   const configApi = useConfigApi(client as BCSCApiClient)
-  const evidenceApi = useEvidenceApi(client as BCSCApiClient)
+  const evidenceService = useEvidenceService()
   const tokenApi = useTokenApi(client as BCSCApiClient)
   const tokenService = useTokenService()
   const registrationService = useRegistrationService()
@@ -172,7 +172,7 @@ export const useCreateSystemChecks = (): UseGetSystemChecksReturn => {
       const { deviceCode, userCode } = store.bcscSecure
       systemChecks.push(
         new VerificationRequestStatusSystemCheck(
-          () => evidenceApi.getVerificationRequestStatus(verificationRequestId),
+          () => evidenceService.getVerificationRequestStatus(verificationRequestId),
           () => {
             if (!deviceCode || !userCode) {
               return Promise.reject(new Error('Missing deviceCode or userCode for verification token exchange'))
@@ -227,20 +227,20 @@ export const useCreateSystemChecks = (): UseGetSystemChecksReturn => {
   }, [
     isVerified,
     verificationRequestId,
-    evidenceApi,
-    tokenApi,
-    utils,
-    emitAlert,
-    navigation,
-    isBCServicesCardBundle,
-    tokenService,
-    registrationService,
-    configApi,
     store.bcscSecure,
+    store.bcsc.acceptedTermsOfUseVersion,
     store.bcsc.selectedNickname,
     store.bcsc.appVersion,
     store.bcsc.appBuildNumber,
-    store.bcsc.acceptedTermsOfUseVersion,
+    navigation,
+    utils,
+    isBCServicesCardBundle,
+    tokenService,
+    registrationService,
+    emitAlert,
+    evidenceService,
+    tokenApi,
+    configApi,
   ])
 
   /**

--- a/app/src/bcsc-theme/services/hooks/useEvidenceService.test.tsx
+++ b/app/src/bcsc-theme/services/hooks/useEvidenceService.test.tsx
@@ -1,9 +1,11 @@
 import useEvidenceApi from '@/bcsc-theme/api/hooks/useEvidenceApi'
 import { useBCSCApiClientState } from '@/bcsc-theme/hooks/useBCSCApiClient'
+import { BCSCModals } from '@/bcsc-theme/types/navigators'
 import { AppError, ErrorCategory } from '@/errors'
 import { AppEventCode } from '@/events/appEventCode'
 import * as Bifold from '@bifold/core'
 import { mockAppError } from '@mocks/helpers/error'
+import { CommonActions, useNavigation } from '@react-navigation/native'
 import { renderHook } from '@testing-library/react-native'
 import { AxiosError } from 'axios'
 import { useEvidenceService } from './useEvidenceService'
@@ -31,7 +33,12 @@ jest.mock('@/bcsc-theme/hooks/useSecureActions', () => ({
 
 const mockServerErrorAlert = jest.fn()
 const mockUnknownErrorModal = jest.fn()
-const mockAlerts = { serverErrorAlert: mockServerErrorAlert, unknownErrorModal: mockUnknownErrorModal }
+const mockAppUpdateRequiredAlert = jest.fn()
+const mockAlerts = {
+  serverErrorAlert: mockServerErrorAlert,
+  unknownErrorModal: mockUnknownErrorModal,
+  appUpdateRequiredAlert: mockAppUpdateRequiredAlert,
+}
 jest.mock('@/hooks/useAlerts', () => ({
   ...jest.requireActual('@/hooks/useAlerts'),
   useAlerts: () => mockAlerts,
@@ -50,9 +57,19 @@ const notFoundError = new AppError(
   { cause: new AxiosError('Not Found', 'ERR_BAD_REQUEST', undefined, undefined, { status: 404 } as any), track: false }
 )
 
+const unauthorizedError = new AppError(
+  'Unauthorized',
+  { category: ErrorCategory.NETWORK, appEvent: AppEventCode.ERR_210_UNAUTHORIZED, statusCode: 2110 },
+  {
+    cause: new AxiosError('Unauthorized', 'ERR_BAD_REQUEST', undefined, undefined, { status: 401 } as any),
+    track: false,
+  }
+)
+
 describe('useEvidenceService', () => {
   const mockEvidenceApi = {
     cancelVerificationRequest: jest.fn(),
+    getVerificationRequestStatus: jest.fn(),
   }
 
   beforeEach(() => {
@@ -117,6 +134,97 @@ describe('useEvidenceService', () => {
       expect(mockUnknownErrorModal).toHaveBeenCalledWith(mockError)
       expect(mockUpdateVerificationRequest).not.toHaveBeenCalled()
     })
+
+    it('should navigate to the VerificationSessionExpired modal for a 401 error, without showing an alert', async () => {
+      mockEvidenceApi.cancelVerificationRequest.mockRejectedValue(unauthorizedError)
+      const navigation = useNavigation()
+
+      const { result } = renderHook(() => useEvidenceService())
+
+      await expect(result.current.cancelVerificationRequest('verification-id')).rejects.toThrow(unauthorizedError)
+      expect(navigation.dispatch).toHaveBeenCalledWith(
+        CommonActions.navigate({ name: BCSCModals.VerificationSessionExpired })
+      )
+      expect(mockServerErrorAlert).not.toHaveBeenCalled()
+      expect(mockUnknownErrorModal).not.toHaveBeenCalled()
+      expect(mockUpdateVerificationRequest).not.toHaveBeenCalled()
+    })
+
+    it('should show the app update alert for an iOS app-update-required error', async () => {
+      const mockError = mockAppError(AppEventCode.IOS_APP_UPDATE_REQUIRED)
+      mockEvidenceApi.cancelVerificationRequest.mockRejectedValue(mockError)
+
+      const { result } = renderHook(() => useEvidenceService())
+
+      await expect(result.current.cancelVerificationRequest('verification-id')).rejects.toThrow(mockError)
+      expect(mockAppUpdateRequiredAlert).toHaveBeenCalled()
+      expect(mockServerErrorAlert).not.toHaveBeenCalled()
+    })
+
+    it('should show the app update alert for an Android app-update-required error', async () => {
+      const mockError = mockAppError(AppEventCode.ANDROID_APP_UPDATE_REQUIRED)
+      mockEvidenceApi.cancelVerificationRequest.mockRejectedValue(mockError)
+
+      const { result } = renderHook(() => useEvidenceService())
+
+      await expect(result.current.cancelVerificationRequest('verification-id')).rejects.toThrow(mockError)
+      expect(mockAppUpdateRequiredAlert).toHaveBeenCalled()
+      expect(mockServerErrorAlert).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getVerificationRequestStatus', () => {
+    it('should call evidenceApi.getVerificationRequestStatus with skipOnErrorHandler and return the data', async () => {
+      const mockData = { id: 'verification-id', status: 'verified' }
+      mockEvidenceApi.getVerificationRequestStatus.mockResolvedValue(mockData)
+
+      const { result } = renderHook(() => useEvidenceService())
+
+      const data = await result.current.getVerificationRequestStatus('verification-id')
+
+      expect(mockEvidenceApi.getVerificationRequestStatus).toHaveBeenCalledWith('verification-id', {
+        skipOnErrorHandler: true,
+      })
+      expect(data).toEqual(mockData)
+    })
+
+    it('should clear the verification request and return a cancelled status when the request is not found (404)', async () => {
+      mockEvidenceApi.getVerificationRequestStatus.mockRejectedValue(notFoundError)
+
+      const { result } = renderHook(() => useEvidenceService())
+
+      const data = await result.current.getVerificationRequestStatus('verification-id')
+
+      expect(mockUpdateVerificationRequest).toHaveBeenCalledWith(undefined, null)
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Verification request not found for ID: verification-id')
+      )
+      expect(mockServerErrorAlert).not.toHaveBeenCalled()
+      expect(data).toEqual({ id: 'verification-id', status: 'cancelled' })
+    })
+
+    it('should show an alert and rethrow the error for non-404 errors', async () => {
+      const mockError = mockAppError(AppEventCode.SERVER_ERROR)
+      mockEvidenceApi.getVerificationRequestStatus.mockRejectedValue(mockError)
+
+      const { result } = renderHook(() => useEvidenceService())
+
+      await expect(result.current.getVerificationRequestStatus('verification-id')).rejects.toThrow(mockError)
+      expect(mockServerErrorAlert).toHaveBeenCalledWith(mockError)
+      expect(mockUpdateVerificationRequest).not.toHaveBeenCalled()
+    })
+
+    it('should navigate to the VerificationSessionExpired modal for a 401 error', async () => {
+      mockEvidenceApi.getVerificationRequestStatus.mockRejectedValue(unauthorizedError)
+      const navigation = useNavigation()
+
+      const { result } = renderHook(() => useEvidenceService())
+
+      await expect(result.current.getVerificationRequestStatus('verification-id')).rejects.toThrow(unauthorizedError)
+      expect(navigation.dispatch).toHaveBeenCalledWith(
+        CommonActions.navigate({ name: BCSCModals.VerificationSessionExpired })
+      )
+    })
   })
 
   it('should return a memoized cancelVerificationRequest function', () => {
@@ -127,5 +235,15 @@ describe('useEvidenceService', () => {
     rerender(undefined)
 
     expect(result.current.cancelVerificationRequest).toBe(firstCancelVerificationRequest)
+  })
+
+  it('should return a memoized getVerificationRequestStatus function', () => {
+    const { result, rerender } = renderHook(() => useEvidenceService())
+
+    const firstGetVerificationRequestStatus = result.current.getVerificationRequestStatus
+
+    rerender(undefined)
+
+    expect(result.current.getVerificationRequestStatus).toBe(firstGetVerificationRequestStatus)
   })
 })

--- a/app/src/bcsc-theme/services/hooks/useEvidenceService.test.tsx
+++ b/app/src/bcsc-theme/services/hooks/useEvidenceService.test.tsx
@@ -1,4 +1,5 @@
-import useApi from '@/bcsc-theme/api/hooks/useApi'
+import useEvidenceApi from '@/bcsc-theme/api/hooks/useEvidenceApi'
+import { useBCSCApiClientState } from '@/bcsc-theme/hooks/useBCSCApiClient'
 import { AppError, ErrorCategory } from '@/errors'
 import { AppEventCode } from '@/events/appEventCode'
 import * as Bifold from '@bifold/core'
@@ -7,7 +8,8 @@ import { renderHook } from '@testing-library/react-native'
 import { AxiosError } from 'axios'
 import { useEvidenceService } from './useEvidenceService'
 
-jest.mock('@/bcsc-theme/api/hooks/useApi')
+jest.mock('@/bcsc-theme/api/hooks/useEvidenceApi')
+jest.mock('@/bcsc-theme/hooks/useBCSCApiClient')
 jest.mock('@bifold/core', () => ({
   __esModule: true,
   TOKENS: { UTIL_LOGGER: 'UTIL_LOGGER' },
@@ -28,8 +30,10 @@ jest.mock('@/bcsc-theme/hooks/useSecureActions', () => ({
 }))
 
 const mockServerErrorAlert = jest.fn()
-const mockAlerts = { serverErrorAlert: mockServerErrorAlert }
+const mockUnknownErrorModal = jest.fn()
+const mockAlerts = { serverErrorAlert: mockServerErrorAlert, unknownErrorModal: mockUnknownErrorModal }
 jest.mock('@/hooks/useAlerts', () => ({
+  ...jest.requireActual('@/hooks/useAlerts'),
   useAlerts: () => mockAlerts,
 }))
 
@@ -56,7 +60,8 @@ describe('useEvidenceService', () => {
     mockUpdateVerificationRequest.mockResolvedValue(undefined)
 
     jest.mocked(Bifold).useServices.mockReturnValue([mockLogger] as any)
-    jest.mocked(useApi).mockReturnValue({ evidence: mockEvidenceApi } as any)
+    jest.mocked(useBCSCApiClientState).mockReturnValue({ client: {} as any, isClientReady: true, error: null })
+    jest.mocked(useEvidenceApi).mockReturnValue(mockEvidenceApi as any)
   })
 
   describe('cancelVerificationRequest', () => {
@@ -101,7 +106,7 @@ describe('useEvidenceService', () => {
       expect(mockUpdateVerificationRequest).not.toHaveBeenCalled()
     })
 
-    it('should rethrow non-AppErrors without showing an alert or clearing the verification request', async () => {
+    it('should rethrow non-AppErrors, showing the generic unknown error modal, without clearing the verification request', async () => {
       const mockError = new Error('Unexpected failure')
       mockEvidenceApi.cancelVerificationRequest.mockRejectedValue(mockError)
 
@@ -109,6 +114,7 @@ describe('useEvidenceService', () => {
 
       await expect(result.current.cancelVerificationRequest('verification-id')).rejects.toThrow(mockError)
       expect(mockServerErrorAlert).not.toHaveBeenCalled()
+      expect(mockUnknownErrorModal).toHaveBeenCalledWith(mockError)
       expect(mockUpdateVerificationRequest).not.toHaveBeenCalled()
     })
   })

--- a/app/src/bcsc-theme/services/hooks/useEvidenceService.tsx
+++ b/app/src/bcsc-theme/services/hooks/useEvidenceService.tsx
@@ -1,10 +1,13 @@
-import { getGlobalAlertMap } from '@/bcsc-theme/api/clientErrorPolicies'
-import useApi from '@/bcsc-theme/api/hooks/useApi'
+import BCSCApiClient from '@/bcsc-theme/api/client'
+import useEvidenceApi, { VerificationStatusResponseData } from '@/bcsc-theme/api/hooks/useEvidenceApi'
+import { useBCSCApiClientState } from '@/bcsc-theme/hooks/useBCSCApiClient'
 import { useSecureActions } from '@/bcsc-theme/hooks/useSecureActions'
+import { BCSCModals } from '@/bcsc-theme/types/navigators'
 import { isAppError, isAxiosAppError } from '@/errors/appError'
-import { useAlerts } from '@/hooks/useAlerts'
+import { AppEventCode } from '@/events/appEventCode'
+import { showErrorAlert, useAlerts } from '@/hooks/useAlerts'
 import { TOKENS, useServices } from '@bifold/core'
-import { NavigationProp, ParamListBase, useNavigation } from '@react-navigation/native'
+import { CommonActions, NavigationProp, ParamListBase, useNavigation } from '@react-navigation/native'
 import { useCallback, useMemo } from 'react'
 
 /**
@@ -14,33 +17,40 @@ import { useCallback, useMemo } from 'react'
  * @returns Evidence service
  */
 export const useEvidenceService = () => {
-  const { evidence: evidenceApi } = useApi()
+  const { client } = useBCSCApiClientState()
+  const evidenceApi = useEvidenceApi(client as BCSCApiClient)
   const { updateVerificationRequest } = useSecureActions()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const navigation = useNavigation<NavigationProp<ParamListBase>>()
   const alerts = useAlerts(navigation)
 
   /**
-   * Emits an alert for Evidence-related errors based on the appEvent code.
+   * Handles errors from evidence API calls and emits the appropriate actions
    *
-   * @param error - The error object to evaluate for alert emission.
+   * @param error - The error object
    * @returns void
    */
-  const emitEvidenceAlert = useCallback(
-    (error: unknown) => {
-      if (!isAppError(error)) {
-        return
+  const handleEvidenceApiError = useCallback(
+    (error: unknown): void => {
+      if (isAxiosAppError(error, 401)) {
+        return navigation.dispatch(
+          CommonActions.navigate({
+            name: BCSCModals.VerificationSessionExpired,
+          })
+        )
       }
 
-      const globalAlertMap = getGlobalAlertMap(alerts)
-      const alertHandler = globalAlertMap.get(error.appEvent)
-
-      if (alertHandler) {
-        // If the error matches a known global alert, show that specific alert
-        alertHandler(error)
+      if (isAppError(error, AppEventCode.IOS_APP_UPDATE_REQUIRED)) {
+        return alerts.appUpdateRequiredAlert()
       }
+
+      if (isAppError(error, AppEventCode.ANDROID_APP_UPDATE_REQUIRED)) {
+        return alerts.appUpdateRequiredAlert()
+      }
+
+      showErrorAlert(error, alerts)
     },
-    [alerts]
+    [alerts, navigation]
   )
 
   /**
@@ -70,19 +80,53 @@ export const useEvidenceService = () => {
           return
         }
 
-        // For other errors, emit an alert and rethrow the error
-        emitEvidenceAlert(error)
+        // For other errors, handle them using the evidence error handler and rethrow
+        handleEvidenceApiError(error)
         throw error
       }
     },
-    [emitEvidenceAlert, evidenceApi, logger, updateVerificationRequest]
+    [handleEvidenceApiError, evidenceApi, logger, updateVerificationRequest]
+  )
+
+  /**
+   * Fetches the status of a verification request by its ID and handles errors appropriately.
+   * @param verificationRequestId - The ID of the verification request to check.
+   * @returns Promise resolving to the verification status response data.
+   */
+  const getVerificationRequestStatus = useCallback(
+    async (verificationRequestId: string): Promise<VerificationStatusResponseData> => {
+      try {
+        // TODO (MD): Drop the `skipOnErrorHandler` option once useEvidenceApi.getVerificationRequestStatus applies this by default
+        return await evidenceApi.getVerificationRequestStatus(verificationRequestId, { skipOnErrorHandler: true })
+      } catch (error) {
+        if (isAxiosAppError(error, 404)) {
+          // If the verification request is not found, it means it has already been deleted or does not exist.
+          logger.info(
+            `[useEvidenceService] Verification request not found for ID: ${verificationRequestId}. Expected resource already deleted. Handling as cancelled.`
+          )
+
+          await updateVerificationRequest(undefined, null)
+          // Return a default response indicating the request is cancelled
+          return {
+            id: verificationRequestId,
+            status: 'cancelled',
+          }
+        }
+
+        // For other errors, handle them using the evidence error handler and rethrow
+        handleEvidenceApiError(error)
+        throw error
+      }
+    },
+    [evidenceApi, handleEvidenceApiError, logger, updateVerificationRequest]
   )
 
   return useMemo(
     () => ({
       ...evidenceApi, // Spread the base API to include all its methods
       cancelVerificationRequest,
+      getVerificationRequestStatus,
     }),
-    [cancelVerificationRequest, evidenceApi]
+    [cancelVerificationRequest, evidenceApi, getVerificationRequestStatus]
   )
 }

--- a/app/src/hooks/useAlerts.test.tsx
+++ b/app/src/hooks/useAlerts.test.tsx
@@ -3,10 +3,11 @@ import { mockUseServices, mockUseStore } from '@/bcsc-theme/hooks/useCreateSyste
 import { BCSCScreens } from '@/bcsc-theme/types/navigators'
 import * as ErrorAlertContext from '@/contexts/ErrorAlertContext'
 import { AppEventCode } from '@/events/appEventCode'
+import { mockAppError } from '@mocks/helpers/error'
 import { CommonActions } from '@react-navigation/native'
 import { renderHook } from '@testing-library/react-native'
 import RN, { Platform } from 'react-native'
-import { useAlerts } from './useAlerts'
+import { showErrorAlert, useAlerts } from './useAlerts'
 
 jest.mock('@bifold/core', () => ({
   useStore: () => mockUseStore(),
@@ -1887,6 +1888,63 @@ describe('useAlerts', () => {
           expect.objectContaining({ appEvent: AppEventCode.DEVICE_AUTHENTICATION_ERROR })
         )
       })
+    })
+  })
+
+  describe('showErrorAlert', () => {
+    it('should call the mapped alert for an app event in the HTTP alert map', () => {
+      const mockServerErrorAlert = jest.fn()
+      const mockUnknownErrorModal = jest.fn()
+      const alerts = { serverErrorAlert: mockServerErrorAlert, unknownErrorModal: mockUnknownErrorModal } as any
+      const error = mockAppError(AppEventCode.SERVER_ERROR)
+
+      showErrorAlert(error, alerts)
+
+      expect(mockServerErrorAlert).toHaveBeenCalledWith(error)
+      expect(mockUnknownErrorModal).not.toHaveBeenCalled()
+    })
+
+    it('should call the mapped alert for an app event in the IAS alert map', () => {
+      const mockForbiddenAlert = jest.fn()
+      const mockUnknownErrorModal = jest.fn()
+      const alerts = { forbiddenAlert: mockForbiddenAlert, unknownErrorModal: mockUnknownErrorModal } as any
+      const error = mockAppError(AppEventCode.FORBIDDEN)
+
+      showErrorAlert(error, alerts)
+
+      expect(mockForbiddenAlert).toHaveBeenCalledWith(error)
+      expect(mockUnknownErrorModal).not.toHaveBeenCalled()
+    })
+
+    it('should fall back to the unknown error modal for a non-AppError', () => {
+      const mockUnknownErrorModal = jest.fn()
+      const alerts = { unknownErrorModal: mockUnknownErrorModal } as any
+      const error = new Error('Unexpected failure')
+
+      showErrorAlert(error, alerts)
+
+      expect(mockUnknownErrorModal).toHaveBeenCalledWith(error)
+    })
+
+    it('should fall back to the unknown error modal for an AppError whose app event is not in either alert map', () => {
+      const mockUnknownErrorModal = jest.fn()
+      const alerts = { unknownErrorModal: mockUnknownErrorModal } as any
+      const error = mockAppError(AppEventCode.GENERAL)
+
+      showErrorAlert(error, alerts)
+
+      expect(mockUnknownErrorModal).toHaveBeenCalledWith(error)
+    })
+
+    it('should fall back to the unknown error modal when the mapped alert is not defined on the given alerts object', () => {
+      const mockUnknownErrorModal = jest.fn()
+      // serverErrorAlert intentionally omitted, even though SERVER_ERROR is a recognized app event
+      const alerts = { unknownErrorModal: mockUnknownErrorModal } as any
+      const error = mockAppError(AppEventCode.SERVER_ERROR)
+
+      showErrorAlert(error, alerts)
+
+      expect(mockUnknownErrorModal).toHaveBeenCalledWith(error)
     })
   })
 })

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -1,3 +1,4 @@
+import { getGlobalAlertMap } from '@/bcsc-theme/api/clientErrorPolicies'
 import { useFactoryReset } from '@/bcsc-theme/api/hooks/useFactoryReset'
 import { useBCSCStack } from '@/bcsc-theme/contexts/BCSCStackContext'
 import { BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
@@ -411,4 +412,26 @@ export const useAlerts = (navigation: NavigationProp<any>) => {
       _createProblemWithAccountErrorModal,
     ]
   )
+}
+
+/**
+ * Shows an error alert based on the provided error.
+ * Fallsback to a generic unknown error modal if not recognized.
+ * @param error - The error to handle.
+ * @param alerts - The AppAlerts object containing alert functions.
+ * @returns void
+ */
+export function showErrorAlert(error: unknown, alerts: AppAlerts) {
+  const alertMap = getGlobalAlertMap(alerts)
+
+  const globalAlert = isAppError(error) ? alertMap.get(error.appEvent) : undefined
+
+  if (globalAlert) {
+    // If a specific alert is found for the error, show that alert.
+    globalAlert(error)
+    return
+  }
+
+  // If no specific alert is found for the error, show a generic unknown error modal.
+  alerts.unknownErrorModal(error)
 }

--- a/app/src/hooks/useAlerts.tsx
+++ b/app/src/hooks/useAlerts.tsx
@@ -416,19 +416,16 @@ export const useAlerts = (navigation: NavigationProp<any>) => {
 
 /**
  * Shows an error alert based on the provided error.
- * Fallsback to a generic unknown error modal if not recognized.
+ * Falls back to a generic unknown error modal if not recognized.
  * @param error - The error to handle.
  * @param alerts - The AppAlerts object containing alert functions.
  * @returns void
  */
 export function showErrorAlert(error: unknown, alerts: AppAlerts) {
-  const alertMap = getGlobalAlertMap(alerts)
+  const alert = isAppError(error) && getGlobalAlertMap(alerts).get(error.appEvent)
 
-  const globalAlert = isAppError(error) ? alertMap.get(error.appEvent) : undefined
-
-  if (globalAlert) {
-    // If a specific alert is found for the error, show that alert.
-    globalAlert(error)
+  if (alert) {
+    alert(error)
     return
   }
 


### PR DESCRIPTION
# Summary of Changes

This PR fixes a bug when upgrading with a previously cancelled verification request. 

Why? In 4.0.2 we are not correctly clearing the the persisted verification request when cancelling. We call `updateVerificationRequest` with `null` but dont clear it from native storage. When we upgrade to V4.1.0 we check native storage in hydrateSecureState and pull that value. This makes it seem like we have a verification request in flight when we actually dont.

### V4.0.2
https://github.com/bcgov/bc-wallet-mobile/blob/9d66d7fd2d0a2844231e29adf5ae7ee059e89227/app/src/bcsc-theme/features/verify/_models/useSetupStepsModel.tsx#L92

https://github.com/bcgov/bc-wallet-mobile/blob/9d66d7fd2d0a2844231e29adf5ae7ee059e89227/app/src/bcsc-theme/hooks/useSecureActions.tsx#L538-L540

- Extends useEvidenceService to include getVerificationRequestStatus - handles 404's as already cancelled
- Updates initial callsites to use useEvidenceSerivce.getVerificationRequestStatus
- Adds showErrorAlert function utility to be used in use<name>Service (matching clientErrorPolicy global handlers)
- Pulls evidence endpoint logic from clientErrorPolicy into handleEvidenceApiError

# Testing Instructions

https://github.com/orgs/bcgov/projects/108?pane=issue&itemId=230765370&issue=bcgov%7Cbc-wallet-mobile%7C4489

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Related Issues

Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
