### PR TITLE
fix: non-bcsc backwards navigation after id capture

### DIFF
--- a/app/src/bcsc-theme/navigators/VerifyStack.tsx
+++ b/app/src/bcsc-theme/navigators/VerifyStack.tsx
@@ -71,6 +71,7 @@ import VideoReviewScreen from '../features/verify/send-video/VideoReviewScreen'
 import VideoTooLongScreen from '../features/verify/send-video/VideoTooLongScreen'
 import { WebViewScreen } from '../features/webview/WebViewScreen'
 import { useLeaveVerification } from '../hooks/useLeaveVerification'
+import useSecureActions from '../hooks/useSecureActions'
 import { SystemCheckScope, useSystemChecks } from '../hooks/useSystemChecks'
 import { getResumeStepRoute } from '../utils/resume-step-route'
 
@@ -136,6 +137,7 @@ const VerifyStack = ({ showVerifyPrompt = false, onVerifyPromptAnswered }: Verif
   const { t } = useTranslation()
   const defaultStackOptions = useDefaultStackOptions(theme)
   const [store] = useStore<BCState>()
+  const { clearAdditionalEvidence } = useSecureActions()
   const resumeRoute = getResumeStepRoute(store)
   // Opening on the prompt (rather than swapping stacks to reach it) lets prompt → setup question
   // animate as an in-stack slide. Everyone else resumes at the step they left off on.
@@ -147,6 +149,8 @@ const VerifyStack = ({ showVerifyPrompt = false, onVerifyPromptAnswered }: Verif
 
   // Detect an expired in-progress verification session (device_code) and route to the restart screen.
   useSystemChecks(SystemCheckScope.VERIFY)
+
+  console.log({ evidence: store.bcscSecure.additionalEvidenceData })
 
   return (
     <Stack.Navigator
@@ -414,7 +418,14 @@ const VerifyStack = ({ showVerifyPrompt = false, onVerifyPromptAnswered }: Verif
         }
         options={{
           header: createProgressHeader(2, 75),
-          headerLeft: createVerifyHeaderBackButton(),
+          headerLeft: createVerifyHeaderBackButton((navigation) => {
+            if (navigation.canGoBack()) {
+              return navigation.goBack()
+            }
+
+            clearAdditionalEvidence()
+            navigation.replace(BCSCScreens.IdentitySelection)
+          }),
         }}
       />
       <Stack.Screen name={BCSCScreens.VerifyWebView} component={WebViewScreen} />

--- a/app/src/bcsc-theme/navigators/VerifyStack.tsx
+++ b/app/src/bcsc-theme/navigators/VerifyStack.tsx
@@ -150,8 +150,6 @@ const VerifyStack = ({ showVerifyPrompt = false, onVerifyPromptAnswered }: Verif
   // Detect an expired in-progress verification session (device_code) and route to the restart screen.
   useSystemChecks(SystemCheckScope.VERIFY)
 
-  console.log({ evidence: store.bcscSecure.additionalEvidenceData })
-
   return (
     <Stack.Navigator
       // Users resume their verification journey directly at the step they are on.

--- a/app/src/bcsc-theme/navigators/VerifyStack.tsx
+++ b/app/src/bcsc-theme/navigators/VerifyStack.tsx
@@ -398,7 +398,14 @@ const VerifyStack = ({ showVerifyPrompt = false, onVerifyPromptAnswered }: Verif
         }
         options={{
           header: createProgressHeader(2, 60),
-          headerLeft: createVerifyHeaderBackButton(),
+          headerLeft: createVerifyHeaderBackButton((navigation) => {
+            if (navigation.canGoBack()) {
+              return navigation.goBack()
+            }
+
+            clearAdditionalEvidence()
+            navigation.replace(BCSCScreens.IdentitySelection)
+          }),
         }}
       />
       <Stack.Screen


### PR DESCRIPTION
Closes #4428 

<!-- The issue number goes above, e.g. "Closes #1234" — that's what links the PR
     to the board. A bare "#1234" further down doesn't. No issue? Say why. -->

## What changed

<!-- Enough context to read the diff. The backstory lives in the issue.
     Drop in a screenshot or a short video if it shows what changed or how
     it's meant to work — often quicker than describing it. -->
Fixes the navigation for the non-bcsc flow when re-entering the flow after capturing 1st non-bcsc id.

## What should the reviewer focus on

<!-- Point at the scary bit — or say there isn't one:
     "Copy change, quick skim is fine."
     "The cancel path in useEvidenceUpload — not sure it clears the timer."
     "iOS only, Android untouched." -->
The navigation after scanning 1-2 non-bcsc IDs. Backward navigation is correct when continuing flow and after re-entering flow from home.

## How to test
Expected behaviour without exiting verification
1. Capture 1 non-bcsc id
2. Navigate back normally
3. Capture 2 non-bcsc id
4. Navigate back normally

Expected behaviour after exiting verification
1. Capture 1 non-bcsc id
2. Go to home
3. Continue verification
4. Go back
5. Should see scan ID screen
6. Evidence is cleared

<!-- How someone else checks it. "Covered by unit tests" counts. -->
