### PR TITLE
fix: let Dependabot pull requests pass CI without secrets

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1116,9 +1116,9 @@ jobs:
           echo "Debug: build-android.result=$ANDROID_RESULT"
           echo "Debug: build-ios.result=$IOS_RESULT"
 
-          # These jobs aren't gated by check-secrets and run even when
-          # should_skip_build is true, so check them first — a real failure
-          # here must not slip past the skip/skipped-build tolerance below.
+          # check-vars and compute-variants run even when should_skip_build is
+          # true, so check all five upstream jobs before the skip branches
+          # below — a real failure must not slip past their "skipped" tolerance.
           upstream_checks="early-exit-check=$EARLY_EXIT_RESULT check-vars=$CHECK_VARS_RESULT compute-variants=$COMPUTE_VARIANTS_RESULT prepare-ios=$PREPARE_IOS_RESULT prepare-android=$PREPARE_ANDROID_RESULT"
           for entry in $upstream_checks; do
             job="${entry%%=*}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1101,6 +1101,8 @@ jobs:
     needs:
       - early-exit-check
       - check-secrets
+      - check-vars
+      - compute-variants
       - prepare-ios
       - prepare-android
       - build-android
@@ -1112,6 +1114,8 @@ jobs:
           SHOULD_SKIP: ${{ needs.early-exit-check.outputs.should_skip_build }}
           EARLY_EXIT_RESULT: ${{ needs.early-exit-check.result }}
           SECRETS_RESULT: ${{ needs.check-secrets.result }}
+          CHECK_VARS_RESULT: ${{ needs.check-vars.result }}
+          COMPUTE_VARIANTS_RESULT: ${{ needs.compute-variants.result }}
           PREPARE_IOS_RESULT: ${{ needs.prepare-ios.result }}
           PREPARE_ANDROID_RESULT: ${{ needs.prepare-android.result }}
           ANDROID_RESULT: ${{ needs.build-android.result }}
@@ -1120,6 +1124,8 @@ jobs:
           echo "Debug: should_skip_build=$SHOULD_SKIP"
           echo "Debug: early-exit-check.result=$EARLY_EXIT_RESULT"
           echo "Debug: check-secrets.result=$SECRETS_RESULT"
+          echo "Debug: check-vars.result=$CHECK_VARS_RESULT"
+          echo "Debug: compute-variants.result=$COMPUTE_VARIANTS_RESULT"
           echo "Debug: prepare-ios.result=$PREPARE_IOS_RESULT"
           echo "Debug: prepare-android.result=$PREPARE_ANDROID_RESULT"
           echo "Debug: build-android.result=$ANDROID_RESULT"
@@ -1143,18 +1149,28 @@ jobs:
           fi
 
           # A skipped check-secrets (fork or Dependabot PR run) below is only
-          # ever a valid pass if nothing it gates on actually failed. Because
-          # build-ios/build-android also report "skipped" whenever an
-          # upstream `needs:` job fails (their `if:` implicitly requires
-          # success() of every job they need), a real failure in
-          # early-exit-check or either prepare job would otherwise be
-          # invisible to the checks above and get waved through by the
-          # secrets-skip branch next. Catch that here, before the skip is
-          # ever treated as a pass.
-          if [ "$EARLY_EXIT_RESULT" == "failure" ] || [ "$PREPARE_IOS_RESULT" == "failure" ] || [ "$PREPARE_ANDROID_RESULT" == "failure" ]; then
-            echo "❌ Upstream job failed: early-exit-check=$EARLY_EXIT_RESULT, prepare-ios=$PREPARE_IOS_RESULT, prepare-android=$PREPARE_ANDROID_RESULT"
-            exit 1
-          fi
+          # ever a valid pass if every other job the builds depend on
+          # actually succeeded. early-exit-check, check-vars,
+          # compute-variants, prepare-ios, and prepare-android aren't gated
+          # by check-secrets, so a real failure in any of them would still
+          # show build-android/build-ios as "skipped" (their `needs:` gate
+          # skips them too) and slip past the checks above. check-secrets
+          # itself is deliberately excluded from this loop — it is
+          # legitimately skipped on this path, which is exactly what the
+          # branch below handles. Same success-or-skipped tolerance as the
+          # Android/iOS checks above: each of these jobs can also be
+          # legitimately skipped (the should_skip_build path already
+          # returned above, so "skipped" here only happens on this
+          # fork/Dependabot path via a cancelled or upstream-skipped run).
+          upstream_checks="early-exit-check=$EARLY_EXIT_RESULT check-vars=$CHECK_VARS_RESULT compute-variants=$COMPUTE_VARIANTS_RESULT prepare-ios=$PREPARE_IOS_RESULT prepare-android=$PREPARE_ANDROID_RESULT"
+          for entry in $upstream_checks; do
+            job="${entry%%=*}"
+            result="${entry#*=}"
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              echo "❌ $job failed with result: $result"
+              exit 1
+            fi
+          done
 
           # check-secrets was skipped (fork or Dependabot run): secrets are
           # unavailable, so build-ios/build-android skipping is the intended outcome.

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1116,6 +1116,19 @@ jobs:
           echo "Debug: build-android.result=$ANDROID_RESULT"
           echo "Debug: build-ios.result=$IOS_RESULT"
 
+          # These jobs aren't gated by check-secrets and run even when
+          # should_skip_build is true, so check them first — a real failure
+          # here must not slip past the skip/skipped-build tolerance below.
+          upstream_checks="early-exit-check=$EARLY_EXIT_RESULT check-vars=$CHECK_VARS_RESULT compute-variants=$COMPUTE_VARIANTS_RESULT prepare-ios=$PREPARE_IOS_RESULT prepare-android=$PREPARE_ANDROID_RESULT"
+          for entry in $upstream_checks; do
+            job="${entry%%=*}"
+            result="${entry#*=}"
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              echo "❌ $job failed with result: $result"
+              exit 1
+            fi
+          done
+
           # If builds were intentionally skipped, that's okay
           if [ "$SHOULD_SKIP" == "true" ]; then
             echo "✅ No relevant file changes. Build skipped intentionally."
@@ -1132,20 +1145,6 @@ jobs:
             echo "❌ iOS build(s) failed with result: $IOS_RESULT"
             exit 1
           fi
-
-          # These jobs aren't gated by check-secrets, so a real failure in
-          # any of them would still show build-android/build-ios as
-          # "skipped" and slip past the checks above. check-secrets itself
-          # is excluded — it's legitimately skipped below on this path.
-          upstream_checks="early-exit-check=$EARLY_EXIT_RESULT check-vars=$CHECK_VARS_RESULT compute-variants=$COMPUTE_VARIANTS_RESULT prepare-ios=$PREPARE_IOS_RESULT prepare-android=$PREPARE_ANDROID_RESULT"
-          for entry in $upstream_checks; do
-            job="${entry%%=*}"
-            result="${entry#*=}"
-            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
-              echo "❌ $job failed with result: $result"
-              exit 1
-            fi
-          done
 
           # check-secrets was skipped (fork or Dependabot run): secrets are
           # unavailable, so build-ios/build-android skipping is the intended outcome.

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,24 +29,9 @@ jobs:
     # outcome (a skipped `needs:` job still fails the default success()
     # gate on build-ios/build-android, same as a failed one did).
     #
-    # Dependabot runs are treated the same way: they read GitHub's
-    # separate Dependabot secrets store, so OP_SERVICE_ACCOUNT_TOKEN etc.
-    # arrive empty exactly like a fork PR, and the same downstream skip
-    # cascade applies. `github.actor` (not the PR author) is checked
-    # because it tracks who triggered the run — it flips to a human, and
-    # secrets become available, as soon as someone pushes to the branch.
-    #
-    # The Dependabot skip is scoped to `github.event_name == 'pull_request'`
-    # deliberately: it's only ever correct on the PR-validation run, where
-    # skipping the native builds is safe because nothing merges on their
-    # say-so. With the merge queue enabled, a Dependabot PR can be enqueued
-    # via `@dependabot merge`, and that `merge_group` run's actor IS
-    # `dependabot[bot]` — so without this clause it would skip here too,
-    # letting build-summary pass with no native build having run on the
-    # code actually reaching main. The event-name clause closes that:
-    # on merge_group (and on push) this job always runs, so a Dependabot
-    # merge_group run fails loudly here (empty secrets) instead of
-    # skipping, and build-summary's unexpected-skip check catches it.
+    # Dependabot gets no repo secrets either (separate secrets store), so
+    # the same skip applies — scoped to pull_request only: a Dependabot
+    # merge_group run (queue merge) must still run this job for real.
     if: >-
       github.event.pull_request.head.repo.fork != true &&
       !(github.event_name == 'pull_request' &&
@@ -1148,20 +1133,10 @@ jobs:
             exit 1
           fi
 
-          # A skipped check-secrets (fork or Dependabot PR run) below is only
-          # ever a valid pass if every other job the builds depend on
-          # actually succeeded. early-exit-check, check-vars,
-          # compute-variants, prepare-ios, and prepare-android aren't gated
-          # by check-secrets, so a real failure in any of them would still
-          # show build-android/build-ios as "skipped" (their `needs:` gate
-          # skips them too) and slip past the checks above. check-secrets
-          # itself is deliberately excluded from this loop — it is
-          # legitimately skipped on this path, which is exactly what the
-          # branch below handles. Same success-or-skipped tolerance as the
-          # Android/iOS checks above: each of these jobs can also be
-          # legitimately skipped (the should_skip_build path already
-          # returned above, so "skipped" here only happens on this
-          # fork/Dependabot path via a cancelled or upstream-skipped run).
+          # These jobs aren't gated by check-secrets, so a real failure in
+          # any of them would still show build-android/build-ios as
+          # "skipped" and slip past the checks above. check-secrets itself
+          # is excluded — it's legitimately skipped below on this path.
           upstream_checks="early-exit-check=$EARLY_EXIT_RESULT check-vars=$CHECK_VARS_RESULT compute-variants=$COMPUTE_VARIANTS_RESULT prepare-ios=$PREPARE_IOS_RESULT prepare-android=$PREPARE_ANDROID_RESULT"
           for entry in $upstream_checks; do
             job="${entry%%=*}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,9 +34,23 @@ jobs:
     # arrive empty exactly like a fork PR, and the same downstream skip
     # cascade applies. `github.actor` (not the PR author) is checked
     # because it tracks who triggered the run — it flips to a human, and
-    # secrets become available, as soon as someone pushes to the branch,
-    # and it's defined on push/merge_group where event.pull_request isn't.
-    if: github.event.pull_request.head.repo.fork != true && github.actor != 'dependabot[bot]'
+    # secrets become available, as soon as someone pushes to the branch.
+    #
+    # The Dependabot skip is scoped to `github.event_name == 'pull_request'`
+    # deliberately: it's only ever correct on the PR-validation run, where
+    # skipping the native builds is safe because nothing merges on their
+    # say-so. With the merge queue enabled, a Dependabot PR can be enqueued
+    # via `@dependabot merge`, and that `merge_group` run's actor IS
+    # `dependabot[bot]` — so without this clause it would skip here too,
+    # letting build-summary pass with no native build having run on the
+    # code actually reaching main. The event-name clause closes that:
+    # on merge_group (and on push) this job always runs, so a Dependabot
+    # merge_group run fails loudly here (empty secrets) instead of
+    # skipping, and build-summary's unexpected-skip check catches it.
+    if: >-
+      github.event.pull_request.head.repo.fork != true &&
+      !(github.event_name == 'pull_request' &&
+        github.actor == 'dependabot[bot]')
     runs-on: ubuntu-22.04
     permissions: {}
     steps:
@@ -1087,6 +1101,8 @@ jobs:
     needs:
       - early-exit-check
       - check-secrets
+      - prepare-ios
+      - prepare-android
       - build-android
       - build-ios
     if: always()
@@ -1094,12 +1110,18 @@ jobs:
       - name: Check matrix results
         env:
           SHOULD_SKIP: ${{ needs.early-exit-check.outputs.should_skip_build }}
+          EARLY_EXIT_RESULT: ${{ needs.early-exit-check.result }}
           SECRETS_RESULT: ${{ needs.check-secrets.result }}
+          PREPARE_IOS_RESULT: ${{ needs.prepare-ios.result }}
+          PREPARE_ANDROID_RESULT: ${{ needs.prepare-android.result }}
           ANDROID_RESULT: ${{ needs.build-android.result }}
           IOS_RESULT: ${{ needs.build-ios.result }}
         run: |
           echo "Debug: should_skip_build=$SHOULD_SKIP"
+          echo "Debug: early-exit-check.result=$EARLY_EXIT_RESULT"
           echo "Debug: check-secrets.result=$SECRETS_RESULT"
+          echo "Debug: prepare-ios.result=$PREPARE_IOS_RESULT"
+          echo "Debug: prepare-android.result=$PREPARE_ANDROID_RESULT"
           echo "Debug: build-android.result=$ANDROID_RESULT"
           echo "Debug: build-ios.result=$IOS_RESULT"
 
@@ -1117,6 +1139,20 @@ jobs:
 
           if [ "$IOS_RESULT" != "success" ] && [ "$IOS_RESULT" != "skipped" ]; then
             echo "❌ iOS build(s) failed with result: $IOS_RESULT"
+            exit 1
+          fi
+
+          # A skipped check-secrets (fork or Dependabot PR run) below is only
+          # ever a valid pass if nothing it gates on actually failed. Because
+          # build-ios/build-android also report "skipped" whenever an
+          # upstream `needs:` job fails (their `if:` implicitly requires
+          # success() of every job they need), a real failure in
+          # early-exit-check or either prepare job would otherwise be
+          # invisible to the checks above and get waved through by the
+          # secrets-skip branch next. Catch that here, before the skip is
+          # ever treated as a pass.
+          if [ "$EARLY_EXIT_RESULT" == "failure" ] || [ "$PREPARE_IOS_RESULT" == "failure" ] || [ "$PREPARE_ANDROID_RESULT" == "failure" ]; then
+            echo "❌ Upstream job failed: early-exit-check=$EARLY_EXIT_RESULT, prepare-ios=$PREPARE_IOS_RESULT, prepare-android=$PREPARE_ANDROID_RESULT"
             exit 1
           fi
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,7 +28,15 @@ jobs:
     # confusing red "failed" check, without changing that downstream
     # outcome (a skipped `needs:` job still fails the default success()
     # gate on build-ios/build-android, same as a failed one did).
-    if: github.event.pull_request.head.repo.fork != true
+    #
+    # Dependabot runs are treated the same way: they read GitHub's
+    # separate Dependabot secrets store, so OP_SERVICE_ACCOUNT_TOKEN etc.
+    # arrive empty exactly like a fork PR, and the same downstream skip
+    # cascade applies. `github.actor` (not the PR author) is checked
+    # because it tracks who triggered the run — it flips to a human, and
+    # secrets become available, as soon as someone pushes to the branch,
+    # and it's defined on push/merge_group where event.pull_request isn't.
+    if: github.event.pull_request.head.repo.fork != true && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-22.04
     permissions: {}
     steps:
@@ -1078,6 +1086,7 @@ jobs:
     permissions: {}
     needs:
       - early-exit-check
+      - check-secrets
       - build-android
       - build-ios
     if: always()
@@ -1085,10 +1094,12 @@ jobs:
       - name: Check matrix results
         env:
           SHOULD_SKIP: ${{ needs.early-exit-check.outputs.should_skip_build }}
+          SECRETS_RESULT: ${{ needs.check-secrets.result }}
           ANDROID_RESULT: ${{ needs.build-android.result }}
           IOS_RESULT: ${{ needs.build-ios.result }}
         run: |
           echo "Debug: should_skip_build=$SHOULD_SKIP"
+          echo "Debug: check-secrets.result=$SECRETS_RESULT"
           echo "Debug: build-android.result=$ANDROID_RESULT"
           echo "Debug: build-ios.result=$IOS_RESULT"
 
@@ -1107,6 +1118,13 @@ jobs:
           if [ "$IOS_RESULT" != "success" ] && [ "$IOS_RESULT" != "skipped" ]; then
             echo "❌ iOS build(s) failed with result: $IOS_RESULT"
             exit 1
+          fi
+
+          # check-secrets was skipped (fork or Dependabot run): secrets are
+          # unavailable, so build-ios/build-android skipping is the intended outcome.
+          if [ "$SECRETS_RESULT" == "skipped" ]; then
+            echo "✅ Builds skipped: secrets unavailable (fork or Dependabot run)."
+            exit 0
           fi
 
           # If we didn't skip but builds didn't run, that's an error

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,13 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Dependabot runs read GitHub's separate Dependabot secrets store,
-      # so OP_SERVICE_ACCOUNT_TOKEN (and fork PRs, which never get repo
-      # secrets at all) arrive empty here. The `secrets` context isn't
-      # readable in job-level `if:`, so availability is computed in a step
-      # and used to gate only the secret-dependent steps below — build,
-      # typecheck and test stay unconditional so this job still gates the
-      # merge on the real validation.
+      # Dependabot/fork runs get no repo secrets, so gate only the
+      # secret-dependent steps below on this — build/typecheck/test stay
+      # unconditional (job-level `if:` can't read `secrets`).
       - name: Check secret availability
         id: secrets-check
         if: always()

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,6 +17,26 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Dependabot runs read GitHub's separate Dependabot secrets store,
+      # so OP_SERVICE_ACCOUNT_TOKEN (and fork PRs, which never get repo
+      # secrets at all) arrive empty here. The `secrets` context isn't
+      # readable in job-level `if:`, so availability is computed in a step
+      # and used to gate only the secret-dependent steps below — build,
+      # typecheck and test stay unconditional so this job still gates the
+      # merge on the real validation.
+      - name: Check secret availability
+        id: secrets-check
+        if: always()
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          if [ -n "$OP_SERVICE_ACCOUNT_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "OP_SERVICE_ACCOUNT_TOKEN unavailable (Dependabot or fork run); skipping 1Password load and codecov upload."
+          fi
+
       - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
@@ -60,14 +80,14 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           CODECOV_TOKEN: op://bcsc-mobile-app-cd/codecov/credential
-        if: always() && !startsWith(github.base_ref, 'release/') && !startsWith(github.ref_name, 'release/')
+        if: always() && steps.secrets-check.outputs.available == 'true' && !startsWith(github.base_ref, 'release/') && !startsWith(github.ref_name, 'release/')
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # (v7.0.0) pinning for SonarQube
         with:
           token: ${{ env.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
-        if: always() && !startsWith(github.base_ref, 'release/') && !startsWith(github.ref_name, 'release/')
+        if: always() && steps.secrets-check.outputs.available == 'true' && !startsWith(github.base_ref, 'release/') && !startsWith(github.ref_name, 'release/')
 
   lint-format:
     runs-on: macos-26


### PR DESCRIPTION
Closes #4537

## What changed

Dependabot pull requests could never merge: Dependabot runs read a separate GitHub secrets store, so `OP_SERVICE_ACCOUNT_TOKEN` arrives empty and two required checks always failed. CI now treats Dependabot the way it already treats fork PRs — the secret-dependent steps skip cleanly, while build, typecheck, tests, lint and the native test suites still run and still gate the merge.

**Deliberate side effect:** this fixes the same failure for fork PRs, which hit it today for the same reason.

## What should the reviewer focus on

The `build-summary` job's branching order — it has to tell "builds skipped because secrets are unavailable" (expected, pass) apart from "builds skipped because something upstream broke" (a real failure, must still fail). An early version of this PR got that wrong and reported green when a build-preparation job had failed, so the ordering is worth a careful read.

## How to test

No app code changed — CI workflow YAML only. Verified locally with `actionlint` (no new findings) and `yarn check` (typecheck, lint, format, full test suite pass). The real test is the next Dependabot PR reaching a green, mergeable state on its own.
