### PR TITLE
chore: add non-blocking PR hygiene check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,13 @@
 Closes #
 
-<!-- The issue number goes above, e.g. "Closes #1234" — that's what links the PR
-     to the board. A bare "#1234" further down doesn't. No issue? Say why. -->
+<!-- Put the issue number after "Closes #" above, like "Closes #1234". That's
+     what links this PR to the issue and moves the card on the board. A bare
+     "#1234" further down in the description won't do it. Linking from the
+     Development panel on the right works just as well if you prefer.
+
+     No issue to link? That's completely fine — plenty of work doesn't have
+     one. Delete the "Closes #" line and add the `status/no-issue` label, and
+     the PR checks will be happy. -->
 
 ## What changed
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,8 @@
 Closes #
 
-<!-- Put the issue number after "Closes #" above, like "Closes #1234". That's
-     what links this PR to the issue and moves the card on the board. A bare
-     "#1234" further down in the description won't do it. Linking from the
-     Development panel on the right works just as well if you prefer.
-
-     No issue to link? That's completely fine — plenty of work doesn't have
-     one. Delete the "Closes #" line and add the `status/no-issue` label, and
-     the PR checks will be happy. -->
+<!-- Add the number above, like "Closes #1234", or link it in the Development
+     panel. A bare "#1234" lower down doesn't count.
+     No issue? Delete the line and add the `status/no-issue` label. -->
 
 ## What changed
 

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -1,0 +1,98 @@
+# Checks that a PR asking for review is linked to an issue and has its template
+# sections filled in. Deterministic — no judgement calls, no API cost beyond one
+# GraphQL query.
+#
+# Lands non-blocking. Make it a required check on `main` and `release/**` only
+# after it has run quietly for a week (see the rollout plan).
+name: PR Hygiene
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, edited, synchronize]
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-hygiene-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: PR hygiene
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const pr = context.payload.pull_request
+
+            const pass = async (reason) => {
+              core.info(`PASS — ${reason}`)
+              await core.summary.addRaw(`✅ **PR hygiene passed** — ${reason}`).write()
+            }
+            const fail = async (problems) => {
+              const list = problems.map((p) => `- ${p}`).join('\n')
+              await core.summary
+                .addRaw(`❌ **PR hygiene**\n\n${list}\n\n<sub>Escape hatches: the \`status/no-issue\` label, or a \`chore:\`/\`build:\`/\`docs:\`/\`release:\` title.</sub>`)
+                .write()
+              core.setFailed(problems.join(' | '))
+            }
+
+            // merge_group carries no PR payload; the check already ran on the PR itself.
+            if (!pr) return pass('merge group')
+            if (pr.draft) return pass('draft — not asking for review yet')
+
+            const login = pr.user?.login ?? ''
+            if (pr.user?.type === 'Bot' || login.endsWith('[bot]')) return pass(`bot author (${login})`)
+
+            const labels = pr.labels.map((l) => l.name)
+            for (const skip of ['dependencies', 'status/no-issue']) {
+              if (labels.includes(skip)) return pass(`\`${skip}\` label`)
+            }
+
+            // Conventional-commit prefixes for work that legitimately has no issue.
+            if (/^(chore|build|docs|release)(\([^)]*\))?!?:/i.test(pr.title)) {
+              return pass('title prefix exempts it')
+            }
+
+            const problems = []
+
+            // Ask for links GitHub actually tracks — a bare "#123" in prose creates none.
+            const { repository } = await github.graphql(
+              `query($owner:String!, $repo:String!, $number:Int!) {
+                 repository(owner:$owner, name:$repo) {
+                   pullRequest(number:$number) {
+                     closingIssuesReferences(first: 5) { nodes { number } }
+                   }
+                 }
+               }`,
+              { owner: context.repo.owner, repo: context.repo.repo, number: pr.number }
+            )
+            const linked = repository.pullRequest.closingIssuesReferences.nodes
+            if (linked.length === 0) {
+              problems.push(
+                'No linked issue. Put `Closes #1234` on the first line, or link one in the Development sidebar. ' +
+                  'A bare `#1234` in the body does not create a link GitHub tracks.'
+              )
+            }
+
+            // Guidance lives in HTML comments, so strip them before measuring.
+            const body = (pr.body ?? '').replace(/<!--[\s\S]*?-->/g, '')
+            const SECTIONS = ['What changed', 'What should the reviewer focus on', 'How to test']
+            const MIN = 15
+
+            for (const heading of SECTIONS) {
+              const re = new RegExp(`^#{1,6}\\s*${heading}\\s*$([\\s\\S]*?)(?=^#{1,6}\\s|$(?![\\s\\S]))`, 'im')
+              const match = body.match(re)
+              if (!match) {
+                problems.push(`Missing section: **${heading}**`)
+              } else if (match[1].trim().length < MIN) {
+                problems.push(`**${heading}** is empty or too short (needs ${MIN}+ characters)`)
+              }
+            }
+
+            if (problems.length) return fail(problems)
+            await pass(`linked to #${linked.map((n) => n.number).join(', #')}, all sections filled in`)

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -8,7 +8,9 @@ name: PR Hygiene
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, edited, synchronize]
+    # `labeled`/`unlabeled` matter: the escape-hatch labels are usually added in
+    # response to a red check, and without them nothing re-evaluates.
+    types: [opened, reopened, ready_for_review, edited, synchronize, labeled, unlabeled]
   merge_group:
 
 permissions:

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -36,7 +36,7 @@ jobs:
             const fail = async (problems) => {
               const list = problems.map((p) => `- ${p}`).join('\n')
               await core.summary
-                .addRaw(`❌ **PR hygiene**\n\n${list}\n\n<sub>Escape hatches: the \`status/no-issue\` label, or a \`chore:\`/\`build:\`/\`docs:\`/\`release:\` title.</sub>`)
+                .addRaw(`❌ **PR hygiene**\n\n${list}\n\n<sub>No issue to link? Add the \`status/no-issue\` label.</sub>`)
                 .write()
               core.setFailed(problems.join(' | '))
             }
@@ -53,8 +53,10 @@ jobs:
               if (labels.includes(skip)) return pass(`\`${skip}\` label`)
             }
 
-            // Conventional-commit prefixes for work that legitimately has no issue.
-            if (/^(chore|build|docs|release)(\([^)]*\))?!?:/i.test(pr.title)) {
+            // Prefixes for work that structurally cannot have an issue. `chore:` is
+            // deliberately NOT here — it exempted ~19% of merged PRs on a self-declared
+            // title nobody verifies, so chores use the `status/no-issue` label instead.
+            if (/^(build|docs|release)(\([^)]*\))?!?:/i.test(pr.title)) {
               return pass('title prefix exempts it')
             }
 

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
     # `labeled`/`unlabeled` matter: the escape-hatch labels are usually added in
     # response to a red check, and without them nothing re-evaluates.
-    types: [opened, reopened, ready_for_review, edited, synchronize, labeled, unlabeled]
+    types: [opened, reopened, ready_for_review, converted_to_draft, edited, synchronize, labeled, unlabeled]
   merge_group:
 
 permissions:


### PR DESCRIPTION
Part of #4506's sibling work — Phase 2 of the issue/PR plan. Draft-then-ready on purpose; not for merging yet.

## What changed

`pr-hygiene.yml` — on PRs marked ready for review, checks there's a tracked linked issue (GraphQL `closingIssuesReferences`, not a body grep) and that the three template sections have 15+ characters once HTML comments are stripped.

Exempt: drafts, merge queue, bots, `dependencies`, `build:`/`docs:`/`release:` titles, and the `status/no-issue` label.

`chore:` is deliberately **not** exempt. Of the last 100 merged PRs the original prefix list let 19 through, and only 1 was a dependency bump — the rest were ordinary chores skipping the check on a self-declared title. Applying a label is a deliberate act; naming a PR `chore:` isn't.

Also updates `pull_request_template.md` so the instructions match what the check enforces.

## What should the reviewer focus on

**Whether dropping `chore:` makes this too strict.** All 100 of the last 100 merged PRs would now be evaluated, so `status/no-issue` becomes load-bearing rather than a rare override. That's the intent, but the non-blocking week is what will show whether it reads as reasonable or as friction.

The three section headings are matched by regex, so renaming one in the template means updating this workflow in the same PR.

## How to test

Verified live on this PR: the check failed with no linked issue, then passed with `PASS — status/no-issue label`.

Testing found two trigger gaps, both fixed — adding the label didn't re-run the check (41-second gap between the red run and the label), and neither did converting to draft. Section matching was also run against real PR bodies first, which caught a `\Z` regex terminator that's valid in Python but a literal "Z" in JavaScript — it would have failed every PR on the last section.

## Not merging yet

The plan leaves a fortnight between the template landing and the gate arriving. Making it a required check on `main` and `release/**` is a separate branch-protection change, after a quiet week.
