### PR TITLE
feat: return the server's keys when re-registering

### DIFF
--- a/app/src/bcsc-theme/utils/key-recovery.test.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.test.ts
@@ -428,10 +428,8 @@ describe('reRegisterNewestKey', () => {
 
     const result = await reRegisterNewestKey(apiClient, CLIENT_ID, REG_TOKEN, makeLogger())
 
-    // toStrictEqual (not toEqual) so this also pins that serverKeyNs is actually PRESENT with
-    // the expected values — toEqual ignores undefined-valued properties and would pass even if
-    // the implementation always set (rather than omitted) the key, which defeats the point of
-    // the sibling "omits" test below.
+    // toStrictEqual, not toEqual — toEqual ignores undefined-valued properties and would pass
+    // even if the key were always set (never omitted), defeating the sibling "omits" test below.
     expect(result).toStrictEqual({ success: true, newRegistrationAccessToken: undefined, serverKeyNs: [n(1), n(2)] })
   })
 
@@ -442,9 +440,8 @@ describe('reRegisterNewestKey', () => {
 
     const result = await reRegisterNewestKey(apiClient, CLIENT_ID, REG_TOKEN, makeLogger())
 
-    // toStrictEqual (not toEqual) distinguishes "no serverKeyNs key at all" from "serverKeyNs:
-    // undefined" — the whole point of this test. Object.keys is a second, independent proof of
-    // the same thing, in case toStrictEqual's semantics ever change.
+    // toStrictEqual distinguishes "no serverKeyNs key" from "serverKeyNs: undefined"; Object.keys
+    // is a second, independent check of the same thing.
     expect(result).toStrictEqual({ success: true, newRegistrationAccessToken: 'rotated-put-token' })
     expect(Object.keys(result)).not.toContain('serverKeyNs')
   })

--- a/app/src/bcsc-theme/utils/key-recovery.test.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.test.ts
@@ -514,13 +514,28 @@ describe('reRegisterNewestKey', () => {
     await reRegisterNewestKey(apiClient, CLIENT_ID, REG_TOKEN, logger)
 
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('event=echoed_jwks'))
-    // the fingerprint keeps only the first/last 8 chars of the *normalized* modulus, so a middle
-    // substring of the raw n must never appear in any logged string — edge substrings can
-    // legitimately coincide and wouldn't prove truncation.
+    // A middle substring proves truncation; an edge one could coincide with the kept first/last 8.
     const middleSubstring = LONG_N.slice(10, 30)
     const allLoggedStrings = [...logger.info.mock.calls, ...logger.warn.mock.calls, ...logger.error.mock.calls].map(
       (call) => call[0]
     )
     expect(allLoggedStrings.some((msg) => msg.includes(middleSubstring))).toBe(false)
+  })
+
+  it('coerces a non-string echoed n to undefined instead of throwing into the failure path', async () => {
+    mockedGetAccount.mockResolvedValue({ nickname: 'My Phone' } as any)
+    mockedGetDCRBody.mockResolvedValue(JSON.stringify({ client_name: 'My Phone' }))
+    const apiClient = makeApiClient(undefined)
+    apiClient.put.mockResolvedValue({
+      data: { registration_access_token: undefined, jwks: { keys: [{ kid: 'x', n: 123 }, { n: n(2) }] } },
+    })
+    const logger = makeLogger()
+
+    const result = await reRegisterNewestKey(apiClient, CLIENT_ID, REG_TOKEN, logger)
+
+    expect(result.success).toBe(true)
+    expect(result.serverKeyNs).toStrictEqual([undefined, n(2)])
+    expect(logger.error).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('event=echoed_jwks'))
   })
 })

--- a/app/src/bcsc-theme/utils/key-recovery.test.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.test.ts
@@ -417,4 +417,27 @@ describe('reRegisterNewestKey', () => {
     expect(apiClient.put).not.toHaveBeenCalled()
     expect(mockedDeleteKey).not.toHaveBeenCalled()
   })
+
+  it('surfaces serverKeyNs from the PUT response jwks (used by key-rotation to confirm registration)', async () => {
+    mockedGetAccount.mockResolvedValue({ nickname: 'My Phone' } as any)
+    mockedGetDCRBody.mockResolvedValue(JSON.stringify({ client_name: 'My Phone' }))
+    const apiClient = makeApiClient(undefined)
+    apiClient.put.mockResolvedValue({
+      data: { registration_access_token: undefined, jwks: { keys: [{ n: n(1) }, { n: n(2) }] } },
+    })
+
+    const result = await reRegisterNewestKey(apiClient, CLIENT_ID, REG_TOKEN, makeLogger())
+
+    expect(result).toEqual({ success: true, newRegistrationAccessToken: undefined, serverKeyNs: [n(1), n(2)] })
+  })
+
+  it('serverKeyNs is undefined when the PUT response carries no jwks (no behavior change for existing callers)', async () => {
+    mockedGetAccount.mockResolvedValue({ nickname: 'My Phone' } as any)
+    mockedGetDCRBody.mockResolvedValue(JSON.stringify({ client_name: 'My Phone' }))
+    const apiClient = makeApiClient(undefined, { registrationAccessToken: 'rotated-put-token' })
+
+    const result = await reRegisterNewestKey(apiClient, CLIENT_ID, REG_TOKEN, makeLogger())
+
+    expect(result.serverKeyNs).toBeUndefined()
+  })
 })

--- a/app/src/bcsc-theme/utils/key-recovery.test.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.test.ts
@@ -428,16 +428,24 @@ describe('reRegisterNewestKey', () => {
 
     const result = await reRegisterNewestKey(apiClient, CLIENT_ID, REG_TOKEN, makeLogger())
 
-    expect(result).toEqual({ success: true, newRegistrationAccessToken: undefined, serverKeyNs: [n(1), n(2)] })
+    // toStrictEqual (not toEqual) so this also pins that serverKeyNs is actually PRESENT with
+    // the expected values — toEqual ignores undefined-valued properties and would pass even if
+    // the implementation always set (rather than omitted) the key, which defeats the point of
+    // the sibling "omits" test below.
+    expect(result).toStrictEqual({ success: true, newRegistrationAccessToken: undefined, serverKeyNs: [n(1), n(2)] })
   })
 
-  it('serverKeyNs is undefined when the PUT response carries no jwks (no behavior change for existing callers)', async () => {
+  it('omits serverKeyNs entirely (not merely undefined) when the PUT response carries no jwks — the result shape for existing callers is unchanged', async () => {
     mockedGetAccount.mockResolvedValue({ nickname: 'My Phone' } as any)
     mockedGetDCRBody.mockResolvedValue(JSON.stringify({ client_name: 'My Phone' }))
     const apiClient = makeApiClient(undefined, { registrationAccessToken: 'rotated-put-token' })
 
     const result = await reRegisterNewestKey(apiClient, CLIENT_ID, REG_TOKEN, makeLogger())
 
-    expect(result.serverKeyNs).toBeUndefined()
+    // toStrictEqual (not toEqual) distinguishes "no serverKeyNs key at all" from "serverKeyNs:
+    // undefined" — the whole point of this test. Object.keys is a second, independent proof of
+    // the same thing, in case toStrictEqual's semantics ever change.
+    expect(result).toStrictEqual({ success: true, newRegistrationAccessToken: 'rotated-put-token' })
+    expect(Object.keys(result)).not.toContain('serverKeyNs')
   })
 })

--- a/app/src/bcsc-theme/utils/key-recovery.test.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.test.ts
@@ -445,4 +445,82 @@ describe('reRegisterNewestKey', () => {
     expect(result).toStrictEqual({ success: true, newRegistrationAccessToken: 'rotated-put-token' })
     expect(Object.keys(result)).not.toContain('serverKeyNs')
   })
+
+  it('tolerates a truthy non-array jwks.keys: preserves success, omits serverKeyNs, logs a malformed-echo warning (not an error)', async () => {
+    mockedGetAccount.mockResolvedValue({ nickname: 'My Phone' } as any)
+    mockedGetDCRBody.mockResolvedValue(JSON.stringify({ client_name: 'My Phone' }))
+    const apiClient = makeApiClient(undefined)
+    apiClient.put.mockResolvedValue({
+      data: { registration_access_token: undefined, jwks: { keys: { kid: 'x', n: n(1) } } },
+    })
+    const logger = makeLogger()
+
+    const result = await reRegisterNewestKey(apiClient, CLIENT_ID, REG_TOKEN, logger)
+
+    expect(result).toStrictEqual({ success: true, newRegistrationAccessToken: undefined })
+    expect(Object.keys(result)).not.toContain('serverKeyNs')
+    expect(logger.error).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('event=succeeded'))
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('event=malformed_jwks_echo'))
+  })
+
+  it('reports serverKeyNs as [] (not omitted) when jwks.keys is an empty array', async () => {
+    mockedGetAccount.mockResolvedValue({ nickname: 'My Phone' } as any)
+    mockedGetDCRBody.mockResolvedValue(JSON.stringify({ client_name: 'My Phone' }))
+    const apiClient = makeApiClient(undefined)
+    apiClient.put.mockResolvedValue({ data: { registration_access_token: undefined, jwks: { keys: [] } } })
+
+    const result = await reRegisterNewestKey(apiClient, CLIENT_ID, REG_TOKEN, makeLogger())
+
+    expect(result).toStrictEqual({ success: true, newRegistrationAccessToken: undefined, serverKeyNs: [] })
+  })
+
+  it('omits serverKeyNs when jwks is present but keys is absent', async () => {
+    mockedGetAccount.mockResolvedValue({ nickname: 'My Phone' } as any)
+    mockedGetDCRBody.mockResolvedValue(JSON.stringify({ client_name: 'My Phone' }))
+    const apiClient = makeApiClient(undefined)
+    apiClient.put.mockResolvedValue({ data: { registration_access_token: undefined, jwks: {} } })
+
+    const result = await reRegisterNewestKey(apiClient, CLIENT_ID, REG_TOKEN, makeLogger())
+
+    expect(result).toStrictEqual({ success: true, newRegistrationAccessToken: undefined })
+    expect(Object.keys(result)).not.toContain('serverKeyNs')
+  })
+
+  it('preserves array position (undefined) for echoed keys missing n, without throwing', async () => {
+    mockedGetAccount.mockResolvedValue({ nickname: 'My Phone' } as any)
+    mockedGetDCRBody.mockResolvedValue(JSON.stringify({ client_name: 'My Phone' }))
+    const apiClient = makeApiClient(undefined)
+    apiClient.put.mockResolvedValue({
+      data: { registration_access_token: undefined, jwks: { keys: [{ kid: 'no-n' }, { n: n(2) }] } },
+    })
+
+    const result = await reRegisterNewestKey(apiClient, CLIENT_ID, REG_TOKEN, makeLogger())
+
+    expect(result.success).toBe(true)
+    expect(result.serverKeyNs).toStrictEqual([undefined, n(2)])
+  })
+
+  it('logs an echoed_jwks line with fingerprints only — never a middle substring of the raw modulus', async () => {
+    mockedGetAccount.mockResolvedValue({ nickname: 'My Phone' } as any)
+    mockedGetDCRBody.mockResolvedValue(JSON.stringify({ client_name: 'My Phone' }))
+    const LONG_N = Buffer.from(Array.from({ length: 64 }, (_, i) => i)).toString('base64')
+    const apiClient = makeApiClient(undefined)
+    apiClient.put.mockResolvedValue({
+      data: { registration_access_token: undefined, jwks: { keys: [{ n: LONG_N }] } },
+    })
+    const logger = makeLogger()
+
+    await reRegisterNewestKey(apiClient, CLIENT_ID, REG_TOKEN, logger)
+
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('event=echoed_jwks'))
+    // the fingerprint keeps only the first/last 8 chars of the *normalized* modulus, so a middle
+    // substring of the raw n must never appear in any logged string — edge substrings can
+    // legitimately coincide and wouldn't prove truncation.
+    const middleSubstring = LONG_N.slice(10, 30)
+    const allLoggedStrings = [...logger.info.mock.calls, ...logger.warn.mock.calls, ...logger.error.mock.calls].map(
+      (call) => call[0]
+    )
+    expect(allLoggedStrings.some((msg) => msg.includes(middleSubstring))).toBe(false)
+  })
 })

--- a/app/src/bcsc-theme/utils/key-recovery.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.ts
@@ -245,8 +245,10 @@ export type ReRegisterResult = {
   /**
    * Raw (unnormalized) `n` values echoed back in the PUT response's `jwks.keys`, if present.
    * Used by the key-rotation flow (#3876) to confirm the newly-registered key actually landed
-   * server-side — see modulusInSet() in jwk-modulus.ts. Undefined when the response carried no
-   * jwks (existing callers ignore this field entirely, so this is not a behavior change for them).
+   * server-side — see modulusInSet() in jwk-modulus.ts. OMITTED entirely (not set to
+   * `undefined`) when the response carried no `jwks.keys`, so the result's shape is identical
+   * to before this field existed for existing callers that never asked for it — verified with
+   * `Object.keys`/`toStrictEqual`, not just `toEqual`, which would hide the difference.
    */
   serverKeyNs?: Array<string | undefined>
 }
@@ -303,10 +305,15 @@ export async function reRegisterNewestKey(
     })
 
     logger.info('[reRegisterNewestKey] event=succeeded re-registered newest local key with server')
+    const serverKeyNs = data?.jwks?.keys?.map((k) => k?.n)
     return {
       success: true,
       newRegistrationAccessToken: data?.registration_access_token,
-      serverKeyNs: data?.jwks?.keys?.map((k) => k?.n),
+      // Conditional spread rather than `serverKeyNs: serverKeyNs` — omits the property entirely
+      // when the server echoed no jwks, instead of setting it to `undefined`, so the result's
+      // shape for that case is byte-for-byte identical to before this field existed (matters for
+      // Object.keys()/toStrictEqual-style checks, not just toEqual).
+      ...(serverKeyNs !== undefined ? { serverKeyNs } : {}),
     }
   } catch (error) {
     logger.error(`[reRegisterNewestKey] event=failed ${describeError(error)}`)

--- a/app/src/bcsc-theme/utils/key-recovery.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.ts
@@ -310,7 +310,9 @@ export async function reRegisterNewestKey(
     const rawKeys = data?.jwks?.keys
     let serverKeyNs: Array<string | undefined> | undefined
     if (Array.isArray(rawKeys)) {
-      serverKeyNs = rawKeys.map((k: ServerJwk | undefined) => k?.n)
+      // Coerce a non-string `n` to undefined: normalizeModulus() would throw on it, flipping an
+      // accepted registration into a failure — the same bug the Array.isArray guard above fixes.
+      serverKeyNs = rawKeys.map((k: ServerJwk | undefined) => (typeof k?.n === 'string' ? k.n : undefined))
       logger.info(
         `[reRegisterNewestKey] event=echoed_jwks server echoed ${serverKeyNs.length} key(s) [${serverKeyNs
           .map((n) => modulusFingerprint(normalizeModulus(n)))

--- a/app/src/bcsc-theme/utils/key-recovery.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.ts
@@ -26,8 +26,7 @@ const modulusFingerprint = (n: string | null): string => {
 /**
  * Format a caught error for logging, surfacing the native error code (e.g. E_KEY_NOT_FOUND) when
  * present. Handles plain-object rejections ({ code, message }) as well as Error instances, so the
- * code is never lost to an "[object Object]" string. Exported for reuse by the key-rotation flow
- * (#3876), which logs the same native-rejection shapes.
+ * code is never lost to an "[object Object]" string. Exported for reuse by the key-rotation flow (#3876).
  */
 export const describeError = (err: unknown): string => {
   if (err && typeof err === 'object') {
@@ -245,10 +244,7 @@ export type ReRegisterResult = {
   /**
    * Raw (unnormalized) `n` values echoed back in the PUT response's `jwks.keys`, if present.
    * Used by the key-rotation flow (#3876) to confirm the newly-registered key actually landed
-   * server-side — see modulusInSet() in jwk-modulus.ts. OMITTED entirely (not set to
-   * `undefined`) when the response carried no `jwks.keys`, so the result's shape is identical
-   * to before this field existed for existing callers that never asked for it — verified with
-   * `Object.keys`/`toStrictEqual`, not just `toEqual`, which would hide the difference.
+   * server-side — see modulusInSet() in jwk-modulus.ts.
    */
   serverKeyNs?: Array<string | undefined>
 }
@@ -309,10 +305,7 @@ export async function reRegisterNewestKey(
     return {
       success: true,
       newRegistrationAccessToken: data?.registration_access_token,
-      // Conditional spread rather than `serverKeyNs: serverKeyNs` — omits the property entirely
-      // when the server echoed no jwks, instead of setting it to `undefined`, so the result's
-      // shape for that case is byte-for-byte identical to before this field existed (matters for
-      // Object.keys()/toStrictEqual-style checks, not just toEqual).
+      // Omit rather than set `undefined`, so the result shape is unchanged for existing callers.
       ...(serverKeyNs !== undefined ? { serverKeyNs } : {}),
     }
   } catch (error) {

--- a/app/src/bcsc-theme/utils/key-recovery.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.ts
@@ -26,9 +26,10 @@ const modulusFingerprint = (n: string | null): string => {
 /**
  * Format a caught error for logging, surfacing the native error code (e.g. E_KEY_NOT_FOUND) when
  * present. Handles plain-object rejections ({ code, message }) as well as Error instances, so the
- * code is never lost to an "[object Object]" string.
+ * code is never lost to an "[object Object]" string. Exported for reuse by the key-rotation flow
+ * (#3876), which logs the same native-rejection shapes.
  */
-const describeError = (err: unknown): string => {
+export const describeError = (err: unknown): string => {
   if (err && typeof err === 'object') {
     const { code, message } = err as { code?: unknown; message?: unknown }
     const parts = [code, message].filter((part): part is string => typeof part === 'string')
@@ -241,6 +242,13 @@ export type ReRegisterResult = {
   success: boolean
   /** Rotated registration_access_token from the PUT response, if the server issued one. */
   newRegistrationAccessToken?: string
+  /**
+   * Raw (unnormalized) `n` values echoed back in the PUT response's `jwks.keys`, if present.
+   * Used by the key-rotation flow (#3876) to confirm the newly-registered key actually landed
+   * server-side — see modulusInSet() in jwk-modulus.ts. Undefined when the response carried no
+   * jwks (existing callers ignore this field entirely, so this is not a behavior change for them).
+   */
+  serverKeyNs?: Array<string | undefined>
 }
 
 /**
@@ -249,7 +257,10 @@ export type ReRegisterResult = {
  * registration). Rather than forcing the user through a full card re-setup, PUT a fresh
  * registration for the current newest local key using the existing registration_access_token
  * — the same request shape as `useRegistrationApi.updateRegistration`'s PUT, rebuilt here
- * without the hook since this runs from the key-recovery path, outside React.
+ * without the hook since every caller runs outside React.
+ *
+ * Also the registration step of the key-rotation flow (#3876), which calls this immediately
+ * after generating a new key and then confirms the result via `serverKeyNs`.
  *
  * Deliberately does NOT round-trip GET metadata into the PUT (only jwks + client_id are
  * echoed by the server; scopes/grants/etc. are server policy) and NEVER prunes local keys —
@@ -280,20 +291,23 @@ export async function reRegisterNewestKey(
     // useRegistrationApi.tsx's updateRegistration — keep all three in sync if it ever changes.
     payload.scope = 'openid profile email address offline_access'
 
-    const { data } = await apiClient.put<{ registration_access_token?: string }>(
-      `${apiClient.endpoints.registration}/${clientId}`,
-      payload,
-      {
-        skipBearerAuth: true,
-        // Same as the recovery GET: an unattended re-registration must fail silently (→ our catch
-        // → { success: false }), never surface a user-facing error via the global onError handler.
-        skipOnErrorHandler: true,
-        headers: { Authorization: `Bearer ${registrationAccessToken}` },
-      }
-    )
+    const { data } = await apiClient.put<{
+      registration_access_token?: string
+      jwks?: { keys?: ServerJwk[] }
+    }>(`${apiClient.endpoints.registration}/${clientId}`, payload, {
+      skipBearerAuth: true,
+      // Same as the recovery GET: an unattended re-registration must fail silently (→ our catch
+      // → { success: false }), never surface a user-facing error via the global onError handler.
+      skipOnErrorHandler: true,
+      headers: { Authorization: `Bearer ${registrationAccessToken}` },
+    })
 
     logger.info('[reRegisterNewestKey] event=succeeded re-registered newest local key with server')
-    return { success: true, newRegistrationAccessToken: data?.registration_access_token }
+    return {
+      success: true,
+      newRegistrationAccessToken: data?.registration_access_token,
+      serverKeyNs: data?.jwks?.keys?.map((k) => k?.n),
+    }
   } catch (error) {
     logger.error(`[reRegisterNewestKey] event=failed ${describeError(error)}`)
     return { success: false }

--- a/app/src/bcsc-theme/utils/key-recovery.ts
+++ b/app/src/bcsc-theme/utils/key-recovery.ts
@@ -245,6 +245,9 @@ export type ReRegisterResult = {
    * Raw (unnormalized) `n` values echoed back in the PUT response's `jwks.keys`, if present.
    * Used by the key-rotation flow (#3876) to confirm the newly-registered key actually landed
    * server-side — see modulusInSet() in jwk-modulus.ts.
+   *
+   * Absent ≡ empty ≡ unconfirmed: an absent (or malformed) echo must NEVER be read as
+   * confirmation that a key registered.
    */
   serverKeyNs?: Array<string | undefined>
 }
@@ -291,7 +294,9 @@ export async function reRegisterNewestKey(
 
     const { data } = await apiClient.put<{
       registration_access_token?: string
-      jwks?: { keys?: ServerJwk[] }
+      // Unvalidated server response — `keys` is checked with Array.isArray below rather than
+      // trusted as ServerJwk[], so a malformed echo degrades to "unconfirmed" instead of throwing.
+      jwks?: { keys?: unknown }
     }>(`${apiClient.endpoints.registration}/${clientId}`, payload, {
       skipBearerAuth: true,
       // Same as the recovery GET: an unattended re-registration must fail silently (→ our catch
@@ -301,7 +306,22 @@ export async function reRegisterNewestKey(
     })
 
     logger.info('[reRegisterNewestKey] event=succeeded re-registered newest local key with server')
-    const serverKeyNs = data?.jwks?.keys?.map((k) => k?.n)
+
+    const rawKeys = data?.jwks?.keys
+    let serverKeyNs: Array<string | undefined> | undefined
+    if (Array.isArray(rawKeys)) {
+      serverKeyNs = rawKeys.map((k: ServerJwk | undefined) => k?.n)
+      logger.info(
+        `[reRegisterNewestKey] event=echoed_jwks server echoed ${serverKeyNs.length} key(s) [${serverKeyNs
+          .map((n) => modulusFingerprint(normalizeModulus(n)))
+          .join(', ')}]`
+      )
+    } else if (rawKeys != null) {
+      logger.warn(
+        '[reRegisterNewestKey] event=malformed_jwks_echo jwks.keys is not an array; treating echo as unconfirmed'
+      )
+    }
+
     return {
       success: true,
       newRegistrationAccessToken: data?.registration_access_token,


### PR DESCRIPTION
Closes #3876

Stacked on #4517 — that merges first, then this retargets to `main` automatically.

## What changed

When the app registers a signing key, the identity server echoes back the keys it now holds. We currently discard that echo. This keeps it.

The next PR needs it: once we send up a new key, we want to confirm the server actually stored it before treating rotation as successful. This is only the plumbing — it confirms nothing itself, nothing calls it yet, and app behaviour is unchanged.

Also here: a helper made reusable for the next PR, and a stale comment fixed.

## What should the reviewer focus on

**Whether this is safe to land ahead of the feature that uses it.** The existing caller is the key-recovery path — the app's self-heal route when a device's signing key falls out of sync with the server — so a regression there is expensive and hard to spot in the field.

That caller never reads the new data, and when the server echoes nothing, the result it gets back is exactly what it was before: the field is absent, not present-but-empty. The tests pin that distinction on purpose, since the looser way of writing them would have let an empty-but-present field through unnoticed.

One opinion worth having: the "include only when present" line is a conditional spread — compact, but not the most readable thing in the file. Happy to write it plainer.

## How to test

Covered by unit tests; no manual testing, since nothing calls this yet. Two new cases cover both directions (server echoes keys / echoes nothing). The 18 existing key-recovery tests pass unchanged — that's the real evidence the self-heal path didn't move.

