### PR TITLE
fix: credential json details

### DIFF
--- a/app/container-imp.ts
+++ b/app/container-imp.ts
@@ -35,8 +35,6 @@ import { DependencyContainer } from 'tsyringe'
 
 import EmptyWalletList from '@/bcsc-theme/components/EmptyWalletList'
 import { createFloatingHelpMenuButton } from '@/bcsc-theme/components/FloatingHelpMenuHeaderButton'
-import { createStackHeaderWithoutBanner } from '@/bcsc-theme/components/HeaderWithBanner'
-import { createMainSettingsHeaderButton } from '@/bcsc-theme/components/SettingsHeaderButton'
 import { CredentialDetailsSubHeader } from '@/bcsc-theme/features/credentials/CredentialDetailsSubHeader'
 import { BCSCScreens } from '@/bcsc-theme/types/navigators'
 import filePersistedLedgers from '@/configs/ledgers/indy/ledgers'
@@ -272,10 +270,7 @@ export class AppContainer implements Container {
       this._container.registerInstance(TOKENS.OBJECT_SCREEN_CONFIG, {
         ...DefaultScreenOptionsDictionary,
         [Screens.Credentials]: {
-          ...DefaultScreenOptionsDictionary[Screens.Credentials],
-          title: 'Wallet',
-          headerLeft: createMainSettingsHeaderButton(),
-          header: createStackHeaderWithoutBanner,
+          headerShown: false,
         },
       })
     }

--- a/app/src/bcsc-theme/features/credentials/CredentialJSONDetailsScreen.tsx
+++ b/app/src/bcsc-theme/features/credentials/CredentialJSONDetailsScreen.tsx
@@ -14,7 +14,7 @@ interface CredentialJSONDetailsScreenProps {
 /**
  * CredentialJSONDetailsScreen is a React component that displays a JSON blob in a styled container.
  * TODO (MD): Refactor ContactJSONDetailsScreen to use a shared component with this screen.
- * @params route - The route prop containing the JSON blob to display.
+ * @param route - The route prop containing the JSON blob to display.
  * @returns a React element that renders the CredentialJSONDetailsScreen component.
  */
 const CredentialJSONDetailsScreen = ({ route }: CredentialJSONDetailsScreenProps) => {

--- a/app/src/bcsc-theme/features/credentials/CredentialJSONDetailsScreen.tsx
+++ b/app/src/bcsc-theme/features/credentials/CredentialJSONDetailsScreen.tsx
@@ -5,7 +5,7 @@ import Clipboard from '@react-native-clipboard/clipboard'
 import { RouteProp } from '@react-navigation/native'
 import React, { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, View } from 'react-native'
+import { Platform, StyleSheet, View } from 'react-native'
 
 interface CredentialJSONDetailsScreenProps {
   route: RouteProp<BCSCMainStackParams, BCSCScreens.CredentialJSONDetails>
@@ -34,7 +34,7 @@ const CredentialJSONDetailsScreen = ({ route }: CredentialJSONDetailsScreenProps
       marginBottom: Spacing.md,
     },
     code: {
-      fontFamily: 'Courier',
+      fontFamily: Platform.select({ ios: 'Courier', android: 'monospace' }),
       fontSize: 12,
       color: ColorPalette.grayscale.black,
     },

--- a/app/src/bcsc-theme/features/credentials/CredentialJSONDetailsScreen.tsx
+++ b/app/src/bcsc-theme/features/credentials/CredentialJSONDetailsScreen.tsx
@@ -1,0 +1,52 @@
+import { ActionScreenLayout } from '@/bcsc-theme/components/ActionScreenLayout'
+import { BCSCMainStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
+import { ThemedText, useTheme } from '@bifold/core'
+import Clipboard from '@react-native-clipboard/clipboard'
+import { RouteProp } from '@react-navigation/native'
+import React, { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, View } from 'react-native'
+
+interface CredentialJSONDetailsScreenProps {
+  route: RouteProp<BCSCMainStackParams, BCSCScreens.CredentialJSONDetails>
+}
+
+/**
+ * CredentialJSONDetailsScreen is a React component that displays a JSON blob in a styled container.
+ * TODO (MD): Refactor ContactJSONDetailsScreen to use a shared component with this screen.
+ * @params route - The route prop containing the JSON blob to display.
+ * @returns a React element that renders the CredentialJSONDetailsScreen component.
+ */
+const CredentialJSONDetailsScreen = ({ route }: CredentialJSONDetailsScreenProps) => {
+  const { jsonBlob } = route.params
+  const { t } = useTranslation()
+  const { Spacing, ColorPalette } = useTheme()
+
+  const onCopy = useCallback(() => {
+    Clipboard.setString(jsonBlob)
+  }, [jsonBlob])
+
+  const styles = StyleSheet.create({
+    blob: {
+      backgroundColor: ColorPalette.grayscale.veryLightGrey,
+      padding: Spacing.md,
+      borderRadius: Spacing.sm,
+      marginBottom: Spacing.md,
+    },
+    code: {
+      fontFamily: 'Courier',
+      fontSize: 12,
+      color: ColorPalette.grayscale.black,
+    },
+  })
+
+  return (
+    <ActionScreenLayout primaryActionText={t('BCSC.Contacts.JSON.Copy')} onPressPrimaryAction={onCopy}>
+      <View style={styles.blob}>
+        <ThemedText style={styles.code}>{jsonBlob}</ThemedText>
+      </View>
+    </ActionScreenLayout>
+  )
+}
+
+export default CredentialJSONDetailsScreen

--- a/app/src/bcsc-theme/features/qr-core/BifoldNavigationAdapter.test.ts
+++ b/app/src/bcsc-theme/features/qr-core/BifoldNavigationAdapter.test.ts
@@ -137,6 +137,26 @@ describe('BifoldNavigationAdapter', () => {
     )
   })
 
+  it('translates a Bifold chat-path reset dispatch that only references "Chat" (no "Tab Stack" route)', () => {
+    const { nav } = mkNav()
+    const adapted = createBifoldNavigationAdapter(nav as any, { t })
+    adapted.dispatch(
+      CommonActions.reset({
+        index: 0,
+        routes: [{ name: 'Chat', params: { connectionId: 'c-2' } }],
+      })
+    )
+    expect(nav.dispatch).toHaveBeenCalledWith(
+      CommonActions.reset({
+        index: 1,
+        routes: [
+          { name: BCSCStacks.Tab, state: { routes: [{ name: BCSCScreens.Home }] } },
+          { name: BCSCScreens.ContactChat, params: { connectionId: 'c-2' } },
+        ],
+      })
+    )
+  })
+
   it('falls back to a Home reset for a chat-path reset that carries no connectionId', () => {
     const { nav } = mkNav()
     const adapted = createBifoldNavigationAdapter(nav as any, { t })
@@ -152,6 +172,14 @@ describe('BifoldNavigationAdapter', () => {
         routes: [{ name: BCSCStacks.Tab, state: { routes: [{ name: BCSCScreens.Home }] } }],
       })
     )
+  })
+
+  it('treats a RESET action with no payload/routes as unmatched (defensive `?? []` fallback)', () => {
+    const { nav } = mkNav()
+    const adapted = createBifoldNavigationAdapter(nav as any, { t })
+    const action = { type: 'RESET' } as any
+    adapted.dispatch(action)
+    expect(nav.dispatch).toHaveBeenCalledWith(action)
   })
 
   it('lets non-chat dispatch actions pass through unchanged', () => {
@@ -170,6 +198,21 @@ describe('BifoldNavigationAdapter', () => {
     const action = CommonActions.navigate('Chat')
     adapted.dispatch(action)
     expect(nav.dispatch).toHaveBeenCalledWith(action)
+  })
+
+  it('lets a RESET dispatch action pass through unchanged when its routes reference no Bifold names', () => {
+    const { nav } = mkNav()
+    const adapted = createBifoldNavigationAdapter(nav as any, { t })
+    const action = CommonActions.reset({ index: 0, routes: [{ name: 'SomeBcscRoute' }] })
+    adapted.dispatch(action)
+    expect(nav.dispatch).toHaveBeenCalledWith(action)
+  })
+
+  it('passes through property access for anything other than navigate/dispatch/getParent', () => {
+    const isFocused = jest.fn(() => true)
+    const nav = { navigate: jest.fn(), dispatch: jest.fn(), getParent: jest.fn(), isFocused }
+    const adapted = createBifoldNavigationAdapter(nav as any, { t })
+    expect((adapted as any).isFocused).toBe(isFocused)
   })
 
   // The following cases mirror the exact navigate payloads Bifold's
@@ -212,5 +255,22 @@ describe('BifoldNavigationAdapter', () => {
     adapted.navigate('Contacts Stack' as never, { screen: 'JSON Details' } as never)
     expect(Toast.show).toHaveBeenCalledWith({ type: 'info', text1: 'BCSC.Scan.FeatureUnavailable' })
     expect(nav.navigate).not.toHaveBeenCalled()
+  })
+
+  it('retargets CredentialDetails "View JSON" to BCSC CredentialJSONDetailsScreen', () => {
+    // CredentialDetails.js: navigation.navigate('Contacts Stack', { screen: 'JSON Details', params: { jsonBlob: credential } })
+    const { nav } = mkNav()
+    const adapted = createBifoldNavigationAdapter(nav as any, { t })
+    adapted.navigate(
+      'Contacts Stack' as never,
+      {
+        screen: 'JSON Details',
+        params: { jsonBlob: { foo: 'bar' } },
+      } as never
+    )
+    expect(nav.navigate).toHaveBeenCalledWith(BCSCScreens.CredentialJSONDetails, {
+      jsonBlob: JSON.stringify({ foo: 'bar' }, null, 2),
+    })
+    expect(Toast.show).not.toHaveBeenCalled()
   })
 })

--- a/app/src/bcsc-theme/features/qr-core/BifoldNavigationAdapter.ts
+++ b/app/src/bcsc-theme/features/qr-core/BifoldNavigationAdapter.ts
@@ -96,7 +96,7 @@ const isCredentialJSONDetailsNavigation = (
     params: z.object({
       screen: z.literal(Screens.JSONDetails),
       params: z.object({
-        jsonBlob: z.unknown(),
+        jsonBlob: z.object(),
       }),
     }),
   })

--- a/app/src/bcsc-theme/features/qr-core/BifoldNavigationAdapter.ts
+++ b/app/src/bcsc-theme/features/qr-core/BifoldNavigationAdapter.ts
@@ -4,7 +4,7 @@ import Toast from 'react-native-toast-message'
 
 import { Screens } from '@bifold/core'
 import type { TFunction } from 'i18next'
-import z from 'zod'
+import { z } from 'zod'
 
 /**
  * Bifold's Connection / CredentialOffer / ProofRequest screens, when reused

--- a/app/src/bcsc-theme/features/qr-core/BifoldNavigationAdapter.ts
+++ b/app/src/bcsc-theme/features/qr-core/BifoldNavigationAdapter.ts
@@ -2,7 +2,9 @@ import { BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
 import { CommonActions, NavigationProp } from '@react-navigation/native'
 import Toast from 'react-native-toast-message'
 
+import { Screens } from '@bifold/core'
 import type { TFunction } from 'i18next'
+import z from 'zod'
 
 /**
  * Bifold's Connection / CredentialOffer / ProofRequest screens, when reused
@@ -81,6 +83,27 @@ const resetToBCSCContactChat = (navigation: NavigationProp<any>, connectionId: s
   )
 }
 
+// Detect Bifold's navigation to JSONDetails
+const isCredentialJSONDetailsNavigation = (
+  name: string,
+  params: unknown
+): params is {
+  screen: string
+  params: { jsonBlob: unknown }
+} => {
+  const jsonDetailsNavigationSchema = z.object({
+    name: z.literal(BIFOLD_CONTACTS_STACK),
+    params: z.object({
+      screen: z.literal(Screens.JSONDetails),
+      params: z.object({
+        jsonBlob: z.unknown(),
+      }),
+    }),
+  })
+
+  return jsonDetailsNavigationSchema.safeParse({ name, params }).success
+}
+
 // Detect Bifold's `reset({ … TabStack … Chat … })` action, dispatched by
 // Connection.tsx on the enableChat=true completion path. The reset routes
 // reference Bifold's nav graph, which BCSC doesn't register; if the Chat route
@@ -123,10 +146,12 @@ export const createBifoldNavigationAdapter = <T extends NavigationProp<any>>(
             resetToBCSCHome(target)
             return
           }
+
           if (name === BIFOLD_TAB_CREDENTIAL_STACK) {
             resetToBCSCWallet(target)
             return
           }
+
           if (name === BIFOLD_CHAT) {
             const connectionId = (params as { connectionId?: string } | undefined)?.connectionId
             if (connectionId) {
@@ -138,6 +163,13 @@ export const createBifoldNavigationAdapter = <T extends NavigationProp<any>>(
             Toast.show({ type: 'info', text1: t('BCSC.Scan.FeatureUnavailable') })
             return
           }
+
+          if (isCredentialJSONDetailsNavigation(name, params)) {
+            return navigation.navigate(BCSCScreens.CredentialJSONDetails, {
+              jsonBlob: JSON.stringify(params.params.jsonBlob, null, 2),
+            })
+          }
+
           if (name === BIFOLD_CONTACTS_STACK || name === BIFOLD_PROOF_REQUESTS_STACK) {
             Toast.show({ type: 'info', text1: t('BCSC.Scan.FeatureUnavailable') })
             return

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -11,7 +11,7 @@ import {
 } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { createStackNavigator, StackNavigationProp } from '@react-navigation/stack'
-import { useEffect, useMemo, useState } from 'react'
+import { ComponentProps, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { View } from 'react-native'
 import Developer from '../../screens/Developer'
@@ -43,6 +43,7 @@ import ContactsScreen from '../features/contacts/ContactsScreen'
 import EditContactNameScreen from '../features/contacts/EditContactNameScreen'
 import RemoveContactScreen from '../features/contacts/RemoveContactScreen'
 import WhatAreContactsScreen from '../features/contacts/WhatAreContactsScreen'
+import CredentialJSONDetailsScreen from '../features/credentials/CredentialJSONDetailsScreen'
 import { DeviceInvalidated } from '../features/modal/DeviceInvalidated'
 import { InternetDisconnected } from '../features/modal/InternetDisconnected'
 import { MandatoryUpdate } from '../features/modal/MandatoryUpdate'
@@ -52,6 +53,7 @@ import { VerifyPromptScreen } from '../features/onboarding/VerifyPromptScreen'
 import { pairingPayloadToServiceLoginParams, usePairingService } from '../features/pairing'
 import ManualPairingCode from '../features/pairing/ManualPairing'
 import PairingConfirmation from '../features/pairing/PairingConfirmation'
+import { createBifoldNavigationAdapter } from '../features/qr-core/BifoldNavigationAdapter'
 import ConnectionLoadingScreen from '../features/qr-core/ConnectionLoadingScreen'
 import { ServiceLoginScreen } from '../features/services/ServiceLoginScreen'
 import { AutoLockScreen } from '../features/settings/AutoLockScreen'
@@ -70,11 +72,16 @@ import QRCoreStack from './QRCoreStack'
 import { getDefaultModalOptions } from './stack-utils'
 import BCSCTabStack from './TabStack'
 
-const ScopedCredentialDetails: React.FC<React.ComponentProps<typeof CredentialDetails>> = (props) => (
-  <AgentReadyGate testID={testIdWithKey('CredentialDetails.Loading')}>
-    <CredentialDetails {...props} />
-  </AgentReadyGate>
-)
+type CredentialDetailsProps = ComponentProps<typeof CredentialDetails>
+
+const ScopedCredentialDetails = (props: CredentialDetailsProps) => {
+  const { t } = useTranslation()
+  return (
+    <AgentReadyGate testID={testIdWithKey('CredentialDetails.Loading')}>
+      <CredentialDetails {...props} navigation={createBifoldNavigationAdapter(props.navigation, { t })} />
+    </AgentReadyGate>
+  )
+}
 
 const VerifyPromptScreenNoSkip = () => <VerifyPromptScreen showSkip={false} />
 
@@ -204,6 +211,14 @@ const MainStack: React.FC = () => {
               headerShown: true,
               title: route.params?.title ?? t('BCSC.Contacts.JSON.Title'),
             })}
+          />
+          <Stack.Screen
+            name={BCSCScreens.CredentialJSONDetails}
+            component={CredentialJSONDetailsScreen}
+            options={{
+              headerShown: true,
+              headerTitle: t('Credentials.JSONDetailsTitle'),
+            }}
           />
           <Stack.Screen
             name={BCSCScreens.ContactChat}

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -76,9 +76,10 @@ type CredentialDetailsProps = ComponentProps<typeof CredentialDetails>
 
 const ScopedCredentialDetails = (props: CredentialDetailsProps) => {
   const { t } = useTranslation()
+  const navigation = useMemo(() => createBifoldNavigationAdapter(props.navigation, { t }), [props.navigation, t])
   return (
     <AgentReadyGate testID={testIdWithKey('CredentialDetails.Loading')}>
-      <CredentialDetails {...props} navigation={createBifoldNavigationAdapter(props.navigation, { t })} />
+      <CredentialDetails {...props} navigation={navigation} />
     </AgentReadyGate>
   )
 }

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -9,9 +9,9 @@ import {
   useTheme,
   useTour,
 } from '@bifold/core'
-import { useNavigation } from '@react-navigation/native'
+import { NavigationProp, useNavigation } from '@react-navigation/native'
 import { createStackNavigator, StackNavigationProp } from '@react-navigation/stack'
-import { useEffect, useMemo, useState } from 'react'
+import { ComponentProps, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { View } from 'react-native'
 import Developer from '../../screens/Developer'
@@ -43,6 +43,7 @@ import ContactsScreen from '../features/contacts/ContactsScreen'
 import EditContactNameScreen from '../features/contacts/EditContactNameScreen'
 import RemoveContactScreen from '../features/contacts/RemoveContactScreen'
 import WhatAreContactsScreen from '../features/contacts/WhatAreContactsScreen'
+import CredentialJSONDetailsScreen from '../features/credentials/CredentialJSONDetailsScreen'
 import { DeviceInvalidated } from '../features/modal/DeviceInvalidated'
 import { InternetDisconnected } from '../features/modal/InternetDisconnected'
 import { MandatoryUpdate } from '../features/modal/MandatoryUpdate'
@@ -70,11 +71,30 @@ import QRCoreStack from './QRCoreStack'
 import { getDefaultModalOptions } from './stack-utils'
 import BCSCTabStack from './TabStack'
 
-const ScopedCredentialDetails: React.FC<React.ComponentProps<typeof CredentialDetails>> = (props) => (
-  <AgentReadyGate testID={testIdWithKey('CredentialDetails.Loading')}>
-    <CredentialDetails {...props} />
-  </AgentReadyGate>
-)
+const BIFOLD_CONTACTS_STACK = 'Contacts Stack'
+
+type CredentialDetailsProps = ComponentProps<typeof CredentialDetails>
+
+const ScopedCredentialDetails = (props: CredentialDetailsProps) => {
+  const navigation = {
+    ...props.navigation,
+    navigate: (name, params) => {
+      if (name === BIFOLD_CONTACTS_STACK && params?.screen === Screens.JSONDetails) {
+        // Intercept Bifold's JSONDetails navigation and route to our own CredentialJSONDetails screen instead
+        return (props.navigation as NavigationProp<any>).navigate(BCSCScreens.CredentialJSONDetails, {
+          jsonBlob: JSON.stringify(params.params?.jsonBlob, null, 2),
+        })
+      }
+      return props.navigation.navigate(name as any, params)
+    },
+  } as CredentialDetailsProps['navigation']
+
+  return (
+    <AgentReadyGate testID={testIdWithKey('CredentialDetails.Loading')}>
+      <CredentialDetails {...props} navigation={navigation} />
+    </AgentReadyGate>
+  )
+}
 
 const VerifyPromptScreenNoSkip = () => <VerifyPromptScreen showSkip={false} />
 
@@ -204,6 +224,14 @@ const MainStack: React.FC = () => {
               headerShown: true,
               title: route.params?.title ?? t('BCSC.Contacts.JSON.Title'),
             })}
+          />
+          <Stack.Screen
+            name={BCSCScreens.CredentialJSONDetails}
+            component={CredentialJSONDetailsScreen}
+            options={{
+              headerShown: true,
+              headerTitle: t('Credentials.JSONDetailsTitle'),
+            }}
           />
           <Stack.Screen
             name={BCSCScreens.ContactChat}

--- a/app/src/bcsc-theme/navigators/TabStack.tsx
+++ b/app/src/bcsc-theme/navigators/TabStack.tsx
@@ -273,7 +273,8 @@ const BCSCTabStack: React.FC = () => {
             tabBarShowLabel: false,
             tabBarAccessibilityLabel: 'Wallet',
             tabBarTestID: testIdWithKey('Wallet'),
-            headerShown: false,
+            headerLeft: createMainSettingsHeaderButton(),
+            headerShown: true,
           }}
         />
       </Tab.Navigator>

--- a/app/src/bcsc-theme/types/navigators.ts
+++ b/app/src/bcsc-theme/types/navigators.ts
@@ -71,6 +71,7 @@ export enum BCSCScreens {
   ContactJSONDetails = 'Contact JSON Details',
   ContactChat = 'Contact Chat',
   RemoveContact = 'Remove Contact',
+  CredentialJSONDetails = 'Credential JSON Details',
   /**
    * FIXME (MD): EvidenceTypeList screen in V4 maps to multiple screens in V3 https://github.com/bcgov/bc-wallet-mobile/issues/3409
    *
@@ -301,6 +302,7 @@ export type BCSCMainStackParams = {
   // Bifold's AnonCreds credential detail screen reused inside BCSC's MainStack
   // so ListCredentials (rendered in the Wallet tab) can navigate to it.
   [Screens.CredentialDetails]: { credentialId: string }
+  [BCSCScreens.CredentialJSONDetails]: { jsonBlob: string }
 
   [BCSCScreens.QRCore]: NavigatorScreenParams<BCSCQRCoreTabParams> | undefined
   [BCSCScreens.ConnectionLoading]: { oobRecordId?: string; credentialId?: string; proofId?: string }

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -70,6 +70,7 @@ const translation = {
     "AddFirstCredential": "Add your first credential",
     "NotAnIDInfoTitle": "This does not replace your physical ID",
     "NotAnIDInfoDescription": "Do not share this screen as ID. This credential is used for digital interactions via the BC Services Card app only.",
+    "JSONDetailsTitle": "Credential JSON Details",
   },
   "Onboarding": {
     "DifferentWalletHeading": "A different smart wallet",

--- a/app/src/localization/fr/index.ts
+++ b/app/src/localization/fr/index.ts
@@ -70,6 +70,7 @@ const translation = {
     "AddFirstCredential": "Ajouter votre premier identifiant",
     "NotAnIDInfoTitle": "This does not replace your physical ID (FR)",
     "NotAnIDInfoDescription": "Do not share this screen as ID. This credential is used for digital interactions via the BC Services Card app only. (FR)",
+    "JSONDetailsTitle": "Credential JSON Details (FR)",
   },
   "Onboarding": {
     "DifferentWalletHeading": "Un portefeuille intelligent unique",

--- a/app/src/localization/pt-br/index.ts
+++ b/app/src/localization/pt-br/index.ts
@@ -70,6 +70,7 @@ const translation = {
     "AddFirstCredential": "Add your first credential (PT-BR)",
     "NotAnIDInfoTitle": "This does not replace your physical ID (PT-BR)",
     "NotAnIDInfoDescription": "Do not share this screen as ID. This credential is used for digital interactions via the BC Services Card app only. (PT-BR)",
+    "JSONDetailsTitle": "Credential JSON Details (PT-BR)",
   },
   "Onboarding": {
     "DifferentWalletHeading": "A different smart wallet (PT-BR)",


### PR DESCRIPTION
Closes #4467
Partially resolves #4278 

<!-- The issue number goes above, e.g. "Closes #1234" — that's what links the PR
     to the board. A bare "#1234" further down doesn't. No issue? Say why. -->

## What changed

<!-- Enough context to read the diff. The backstory lives in the issue.
     Drop in a screenshot or a short video if it shows what changed or how
     it's meant to work — often quicker than describing it. -->
- Wires up the credential JSON details
- Properly adds the header to the wallet tab

## What should the reviewer focus on

<!-- Point at the scary bit — or say there isn't one:
     "Copy change, quick skim is fine."
     "The cancel path in useEvidenceUpload — not sure it clears the timer."
     "iOS only, Android untouched." -->
- Pressing "view json details" in the credential shows the credential JSON
- The wallet header renders while the wallet is loading

## How to test

<!-- How someone else checks it. "Covered by unit tests" counts. -->
- Credential JSON looks correct
- Navigation to wallet -> credential -> JSON details -> back works
- Header title renders while wallet loading