### PR TITLE
chore: publish to Google Play via codemagic-cli-tools

### DIFF
--- a/.github/workflows/actions/ship-to-play/action.yml
+++ b/.github/workflows/actions/ship-to-play/action.yml
@@ -1,8 +1,9 @@
 name: Ship to Google Play
 description: |
-  Upload an already-built, signed AAB to the Google Play internal track via
-  @bcgov/gpublish. This action only uploads — it does NOT promote the release
-  to any other track.
+  Upload an already-built, signed AAB to a Google Play track using the
+  `google-play` command from codemagic-cli-tools. This action only uploads —
+  it does NOT promote the release to another track. Use `google-play tracks
+  promote-release` for that.
 
 inputs:
   service_account_file:
@@ -10,44 +11,64 @@ inputs:
       Path to the Google Play publisher service-account JSON
       (`op://bcsc-mobile-app-cd/google-play-publisher/service-account.json`).
     required: true
-  package_name:
-    description: 'Android application ID to publish under (e.g. ca.bc.gov.id.servicescard).'
-    required: true
   version_name:
     description: 'Marketing version, used in the Play release name (e.g. 4.1.0).'
     required: true
   bundle_path:
     description: |
-      Path to the .aab to upload.
+      Path to the .aab to upload. The Play package name and version code are
+      read from the bundle itself.
       Defaults to the Gradle release bundle output.
     required: false
     default: 'app/android/app/build/outputs/bundle/release/app-release.aab'
+  track:
+    description: 'Google Play track to release to.'
+    required: false
+    default: 'internal'
+  release_notes:
+    description: "Tester-facing \"what to test\" note, published as en-CA."
+    required: false
+    default: 'This is what to test.'
 
 runs:
   using: composite
   steps:
-    - name: Upload to Google Play internal track
+    # Pinned: an unpinned install would let an upstream release change what
+    # the release pipeline runs with no PR here.
+    - name: Install codemagic-cli-tools
+      shell: bash
+      run: |
+        set -euo pipefail
+        python3 -m venv "${RUNNER_TEMP}/codemagic-venv"
+        "${RUNNER_TEMP}/codemagic-venv/bin/pip" install --quiet codemagic-cli-tools==0.69.0
+
+    - name: Upload to Google Play
       shell: bash
       env:
-        GOOGLE_API_CREDENTIALS: ${{ inputs.service_account_file }}
-        ANDROID_PACKAGE_NAME: ${{ inputs.package_name }}
+        CREDENTIALS_FILE: ${{ inputs.service_account_file }}
+        BUNDLE_PATH: ${{ inputs.bundle_path }}
+        TRACK: ${{ inputs.track }}
         VERSION_NAME: ${{ inputs.version_name }}
-        ANDROID_BUNDLE_PATH: ${{ inputs.bundle_path }}
+        RELEASE_NOTES: ${{ inputs.release_notes }}
       run: |
         set -euo pipefail
 
-        if [ ! -f "${GOOGLE_API_CREDENTIALS}" ]; then
-          echo "::error::No Google Play service-account file at ${GOOGLE_API_CREDENTIALS}"
+        if [ ! -f "${CREDENTIALS_FILE}" ]; then
+          echo "::error::No Google Play service-account file at ${CREDENTIALS_FILE}"
           exit 1
         fi
 
-        if [ ! -f "${ANDROID_BUNDLE_PATH}" ]; then
-          echo "::error::No Android bundle at ${ANDROID_BUNDLE_PATH}"
+        if [ ! -f "${BUNDLE_PATH}" ]; then
+          echo "::error::No Android bundle at ${BUNDLE_PATH}"
           exit 1
         fi
 
-        echo "Uploading ${ANDROID_BUNDLE_PATH} to the Play internal track..."
+        NOTES_JSON=$(RELEASE_NOTES="${RELEASE_NOTES}" python3 -c \
+          'import json, os; print(json.dumps([{"language": "en-CA", "text": os.environ["RELEASE_NOTES"]}]))')
 
-        # gpublish takes the Play version code from GITHUB_RUN_NUMBER, which
-        # Actions sets automatically — there is deliberately no input for it.
-        npx @bcgov/gpublish
+        "${RUNNER_TEMP}/codemagic-venv/bin/google-play" bundles publish \
+          --credentials "@file:${CREDENTIALS_FILE}" \
+          --bundle "${BUNDLE_PATH}" \
+          --track "${TRACK}" \
+          --release-name "v${VERSION_NAME}-${GITHUB_RUN_NUMBER}" \
+          --release-notes "${NOTES_JSON}"

--- a/.github/workflows/actions/ship-to-play/action.yml
+++ b/.github/workflows/actions/ship-to-play/action.yml
@@ -14,6 +14,13 @@ inputs:
   version_name:
     description: 'Marketing version, used in the Play release name (e.g. 4.1.0).'
     required: true
+  build_number:
+    description: |
+      Build number of the run that produced the AAB, used in the Play release
+      name. Required rather than defaulted: a workflow publishing an earlier
+      build must pass that build's number, not its own run number. The version
+      code Play releases against still comes from the AAB itself.
+    required: true
   bundle_path:
     description: |
       Path to the .aab to upload. The Play package name and version code are
@@ -49,6 +56,7 @@ runs:
         BUNDLE_PATH: ${{ inputs.bundle_path }}
         TRACK: ${{ inputs.track }}
         VERSION_NAME: ${{ inputs.version_name }}
+        BUILD_NUMBER: ${{ inputs.build_number }}
         RELEASE_NOTES: ${{ inputs.release_notes }}
       run: |
         set -euo pipefail
@@ -70,5 +78,5 @@ runs:
           --credentials "@file:${CREDENTIALS_FILE}" \
           --bundle "${BUNDLE_PATH}" \
           --track "${TRACK}" \
-          --release-name "v${VERSION_NAME}-${GITHUB_RUN_NUMBER}" \
+          --release-name "v${VERSION_NAME}-${BUILD_NUMBER}" \
           --release-notes "${NOTES_JSON}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1068,7 +1068,6 @@ jobs:
         uses: ./.github/workflows/actions/ship-to-play
         with:
           service_account_file: ${{ runner.temp }}/play-service-account.json
-          package_name: ${{ env.ANDROID_PACKAGE_NAME }}
           version_name: ${{ env.APP_VERSION }}
           bundle_path: app/android/app/build/outputs/bundle/release/app-release.aab
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1069,6 +1069,7 @@ jobs:
         with:
           service_account_file: ${{ runner.temp }}/play-service-account.json
           version_name: ${{ env.APP_VERSION }}
+          build_number: ${{ env.APP_BUILD_NUMBER }}
           bundle_path: app/android/app/build/outputs/bundle/release/app-release.aab
 
   build-summary:


### PR DESCRIPTION
Closes #4522

## What changed

Swaps `ship-to-play` from the bespoke `@bcgov/gpublish` to `google-play bundles publish` (codemagic-cli-tools, pinned to `0.69.0`).

Like for like: internal track, `completed` status, release name `v<version>-<run number>`, en-CA tester note, same API sequence, same service account — no new Play permissions.

`package_name` input dropped since the tool reads it from the AAB, as altool does from the IPA. `track` and `release_notes` are new inputs whose defaults reproduce today's behaviour, and `build_number` is a new required input — the release name used to come from the ambient `GITHUB_RUN_NUMBER`, which is only correct while the step runs inside the build that produced the AAB.

## What should the reviewer focus on

Gated `if: github.ref_name == 'main'`, so PR CI only proves the YAML parses. The real check is the first main build.

Locally I ran the pinned tool: every flag accepted, `--credentials @file:` parses the service account, bundletool executes. Only the live Play API call is untested.

## How to test

`actionlint` reports no new findings and `shellcheck` is clean on both steps. After merge, the first main build should produce an identical Play internal-track release — same release name, tester note, and version code.

