### PR TITLE
chore: rewrite the PR template around reviewer focus

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,35 @@
-# Summary of Changes
+Closes #
 
-Replace this text with a high-level summary of the changes included in this PR.
+<!--
+Put the issue number on the line above, e.g. "Closes #1234". This is what links
+the PR to the issue: it puts the PR on the issue's timeline and shows the work
+on the board. A plain "#1234" somewhere in the body does not do this.
 
-# Testing Instructions
+No issue? Say why in the description (a chore, a dependency bump, a release).
+-->
 
-Replace this text with detailed instructions on how to test the changes included in this PR.
+## What changed
 
-# Acceptance Criteria
+<!--
+A couple of hundred words at most. What a reviewer needs to understand the diff,
+not the full history of the problem — that belongs in the issue.
+-->
 
-Replace this text with the acceptance criteria that must be met for this PR to be approved.
+## What should the reviewer focus on
 
-# Screenshots, videos, or gifs
+<!--
+The section that does the work. Point reviewers at the part you are least sure
+about, or tell them there isn't one. All of these are good answers:
 
-Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A
+  - "Nothing tricky — this is a copy change, a quick skim is fine."
+  - "The retry logic in useEvidenceUpload; I'm not certain the cancel path
+     clears the timer."
+  - "iOS only. Android is untouched, so no need to check it."
+-->
 
-# Related Issues
+## How to test
 
-Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
+<!--
+Enough for someone who has not touched this area to check it themselves.
+"Covered by unit tests" is a complete answer when it's true.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,9 @@ Closes #
 
 ## What changed
 
-<!-- Enough context to read the diff. The backstory lives in the issue. -->
+<!-- Enough context to read the diff. The backstory lives in the issue.
+     Drop in a screenshot or a short video if it shows what changed or how
+     it's meant to work — often quicker than describing it. -->
 
 ## What should the reviewer focus on
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,35 +1,19 @@
 Closes #
 
-<!--
-Put the issue number on the line above, e.g. "Closes #1234". This is what links
-the PR to the issue: it puts the PR on the issue's timeline and shows the work
-on the board. A plain "#1234" somewhere in the body does not do this.
-
-No issue? Say why in the description (a chore, a dependency bump, a release).
--->
+<!-- The issue number goes above, e.g. "Closes #1234" — that's what links the PR
+     to the board. A bare "#1234" further down doesn't. No issue? Say why. -->
 
 ## What changed
 
-<!--
-A couple of hundred words at most. What a reviewer needs to understand the diff,
-not the full history of the problem — that belongs in the issue.
--->
+<!-- Enough context to read the diff. The backstory lives in the issue. -->
 
 ## What should the reviewer focus on
 
-<!--
-The section that does the work. Point reviewers at the part you are least sure
-about, or tell them there isn't one. All of these are good answers:
-
-  - "Nothing tricky — this is a copy change, a quick skim is fine."
-  - "The retry logic in useEvidenceUpload; I'm not certain the cancel path
-     clears the timer."
-  - "iOS only. Android is untouched, so no need to check it."
--->
+<!-- Point at the scary bit — or say there isn't one:
+     "Copy change, quick skim is fine."
+     "The cancel path in useEvidenceUpload — not sure it clears the timer."
+     "iOS only, Android untouched." -->
 
 ## How to test
 
-<!--
-Enough for someone who has not touched this area to check it themselves.
-"Covered by unit tests" is a complete answer when it's true.
--->
+<!-- How someone else checks it. "Covered by unit tests" counts. -->


### PR DESCRIPTION
No issue — this is part of the issue/PR process rework.

## What changed

The PR template drops from five prose sections to four, led by `Closes #` on line one. `Testing Instructions`, `Acceptance Criteria`, `Screenshots`, and `Related Issues` collapse into **What changed**, **What should the reviewer focus on**, and **How to test**. All guidance moved into HTML comments, so a filled-in PR renders clean instead of carrying "Replace this text with..." prompts.

This PR body is written in the new format, so it doubles as the worked example.

Two things drove it. Descriptions were long and unclear on the ask — the old template made length the specified output. And `Related Issues: #1234` is plain text that creates no link GitHub tracks, so the issue timeline never showed the PR; only a closing keyword does, which is why `Closes #` moves to line one.

## What should the reviewer focus on

**The four section headings.** The planned `pr-hygiene.yml` check greps for them, so they become API the moment this merges — renaming one later means updating the workflow in the same PR. Worth agreeing on now rather than after the check lands.

Everything else is wording, and easy to change later.

One note: `Closes #` no longer closes anything. Auto-close for merged linked PRs was turned off on 2026-08-20 — people close issues, `UAT`-labelled ones specifically by a UAT team member. The keyword is kept purely for the machine-readable link.

## How to test

Open any new PR and confirm the template loads and renders without the comment blocks. Nothing is enforced yet — the blocking check lands separately in a few weeks.
