### PR TITLE
chore: pin dependabot labels and update stale-bot exempt labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
   #  - Group all updates into a single PR
   - package-ecosystem: "github-actions"
     directory: "/"
+    labels: ["dependencies"]
     schedule:
       interval: "weekly"
     groups:
@@ -16,6 +17,7 @@ updates:
   # Maintain dependencies for TypeScript and JavaScript
   - package-ecosystem: "npm"
     directory: "/"
+    labels: ["dependencies"]
     schedule:
       interval: "weekly"
       day: "monday"
@@ -28,6 +30,7 @@ updates:
   # Maintain dependencies for TypeScript and JavaScript
   - package-ecosystem: "npm"
     directory: "/scripts/gpublish"
+    labels: ["dependencies"]
     schedule:
       interval: "weekly"
       day: "monday"
@@ -40,6 +43,7 @@ updates:
   # Maintain dependencies for Gradle
   - package-ecosystem: "gradle"
     directory: "/app/android"
+    labels: ["dependencies"]
     schedule:
       interval: "weekly"
       day: "monday"
@@ -52,6 +56,7 @@ updates:
   # Maintain dependencies for Gradle
   - package-ecosystem: "gradle"
     directory: "/app/android/app"
+    labels: ["dependencies"]
     schedule:
       interval: "weekly"
       day: "monday"
@@ -64,6 +69,7 @@ updates:
   # Maintain dependencies for Ruby
   - package-ecosystem: "bundler"
     directory: "/app"
+    labels: ["dependencies"]
     schedule:
       interval: "weekly"
       day: "monday"
@@ -76,6 +82,7 @@ updates:
   # Maintain dependencies for docker images inside manifests
   - package-ecosystem: "docker"
     directory: "/devops/charts/loki-logstack"
+    labels: ["dependencies"]
     schedule:
       interval: "weekly"
       day: "monday"
@@ -84,6 +91,7 @@ updates:
       
   - package-ecosystem: "docker"
     directory: "devops/charts/loki-logstack/templates"
+    labels: ["dependencies"]
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -22,7 +22,7 @@ jobs:
           days-before-stale: 270 # 9 months
           days-before-close: 30 # 1 month
           stale-issue-label: stale
-          exempt-issue-labels: status/external-dependency
+          exempt-issue-labels: status/external-dependency,status/blocked
           exempt-pr-labels: dependencies
           stale-issue-message: >
             This issue has been inactive for a while, so it's

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -22,7 +22,7 @@ jobs:
           days-before-stale: 270 # 9 months
           days-before-close: 30 # 1 month
           stale-issue-label: stale
-          exempt-issue-labels: help wanted,external-dependency
+          exempt-issue-labels: status/external-dependency
           exempt-pr-labels: dependencies
           stale-issue-message: >
             This issue has been inactive for a while, so it's


### PR DESCRIPTION
Part of #4506 — the config slice only, not the whole consolidation.

## What changed

Two config files, ahead of the label deletions in #4506.

`dependabot.yml` gets an explicit `labels: ["dependencies"]` on all 8 ecosystem entries. Without it Dependabot applies its defaults — `dependencies` *plus* an ecosystem label — which is where `java`, `ruby`, `javascript`, and `github_actions` came from. Delete those four without this and they reappear on the next dependency PR.

`maintenance.yml` had `exempt-issue-labels: help wanted,external-dependency`. `help wanted` is being retired (it was on 0 issues), and `external-dependency` was renamed to `status/external-dependency` — left as-is, the stale bot would have stopped exempting issues waiting on a third party.

The line now reads `status/external-dependency,status/blocked`. Adding `status/blocked` is a small widening: an issue that can't proceed until something else lands shouldn't be staled for sitting still, which is the same argument that already protects the external-dependency ones.

`exempt-pr-labels: dependencies` is unchanged — that label stays, bot-owned and unprefixed.

## What should the reviewer focus on

**The `maintenance.yml` line.** It is the one with teeth: get the label name wrong and the stale bot starts closing issues that are legitimately parked. Worth confirming `status/external-dependency` matches the renamed label exactly, including the prefix.

The dependabot change is mechanical — the same line added to 8 entries, no other keys touched.

Timing matters here more than the diff: this needs to merge **before** the 24 label deletions run, or Dependabot recreates the ecosystem labels in the gap.

## How to test

Nothing to run. Both files parse as YAML and `dependabot.yml` still has its 8 entries, each now carrying exactly `["dependencies"]`. The real confirmation is the next Dependabot PR arriving with one label instead of two.

