### PR TITLE
feat: auto focus postal code after province selection

### DIFF
--- a/app/src/bcsc-theme/components/DropdownWithValidation.tsx
+++ b/app/src/bcsc-theme/components/DropdownWithValidation.tsx
@@ -19,6 +19,7 @@ type DropdownWithValidationProps<T> = {
   value: T | null
   options: DropdownOption<T>[]
   onChange: (value: T) => void
+  onModalClose?: () => void
   label: string
   placeholder?: string
   subtext?: string
@@ -40,6 +41,7 @@ export const DropdownWithValidation = <T extends string | number>({
   value,
   options,
   onChange,
+  onModalClose,
   label,
   placeholder = 'Select an option',
   subtext,
@@ -206,7 +208,7 @@ export const DropdownWithValidation = <T extends string | number>({
         </ThemedText>
       ) : null}
 
-      <Modal visible={isOpen} transparent animationType="slide" onRequestClose={handleClose}>
+      <Modal visible={isOpen} transparent animationType="slide" onRequestClose={handleClose} onDismiss={onModalClose}>
         <View
           style={[styles.modalContent, { paddingTop: insets.top, paddingBottom: insets.bottom }]}
           testID={testIdWithKey(`${id}-modal-content`)}

--- a/app/src/bcsc-theme/components/InputWithValidation.tsx
+++ b/app/src/bcsc-theme/components/InputWithValidation.tsx
@@ -2,7 +2,7 @@ import { useBCSCActivity } from '@/bcsc-theme/contexts/BCSCActivityContext'
 import { hitSlop } from '@/constants'
 import { a11yLabel } from '@/utils/accessibility'
 import { testIdWithKey, ThemedText, useTheme } from '@bifold/core'
-import type { ReactNode } from 'react'
+import type { ReactNode, RefObject } from 'react'
 import { useRef, useState } from 'react'
 import {
   LayoutChangeEvent,
@@ -17,6 +17,7 @@ import {
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
 type InputWithValidationProps = {
+  ref?: RefObject<TextInput | null>
   id: string // unique input identifier
   value: string
   onChange?: (value: string) => void
@@ -49,8 +50,10 @@ type InputWithValidationProps = {
 export const InputWithValidation: React.FC<InputWithValidationProps> = (props: InputWithValidationProps) => {
   const { Inputs, ColorPalette, Spacing, TextTheme } = useTheme()
   const { reportActivity } = useBCSCActivity() ?? {}
-  const inputRef = useRef<TextInput>(null)
+  const _inputRef = useRef<TextInput>(null)
   const [isFocused, setIsFocused] = useState(false)
+
+  const inputRef = props.ref ?? _inputRef
 
   const styles = StyleSheet.create({
     label: {

--- a/app/src/bcsc-theme/features/verify/ResidentialAddressScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/ResidentialAddressScreen.tsx
@@ -13,7 +13,9 @@ import {
   useTheme,
 } from '@bifold/core'
 import { StackScreenProps } from '@react-navigation/stack'
+import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import { TextInput } from 'react-native'
 import useResidentialAddressModel from './_models/useResidentialAddressModel'
 
 type ResidentialAddressScreenProps = StackScreenProps<BCSCVerifyStackParams, BCSCScreens.ResidentialAddress>
@@ -27,6 +29,7 @@ export const ResidentialAddressScreen = ({ navigation }: ResidentialAddressScree
   const { t } = useTranslation()
   const { ColorPalette, Spacing } = useTheme()
   const { ButtonLoading } = useAnimatedComponents()
+  const postalCodeRef = useRef<TextInput>(null)
 
   const { formState, formErrors, isSubmitting, handleChange, handleSubmit } = useResidentialAddressModel({ navigation })
 
@@ -98,12 +101,19 @@ export const ResidentialAddressScreen = ({ navigation }: ResidentialAddressScree
         value={formState.province}
         options={PROVINCE_OPTIONS}
         onChange={(value) => handleChange('province', value)}
+        onModalClose={() => {
+          if (!formState.postalCode) {
+            // Focus the postal code input after the province dropdown is closed, if postal code is empty
+            postalCodeRef.current?.focus()
+          }
+        }}
         error={formErrors.province}
         placeholder={t('BCSC.Address.ProvincePlaceholder')}
         subtext={t('BCSC.Address.ProvinceSubtext')}
       />
 
       <InputWithValidation
+        ref={postalCodeRef}
         id={'postalCode'}
         label={t('BCSC.Address.PostalCodeLabel')}
         labelProps={labelProps}


### PR DESCRIPTION
Closes #4313 

<!-- The issue number goes above, e.g. "Closes #1234" — that's what links the PR
     to the board. A bare "#1234" further down doesn't. No issue? Say why. -->

## What changed

<!-- Enough context to read the diff. The backstory lives in the issue.
     Drop in a screenshot or a short video if it shows what changed or how
     it's meant to work — often quicker than describing it. -->
Auto focuses the postal code input after the province selection

## What should the reviewer focus on

<!-- Point at the scary bit — or say there isn't one:
     "Copy change, quick skim is fine."
     "The cancel path in useEvidenceUpload — not sure it clears the timer."
     "iOS only, Android untouched." -->
Postal code input focus
## How to test
1. Non-BCSC verification
2. Enter user metadata
3. Enter province
4. Postal code input focused (if empty)
<!-- How someone else checks it. "Covered by unit tests" counts. -->
