### PR TITLE
chore: name the pre-prod environments and drop the bug form self-check

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -53,7 +53,10 @@ body:
       description: Which environment were you using when the bug happened?
       options:
         - Production
-        - Development
+        - PREPROD
+        - TEST
+        - QA
+        - SIT
     validations:
       required: true
 
@@ -105,11 +108,3 @@ body:
       placeholder: "4.1.0-6892"
     validations:
       required: true
-
-  - type: checkboxes
-    id: confirm
-    attributes:
-      label: Before you submit
-      options:
-        - label: Someone who has never seen this screen could follow my steps to reproduce.
-          required: true

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -53,9 +53,8 @@ body:
       description: Which environment were you using when the bug happened?
       options:
         - Production
-        - PREPROD
-        - TEST
         - QA
+        - Test
         - SIT
     validations:
       required: true


### PR DESCRIPTION
Part of #4506's sibling work — feedback on the bug form from the UAT team.

## What changed

**The environment dropdown now names the pre-prod environments.** `Production / Development` becomes `Production / QA / Test / SIT`. A bug seen in QA but not SIT is a different investigation from one seen everywhere, and often starts with the API team rather than the app — the generic "Development" hid that.

**Removed the required self-check** ("Someone who has never seen this screen could follow my steps to reproduce"). It was an attestation rather than information: unverifiable, and easy to tick without reading.

## What should the reviewer focus on

**The environment list, since it's the part people will hit daily.** Production is first as the most common answer; the rest are listed closest-to-production first. Say if you'd rather they ran in pipeline order.

Reporters who aren't on the UAT team — devs on a local build, POs on TestFlight — have no obviously-right option here. That's the trade for naming the environments, and worth watching once real reports come in.

## How to test

The form parses and keeps its `Bug` type stamp. Required fields: what happened, what you expected, steps to reproduce, environment, how often, and build number.

---

**Not changed: the order of the first three fields.** The request was to reorder to Description / Steps / Expected / Actual. The current order front-loads what's easy and top-of-mind so momentum carries the reporter to the end, with build number and screenshots last because by then they're context-switching to look things up on their device. Adding a free-form "Description" ahead of the structured fields also risks people telling the whole story there and leaving expected/actual thin — which is the problem the split was introduced to fix. Left as-is for now.
