### PR TITLE
chore: extract ship-to-play composite action

### DIFF
--- a/.github/workflows/actions/ship-to-play/action.yml
+++ b/.github/workflows/actions/ship-to-play/action.yml
@@ -1,0 +1,53 @@
+name: Ship to Google Play
+description: |
+  Upload an already-built, signed AAB to the Google Play internal track via
+  @bcgov/gpublish. This action only uploads — it does NOT promote the release
+  to any other track.
+
+inputs:
+  service_account_file:
+    description: |
+      Path to the Google Play publisher service-account JSON
+      (`op://bcsc-mobile-app-cd/google-play-publisher/service-account.json`).
+    required: true
+  package_name:
+    description: 'Android application ID to publish under (e.g. ca.bc.gov.id.servicescard).'
+    required: true
+  version_name:
+    description: 'Marketing version, used in the Play release name (e.g. 4.1.0).'
+    required: true
+  bundle_path:
+    description: |
+      Path to the .aab to upload.
+      Defaults to the Gradle release bundle output.
+    required: false
+    default: 'app/android/app/build/outputs/bundle/release/app-release.aab'
+
+runs:
+  using: composite
+  steps:
+    - name: Upload to Google Play internal track
+      shell: bash
+      env:
+        GOOGLE_API_CREDENTIALS: ${{ inputs.service_account_file }}
+        ANDROID_PACKAGE_NAME: ${{ inputs.package_name }}
+        VERSION_NAME: ${{ inputs.version_name }}
+        ANDROID_BUNDLE_PATH: ${{ inputs.bundle_path }}
+      run: |
+        set -euo pipefail
+
+        if [ ! -f "${GOOGLE_API_CREDENTIALS}" ]; then
+          echo "::error::No Google Play service-account file at ${GOOGLE_API_CREDENTIALS}"
+          exit 1
+        fi
+
+        if [ ! -f "${ANDROID_BUNDLE_PATH}" ]; then
+          echo "::error::No Android bundle at ${ANDROID_BUNDLE_PATH}"
+          exit 1
+        fi
+
+        echo "Uploading ${ANDROID_BUNDLE_PATH} to the Play internal track..."
+
+        # gpublish takes the Play version code from GITHUB_RUN_NUMBER, which
+        # Actions sets automatically — there is deliberately no input for it.
+        npx @bcgov/gpublish

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1054,24 +1054,23 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Ship to Google Play
+      - name: Fetch Google Play publisher credentials
         if: github.ref_name == 'main'
-        # working-directory: app/android
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          GOOGLE_API_CREDENTIALS_FILE: 'api_keys.json'
-          ANDROID_BUNDLE_PATH: 'app/android/app/build/outputs/bundle/release/app-release.aab'
-          ANDROID_PACKAGE_NAME: ${{ env.ANDROID_PACKAGE_NAME }}
-          VERSION_CODE: ${{ env.APP_BUILD_NUMBER }}
-          VERSION_NAME: ${{ env.APP_VERSION }}
         run: |
-          # when we updated to yarn we started getting an error with paths
-          # and had to add `/android` to the path.
-          #
           # `op read` to stdout appends a trailing newline, which would corrupt
           # this JSON credentials file. --out-file writes the bytes as-is.
-          op read "op://bcsc-mobile-app-cd/google-play-publisher/service-account.json" --out-file "${GOOGLE_API_CREDENTIALS_FILE}" --force && \
-          GOOGLE_API_CREDENTIALS="$PWD/${GOOGLE_API_CREDENTIALS_FILE}" npx @bcgov/gpublish
+          op read "op://bcsc-mobile-app-cd/google-play-publisher/service-account.json" --out-file "${RUNNER_TEMP}/play-service-account.json" --force
+
+      - name: Ship to Google Play
+        if: github.ref_name == 'main'
+        uses: ./.github/workflows/actions/ship-to-play
+        with:
+          service_account_file: ${{ runner.temp }}/play-service-account.json
+          package_name: ${{ env.ANDROID_PACKAGE_NAME }}
+          version_name: ${{ env.APP_VERSION }}
+          bundle_path: app/android/app/build/outputs/bundle/release/app-release.aab
 
   build-summary:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #4522

## What changed

Google Play was the only publish target still inlined in a build job — extracted it to a `ship-to-play` composite action, matching `ship-to-itunes`.

Two side-effects: publisher credentials now land in `RUNNER_TEMP` instead of the repo checkout, and the unused `VERSION_CODE` env var is gone (gpublish reads `GITHUB_RUN_NUMBER`).

## What should the reviewer focus on

Both steps are gated `if: github.ref_name == 'main'`, so PR CI only proves the YAML parses. The real check is the first main build.

The credentials handoff: `op read` writes to `$RUNNER_TEMP`, the action reads `${{ runner.temp }}`, and both steps carry the same `if:`.

## How to test

`actionlint` reports no new findings versus main and `shellcheck` is clean on the extracted script. After merge, the first main build should show the same Play internal-track release as today.
