### PR TITLE
feat: add native support for creating a new signing key

### DIFF
--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -395,6 +395,91 @@ class BcscCoreModule(
         }
     }
 
+    /**
+     * Generate a new signing keypair under a freshly incremented alias and return its public
+     * RSA components, for the JS-side key-rotation flow (issue #3876).
+     *
+     * IMPORTANT side effect: [BcscKeyPairSource.getNewBcscKeyPair] stamps the new alias'
+     * `createdAt` to now, so [BcscKeyPairSource.getCurrentBcscKeyPair] (newest-by-`createdAt`)
+     * picks it up as the active signing key immediately — there is no separate "activate" step.
+     * The JS caller is responsible for registering the new key with the server or rolling back
+     * via [deleteKey].
+     *
+     * Reuses [BcscKeyPairSource.convertBcscKeyPairToJWK] so the n/e encoding matches what
+     * registration actually sends (Nimbus canonical unsigned base64url).
+     */
+    @ReactMethod
+    fun createNewKeyPair(promise: Promise) {
+        // Captured once getNewBcscKeyPair() succeeds so a later failure in this method can
+        // best-effort delete it — see cleanUpUnregisteredKeyAfterGenerationFailure below.
+        var bcscKeyPair: BcscKeyPair? = null
+        try {
+            if (!keyPairSource.isAvailable()) {
+                promise.reject("E_KEYSTORE_UNAVAILABLE", "Android KeyStore is not available on this device")
+                return
+            }
+            bcscKeyPair = keyPairSource.getNewBcscKeyPair()
+            val jwk = keyPairSource.convertBcscKeyPairToJWK(bcscKeyPair)
+            if (jwk !is RSAKey) {
+                cleanUpUnregisteredKeyAfterGenerationFailure(bcscKeyPair.getKeyInfo().getAlias(), "not an RSA key")
+                promise.reject(
+                    "E_KEYSTORE_ERROR",
+                    "Newly generated key '${bcscKeyPair.getKeyInfo().getAlias()}' is not an RSA key",
+                )
+                return
+            }
+            val entry: WritableMap = Arguments.createMap()
+            entry.putString("id", bcscKeyPair.getKeyInfo().getAlias())
+            entry.putDouble("created", bcscKeyPair.getKeyInfo().getCreatedAt().toDouble())
+            entry.putString("n", jwk.modulus.toString())
+            entry.putString("e", jwk.publicExponent.toString())
+            promise.resolve(entry)
+        } catch (e: BcscException) {
+            bcscKeyPair?.let {
+                cleanUpUnregisteredKeyAfterGenerationFailure(
+                    it.getKeyInfo().getAlias(),
+                    "BcscException after generation",
+                )
+            }
+            promise.reject("E_KEYSTORE_ERROR", "Error generating new key pair: ${e.devMessage}", e)
+        } catch (e: Exception) {
+            bcscKeyPair?.let {
+                cleanUpUnregisteredKeyAfterGenerationFailure(
+                    it.getKeyInfo().getAlias(),
+                    "unexpected error after generation",
+                )
+            }
+            promise.reject("E_KEYSTORE_ERROR", "Unexpected error generating new key pair: ${e.message}", e)
+        }
+    }
+
+    /**
+     * Best-effort cleanup for [createNewKeyPair]'s post-generation failure paths.
+     *
+     * [BcscKeyPairSource.getNewBcscKeyPair] stamps the new alias' `createdAt` to now, so it
+     * becomes the active signing key (via [BcscKeyPairSource.getCurrentBcscKeyPair]'s
+     * newest-by-`createdAt` pick) the instant generation succeeds — before JS ever receives its
+     * alias. If anything after that point fails (JWK conversion, non-RSA key), JS gets a
+     * rejection with no alias and cannot roll back via [deleteKey], which would strand the
+     * device signing `private_key_jwt` client assertions with a key IAS has never registered
+     * (the #4166/2111 "Signature did not validate" failure mode). Deletion here is best-effort
+     * only: a cleanup failure is logged but never masks the original error the caller still
+     * rejects with.
+     */
+    private fun cleanUpUnregisteredKeyAfterGenerationFailure(
+        alias: String,
+        context: String,
+    ) {
+        try {
+            keyPairSource.deleteBcscKeyPair(alias)
+        } catch (e: Exception) {
+            Log.w(
+                NAME,
+                "createNewKeyPair: best-effort cleanup failed to delete unregistered key '$alias' after $context: ${e.message}",
+            )
+        }
+    }
+
     @ReactMethod
     override fun getToken(
         tokenType: Int,

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -475,10 +475,21 @@ class BcscCoreModule(
         } catch (e: Exception) {
             Log.w(
                 NAME,
-                "createNewKeyPair: best-effort cleanup failed to delete unregistered key '$alias' after $context: ${e.message}",
+                "createNewKeyPair: best-effort cleanup failed to delete unregistered key '${redactAlias(
+                    alias,
+                )}' after $context: ${e.message}",
             )
         }
     }
+
+    /**
+     * Redacts a keystore alias to its trailing 8 characters for logging. Android aliases are
+     * low-cardinality (`rsa1`, `rsa2`, ...) rather than UUID-based like iOS, but this keeps
+     * the treatment of key aliases in logs consistent across platforms — these logs ship to
+     * Loki from a public repo, and the trailing suffix still lets one device's log lines be
+     * correlated with each other.
+     */
+    private fun redactAlias(alias: String): String = if (alias.length <= 8) alias else "…" + alias.takeLast(8)
 
     @ReactMethod
     override fun getToken(

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -422,9 +422,11 @@ class BcscCoreModule(
             val jwk = keyPairSource.convertBcscKeyPairToJWK(bcscKeyPair)
             if (jwk !is RSAKey) {
                 cleanUpUnregisteredKeyAfterGenerationFailure(bcscKeyPair.getKeyInfo().getAlias(), "not an RSA key")
+                // Redacted: this message surfaces via AppError.technicalMessage, analytics, and
+                // user-visible debug details — a channel that travels further than logs.
                 promise.reject(
                     "E_KEYSTORE_ERROR",
-                    "Newly generated key '${bcscKeyPair.getKeyInfo().getAlias()}' is not an RSA key",
+                    "Newly generated key '${redactAlias(bcscKeyPair.getKeyInfo().getAlias())}' is not an RSA key",
                 )
                 return
             }

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -395,23 +395,10 @@ class BcscCoreModule(
         }
     }
 
-    /**
-     * Generate a new signing keypair under a freshly incremented alias and return its public
-     * RSA components, for the JS-side key-rotation flow (issue #3876).
-     *
-     * IMPORTANT side effect: [BcscKeyPairSource.getNewBcscKeyPair] stamps the new alias'
-     * `createdAt` to now, so [BcscKeyPairSource.getCurrentBcscKeyPair] (newest-by-`createdAt`)
-     * picks it up as the active signing key immediately — there is no separate "activate" step.
-     * The JS caller is responsible for registering the new key with the server or rolling back
-     * via [deleteKey].
-     *
-     * Reuses [BcscKeyPairSource.convertBcscKeyPairToJWK] so the n/e encoding matches what
-     * registration actually sends (Nimbus canonical unsigned base64url).
-     */
+    /** Generates a new signing keypair; activation is implicit on generation — see the JS wrapper's warning. */
     @ReactMethod
     fun createNewKeyPair(promise: Promise) {
-        // Captured once getNewBcscKeyPair() succeeds so a later failure in this method can
-        // best-effort delete it — see cleanUpUnregisteredKeyAfterGenerationFailure below.
+        // Captured once generated so a failure below can best-effort delete it (see cleanup fun).
         var bcscKeyPair: BcscKeyPair? = null
         try {
             if (!keyPairSource.isAvailable()) {
@@ -422,8 +409,7 @@ class BcscCoreModule(
             val jwk = keyPairSource.convertBcscKeyPairToJWK(bcscKeyPair)
             if (jwk !is RSAKey) {
                 cleanUpUnregisteredKeyAfterGenerationFailure(bcscKeyPair.getKeyInfo().getAlias(), "not an RSA key")
-                // Redacted: this message surfaces via AppError.technicalMessage, analytics, and
-                // user-visible debug details — a channel that travels further than logs.
+                // Redacted: surfaces via AppError.technicalMessage/analytics, which travel further than logs.
                 promise.reject(
                     "E_KEYSTORE_ERROR",
                     "Newly generated key '${redactAlias(bcscKeyPair.getKeyInfo().getAlias())}' is not an RSA key",
@@ -456,17 +442,9 @@ class BcscCoreModule(
     }
 
     /**
-     * Best-effort cleanup for [createNewKeyPair]'s post-generation failure paths.
-     *
-     * [BcscKeyPairSource.getNewBcscKeyPair] stamps the new alias' `createdAt` to now, so it
-     * becomes the active signing key (via [BcscKeyPairSource.getCurrentBcscKeyPair]'s
-     * newest-by-`createdAt` pick) the instant generation succeeds — before JS ever receives its
-     * alias. If anything after that point fails (JWK conversion, non-RSA key), JS gets a
-     * rejection with no alias and cannot roll back via [deleteKey], which would strand the
-     * device signing `private_key_jwt` client assertions with a key IAS has never registered
-     * (the #4166/2111 "Signature did not validate" failure mode). Deletion here is best-effort
-     * only: a cleanup failure is logged but never masks the original error the caller still
-     * rejects with.
+     * A key activates the instant generation succeeds, before JS gets its alias — so a failure
+     * after that point must delete it here or strand signing on an unregistered key (#4166/2111).
+     * Best-effort only: a cleanup failure is logged but never masks the caller's error.
      */
     private fun cleanUpUnregisteredKeyAfterGenerationFailure(
         alias: String,
@@ -484,13 +462,7 @@ class BcscCoreModule(
         }
     }
 
-    /**
-     * Redacts a keystore alias to its trailing 8 characters for logging. Android aliases are
-     * low-cardinality (`rsa1`, `rsa2`, ...) rather than UUID-based like iOS, but this keeps
-     * the treatment of key aliases in logs consistent across platforms — these logs ship to
-     * Loki from a public repo, and the trailing suffix still lets one device's log lines be
-     * correlated with each other.
-     */
+    /** Truncates for logging, matching iOS's redaction even though Android aliases (`rsa1`, `rsa2`, ...) aren't UUID-based. */
     private fun redactAlias(alias: String): String = if (alias.length <= 8) alias else "…" + alias.takeLast(8)
 
     @ReactMethod

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
@@ -248,9 +248,9 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
               + redactAlias(alias) + "' after key-pair retrieval failure", e);
         }
         throw new KeyNotFoundException(
-            "Failed to retrieve newly generated key pair for alias '" + alias + "': " + e.getMessage(), e);
+            "Failed to retrieve newly generated key pair for alias '" + redactAlias(alias) + "': " + e.getMessage(), e);
       }
-      SimpleLog.d(TAG, "Generated new key pair " + alias);
+      SimpleLog.d(TAG, "Generated new key pair " + redactAlias(alias));
       return new BcscKeyPair(keyPair, newInfo);
     } catch (KeypairGenerationException e) {
       throw e;
@@ -450,8 +450,11 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
     try {
       KeyStore keyStore = loadAndroidKeyStore();
       if (keyStore.containsAlias(alias)) {
+        // Redacted: this message can surface through createNewKeyPair's promise rejection
+        // (BcscCoreModule.kt forwards e.devMessage), which reaches AppError.technicalMessage,
+        // analytics, and user-visible debug details — a channel that travels further than logs.
         throw new KeyAlreadyExistsException(
-            "Key pair already exists for alias '" + alias + "'");
+            "Key pair already exists for alias '" + redactAlias(alias) + "'");
       }
 
       final KeyGenParameterSpec.Builder builder = new KeyGenParameterSpec.Builder(
@@ -483,10 +486,12 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
         | NoSuchAlgorithmException
         | NoSuchProviderException e) {
       SimpleLog.e(TAG, "Failed to generate key pair", e);
-      throw new KeypairGenerationException("Failed to generate key pair for alias '" + alias + "': " + e.getMessage(), e);
+      throw new KeypairGenerationException(
+          "Failed to generate key pair for alias '" + redactAlias(alias) + "': " + e.getMessage(), e);
     } catch (Exception e) {
       SimpleLog.e(TAG, "Failed to generate key pair", e);
-      throw new KeypairGenerationException("Failed to generate key pair for alias '" + alias + "': " + e.getMessage(), e);
+      throw new KeypairGenerationException(
+          "Failed to generate key pair for alias '" + redactAlias(alias) + "': " + e.getMessage(), e);
     }
   }
 

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
@@ -229,6 +229,24 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
       try {
         keyPair = getKeyPair(keyStore, alias);
       } catch (Exception e) {
+        // Best-effort cleanup: by this point BOTH the keystore entry (generateKeyPair) and the
+        // metadata row (saveKeyPairInfo, above) already exist for this alias — unlike the
+        // saveKeyPairInfo failure branch above, where only the keystore entry exists. Leaving
+        // either behind would strand the device signing with this alias (newest-by-createdAt)
+        // despite JS never receiving it (this whole call throws), and orphan metadata the next
+        // rotation attempt would collide with. Neither cleanup failure may mask the original
+        // retrieval error.
+        try {
+          keyPairInfoSource.deleteKeyPairInfo(alias);
+        } catch (Exception metaCleanupError) {
+          SimpleLog.e(TAG, "getNewBcscKeyPair: failed to clean up untracked metadata for '"
+              + redactAlias(alias) + "' after key-pair retrieval failure", metaCleanupError);
+        }
+        boolean cleanedUp = deleteKeyEntry(alias);
+        if (!cleanedUp) {
+          SimpleLog.e(TAG, "getNewBcscKeyPair: failed to clean up untracked keystore entry '"
+              + redactAlias(alias) + "' after key-pair retrieval failure", e);
+        }
         throw new KeyNotFoundException(
             "Failed to retrieve newly generated key pair for alias '" + alias + "': " + e.getMessage(), e);
       }
@@ -299,8 +317,13 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
     return infoMap.get(alias);
   }
 
+  // protected (not private): Robolectric cannot exercise the real "AndroidKeyStore" provider
+  // (confirmed empirically — NoSuchAlgorithmException), so getNewBcscKeyPair()'s post-generation
+  // cleanup behavior (issue #3876 review) is tested via a package-private test subclass that
+  // overrides this and the two methods below with controllable fakes. Not otherwise overridden
+  // in production.
   @NonNull
-  private KeyStore loadAndroidKeyStore() throws Exception {
+  protected KeyStore loadAndroidKeyStore() throws Exception {
     KeyStore keyStore = KeyStore.getInstance(KEYSTORE_TYPE);
     keyStore.load(null);
     return keyStore;
@@ -423,7 +446,7 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
    * @param alias the alias to store the key pair under
    * @throws KeypairGenerationException if key generation fails
    */
-  private void generateKeyPair(String alias) throws KeypairGenerationException {
+  protected void generateKeyPair(String alias) throws KeypairGenerationException {
     try {
       KeyStore keyStore = loadAndroidKeyStore();
       if (keyStore.containsAlias(alias)) {
@@ -534,7 +557,7 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
   }
 
   @NonNull
-  private KeyPair getKeyPair(@NonNull KeyStore keyStore, @NonNull String kid)
+  protected KeyPair getKeyPair(@NonNull KeyStore keyStore, @NonNull String kid)
       throws UnrecoverableEntryException, NoSuchAlgorithmException, KeyStoreException {
     if (Build.VERSION.SDK_INT <= VERSION_CODES.O_MR1) {
       final PrivateKey privateKey = (PrivateKey) keyStore.getKey(kid, null);

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
@@ -199,9 +199,32 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
       final String alias = String.format(Locale.ROOT, "%s%d", RSA_ALIAS_PREFIX, id);
 
       final KeyPairInfo newInfo = new KeyPairInfo(alias, System.currentTimeMillis());
-      keyPairInfoSource.saveKeyPairInfo(newInfo);
 
       generateKeyPair(alias);
+
+      // Persist the new alias' metadata only AFTER native key generation has actually
+      // succeeded. Saving it first (as this used to) would leave an orphan KeyPairInfo row —
+      // newest by createdAt — if generateKeyPair() throws (keystore full/locked/StrongBox
+      // failure): getCurrentBcscKeyPair()'s newest-lookup would then pick that orphan as the
+      // "active" key despite no keystore entry existing for it, and silently mint yet ANOTHER
+      // unregistered key on the very next call — one the server has never seen, breaking every
+      // client-assertion/token refresh until the next key-recovery pass. See issue #3876 review.
+      try {
+        keyPairInfoSource.saveKeyPairInfo(newInfo);
+      } catch (BcscException saveError) {
+        // Best-effort cleanup: the keystore entry already exists at this point, so leaving it
+        // behind would leak an untracked alias — and worse, the NEXT rotation attempt would
+        // collide with it (generateKeyPair() rejects with KeyAlreadyExistsException for an
+        // alias already present in the keystore), permanently breaking rotation on this device.
+        // The cleanup failure itself must never mask the original error.
+        boolean cleanedUp = deleteKeyEntry(alias);
+        if (!cleanedUp) {
+          SimpleLog.e(TAG, "getNewBcscKeyPair: failed to clean up untracked keystore entry '"
+              + alias + "' after saveKeyPairInfo failure", saveError);
+        }
+        throw saveError;
+      }
+
       final KeyPair keyPair;
       try {
         keyPair = getKeyPair(keyStore, alias);

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
@@ -220,7 +220,7 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
         boolean cleanedUp = deleteKeyEntry(alias);
         if (!cleanedUp) {
           SimpleLog.e(TAG, "getNewBcscKeyPair: failed to clean up untracked keystore entry '"
-              + alias + "' after saveKeyPairInfo failure", saveError);
+              + redactAlias(alias) + "' after saveKeyPairInfo failure", saveError);
         }
         throw saveError;
       }
@@ -465,6 +465,17 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
       SimpleLog.e(TAG, "Failed to generate key pair", e);
       throw new KeypairGenerationException("Failed to generate key pair for alias '" + alias + "': " + e.getMessage(), e);
     }
+  }
+
+  /**
+   * Redacts a keystore alias to its trailing 8 characters for logging. Android aliases here are
+   * low-cardinality ({@code rsa1}, {@code rsa2}, ...) rather than UUID-based like iOS, but this
+   * keeps the treatment of key aliases in logs consistent across platforms — these logs ship to
+   * Loki from a public repo, and the trailing suffix still lets one device's log lines be
+   * correlated with each other.
+   */
+  private static String redactAlias(String alias) {
+    return alias.length() <= 8 ? alias : "\u2026" + alias.substring(alias.length() - 8);
   }
 
   private boolean deleteKeyEntry(String alias) {

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
@@ -202,21 +202,14 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
 
       generateKeyPair(alias);
 
-      // Persist the new alias' metadata only AFTER native key generation has actually
-      // succeeded. Saving it first (as this used to) would leave an orphan KeyPairInfo row —
-      // newest by createdAt — if generateKeyPair() throws (keystore full/locked/StrongBox
-      // failure): getCurrentBcscKeyPair()'s newest-lookup would then pick that orphan as the
-      // "active" key despite no keystore entry existing for it, and silently mint yet ANOTHER
-      // unregistered key on the very next call — one the server has never seen, breaking every
-      // client-assertion/token refresh until the next key-recovery pass. See issue #3876 review.
+      // Persist metadata only after generation succeeds — saving first would leave an orphan
+      // row that getCurrentBcscKeyPair()'s newest-lookup treats as active, silently minting
+      // another unregistered key next call. See issue #3876 review.
       try {
         keyPairInfoSource.saveKeyPairInfo(newInfo);
       } catch (BcscException saveError) {
-        // Best-effort cleanup: the keystore entry already exists at this point, so leaving it
-        // behind would leak an untracked alias — and worse, the NEXT rotation attempt would
-        // collide with it (generateKeyPair() rejects with KeyAlreadyExistsException for an
-        // alias already present in the keystore), permanently breaking rotation on this device.
-        // The cleanup failure itself must never mask the original error.
+        // Best-effort: delete the keystore entry already created, or the next rotation attempt
+        // collides with it (KeyAlreadyExistsException). Must never mask the original error.
         boolean cleanedUp = deleteKeyEntry(alias);
         if (!cleanedUp) {
           SimpleLog.e(TAG, "getNewBcscKeyPair: failed to clean up untracked keystore entry '"
@@ -229,13 +222,9 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
       try {
         keyPair = getKeyPair(keyStore, alias);
       } catch (Exception e) {
-        // Best-effort cleanup: by this point BOTH the keystore entry (generateKeyPair) and the
-        // metadata row (saveKeyPairInfo, above) already exist for this alias — unlike the
-        // saveKeyPairInfo failure branch above, where only the keystore entry exists. Leaving
-        // either behind would strand the device signing with this alias (newest-by-createdAt)
-        // despite JS never receiving it (this whole call throws), and orphan metadata the next
-        // rotation attempt would collide with. Neither cleanup failure may mask the original
-        // retrieval error.
+        // Best-effort: unlike the save failure above, metadata was already persisted too — clean
+        // up both, or the alias strands signing (newest-by-createdAt) despite JS never receiving
+        // it. Neither cleanup failure may mask the original retrieval error.
         try {
           keyPairInfoSource.deleteKeyPairInfo(alias);
         } catch (Exception metaCleanupError) {
@@ -317,11 +306,9 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
     return infoMap.get(alias);
   }
 
-  // protected (not private): Robolectric cannot exercise the real "AndroidKeyStore" provider
-  // (confirmed empirically — NoSuchAlgorithmException), so getNewBcscKeyPair()'s post-generation
-  // cleanup behavior (issue #3876 review) is tested via a package-private test subclass that
-  // overrides this and the two methods below with controllable fakes. Not otherwise overridden
-  // in production.
+  // protected (not private): Robolectric can't exercise the real "AndroidKeyStore" provider
+  // (NoSuchAlgorithmException), so this and the two methods below are overridden with
+  // controllable fakes by a test subclass. Not otherwise overridden in production.
   @NonNull
   protected KeyStore loadAndroidKeyStore() throws Exception {
     KeyStore keyStore = KeyStore.getInstance(KEYSTORE_TYPE);
@@ -450,9 +437,7 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
     try {
       KeyStore keyStore = loadAndroidKeyStore();
       if (keyStore.containsAlias(alias)) {
-        // Redacted: this message can surface through createNewKeyPair's promise rejection
-        // (BcscCoreModule.kt forwards e.devMessage), which reaches AppError.technicalMessage,
-        // analytics, and user-visible debug details — a channel that travels further than logs.
+        // Redacted: surfaces via createNewKeyPair's rejection into AppError.technicalMessage/analytics.
         throw new KeyAlreadyExistsException(
             "Key pair already exists for alias '" + redactAlias(alias) + "'");
       }
@@ -495,13 +480,7 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
     }
   }
 
-  /**
-   * Redacts a keystore alias to its trailing 8 characters for logging. Android aliases here are
-   * low-cardinality ({@code rsa1}, {@code rsa2}, ...) rather than UUID-based like iOS, but this
-   * keeps the treatment of key aliases in logs consistent across platforms — these logs ship to
-   * Loki from a public repo, and the trailing suffix still lets one device's log lines be
-   * correlated with each other.
-   */
+  /** Truncates for logging, matching iOS's redaction even though these aliases aren't UUID-based. */
   private static String redactAlias(String alias) {
     return alias.length() <= 8 ? alias : "\u2026" + alias.substring(alias.length() - 8);
   }

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
@@ -65,6 +65,7 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
   private static final String KEYSTORE_TYPE = "AndroidKeyStore";
   private static final String TAG = "BcscKeyPairRepo";
   private static final Pattern RSA_ALIAS_PATTERN = Pattern.compile("^" + RSA_ALIAS_PREFIX + "(\\d+)$");
+  private static final int MAX_ALIAS_ATTEMPTS = 5;
 
   @NonNull
   private final KeyPairInfoSource keyPairInfoSource;
@@ -185,22 +186,26 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
       // alias rather than colliding with a leftover v3 keystore entry.
       reconcileKeyPairInfoWithKeyStore(keyStore);
 
-      KeyPairInfo info = getNewestKeyPairInfo(keyPairInfoSource.getKeyPairInfo());
-
-      if (info == null) {
-        info = new KeyPairInfo(ALIAS_RSA, System.currentTimeMillis());
-        keyPairInfoSource.saveKeyPairInfo(info);
+      final int firstId = nextRsaAliasId(keyStore);
+      String alias = null;
+      KeyAlreadyExistsException lastCollision = null;
+      for (int attempt = 0; attempt < MAX_ALIAS_ATTEMPTS && alias == null; attempt++) {
+        final String candidate = String.format(Locale.ROOT, "%s%d", RSA_ALIAS_PREFIX, firstId + attempt);
+        try {
+          generateKeyPair(candidate);
+          alias = candidate;
+        } catch (KeyAlreadyExistsException e) {
+          // findRsaAliasesInKeyStore swallows KeyStoreException, which can undercount the
+          // keystore scan; bump and retry rather than looping forever on the same alias.
+          lastCollision = e;
+          SimpleLog.e(TAG, "getNewBcscKeyPair: alias collision at '" + redactAlias(candidate) + "', bumping", e);
+        }
+      }
+      if (alias == null) {
+        throw lastCollision;
       }
 
-      int id = Integer.parseInt(info.getAlias().replaceAll("\\D+", ""));
-
-      id += 1;
-
-      final String alias = String.format(Locale.ROOT, "%s%d", RSA_ALIAS_PREFIX, id);
-
       final KeyPairInfo newInfo = new KeyPairInfo(alias, System.currentTimeMillis());
-
-      generateKeyPair(alias);
 
       // Persist metadata only after generation succeeds — saving first would leave an orphan
       // row that getCurrentBcscKeyPair()'s newest-lookup treats as active, silently minting
@@ -424,6 +429,27 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
       SimpleLog.e(TAG, "Failed to enumerate keystore aliases for reconciliation", e);
     }
     return result;
+  }
+
+  /**
+   * Compute the next rsa\d+ alias id to try, one past the highest id seen across BOTH metadata
+   * and the keystore. Scanning metadata in full (not just the newest-by-createdAt row) avoids a
+   * livelock where markActiveBcscKeyPair() stamps an older alias as newest while a higher-id
+   * alias still exists in both metadata and the keystore — see issue #3876.
+   */
+  private int nextRsaAliasId(@NonNull KeyStore keyStore) throws BcscException {
+    int maxId = 0;
+    for (String alias : keyPairInfoSource.getKeyPairInfo().keySet()) {
+      Matcher m = RSA_ALIAS_PATTERN.matcher(alias);
+      if (m.matches()) {
+        maxId = Math.max(maxId, Integer.parseInt(m.group(1)));
+      }
+    }
+    java.util.TreeMap<Integer, String> keystoreAliases = findRsaAliasesInKeyStore(keyStore);
+    if (!keystoreAliases.isEmpty()) {
+      maxId = Math.max(maxId, keystoreAliases.lastKey());
+    }
+    return maxId + 1;
   }
 
   /**

--- a/packages/bcsc-core/android/src/test/java/com/bcsccore/keypair/repos/key/BcscKeyPairRepoAliasSelectionTest.kt
+++ b/packages/bcsc-core/android/src/test/java/com/bcsccore/keypair/repos/key/BcscKeyPairRepoAliasSelectionTest.kt
@@ -1,0 +1,219 @@
+package com.bcsccore.keypair.repos.key
+
+import com.bcsccore.keypair.core.exceptions.KeyAlreadyExistsException
+import com.bcsccore.keypair.core.interfaces.KeyPairInfoSource
+import com.bcsccore.keypair.core.models.KeyPairInfo
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.KeyStoreException
+import java.util.Collections
+import java.util.HashMap
+
+/**
+ * Verifies [BcscKeyPairRepo.getNewBcscKeyPair]'s alias selection: the next rsa\d+ alias must be
+ * computed from the max id across ALL metadata rows AND all keystore aliases, with a bounded
+ * catch-and-bump retry as defense-in-depth against a stale/blind keystore scan. See issue #3876.
+ */
+@RunWith(RobolectricTestRunner::class)
+class BcscKeyPairRepoAliasSelectionTest {
+    companion object {
+        private val FAKE_KEY_PAIR: KeyPair by lazy {
+            KeyPairGenerator.getInstance("RSA").also { it.initialize(2048) }.generateKeyPair()
+        }
+    }
+
+    // Lightweight in-memory stand-in for SharedPreferences-backed KeyPairInfoSource, matching
+    // the pattern in BcscKeyPairRepoCleanupTest / BcscKeyPairRepoSeedingTest.
+    private class InMemoryKeyPairInfoSource(
+        initial: Map<String, KeyPairInfo> = emptyMap(),
+    ) : KeyPairInfoSource {
+        val store = HashMap<String, KeyPairInfo>(initial)
+
+        override fun getKeyPairInfo(kid: String): KeyPairInfo? = store[kid]
+
+        override fun getKeyPairInfo(): HashMap<String, KeyPairInfo> = HashMap(store)
+
+        override fun saveKeyPairInfo(info: KeyPairInfo) {
+            store[info.alias] = info
+        }
+
+        override fun deleteKeyPairInfo(alias: String) {
+            store.remove(alias)
+        }
+    }
+
+    /**
+     * Robolectric can't exercise the real "AndroidKeyStore" provider, so [loadAndroidKeyStore] is
+     * substituted with a controllable mock and [getKeyPair] with a shared fake key pair.
+     *
+     * Unlike BcscKeyPairRepoCleanupTest's no-op stub, [generateKeyPair] here enforces the real
+     * containsAlias guard against [keystoreEntries] and records every attempted alias in
+     * [generatedAttempts] — without this, the livelock scenarios under test cannot fail
+     * pre-fix, making the tests theatre rather than a regression guard.
+     */
+    private class RecordingBcscKeyPairRepo(
+        infoSource: KeyPairInfoSource,
+        private val fakeKeyStore: KeyStore,
+        private val keystoreEntries: MutableSet<String>,
+    ) : BcscKeyPairRepo(infoSource) {
+        val generatedAttempts: MutableList<String> = mutableListOf()
+
+        override fun loadAndroidKeyStore(): KeyStore = fakeKeyStore
+
+        override fun generateKeyPair(alias: String) {
+            generatedAttempts.add(alias)
+            if (keystoreEntries.contains(alias)) {
+                throw KeyAlreadyExistsException("simulated collision for alias '$alias'")
+            }
+            keystoreEntries.add(alias)
+        }
+
+        override fun getKeyPair(
+            keyStore: KeyStore,
+            kid: String,
+        ): KeyPair = FAKE_KEY_PAIR
+    }
+
+    /**
+     * A keystore mock whose aliases() reflects [keystoreEntries] live on every call — `answers`,
+     * not `returns`, so a second call (the retry path) doesn't see a stale/exhausted enumeration.
+     * An exhausted enumeration on the second call would make findRsaAliasesInKeyStore see an
+     * empty keystore and the retry would rescue an otherwise-broken max computation, masking a
+     * regression.
+     */
+    private fun liveKeyStore(keystoreEntries: MutableSet<String>): KeyStore {
+        val ks = mockk<KeyStore>(relaxed = true)
+        every { ks.aliases() } answers { Collections.enumeration(keystoreEntries.toList()) }
+        return ks
+    }
+
+    private fun blindKeyStore(): KeyStore {
+        val ks = mockk<KeyStore>(relaxed = true)
+        every { ks.aliases() } throws KeyStoreException("simulated blind keystore scan")
+        return ks
+    }
+
+    @Test
+    fun `spec livelock case picks the alias one past the highest keystore id`() {
+        // metadata {rsa1}, keystore {rsa1, rsa2}: pre-fix this computed rsa2 from metadata alone
+        // and collided forever. The fix must land on rsa3 on the first attempt.
+        val infoSource =
+            InMemoryKeyPairInfoSource(mapOf("rsa1" to KeyPairInfo("rsa1", System.currentTimeMillis())))
+        val keystoreEntries = mutableSetOf("rsa1", "rsa2")
+        val repo = RecordingBcscKeyPairRepo(infoSource, liveKeyStore(keystoreEntries), keystoreEntries)
+
+        val result = repo.getNewBcscKeyPair()
+
+        assertEquals("rsa3", result.keyInfo.alias)
+        assertTrue("metadata must gain the new alias", infoSource.store.containsKey("rsa3"))
+        // Load-bearing: with the retry present, a broken max computation could still "succeed" on
+        // a bump. size == 1 is what proves it succeeds on the FIRST attempt.
+        assertEquals(listOf("rsa3"), repo.generatedAttempts)
+    }
+
+    @Test
+    fun `promoted-older-alias case scans all metadata rows not just the newest`() {
+        // markActiveBcscKeyPair("rsa2") stamped an older alias as newest-by-createdAt, while rsa3
+        // still exists in both metadata and keystore. Scanning ALL metadata rows (not just the
+        // newest) must still land past rsa3.
+        val now = System.currentTimeMillis()
+        val infoSource =
+            InMemoryKeyPairInfoSource(
+                mapOf(
+                    "rsa1" to KeyPairInfo("rsa1", now - 20_000L),
+                    "rsa2" to KeyPairInfo("rsa2", now), // newest-stamped, but numerically lower
+                    "rsa3" to KeyPairInfo("rsa3", now - 10_000L),
+                ),
+            )
+        val keystoreEntries = mutableSetOf("rsa1", "rsa2", "rsa3")
+        val repo = RecordingBcscKeyPairRepo(infoSource, liveKeyStore(keystoreEntries), keystoreEntries)
+
+        val result = repo.getNewBcscKeyPair()
+
+        assertEquals("rsa4", result.keyInfo.alias)
+        assertEquals(listOf("rsa4"), repo.generatedAttempts)
+    }
+
+    @Test
+    fun `ordinary case is unchanged when metadata and keystore agree`() {
+        val infoSource =
+            InMemoryKeyPairInfoSource(
+                mapOf(
+                    "rsa1" to KeyPairInfo("rsa1", System.currentTimeMillis() - 1000L),
+                    "rsa2" to KeyPairInfo("rsa2", System.currentTimeMillis()),
+                ),
+            )
+        val keystoreEntries = mutableSetOf("rsa1", "rsa2")
+        val repo = RecordingBcscKeyPairRepo(infoSource, liveKeyStore(keystoreEntries), keystoreEntries)
+
+        val result = repo.getNewBcscKeyPair()
+
+        assertEquals("rsa3", result.keyInfo.alias)
+        assertEquals(listOf("rsa3"), repo.generatedAttempts)
+    }
+
+    @Test
+    fun `empty metadata and empty keystore generates rsa1 with no phantom row`() {
+        val infoSource = InMemoryKeyPairInfoSource()
+        val keystoreEntries = mutableSetOf<String>()
+        val repo = RecordingBcscKeyPairRepo(infoSource, liveKeyStore(keystoreEntries), keystoreEntries)
+
+        val result = repo.getNewBcscKeyPair()
+
+        assertEquals("rsa1", result.keyInfo.alias)
+        assertEquals(listOf("rsa1"), repo.generatedAttempts)
+        assertEquals(
+            "no phantom seed row: only the real rsa1 entry may exist",
+            setOf("rsa1"),
+            infoSource.store.keys,
+        )
+    }
+
+    @Test
+    fun `retry rescues a stale keystore scan when the first candidate collides`() {
+        // aliases() throws (scan blind), so nextRsaAliasId undercounts from metadata alone
+        // (max id 1 -> candidate rsa2). The keystore actually holds rsa2 already, so the first
+        // attempt must collide and the bounded retry must rescue it on the second attempt.
+        val infoSource = InMemoryKeyPairInfoSource(mapOf("rsa1" to KeyPairInfo("rsa1", System.currentTimeMillis())))
+        val keystoreEntries = mutableSetOf("rsa2")
+        val repo = RecordingBcscKeyPairRepo(infoSource, blindKeyStore(), keystoreEntries)
+
+        val result = repo.getNewBcscKeyPair()
+
+        assertEquals("rsa3", result.keyInfo.alias)
+        assertEquals(listOf("rsa2", "rsa3"), repo.generatedAttempts)
+    }
+
+    @Test
+    fun `bounded exhaustion throws KeyAlreadyExistsException after exactly MAX_ALIAS_ATTEMPTS`() {
+        // aliases() throws (scan blind); keystore holds rsa2..rsa10 so every candidate in the
+        // bounded retry window collides. Must throw after exactly 5 attempts, never loop forever.
+        val infoSource = InMemoryKeyPairInfoSource(mapOf("rsa1" to KeyPairInfo("rsa1", System.currentTimeMillis())))
+        val keystoreEntries = (2..10).map { "rsa$it" }.toMutableSet()
+        val repo = RecordingBcscKeyPairRepo(infoSource, blindKeyStore(), keystoreEntries)
+
+        val thrown =
+            try {
+                repo.getNewBcscKeyPair()
+                fail("getNewBcscKeyPair() must throw once all attempts are exhausted")
+                null
+            } catch (e: Exception) {
+                e
+            }
+
+        assertTrue(
+            "the exhaustion failure must be (or wrap) a KeyAlreadyExistsException",
+            thrown is KeyAlreadyExistsException || thrown?.cause is KeyAlreadyExistsException,
+        )
+        assertEquals(listOf("rsa2", "rsa3", "rsa4", "rsa5", "rsa6"), repo.generatedAttempts)
+    }
+}

--- a/packages/bcsc-core/android/src/test/java/com/bcsccore/keypair/repos/key/BcscKeyPairRepoCleanupTest.kt
+++ b/packages/bcsc-core/android/src/test/java/com/bcsccore/keypair/repos/key/BcscKeyPairRepoCleanupTest.kt
@@ -1,0 +1,261 @@
+package com.bcsccore.keypair.repos.key
+
+import com.bcsccore.keypair.core.exceptions.AlertKey
+import com.bcsccore.keypair.core.exceptions.BcscException
+import com.bcsccore.keypair.core.interfaces.KeyPairInfoSource
+import com.bcsccore.keypair.core.models.KeyPairInfo
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.KeyStoreException
+import java.util.HashMap
+
+/**
+ * Verifies the post-generation cleanup safety behavior in
+ * [BcscKeyPairRepo.getNewBcscKeyPair] (issue #3876 review): if anything fails AFTER
+ * `generateKeyPair()` has actually created a keystore entry, that entry (and any metadata row
+ * already persisted for it) must be best-effort deleted before the original exception
+ * propagates — otherwise the orphaned/untracked alias would strand the device signing with an
+ * unregistered key, or collide with the next rotation attempt.
+ *
+ * Robolectric cannot exercise the real "AndroidKeyStore" provider (confirmed empirically —
+ * `KeyPairGenerator.getInstance(..., "AndroidKeyStore")` throws `NoSuchAlgorithmException` under
+ * this project's Robolectric setup), so [TestableBcscKeyPairRepo] substitutes a mocked
+ * [KeyStore] and controllable fakes for `generateKeyPair`/`getKeyPair` — the three methods were
+ * widened from `private` to `protected` specifically to allow this.
+ */
+@RunWith(RobolectricTestRunner::class)
+class BcscKeyPairRepoCleanupTest {
+    companion object {
+        private val FAKE_KEY_PAIR: KeyPair by lazy {
+            KeyPairGenerator.getInstance("RSA").also { it.initialize(2048) }.generateKeyPair()
+        }
+
+        /** True if [target] appears anywhere in [thrown]'s cause chain (including itself). */
+        private fun causeChainContains(
+            thrown: Throwable?,
+            target: Throwable?,
+        ): Boolean {
+            var cause = thrown
+            while (cause != null) {
+                if (cause === target) return true
+                cause = cause.cause
+            }
+            return false
+        }
+    }
+
+    // Lightweight in-memory stand-in for SharedPreferences-backed KeyPairInfoSource, matching
+    // the one in BcscKeyPairRepoSeedingTest (duplicated locally to keep this file self-contained
+    // and focused on cleanup behavior rather than seeding).
+    private open class InMemoryKeyPairInfoSource(
+        initial: Map<String, KeyPairInfo> = emptyMap(),
+    ) : KeyPairInfoSource {
+        val store = HashMap<String, KeyPairInfo>(initial)
+
+        override fun getKeyPairInfo(kid: String): KeyPairInfo? = store[kid]
+
+        override fun getKeyPairInfo(): HashMap<String, KeyPairInfo> = HashMap(store)
+
+        override fun saveKeyPairInfo(info: KeyPairInfo) {
+            store[info.alias] = info
+        }
+
+        override fun deleteKeyPairInfo(alias: String) {
+            store.remove(alias)
+        }
+    }
+
+    /** Throws a (captured, for identity assertions) [BcscException] from saveKeyPairInfo when the alias matches. */
+    private class ThrowingSaveInfoSource(
+        initial: Map<String, KeyPairInfo>,
+        private val throwOnSaveAlias: String,
+    ) : InMemoryKeyPairInfoSource(initial) {
+        var lastThrown: BcscException? = null
+            private set
+
+        override fun saveKeyPairInfo(info: KeyPairInfo) {
+            if (info.alias == throwOnSaveAlias) {
+                val error = BcscException(AlertKey.GENERAL, "simulated saveKeyPairInfo failure for '$throwOnSaveAlias'")
+                lastThrown = error
+                throw error
+            }
+            super.saveKeyPairInfo(info)
+        }
+    }
+
+    /**
+     * Test subclass substituting Robolectric-incompatible native Android Keystore calls with
+     * controllable fakes. [generateKeyPair] is a no-op (pretends generation succeeded — the
+     * behavior under test starts AFTER generation), and [getKeyPair] delegates to
+     * [getKeyPairResult] so each test can choose success or failure.
+     */
+    private class TestableBcscKeyPairRepo(
+        infoSource: KeyPairInfoSource,
+        val fakeKeyStore: KeyStore,
+        private val getKeyPairResult: () -> KeyPair,
+    ) : BcscKeyPairRepo(infoSource) {
+        override fun loadAndroidKeyStore(): KeyStore = fakeKeyStore
+
+        override fun generateKeyPair(alias: String) {
+            // No-op: pretends the native key was generated. The real method's own failure modes
+            // (before any keystore entry exists) are out of scope here — see BcscCore.swift's
+            // and BcscCoreModule.kt's equivalent pre-generation paths, which correctly have no
+            // cleanup because nothing exists yet to clean up.
+        }
+
+        override fun getKeyPair(
+            keyStore: KeyStore,
+            kid: String,
+        ): KeyPair = getKeyPairResult()
+    }
+
+    private fun mockKeyStore(): KeyStore = mockk(relaxed = true)
+
+    // -----------------------------------------------------------------------
+    // saveKeyPairInfo throws -> keystore entry deleted -> original exception propagates
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `saveKeyPairInfo failure deletes the just-generated keystore entry and rethrows the original exception`() {
+        // Seed with an existing rsa1 so reconcile() short-circuits (metadata non-empty) and the
+        // only saveKeyPairInfo call reached is the one for the NEW alias ("rsa2") we want to fail.
+        val infoSource =
+            ThrowingSaveInfoSource(
+                initial = mapOf("rsa1" to KeyPairInfo("rsa1", System.currentTimeMillis())),
+                throwOnSaveAlias = "rsa2",
+            )
+        val keyStore = mockKeyStore()
+        val repo = TestableBcscKeyPairRepo(infoSource, keyStore) { FAKE_KEY_PAIR }
+
+        val thrown =
+            try {
+                repo.getNewBcscKeyPair()
+                fail("getNewBcscKeyPair() must propagate the saveKeyPairInfo failure")
+                null
+            } catch (e: Exception) {
+                e
+            }
+
+        assertTrue(
+            "the original saveKeyPairInfo exception must survive in the cause chain, not be swallowed",
+            causeChainContains(thrown, infoSource.lastThrown),
+        )
+        verify(exactly = 1) { keyStore.deleteEntry("rsa2") }
+        assertFalse(
+            "the failed alias must never end up persisted in metadata",
+            infoSource.store.containsKey("rsa2"),
+        )
+        assertTrue("the pre-existing rsa1 entry must be untouched", infoSource.store.containsKey("rsa1"))
+    }
+
+    @Test
+    fun `saveKeyPairInfo failure cleanup does not mask the original exception even if delete itself fails`() {
+        val infoSource =
+            ThrowingSaveInfoSource(
+                initial = mapOf("rsa1" to KeyPairInfo("rsa1", System.currentTimeMillis())),
+                throwOnSaveAlias = "rsa2",
+            )
+        val keyStore = mockKeyStore()
+        every { keyStore.deleteEntry(any()) } throws KeyStoreException("delete also failed")
+        val repo = TestableBcscKeyPairRepo(infoSource, keyStore) { FAKE_KEY_PAIR }
+
+        val thrown =
+            try {
+                repo.getNewBcscKeyPair()
+                fail("getNewBcscKeyPair() must still propagate the ORIGINAL saveKeyPairInfo failure")
+                null
+            } catch (e: Exception) {
+                e
+            }
+
+        assertTrue(
+            "the cleanup failure must not replace the original exception",
+            causeChainContains(thrown, infoSource.lastThrown),
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // getKeyPair throws post-save -> keystore entry AND metadata row both cleaned up
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `getKeyPair failure after a successful save deletes both the keystore entry and the metadata row`() {
+        val infoSource =
+            InMemoryKeyPairInfoSource(
+                initial = mapOf("rsa1" to KeyPairInfo("rsa1", System.currentTimeMillis())),
+            )
+        val keyStore = mockKeyStore()
+        val retrievalError = KeyStoreException("simulated getKeyPair failure")
+        val repo =
+            TestableBcscKeyPairRepo(infoSource, keyStore) {
+                throw retrievalError
+            }
+
+        val thrown =
+            try {
+                repo.getNewBcscKeyPair()
+                fail("getNewBcscKeyPair() must propagate the getKeyPair failure")
+                null
+            } catch (e: Exception) {
+                e
+            }
+
+        assertTrue(
+            "the original getKeyPair exception must survive in the cause chain",
+            causeChainContains(thrown, retrievalError),
+        )
+
+        // Both the keystore entry AND the now-orphaned metadata row must be cleaned up — this is
+        // the fix (#3876 review, comment 2): the saveKeyPairInfo-failure branch only has a
+        // keystore entry to clean up, but by the time getKeyPair runs, saveKeyPairInfo already
+        // succeeded, so BOTH must go.
+        verify(exactly = 1) { keyStore.deleteEntry("rsa2") }
+        assertFalse(
+            "the orphaned metadata row for the unretrievable key must be deleted",
+            infoSource.store.containsKey("rsa2"),
+        )
+        assertTrue("the pre-existing rsa1 entry must be untouched", infoSource.store.containsKey("rsa1"))
+    }
+
+    @Test
+    fun `getKeyPair failure cleanup does not mask the original exception even if both cleanups themselves fail`() {
+        val infoSource =
+            object : InMemoryKeyPairInfoSource(
+                initial = mapOf("rsa1" to KeyPairInfo("rsa1", System.currentTimeMillis())),
+            ) {
+                override fun deleteKeyPairInfo(alias: String): Unit =
+                    throw BcscException(AlertKey.GENERAL, "simulated metadata cleanup failure")
+            }
+        val keyStore = mockKeyStore()
+        every { keyStore.deleteEntry(any()) } throws KeyStoreException("simulated keystore cleanup failure")
+        val retrievalError = KeyStoreException("simulated getKeyPair failure")
+        val repo =
+            TestableBcscKeyPairRepo(infoSource, keyStore) {
+                throw retrievalError
+            }
+
+        val thrown =
+            try {
+                repo.getNewBcscKeyPair()
+                fail("getNewBcscKeyPair() must still propagate the ORIGINAL getKeyPair failure")
+                null
+            } catch (e: Exception) {
+                e
+            }
+
+        assertTrue(
+            "the original exception must survive even when BOTH best-effort cleanups themselves fail",
+            causeChainContains(thrown, retrievalError),
+        )
+    }
+}

--- a/packages/bcsc-core/android/src/test/java/com/bcsccore/keypair/repos/key/BcscKeyPairRepoCleanupTest.kt
+++ b/packages/bcsc-core/android/src/test/java/com/bcsccore/keypair/repos/key/BcscKeyPairRepoCleanupTest.kt
@@ -20,18 +20,9 @@ import java.security.KeyStoreException
 import java.util.HashMap
 
 /**
- * Verifies the post-generation cleanup safety behavior in
- * [BcscKeyPairRepo.getNewBcscKeyPair] (issue #3876 review): if anything fails AFTER
- * `generateKeyPair()` has actually created a keystore entry, that entry (and any metadata row
- * already persisted for it) must be best-effort deleted before the original exception
- * propagates — otherwise the orphaned/untracked alias would strand the device signing with an
- * unregistered key, or collide with the next rotation attempt.
- *
- * Robolectric cannot exercise the real "AndroidKeyStore" provider (confirmed empirically —
- * `KeyPairGenerator.getInstance(..., "AndroidKeyStore")` throws `NoSuchAlgorithmException` under
- * this project's Robolectric setup), so [TestableBcscKeyPairRepo] substitutes a mocked
- * [KeyStore] and controllable fakes for `generateKeyPair`/`getKeyPair` — the three methods were
- * widened from `private` to `protected` specifically to allow this.
+ * Verifies [BcscKeyPairRepo.getNewBcscKeyPair]'s post-generation cleanup: a failure after the
+ * keystore entry exists must best-effort delete it (and any persisted metadata row) before
+ * rethrowing, or the orphaned alias strands signing or collides with the next rotation.
  */
 @RunWith(RobolectricTestRunner::class)
 class BcscKeyPairRepoCleanupTest {
@@ -94,10 +85,9 @@ class BcscKeyPairRepoCleanupTest {
     }
 
     /**
-     * Test subclass substituting Robolectric-incompatible native Android Keystore calls with
-     * controllable fakes. [generateKeyPair] is a no-op (pretends generation succeeded — the
-     * behavior under test starts AFTER generation), and [getKeyPair] delegates to
-     * [getKeyPairResult] so each test can choose success or failure.
+     * Robolectric can't exercise the real "AndroidKeyStore" provider (`NoSuchAlgorithmException`),
+     * so this substitutes controllable fakes: [generateKeyPair] is a no-op (behavior under test
+     * starts after generation) and [getKeyPair] delegates to [getKeyPairResult].
      */
     private class TestableBcscKeyPairRepo(
         infoSource: KeyPairInfoSource,
@@ -107,10 +97,7 @@ class BcscKeyPairRepoCleanupTest {
         override fun loadAndroidKeyStore(): KeyStore = fakeKeyStore
 
         override fun generateKeyPair(alias: String) {
-            // No-op: pretends the native key was generated. The real method's own failure modes
-            // (before any keystore entry exists) are out of scope here — see BcscCore.swift's
-            // and BcscCoreModule.kt's equivalent pre-generation paths, which correctly have no
-            // cleanup because nothing exists yet to clean up.
+            // No-op: pretends generation succeeded. Pre-generation failures are out of scope here.
         }
 
         override fun getKeyPair(
@@ -120,10 +107,6 @@ class BcscKeyPairRepoCleanupTest {
     }
 
     private fun mockKeyStore(): KeyStore = mockk(relaxed = true)
-
-    // -----------------------------------------------------------------------
-    // saveKeyPairInfo throws -> keystore entry deleted -> original exception propagates
-    // -----------------------------------------------------------------------
 
     @Test
     fun `saveKeyPairInfo failure deletes the just-generated keystore entry and rethrows the original exception`() {
@@ -184,10 +167,6 @@ class BcscKeyPairRepoCleanupTest {
         )
     }
 
-    // -----------------------------------------------------------------------
-    // getKeyPair throws post-save -> keystore entry AND metadata row both cleaned up
-    // -----------------------------------------------------------------------
-
     @Test
     fun `getKeyPair failure after a successful save deletes both the keystore entry and the metadata row`() {
         val infoSource =
@@ -215,10 +194,8 @@ class BcscKeyPairRepoCleanupTest {
             causeChainContains(thrown, retrievalError),
         )
 
-        // Both the keystore entry AND the now-orphaned metadata row must be cleaned up — this is
-        // the fix (#3876 review, comment 2): the saveKeyPairInfo-failure branch only has a
-        // keystore entry to clean up, but by the time getKeyPair runs, saveKeyPairInfo already
-        // succeeded, so BOTH must go.
+        // Unlike the saveKeyPairInfo-failure case, saveKeyPairInfo already succeeded by the time
+        // getKeyPair runs here, so both the keystore entry AND the metadata row must be cleaned up.
         verify(exactly = 1) { keyStore.deleteEntry("rsa2") }
         assertFalse(
             "the orphaned metadata row for the unretrievable key must be deleted",

--- a/packages/bcsc-core/ios/BcscCore.m
+++ b/packages/bcsc-core/ios/BcscCore.m
@@ -12,6 +12,8 @@ RCT_EXTERN_METHOD(setActiveKeyAlias : (NSString *)alias resolve : (RCTPromiseRes
 RCT_EXTERN_METHOD(deleteKey : (NSString *)alias resolve : (RCTPromiseResolveBlock)
                       resolve reject : (RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(createNewKeyPair : (RCTPromiseResolveBlock)resolve reject : (RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(getKeyPair : (NSString *)label resolve : (RCTPromiseResolveBlock)
                       resolve reject : (RCTPromiseRejectBlock)reject)
 

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -489,8 +489,14 @@ class BcscCore: NSObject {
           keyPairManager: keyPairManager,
           context: "RSA component extraction failure"
         )
+        // The key WAS generated (and retrieved) successfully — this is an export/derivation
+        // failure, not a "key doesn't exist" condition. E_KEY_EXPORT_FAILED is the existing code
+        // this file already uses for the equivalent failure in getKeyPair (export public/private
+        // key); reusing it here (rather than E_120_KEYCHAIN_KEY_DOESNT_EXIST_ERROR, which maps to
+        // KEYCHAIN_KEY_NOT_FOUND in native-error-map.ts and would route JS into the wrong
+        // recovery branch) keeps the surfaced error consistent with what actually failed.
         reject(
-          "E_120_KEYCHAIN_KEY_DOESNT_EXIST_ERROR",
+          "E_KEY_EXPORT_FAILED",
           "Generated new key '\(newKeyId)' but could not extract its RSA components",
           nil
         )

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -442,18 +442,7 @@ class BcscCore: NSObject {
     }
   }
 
-  /**
-   * Generate a new signing keypair under a freshly incremented alias and return its public
-   * RSA components, for the JS-side key-rotation flow (issue #3876).
-   *
-   * IMPORTANT side effect: iOS activation is implicitly newest-by-`kSecAttrCreationDate` (see
-   * `signJWT`/`getDynamicClientRegistrationBody`, both of which sort keys and pick the latest) —
-   * generating a key here switches signing to it immediately, before any server confirmation.
-   * The JS caller is responsible for registering the new key or rolling back via `deleteKey`.
-   *
-   * Reuses the same private `generateKeyPair()` alias-increment logic as the DCR self-heal
-   * path, and the same RSA-component derivation as `getAllKeysWithPublicInfo`.
-   */
+  /// Generates a new signing keypair; activation is implicit on generation — see the JS wrapper's warning.
   @objc(createNewKeyPair:reject:)
   func createNewKeyPair(
     _ resolve: @escaping RCTPromiseResolveBlock,
@@ -489,12 +478,9 @@ class BcscCore: NSObject {
           keyPairManager: keyPairManager,
           context: "RSA component extraction failure"
         )
-        // The key WAS generated (and retrieved) successfully — this is an export/derivation
-        // failure, not a "key doesn't exist" condition. E_KEY_EXPORT_FAILED is the existing code
-        // this file already uses for the equivalent failure in getKeyPair (export public/private
-        // key); reusing it here (rather than E_120_KEYCHAIN_KEY_DOESNT_EXIST_ERROR, which maps to
-        // KEYCHAIN_KEY_NOT_FOUND in native-error-map.ts and would route JS into the wrong
-        // recovery branch) keeps the surfaced error consistent with what actually failed.
+        // Reuse E_KEY_EXPORT_FAILED (same as getKeyPair's export failure) rather than
+        // E_120_KEYCHAIN_KEY_DOESNT_EXIST_ERROR — the key exists, this is an export failure,
+        // and that other code maps to KEYCHAIN_KEY_NOT_FOUND, which would misroute JS recovery.
         reject(
           "E_KEY_EXPORT_FAILED",
           "Generated new key '\(redactedAlias(newKeyId))' but could not extract its RSA components",
@@ -537,16 +523,9 @@ class BcscCore: NSObject {
   }
 
   /**
-   * Best-effort cleanup for `createNewKeyPair`'s post-generation failure paths.
-   *
-   * iOS activation is implicitly newest-by-`kSecAttrCreationDate`, so a key becomes the active
-   * signing key the INSTANT `generateKeyPair()` returns — before JS ever receives its alias.
-   * If anything after that point fails (RSA component extraction, re-retrieving the key pair),
-   * JS gets a rejection with no alias and cannot roll back via `deleteKey`, which would strand
-   * the device signing `private_key_jwt` client assertions with a key IAS has never registered
-   * (the #4166/2111 "Signature did not validate" failure mode). Deleting here is best-effort
-   * only: a cleanup failure is logged but never masks the original error the caller still
-   * rejects with — the caller is responsible for calling `reject` itself after this returns.
+   * A key activates the instant `generateKeyPair()` returns, before JS gets its alias — so a
+   * failure after that point must delete it here or strand signing on an unregistered key
+   * (#4166/2111). Best-effort only: a cleanup failure is logged but never masks the caller's error.
    */
   private func cleanUpUnregisteredKeyAfterGenerationFailure(
     _ alias: String, keyPairManager: KeyPairManager, context: String
@@ -559,15 +538,8 @@ class BcscCore: NSObject {
     }
   }
 
-  /**
-   * Redacts a keystore alias to its trailing 8 characters. The alias is `<provider><UUID>/N`
-   * (see `generateKeyPair()`), so the full string embeds a stable per-device UUID component —
-   * exposing it in full would leak that identifier. Used both in log lines (which ship to Loki
-   * from this public repo) and in `reject()` messages (which surface via
-   * `AppError.technicalMessage`, analytics, and user-visible debug details — a channel that
-   * travels further than logs). The trailing suffix still lets one device's log lines/error
-   * reports be correlated with each other without exposing the full identifier.
-   */
+  /// Truncates the alias (`<provider><UUID>/N`) to avoid leaking the embedded per-device UUID
+  /// in logs and reject() messages, while keeping enough to correlate a device's own entries.
   private func redactedAlias(_ alias: String) -> String {
     alias.count <= 8 ? alias : "…" + String(alias.suffix(8))
   }

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -497,7 +497,7 @@ class BcscCore: NSObject {
         // recovery branch) keeps the surfaced error consistent with what actually failed.
         reject(
           "E_KEY_EXPORT_FAILED",
-          "Generated new key '\(newKeyId)' but could not extract its RSA components",
+          "Generated new key '\(redactedAlias(newKeyId))' but could not extract its RSA components",
           nil
         )
         return
@@ -519,7 +519,7 @@ class BcscCore: NSObject {
       )
       reject(
         "E_120_KEYCHAIN_UNAVAILABLE_ERROR",
-        "Keychain temporarily unavailable while retrieving newly generated key '\(newKeyId)' (OSStatus \(status))",
+        "Keychain temporarily unavailable while retrieving newly generated key '\(redactedAlias(newKeyId))' (OSStatus \(status))",
         KeychainError.keychainUnavailable(status)
       )
     } catch {
@@ -530,7 +530,7 @@ class BcscCore: NSObject {
       )
       reject(
         "E_120_KEYCHAIN_KEY_DOESNT_EXIST_ERROR",
-        "Failed to retrieve newly generated key pair '\(newKeyId)': \(error.localizedDescription)",
+        "Failed to retrieve newly generated key pair '\(redactedAlias(newKeyId))': \(error.localizedDescription)",
         error
       )
     }
@@ -560,11 +560,13 @@ class BcscCore: NSObject {
   }
 
   /**
-   * Redacts a keystore alias to its trailing 8 characters for logging. The alias is
-   * `<provider><UUID>/N` (see `generateKeyPair()`), so the full string embeds a stable
-   * per-device UUID component — logging it in full would leak that identifier into remote
-   * logs (this repo is public and logs ship to Loki). The trailing suffix still lets one
-   * device's log lines be correlated with each other without exposing the full identifier.
+   * Redacts a keystore alias to its trailing 8 characters. The alias is `<provider><UUID>/N`
+   * (see `generateKeyPair()`), so the full string embeds a stable per-device UUID component —
+   * exposing it in full would leak that identifier. Used both in log lines (which ship to Loki
+   * from this public repo) and in `reject()` messages (which surface via
+   * `AppError.technicalMessage`, analytics, and user-visible debug details — a channel that
+   * travels further than logs). The trailing suffix still lets one device's log lines/error
+   * reports be correlated with each other without exposing the full identifier.
    */
   private func redactedAlias(_ alias: String) -> String {
     alias.count <= 8 ? alias : "…" + String(alias.suffix(8))

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -547,8 +547,21 @@ class BcscCore: NSObject {
   ) {
     if !keyPairManager.deleteKey(withLabel: alias) {
       logger
-        .warning("createNewKeyPair: best-effort cleanup failed to delete unregistered key '\(alias)' after \(context)")
+        .warning(
+          "createNewKeyPair: best-effort cleanup failed to delete unregistered key '\(redactedAlias(alias))' after \(context)"
+        )
     }
+  }
+
+  /**
+   * Redacts a keystore alias to its trailing 8 characters for logging. The alias is
+   * `<provider><UUID>/N` (see `generateKeyPair()`), so the full string embeds a stable
+   * per-device UUID component — logging it in full would leak that identifier into remote
+   * logs (this repo is public and logs ship to Loki). The trailing suffix still lets one
+   * device's log lines be correlated with each other without exposing the full identifier.
+   */
+  private func redactedAlias(_ alias: String) -> String {
+    alias.count <= 8 ? alias : "…" + String(alias.suffix(8))
   }
 
   func getKeyPair(

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -442,6 +442,115 @@ class BcscCore: NSObject {
     }
   }
 
+  /**
+   * Generate a new signing keypair under a freshly incremented alias and return its public
+   * RSA components, for the JS-side key-rotation flow (issue #3876).
+   *
+   * IMPORTANT side effect: iOS activation is implicitly newest-by-`kSecAttrCreationDate` (see
+   * `signJWT`/`getDynamicClientRegistrationBody`, both of which sort keys and pick the latest) —
+   * generating a key here switches signing to it immediately, before any server confirmation.
+   * The JS caller is responsible for registering the new key or rolling back via `deleteKey`.
+   *
+   * Reuses the same private `generateKeyPair()` alias-increment logic as the DCR self-heal
+   * path, and the same RSA-component derivation as `getAllKeysWithPublicInfo`.
+   */
+  @objc(createNewKeyPair:reject:)
+  func createNewKeyPair(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    let keyPairManager = KeyPairManager()
+    let newKeyId: String
+    do {
+      newKeyId = try generateKeyPair()
+    } catch let KeychainError.keychainUnavailable(status) {
+      reject(
+        "E_120_KEYCHAIN_UNAVAILABLE_ERROR",
+        "Keychain temporarily unavailable while generating new key pair (OSStatus \(status))",
+        KeychainError.keychainUnavailable(status)
+      )
+      return
+    } catch {
+      reject(
+        "E_120_KEYCHAIN_KEY_GENERATION_ERROR",
+        "Failed to generate new key pair: \(error.localizedDescription)",
+        error
+      )
+      return
+    }
+
+    do {
+      let keyPair = try keyPairManager.getKeyPair(with: newKeyId)
+      guard let keyData = RSAUtil.secKeyRefToData(inputKey: keyPair.public),
+            let (modulus, exponent) = RSAUtil.splitIntoComponents(keyData: keyData)
+      else {
+        cleanUpUnregisteredKeyAfterGenerationFailure(
+          newKeyId,
+          keyPairManager: keyPairManager,
+          context: "RSA component extraction failure"
+        )
+        reject(
+          "E_120_KEYCHAIN_KEY_DOESNT_EXIST_ERROR",
+          "Generated new key '\(newKeyId)' but could not extract its RSA components",
+          nil
+        )
+        return
+      }
+      let keys = try? keyPairManager.findAllPrivateKeys()
+      let created = keys?.first(where: { $0.tag == newKeyId })?.created.timeIntervalSince1970
+        ?? Date().timeIntervalSince1970
+      resolve([
+        "id": newKeyId,
+        "created": created,
+        "n": modulus.base64EncodedString(),
+        "e": exponent.base64EncodedString(),
+      ])
+    } catch let KeychainError.keychainUnavailable(status) {
+      cleanUpUnregisteredKeyAfterGenerationFailure(
+        newKeyId,
+        keyPairManager: keyPairManager,
+        context: "keychain-unavailable retrieval failure"
+      )
+      reject(
+        "E_120_KEYCHAIN_UNAVAILABLE_ERROR",
+        "Keychain temporarily unavailable while retrieving newly generated key '\(newKeyId)' (OSStatus \(status))",
+        KeychainError.keychainUnavailable(status)
+      )
+    } catch {
+      cleanUpUnregisteredKeyAfterGenerationFailure(
+        newKeyId,
+        keyPairManager: keyPairManager,
+        context: "retrieval failure"
+      )
+      reject(
+        "E_120_KEYCHAIN_KEY_DOESNT_EXIST_ERROR",
+        "Failed to retrieve newly generated key pair '\(newKeyId)': \(error.localizedDescription)",
+        error
+      )
+    }
+  }
+
+  /**
+   * Best-effort cleanup for `createNewKeyPair`'s post-generation failure paths.
+   *
+   * iOS activation is implicitly newest-by-`kSecAttrCreationDate`, so a key becomes the active
+   * signing key the INSTANT `generateKeyPair()` returns — before JS ever receives its alias.
+   * If anything after that point fails (RSA component extraction, re-retrieving the key pair),
+   * JS gets a rejection with no alias and cannot roll back via `deleteKey`, which would strand
+   * the device signing `private_key_jwt` client assertions with a key IAS has never registered
+   * (the #4166/2111 "Signature did not validate" failure mode). Deleting here is best-effort
+   * only: a cleanup failure is logged but never masks the original error the caller still
+   * rejects with — the caller is responsible for calling `reject` itself after this returns.
+   */
+  private func cleanUpUnregisteredKeyAfterGenerationFailure(
+    _ alias: String, keyPairManager: KeyPairManager, context: String
+  ) {
+    if !keyPairManager.deleteKey(withLabel: alias) {
+      logger
+        .warning("createNewKeyPair: best-effort cleanup failed to delete unregistered key '\(alias)' after \(context)")
+    }
+  }
+
   func getKeyPair(
     _ label: String, resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock

--- a/packages/bcsc-core/src/NativeBcscCore.ts
+++ b/packages/bcsc-core/src/NativeBcscCore.ts
@@ -291,16 +291,7 @@ export interface Spec extends TurboModule {
    * E_KEY_DELETE_REFUSED_LAST if deleting would leave zero private keys.
    */
   deleteKey(alias: string): Promise<void>;
-  /**
-   * Generates a new signing keypair under a freshly incremented alias (`rsa1` -> `rsa2` -> ...)
-   * and returns its public RSA components, for the key-rotation flow (issue #3876).
-   *
-   * IMPORTANT side effect: generating a key implicitly makes it the active signing key on both
-   * platforms (iOS: newest-by-`kSecAttrCreationDate` wins at sign time; Android:
-   * `getCurrentBcscKeyPair` picks newest-by-`createdAt`). There is no separate "activate"
-   * step — callers MUST either register the new key with the server or delete it
-   * (`deleteKey`) to roll back, never leave it dangling as an unregistered active key.
-   */
+  /** Generates a new signing keypair; see the {@link createNewKeyPair} wrapper for the activation side effect. */
   createNewKeyPair(): Promise<KeyPublicInfo>;
   getKeyPair(label: string): Promise<KeyPair>;
   getToken(tokenType: number): Promise<NativeToken | null>;

--- a/packages/bcsc-core/src/NativeBcscCore.ts
+++ b/packages/bcsc-core/src/NativeBcscCore.ts
@@ -291,6 +291,17 @@ export interface Spec extends TurboModule {
    * E_KEY_DELETE_REFUSED_LAST if deleting would leave zero private keys.
    */
   deleteKey(alias: string): Promise<void>;
+  /**
+   * Generates a new signing keypair under a freshly incremented alias (`rsa1` -> `rsa2` -> ...)
+   * and returns its public RSA components, for the key-rotation flow (issue #3876).
+   *
+   * IMPORTANT side effect: generating a key implicitly makes it the active signing key on both
+   * platforms (iOS: newest-by-`kSecAttrCreationDate` wins at sign time; Android:
+   * `getCurrentBcscKeyPair` picks newest-by-`createdAt`). There is no separate "activate"
+   * step — callers MUST either register the new key with the server or delete it
+   * (`deleteKey`) to roll back, never leave it dangling as an unregistered active key.
+   */
+  createNewKeyPair(): Promise<KeyPublicInfo>;
   getKeyPair(label: string): Promise<KeyPair>;
   getToken(tokenType: number): Promise<NativeToken | null>;
 

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -329,13 +329,9 @@ export const deleteKey = (alias: string): Promise<void> => {
 };
 
 /**
- * Generates a new signing keypair under a freshly incremented alias and returns its public
- * RSA components. Used by the key-rotation flow (issue #3876).
- *
- * IMPORTANT: generating a key implicitly makes it the active signing key on both platforms —
- * there is no separate "activate" step. Callers MUST either register the new key with the
- * server (PUT /register) or delete it via {@link deleteKey} to roll back; never leave a
- * generated key dangling as an unregistered active key.
+ * Generates a new signing keypair. Generating implicitly makes it the active signing key on
+ * both platforms — there is no separate "activate" step — so callers MUST register it with
+ * the server or roll back via {@link deleteKey}; never leave it dangling as unregistered.
  */
 export const createNewKeyPair = (): Promise<KeyPublicInfo> => {
   return BcscCore.createNewKeyPair();

--- a/packages/bcsc-core/src/index.ts
+++ b/packages/bcsc-core/src/index.ts
@@ -329,6 +329,19 @@ export const deleteKey = (alias: string): Promise<void> => {
 };
 
 /**
+ * Generates a new signing keypair under a freshly incremented alias and returns its public
+ * RSA components. Used by the key-rotation flow (issue #3876).
+ *
+ * IMPORTANT: generating a key implicitly makes it the active signing key on both platforms —
+ * there is no separate "activate" step. Callers MUST either register the new key with the
+ * server (PUT /register) or delete it via {@link deleteKey} to roll back; never leave a
+ * generated key dangling as an unregistered active key.
+ */
+export const createNewKeyPair = (): Promise<KeyPublicInfo> => {
+  return BcscCore.createNewKeyPair();
+};
+
+/**
  * Retrieves a key pair (public and optionally private) for a given label.
  * @param label The identifier for the key pair.
  * @returns A promise that resolves to a KeyPair object.


### PR DESCRIPTION
Closes #3876

## What changed

Adds a native `createNewKeyPair()` to `react-native-bcsc-core` (iOS Swift, Android Kotlin/Java, TurboModule spec, JS wrapper). It generates a new device signing key and returns its public RSA components in the same shape as the existing `getAllKeysWithPublicInfo`.

Nothing calls it yet — this PR adds a capability, not a behaviour. Rotation itself arrives in later PRs in the series.

It also hardens the generation path, which *is* shared with existing key handling:

- Generating a key implicitly makes it the active signing key on both platforms. Every failure path after that point now best-effort deletes the new key before rejecting, so a partial failure can't leave the device signing with a key the server has never seen. Six such paths across the two platforms.
- Key aliases embed a stable per-device identifier, so they're redacted in log lines *and* error messages (the latter surface in `AppError.technicalMessage` and analytics).
- iOS RSA-extraction failure now rejects with `E_KEY_EXPORT_FAILED` instead of `E_120_KEYCHAIN_KEY_DOESNT_EXIST_ERROR`, which mapped to `KEYCHAIN_KEY_NOT_FOUND` and misdescribed the failure.

## What should the reviewer focus on

**The `private` → `protected` widening of `loadAndroidKeyStore`, `generateKeyPair`, and `getKeyPair` in `BcscKeyPairRepo.java`.** Robolectric can't drive the real `AndroidKeyStore`, so the new cleanup tests need a subclass with fakes. It's a deliberate encapsulation tradeoff — push back if you'd rather have the tests than the visibility.

Secondary: the cleanup ordering in `BcscKeyPairRepo.getNewBcscKeyPair()` — metadata is now persisted only *after* generation succeeds, and cleanup unwinds both the keystore entry and the metadata row.

No app code touched, so no UI or runtime behaviour change to check.

## How to test

Covered by unit tests: 4 new Robolectric cases in `BcscKeyPairRepoCleanupTest` pin the cleanup paths (native suite 116/116). Each was falsification-checked — the cleanup block was deliberately broken, the test confirmed failing, then restored.

CI is green, including Native Tests (iOS) and Native Tests (Android).

For end-to-end rotation behaviour, the complete implementation is on `3876-key-rotation-full-spike`.




