### PR TITLE
chore: add PR description and code review guidance for coding agents

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,35 @@
-# Summary of Changes
+Closes #
 
-Replace this text with a high-level summary of the changes included in this PR.
+<!--
+Put the issue number on the line above, e.g. "Closes #1234". This is what links
+the PR to the issue: it puts the PR on the issue's timeline and shows the work
+on the board. A plain "#1234" somewhere in the body does not do this.
 
-# Testing Instructions
+No issue? Say why in the description (a chore, a dependency bump, a release).
+-->
 
-Replace this text with detailed instructions on how to test the changes included in this PR.
+## What changed
 
-# Acceptance Criteria
+<!--
+A couple of hundred words at most. What a reviewer needs to understand the diff,
+not the full history of the problem — that belongs in the issue.
+-->
 
-Replace this text with the acceptance criteria that must be met for this PR to be approved.
+## What should the reviewer focus on
 
-# Screenshots, videos, or gifs
+<!--
+The section that does the work. Point reviewers at the part you are least sure
+about, or tell them there isn't one. All of these are good answers:
 
-Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A
+  - "Nothing tricky — this is a copy change, a quick skim is fine."
+  - "The retry logic in useEvidenceUpload; I'm not certain the cancel path
+     clears the timer."
+  - "iOS only. Android is untouched, so no need to check it."
+-->
 
-# Related Issues
+## How to test
 
-Replace this text with tagged issue #'s that are relevant to this PR. If there are none, simply enter N/A
+<!--
+Enough for someone who has not touched this area to check it themselves.
+"Covered by unit tests" is a complete answer when it's true.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,9 @@ Closes #
 
 ## What changed
 
-<!-- Enough context to read the diff. The backstory lives in the issue. -->
+<!-- Enough context to read the diff. The backstory lives in the issue.
+     Drop in a screenshot or a short video if it shows what changed or how
+     it's meant to work — often quicker than describing it. -->
 
 ## What should the reviewer focus on
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,35 +1,19 @@
 Closes #
 
-<!--
-Put the issue number on the line above, e.g. "Closes #1234". This is what links
-the PR to the issue: it puts the PR on the issue's timeline and shows the work
-on the board. A plain "#1234" somewhere in the body does not do this.
-
-No issue? Say why in the description (a chore, a dependency bump, a release).
--->
+<!-- The issue number goes above, e.g. "Closes #1234" — that's what links the PR
+     to the board. A bare "#1234" further down doesn't. No issue? Say why. -->
 
 ## What changed
 
-<!--
-A couple of hundred words at most. What a reviewer needs to understand the diff,
-not the full history of the problem — that belongs in the issue.
--->
+<!-- Enough context to read the diff. The backstory lives in the issue. -->
 
 ## What should the reviewer focus on
 
-<!--
-The section that does the work. Point reviewers at the part you are least sure
-about, or tell them there isn't one. All of these are good answers:
-
-  - "Nothing tricky — this is a copy change, a quick skim is fine."
-  - "The retry logic in useEvidenceUpload; I'm not certain the cancel path
-     clears the timer."
-  - "iOS only. Android is untouched, so no need to check it."
--->
+<!-- Point at the scary bit — or say there isn't one:
+     "Copy change, quick skim is fine."
+     "The cancel path in useEvidenceUpload — not sure it clears the timer."
+     "iOS only, Android untouched." -->
 
 ## How to test
 
-<!--
-Enough for someone who has not touched this area to check it themselves.
-"Covered by unit tests" is a complete answer when it's true.
--->
+<!-- How someone else checks it. "Covered by unit tests" counts. -->

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,79 +1,58 @@
 ---
 name: code-review
-description: Review a pull request in bc-wallet-mobile — what to prioritise, what to leave alone, and how to summarise findings for the reviewer who comes next.
+description: Review a pull request in bc-wallet-mobile — what to prioritise, what to leave alone, and how to summarise findings.
 ---
 
 # Reviewing a pull request
 
-This repository is a React Native wallet holding people's real credentials. A
-defect that corrupts wallet state or leaks personal data costs a holder far more
-than a missed style nit costs the team. Review accordingly.
+This is a wallet holding people's real credentials. A defect that corrupts
+wallet state or leaks personal data costs a holder far more than a style nit
+costs the team. Review accordingly.
 
 ## Procedure
 
-1. **Read the PR description first.** The **What should the reviewer focus on**
-   section names where the author is least certain. Start there. If that section
-   says the change is trivial and the diff agrees, a short review is the correct
-   review.
+1. **Read *What should the reviewer focus on* first.** It names where the author
+   is least certain. Start there. If it says the change is trivial and the diff
+   agrees, a short review is the correct review.
 
-2. **Establish the blast radius.** Which of these does the diff touch?
-   - Credential create, store, mutate, or delete
-   - Onboarding, PIN, or biometric state
-   - Native modules (`packages/bcsc-core`, anything under `android/` or `ios/`)
-   - Network calls to IAS or a mediator
-   - Anything else
+2. **Check the blast radius.** Credential create/store/delete, onboarding, PIN,
+   biometrics, native modules, or IAS and mediator calls — read every changed
+   line. Everything else is usually a skim.
 
-   The first four warrant a close read of every changed line. The last is
-   usually a skim.
+3. **Review by priority below**, stopping when you have enough to be useful.
+   Four real findings beat twenty observations.
 
-3. **Review against the priorities below**, highest first, stopping when you
-   have enough to be useful. A review of four real findings beats twenty
-   observations.
-
-4. **Post a short summary that orders the changed files by review risk** —
-   highest first, one line each on what to look at in that file. This is the
-   most valuable thing in the review: it tells the human reviewer where to spend
-   their attention.
+4. **Summarise by ordering the changed files by review risk**, one line each.
+   This is the most valuable part — it tells the human where to spend attention
+   before they open the diff.
 
 ## Priorities
 
-**Credential and wallet state.** Can this leave the wallet in a state the holder
-cannot recover from? Look for partial writes, missing rollback on a failed
-exchange, and assumptions that a credential still exists after an await.
+- **Wallet state** — can this leave the wallet unrecoverable? Partial writes,
+  no rollback on a failed exchange, assuming a credential survives an await.
+- **PII** — personal data, tokens, credential attributes, and whole
+  request/response bodies must not reach a log, an analytics event, or a
+  user-visible error. Remote logging makes it permanent.
+- **iOS/Android divergence** — behaviour changing on one platform only. Hides in
+  native modules, permissions, camera, biometrics. Say which platform looks
+  untested.
+- **Accessibility** — `TouchableOpacity`/`Pressable` need `accessibilityLabel`,
+  `accessibilityRole`, `hitSlop`, `testID`. Text must be localised, without
+  layout `\n`.
+- **Error handling** — errors surface, never swallowed. API hooks throw; service
+  and UI hooks catch. Deleting something absent should succeed. Native errors go
+  through `throwNativeError`/`toNativeAppError`.
+- **Architecture** — new work is MVVM; existing work follows the file it's in.
 
-**PII in logs and errors.** Personal data, tokens, credential attributes, and
-whole request or response bodies must not reach a log line, an analytics event,
-or a user-visible error string. Remote logging makes this permanent.
+## Leave alone
 
-**iOS/Android divergence.** Does this change behaviour on one platform and not
-the other? Native modules, permissions, camera, and biometrics are where this
-hides. Say which platform you believe is untested.
-
-**Accessibility.** `TouchableOpacity` and `Pressable` need `accessibilityLabel`,
-`accessibilityRole`, `hitSlop`, and `testID`. User-facing text must be
-localised, and localised strings must not carry layout characters such as `\n` —
-use `onTextLayout` measurement for wrapped-text layout instead.
-
-**Error handling.** Errors surface rather than being swallowed. API hooks throw;
-service and UI hooks catch and surface. Prefer idempotency: deleting something
-that does not exist should succeed. Native module errors go through
-`throwNativeError` / `toNativeAppError`.
-
-**Architecture.** New work follows MVVM. Existing work follows whatever pattern
-is already in the file — suggest refactoring only where it genuinely pays.
-
-## Do not comment on
-
-- Formatting, import order, or anything Prettier and ESLint enforce
-- Naming preferences, or behaviour-preserving restructuring, unless the current
-  form is genuinely ambiguous
-- Coverage percentages, or missing tests for code the PR did not add
-- Generated files, lockfiles, and dependency bumps
-- Anything the author already flagged as a known limitation
+Formatting and import order (Prettier and ESLint own those), naming
+preferences, behaviour-preserving restructuring, coverage percentages, missing
+tests for code the PR didn't add, lockfiles and dependency bumps, and anything
+the author already flagged as known.
 
 ## Tone
 
-Say what is wrong and why it matters, once. Distinguish "this is a bug" from
-"consider this" so the author can triage. If you are uncertain whether something
-is a defect, say so rather than asserting it — a confident wrong finding costs
-more review time than saying nothing.
+Say what's wrong and why it matters, once. Separate "this is a bug" from
+"consider this" so the author can triage. If you're unsure something is a
+defect, say so — a confident wrong finding costs more than silence.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: code-review
+description: Review a pull request in bc-wallet-mobile — what to prioritise, what to leave alone, and how to summarise findings for the reviewer who comes next.
+---
+
+# Reviewing a pull request
+
+This repository is a React Native wallet holding people's real credentials. A
+defect that corrupts wallet state or leaks personal data costs a holder far more
+than a missed style nit costs the team. Review accordingly.
+
+## Procedure
+
+1. **Read the PR description first.** The **What should the reviewer focus on**
+   section names where the author is least certain. Start there. If that section
+   says the change is trivial and the diff agrees, a short review is the correct
+   review.
+
+2. **Establish the blast radius.** Which of these does the diff touch?
+   - Credential create, store, mutate, or delete
+   - Onboarding, PIN, or biometric state
+   - Native modules (`packages/bcsc-core`, anything under `android/` or `ios/`)
+   - Network calls to IAS or a mediator
+   - Anything else
+
+   The first four warrant a close read of every changed line. The last is
+   usually a skim.
+
+3. **Review against the priorities below**, highest first, stopping when you
+   have enough to be useful. A review of four real findings beats twenty
+   observations.
+
+4. **Post a short summary that orders the changed files by review risk** —
+   highest first, one line each on what to look at in that file. This is the
+   most valuable thing in the review: it tells the human reviewer where to spend
+   their attention.
+
+## Priorities
+
+**Credential and wallet state.** Can this leave the wallet in a state the holder
+cannot recover from? Look for partial writes, missing rollback on a failed
+exchange, and assumptions that a credential still exists after an await.
+
+**PII in logs and errors.** Personal data, tokens, credential attributes, and
+whole request or response bodies must not reach a log line, an analytics event,
+or a user-visible error string. Remote logging makes this permanent.
+
+**iOS/Android divergence.** Does this change behaviour on one platform and not
+the other? Native modules, permissions, camera, and biometrics are where this
+hides. Say which platform you believe is untested.
+
+**Accessibility.** `TouchableOpacity` and `Pressable` need `accessibilityLabel`,
+`accessibilityRole`, `hitSlop`, and `testID`. User-facing text must be
+localised, and localised strings must not carry layout characters such as `\n` —
+use `onTextLayout` measurement for wrapped-text layout instead.
+
+**Error handling.** Errors surface rather than being swallowed. API hooks throw;
+service and UI hooks catch and surface. Prefer idempotency: deleting something
+that does not exist should succeed. Native module errors go through
+`throwNativeError` / `toNativeAppError`.
+
+**Architecture.** New work follows MVVM. Existing work follows whatever pattern
+is already in the file — suggest refactoring only where it genuinely pays.
+
+## Do not comment on
+
+- Formatting, import order, or anything Prettier and ESLint enforce
+- Naming preferences, or behaviour-preserving restructuring, unless the current
+  form is genuinely ambiguous
+- Coverage percentages, or missing tests for code the PR did not add
+- Generated files, lockfiles, and dependency bumps
+- Anything the author already flagged as a known limitation
+
+## Tone
+
+Say what is wrong and why it matters, once. Distinguish "this is a bug" from
+"consider this" so the author can triage. If you are uncertain whether something
+is a defect, say so rather than asserting it — a confident wrong finding costs
+more review time than saying nothing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,12 +277,12 @@ These files are sourced in shell contexts (e.g., GitHub Actions `source variant.
 
 When drafting a PR description, follow `.github/pull_request_template.md`:
 
-- Put `Closes #<issue>` on the first line. A bare `#123` elsewhere in the body does not create a link GitHub tracks. If there is no issue, say why in the description.
-- **What changed** — a couple of hundred words at most. Enough to understand the diff; the problem's history belongs in the issue.
-- **What should the reviewer focus on** — name the part you are least certain about, or state plainly that there isn't one. "Nothing tricky, this is a copy change" is a complete answer.
-- **How to test** — enough for someone who has not touched this area. "Covered by unit tests" is complete when true.
+- `Closes #<issue>` on the first line — that is what links the PR to the board. A bare `#123` further down does not.
+- **What changed** — enough context to read the diff. The backstory lives in the issue.
+- **What should the reviewer focus on** — point at the scary bit, or say there isn't one.
+- **How to test** — how someone else checks it. "Covered by unit tests" counts.
 
-Do not restate acceptance criteria from the issue, and do not pad a section to look thorough. A short PR description is a good one.
+Keep it short. Don't restate the issue's acceptance criteria, and don't pad a section to look thorough.
 
 ## Code Review Priorities
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,3 +272,31 @@ IOS_PRODUCT_NAME="$(TARGET_NAME)"
 ### Rationale
 
 These files are sourced in shell contexts (e.g., GitHub Actions `source variant.env`). Double-quoted strings containing `$`, backticks, or `!` will be interpreted by the shell, leading to unexpected behaviour. Single quotes ensure values are loaded exactly as written.
+
+## Pull Request Descriptions
+
+When drafting a PR description, follow `.github/pull_request_template.md`:
+
+- Put `Closes #<issue>` on the first line. A bare `#123` elsewhere in the body does not create a link GitHub tracks. If there is no issue, say why in the description.
+- **What changed** — a couple of hundred words at most. Enough to understand the diff; the problem's history belongs in the issue.
+- **What should the reviewer focus on** — name the part you are least certain about, or state plainly that there isn't one. "Nothing tricky, this is a copy change" is a complete answer.
+- **How to test** — enough for someone who has not touched this area. "Covered by unit tests" is complete when true.
+
+Do not restate acceptance criteria from the issue, and do not pad a section to look thorough. A short PR description is a good one.
+
+## Code Review Priorities
+
+When reviewing a pull request in this repository, prioritise these, roughly in order:
+
+- **Credential and wallet state.** Anything that creates, stores, mutates, or deletes a credential, or that changes onboarding, PIN, or biometric state. Corrupt wallet state is not recoverable for a holder in the field.
+- **PII in logs and errors.** Personal data, tokens, credential attributes, and full request or response bodies must not reach a log line, an analytics event, or a user-visible error string.
+- **iOS/Android divergence.** Flag changes that alter behaviour on one platform without the other, especially in native modules, permissions, and camera or biometric flows.
+- **Accessibility.** `TouchableOpacity` and `Pressable` require `accessibilityLabel`, `accessibilityRole`, `hitSlop`, and `testID`. New user-facing text must be localised, and localised strings must not carry layout characters such as `\n`.
+- **Error handling.** Errors should surface, not be swallowed. API hooks throw; service and UI hooks catch and surface. Prefer idempotency — deleting something absent should succeed, not throw.
+
+Do not comment on:
+
+- Formatting, import order, or anything Prettier and ESLint already enforce.
+- Naming preferences, or restructuring that does not change behaviour, unless the current form is genuinely ambiguous.
+- Test coverage percentages as a number, or missing tests for code that is not new.
+- Generated files, lockfiles, and dependency bumps.


### PR DESCRIPTION
No issue — part of the issue/PR process rework. Stacked on #4507; merge that first.

## What changed

Two additions telling Copilot (and any other coding agent) how to write a PR description in our format and what to prioritise when reviewing.

`AGENTS.md` gains **Pull Request Descriptions** and **Code Review Priorities**, including an explicit "leave alone" list. `.github/skills/code-review/SKILL.md` is new — the same checklist as a procedure, ending with "order the changed files by review risk."

Copilot already reviews every PR, but with no repo context it comments on whatever is visible: formatting, naming, coverage numbers. Noise a reviewer reads past. Pointing it at what actually matters here — wallet state, PII in logs, iOS/Android divergence, accessibility — makes the same review cheaper to consume.

## What should the reviewer focus on

**The "leave alone" list.** It's a judgement call about what counts as noise, and it's the part most worth arguing with. If something on it has genuinely caught bugs for you, say so and I'll pull it.

Also worth a look: this appends to `AGENTS.md`, and `.github/copilot-instructions.md` is a symlink to it — so this reaches every agent that reads `AGENTS.md`, not just Copilot. The content is written agent-generically for that reason. Breaking the symlink to give Copilot a private file stays possible later; nothing here seemed Copilot-only.

The change is append-only — 28 added lines in `AGENTS.md`, no existing line touched.

## How to test

Nothing to run. Advisory only — no workflow, no key, no blocking behaviour. The real check is whether Copilot's next few reviews get quieter and more useful.
