### PR TITLE
docs: add label and pull request references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,7 +277,7 @@ These files are sourced in shell contexts (e.g., GitHub Actions `source variant.
 
 Write for a PO or PM first. Say what changed for the user or the product, then the technical detail if it earns its place. Favour concision — a short description is a good one.
 
-**PRs** follow `.github/pull_request_template.md`:
+**PRs** follow `.github/pull_request_template.md`; `docs/pull-requests.md` has the detail:
 
 - `Closes #<issue>` on the first line. A bare `#123` further down creates no link GitHub tracks; linking from the Development panel works too.
 - **What changed** — enough to read the diff. The backstory lives in the issue. Screenshots and video go here.
@@ -288,7 +288,7 @@ Aim for a couple of hundred words across the whole body. Don't restate the issue
 
 **Issues** are created from the forms in `.github/ISSUE_TEMPLATE/`. Titles are plain text — the conventional-commit prefixes above are for commits and PR titles only.
 
-**Stacked PRs** each need their own link. Put the same `Closes #<issue>` on every PR in the stack — auto-close is off, so nothing races to close it — or split the work into sub-issues for a stack of four or more. Say which PR to merge first.
+**Stacked PRs** each need their own link — the same `Closes #<issue>` on each, or sub-issues for a stack of four or more. Say which PR to merge first.
 
 ## Code Review Priorities
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,6 +288,8 @@ Aim for a couple of hundred words across the whole body. Don't restate the issue
 
 **Issues** are created from the forms in `.github/ISSUE_TEMPLATE/`. Titles are plain text — the conventional-commit prefixes above are for commits and PR titles only.
 
+**Stacked PRs** each need their own link. Put the same `Closes #<issue>` on every PR in the stack — auto-close is off, so nothing races to close it — or split the work into sub-issues for a stack of four or more. Say which PR to merge first.
+
 ## Code Review Priorities
 
 When reviewing a pull request in this repository, prioritise these, roughly in order:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,3 +300,7 @@ Do not comment on:
 - Naming preferences, or restructuring that does not change behaviour, unless the current form is genuinely ambiguous.
 - Test coverage percentages as a number, or missing tests for code that is not new.
 - Generated files, lockfiles, and dependency bumps.
+
+## Labels
+
+See `docs/labels.md` for the label set and when to use each one. Pick at most one `component/` and one `work/`; `status/` flags go on only while true. Workflow state, priority, and Bug/Feature/Task/Epic live in board fields, not labels.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,16 +273,20 @@ IOS_PRODUCT_NAME="$(TARGET_NAME)"
 
 These files are sourced in shell contexts (e.g., GitHub Actions `source variant.env`). Double-quoted strings containing `$`, backticks, or `!` will be interpreted by the shell, leading to unexpected behaviour. Single quotes ensure values are loaded exactly as written.
 
-## Pull Request Descriptions
+## Issues and Pull Requests
 
-When drafting a PR description, follow `.github/pull_request_template.md`:
+Write for a PO or PM first. Say what changed for the user or the product, then the technical detail if it earns its place. Favour concision — a short description is a good one.
 
-- `Closes #<issue>` on the first line — that is what links the PR to the board. A bare `#123` further down does not.
-- **What changed** — enough context to read the diff. The backstory lives in the issue.
-- **What should the reviewer focus on** — point at the scary bit, or say there isn't one.
+**PRs** follow `.github/pull_request_template.md`:
+
+- `Closes #<issue>` on the first line. A bare `#123` further down creates no link GitHub tracks; linking from the Development panel works too.
+- **What changed** — enough to read the diff. The backstory lives in the issue. Screenshots and video go here.
+- **What should the reviewer focus on** — the part you are least sure about, or say there isn't one.
 - **How to test** — how someone else checks it. "Covered by unit tests" counts.
 
-Keep it short. Don't restate the issue's acceptance criteria, and don't pad a section to look thorough.
+Aim for a couple of hundred words across the whole body. Don't restate the issue's acceptance criteria or pad a section to look thorough. No issue to link? Omit the `Closes` line and add the `status/no-issue` label — a `chore:` title does **not** exempt a PR from the hygiene check.
+
+**Issues** are created from the forms in `.github/ISSUE_TEMPLATE/`. Titles are plain text — the conventional-commit prefixes above are for commits and PR titles only.
 
 ## Code Review Priorities
 
@@ -303,4 +307,4 @@ Do not comment on:
 
 ## Labels
 
-See `docs/labels.md` for the label set and when to use each one. Pick at most one `component/` and one `work/`; `status/` flags go on only while true. Workflow state, priority, and Bug/Feature/Task/Epic live in board fields, not labels.
+See `docs/labels.md`. At most one `component/` and one `work/`; `status/` flags only while true. Workflow state, priority, and Bug/Feature/Task/Epic are board fields, not labels.

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,0 +1,74 @@
+# Issue and PR labels
+
+20 labels, grouped by prefix. Most issues need none or one.
+
+Pick at most one `component/` and one `work/`. `ops/` marks where an issue came
+from and can sit alongside either. `status/` flags go on only while true — take
+them off when they stop being.
+
+## component/ — the area
+
+| Label | Use it when |
+|---|---|
+| `component/accessibility` | Screen reader, contrast, font scaling, WCAG |
+| `component/security` | Auth, keys, data protection, disclosure |
+| `component/performance` | Speed, rendering, memory, app size |
+| `component/cicd` | Pipelines, builds, release automation |
+| `component/test-automation` | E2E, unit tests, test harness |
+| `component/design` | Needs or involves UX design |
+
+## work/ — the kind of work
+
+| Label | Use it when |
+|---|---|
+| `work/tech-debt` | Refactors, cleanup, maintenance |
+| `work/spike` | Timeboxed research; output is a decision, not shipped code |
+
+Not `type/` — issue **Type** is a separate field.
+
+## ops/ — where it came from
+
+| Label | Use it when |
+|---|---|
+| `ops/problem-report` | User-reported error surfaced by remote logging |
+
+## status/ — only while true
+
+| Label | Use it when |
+|---|---|
+| `status/blocked` | Can't proceed until something else lands. Exempt from the stale bot |
+| `status/external-dependency` | Waiting on a third party. Exempt from the stale bot |
+| `status/needs-info` | Waiting on repro steps, a decision, or clarification |
+| `status/good first issue` | Small, well-scoped, safe for a newcomer |
+| `status/do-not-merge` | PR: not to land yet |
+| `status/no-issue` | PR: no linked issue on purpose. Exempt from the PR hygiene check |
+| `status/skip-changelog` | PR: leave out of the generated changelog |
+
+## UAT
+
+| Label | Use it when |
+|---|---|
+| `UAT` | Created by the UAT team |
+| `UAT/blocked` | UAT can't proceed |
+
+Only a UAT team member closes a `UAT` issue.
+
+## Bot-owned — never set by hand
+
+`stale` · `dependencies`
+
+Unprefixed because automation writes them by exact name: the stale bot sets
+`stale`, Dependabot sets `dependencies` (pinned in `.github/dependabot.yml`).
+
+## Use a field, not a label
+
+| For | Use |
+|---|---|
+| Workflow state | Board **Status** |
+| Priority | Board **Priority** |
+| Bug / Feature / Task / Epic | Issue **Type** |
+| Epic membership | **Parent issue** |
+| PR awaiting review | **Linked pull requests** (automatic) |
+| Target release | **Milestone** |
+
+Issues are closed by people, not automation — a merged PR leaves its issue open.

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -71,4 +71,7 @@ Unprefixed because automation writes them by exact name: the stale bot sets
 | PR awaiting review | **Linked pull requests** (automatic) |
 | Target release | **Milestone** |
 
-Issues are closed by people, not automation — a merged PR leaves its issue open.
+Issues are closed by people, not automation. This repo has GitHub's *auto-close
+issues with merged linked pull requests* setting turned **off**, so `Closes #`
+creates the link but closes nothing — a merged PR leaves its issue open awaiting
+verification. A `UAT` issue is closed by a UAT team member.

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -75,3 +75,5 @@ Issues are closed by people, not automation. This repo has GitHub's *auto-close
 issues with merged linked pull requests* setting turned **off**, so `Closes #`
 creates the link but closes nothing — a merged PR leaves its issue open awaiting
 verification. A `UAT` issue is closed by a UAT team member.
+
+PRs: see [pull-requests.md](pull-requests.md).

--- a/docs/pull-requests.md
+++ b/docs/pull-requests.md
@@ -1,0 +1,65 @@
+# Pull requests
+
+Every PR needs a tracked link to an issue, or an explicit note that it has none.
+A check enforces this on PRs marked ready for review.
+
+## Link it
+
+Put the issue number on the first line:
+
+```
+Closes #1234
+```
+
+Or link it from the **Development** panel on the right — same result. A bare
+`#1234` further down in the description looks like a link but isn't one; it
+never reaches the issue timeline or the board.
+
+`Closes` does not close anything here. This repo has GitHub's auto-close setting
+turned off, so the keyword is pure traceability — a merged PR leaves its issue
+open awaiting verification, and a person closes it.
+
+## No issue behind it?
+
+That's normal. Omit the `Closes` line and add the **`status/no-issue`** label.
+
+A `chore:` title does **not** exempt a PR. Only `build:`, `docs:`, and
+`release:` do — those categories structurally can't have an issue.
+
+## Stacked PRs
+
+Each PR in the stack needs its own link.
+
+- **Two or three PRs** — put the same `Closes #1234` on each. Nothing races to
+  close the issue, and its timeline shows the whole stack.
+- **Four or more** — split the work into sub-issues under a parent, and link one
+  per PR.
+
+Say which PR to merge first. Target the parent's branch; GitHub retargets the
+child to `main` when the parent merges.
+
+## Write it short
+
+Follow `.github/pull_request_template.md`. A couple of hundred words for the
+whole body, in language a PO or PM understands.
+
+| Section | What goes in it |
+|---|---|
+| **What changed** | Enough to read the diff. Backstory lives in the issue. Screenshots and video here |
+| **What should the reviewer focus on** | The part you're least sure about — or say there isn't one |
+| **How to test** | How someone else checks it. "Covered by unit tests" counts |
+
+Don't restate the issue's acceptance criteria or pad a section to look thorough.
+"Copy change, quick skim is fine" is a complete answer.
+
+## What the check looks at
+
+| Rule | Passes when |
+|---|---|
+| Linked issue | `closingIssuesReferences` is non-empty — `Closes #` or a Development-panel link |
+| Sections filled | Each of the three has 15+ characters, ignoring HTML comments |
+
+Skipped entirely for: drafts, the merge queue, bot authors, `dependencies`,
+`build:`/`docs:`/`release:` titles, and `status/no-issue`.
+
+Labels: see [labels.md](labels.md).


### PR DESCRIPTION
Closes #4506

## What changed

Two reference docs, both lookup tables rather than essays.

`docs/labels.md` — all 20 labels grouped by prefix, one line each, plus a "use a field, not a label" table pointing at board Status, Priority, Type, Parent issue, and Milestone.

`docs/pull-requests.md` — how to link a PR so it actually registers: `Closes #` on line one or the Development panel, why a bare `#1234` doesn't count, what to do when there's no issue (`status/no-issue`, and `chore:` won't save you), and how stacked PRs link — same issue on each for a small stack, sub-issues beyond that.

`AGENTS.md` picks up pointers to both and the same rules inline, so agents get the constraints without opening a file.

Until now the only reference was the tables inside #4506, which is a proposal thread rather than something you'd look up.

## What should the reviewer focus on

**Whether the one-line label descriptions are right** — they're the whole value of that doc, and I wrote them from the ticket rather than from how the team actually uses each label. `work/spike` and `ops/problem-report` are the two most likely to be off.

**The stacked-PR advice is untested.** No issue in this repo has ever had two PRs linked to it, so "put the same `Closes #1234` on each" is correct as far as I can tell but unproven here. The first real stack after the gate goes live will confirm it.

Neither doc carries rationale — why `work/` isn't `type/`, why bot labels are unprefixed, the migration history — that stays in #4506. The one exception is the auto-close note, where the behaviour is counterintuitive enough that stating it without the reason reads as a mistake.

## How to test

Label names were diffed against the live repo — exact match, all 20. The PR doc describes the check as implemented in #4516.
