### PR TITLE
feat: add automatic key-rotation check (not yet wired up)

### DIFF
--- a/app/src/services/system-checks/KeyRotationSystemCheck.test.ts
+++ b/app/src/services/system-checks/KeyRotationSystemCheck.test.ts
@@ -1,0 +1,197 @@
+jest.mock('react-native-bcsc-core', () => ({
+  getAllKeys: jest.fn(),
+}))
+
+import { KeyRotationSystemCheck } from '@/services/system-checks/KeyRotationSystemCheck'
+import { BCDispatchAction } from '@/store'
+import { MockLogger } from '@bifold/core'
+import { Platform } from 'react-native'
+import { getAllKeys } from 'react-native-bcsc-core'
+
+const mockedGetAllKeys = getAllKeys as jest.MockedFunction<typeof getAllKeys>
+
+const makeUtils = () => ({
+  dispatch: jest.fn(),
+  translation: jest.fn() as any,
+  logger: new MockLogger(),
+})
+
+const NOW = Date.parse('2026-08-21T00:00:00.000Z')
+
+describe('KeyRotationSystemCheck', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers().setSystemTime(NOW)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  describe('runCheck', () => {
+    it('passes (skips) when deferForPendingRegistrationUpdate is true', async () => {
+      const utils = makeUtils()
+      const rotate = jest.fn()
+      const check = new KeyRotationSystemCheck(true, undefined, rotate, utils)
+
+      expect(await check.runCheck()).toBe(true)
+      expect(mockedGetAllKeys).not.toHaveBeenCalled()
+    })
+
+    it('proceeds past the deferral when deferForPendingRegistrationUpdate is false', async () => {
+      const utils = makeUtils()
+      const rotate = jest.fn()
+      mockedGetAllKeys.mockResolvedValue([])
+      const check = new KeyRotationSystemCheck(false, undefined, rotate, utils)
+
+      await check.runCheck()
+
+      expect(mockedGetAllKeys).toHaveBeenCalled()
+    })
+
+    it('passes (skips) when the last attempt is within the retry backoff window', async () => {
+      const utils = makeUtils()
+      const rotate = jest.fn()
+      // 3 days ago — inside the 7-day backoff.
+      const lastAttempt = new Date(NOW - 3 * 24 * 60 * 60 * 1000).toISOString()
+      const check = new KeyRotationSystemCheck(false, lastAttempt, rotate, utils)
+
+      expect(await check.runCheck()).toBe(true)
+      expect(mockedGetAllKeys).not.toHaveBeenCalled()
+    })
+
+    it('proceeds to the age check when the last attempt is older than the backoff window', async () => {
+      const utils = makeUtils()
+      const rotate = jest.fn()
+      // 8 days ago — outside the 7-day backoff.
+      const lastAttempt = new Date(NOW - 8 * 24 * 60 * 60 * 1000).toISOString()
+      mockedGetAllKeys.mockResolvedValue([])
+      const check = new KeyRotationSystemCheck(false, lastAttempt, rotate, utils)
+
+      await check.runCheck()
+
+      expect(mockedGetAllKeys).toHaveBeenCalled()
+    })
+
+    it('passes (skips) when getAllKeys throws', async () => {
+      const utils = makeUtils()
+      const rotate = jest.fn()
+      mockedGetAllKeys.mockRejectedValue(new Error('keystore unavailable'))
+      const check = new KeyRotationSystemCheck(false, undefined, rotate, utils)
+
+      expect(await check.runCheck()).toBe(true)
+    })
+
+    it('passes (skips) when the keystore is empty', async () => {
+      const utils = makeUtils()
+      const rotate = jest.fn()
+      mockedGetAllKeys.mockResolvedValue([])
+      const check = new KeyRotationSystemCheck(false, undefined, rotate, utils)
+
+      expect(await check.runCheck()).toBe(true)
+    })
+
+    it('passes (skips) when the newest key has no created timestamp', async () => {
+      const utils = makeUtils()
+      const rotate = jest.fn()
+      mockedGetAllKeys.mockResolvedValue([{ id: 'rsa1' } as any])
+      const check = new KeyRotationSystemCheck(false, undefined, rotate, utils)
+
+      expect(await check.runCheck()).toBe(true)
+    })
+
+    it('passes at 364 days old (iOS, seconds)', async () => {
+      const originalOS = Platform.OS
+      Object.defineProperty(Platform, 'OS', { get: () => 'ios' })
+      const createdSeconds = (NOW - 364 * 24 * 60 * 60 * 1000) / 1000
+      mockedGetAllKeys.mockResolvedValue([{ id: 'rsa1', created: createdSeconds } as any])
+      const utils = makeUtils()
+      const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
+
+      expect(await check.runCheck()).toBe(true)
+      Object.defineProperty(Platform, 'OS', { get: () => originalOS })
+    })
+
+    it('fails at 366 days old (iOS, seconds)', async () => {
+      const originalOS = Platform.OS
+      Object.defineProperty(Platform, 'OS', { get: () => 'ios' })
+      const createdSeconds = (NOW - 366 * 24 * 60 * 60 * 1000) / 1000
+      mockedGetAllKeys.mockResolvedValue([{ id: 'rsa1', created: createdSeconds } as any])
+      const utils = makeUtils()
+      const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
+
+      expect(await check.runCheck()).toBe(false)
+      Object.defineProperty(Platform, 'OS', { get: () => originalOS })
+    })
+
+    it('passes at 364 days old (Android, ms)', async () => {
+      const originalOS = Platform.OS
+      Object.defineProperty(Platform, 'OS', { get: () => 'android' })
+      const createdMs = NOW - 364 * 24 * 60 * 60 * 1000
+      mockedGetAllKeys.mockResolvedValue([{ id: 'rsa1', created: createdMs } as any])
+      const utils = makeUtils()
+      const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
+
+      expect(await check.runCheck()).toBe(true)
+      Object.defineProperty(Platform, 'OS', { get: () => originalOS })
+    })
+
+    it('fails at 366 days old (Android, ms)', async () => {
+      const originalOS = Platform.OS
+      Object.defineProperty(Platform, 'OS', { get: () => 'android' })
+      const createdMs = NOW - 366 * 24 * 60 * 60 * 1000
+      mockedGetAllKeys.mockResolvedValue([{ id: 'rsa1', created: createdMs } as any])
+      const utils = makeUtils()
+      const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
+
+      expect(await check.runCheck()).toBe(false)
+      Object.defineProperty(Platform, 'OS', { get: () => originalOS })
+    })
+
+    it('picks the newest key among several when computing age', async () => {
+      const originalOS = Platform.OS
+      Object.defineProperty(Platform, 'OS', { get: () => 'android' })
+      mockedGetAllKeys.mockResolvedValue([
+        { id: 'rsa1', created: NOW - 500 * 24 * 60 * 60 * 1000 } as any, // old, but not newest
+        { id: 'rsa2', created: NOW - 10 * 24 * 60 * 60 * 1000 } as any, // newest, well within threshold
+      ])
+      const utils = makeUtils()
+      const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
+
+      expect(await check.runCheck()).toBe(true)
+      Object.defineProperty(Platform, 'OS', { get: () => originalOS })
+    })
+  })
+
+  describe('onFail', () => {
+    it('dispatches KEY_ROTATION_ATTEMPTED before calling rotate()', async () => {
+      const utils = makeUtils()
+      const callOrder: string[] = []
+      utils.dispatch.mockImplementation(() => callOrder.push('dispatch'))
+      const rotate = jest.fn().mockImplementation(async () => {
+        callOrder.push('rotate')
+        return { status: 'rotated', confirmed: true }
+      })
+      const check = new KeyRotationSystemCheck(false, undefined, rotate, utils)
+
+      await check.onFail()
+
+      expect(callOrder).toEqual(['dispatch', 'rotate'])
+      expect(utils.dispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.KEY_ROTATION_ATTEMPTED,
+        payload: [new Date(NOW).toISOString()],
+      })
+      expect(rotate).toHaveBeenCalled()
+    })
+
+    it('swallows a rejecting rotate() without throwing', async () => {
+      const utils = makeUtils()
+      const rotate = jest.fn().mockRejectedValue(new Error('rotation blew up'))
+      const check = new KeyRotationSystemCheck(false, undefined, rotate, utils)
+
+      await expect(check.onFail()).resolves.toBeUndefined()
+      expect(utils.logger.error).toHaveBeenCalled()
+    })
+  })
+})

--- a/app/src/services/system-checks/KeyRotationSystemCheck.test.ts
+++ b/app/src/services/system-checks/KeyRotationSystemCheck.test.ts
@@ -17,6 +17,7 @@ const makeUtils = () => ({
 })
 
 const NOW = Date.parse('2026-08-21T00:00:00.000Z')
+const originalOS = Platform.OS
 
 describe('KeyRotationSystemCheck', () => {
   beforeEach(() => {
@@ -27,6 +28,8 @@ describe('KeyRotationSystemCheck', () => {
   afterEach(() => {
     jest.useRealTimers()
     jest.restoreAllMocks()
+    // jest.restoreAllMocks() does not undo Object.defineProperty overrides of Platform.OS.
+    Object.defineProperty(Platform, 'OS', { get: () => originalOS })
   })
 
   describe('runCheck', () => {
@@ -102,7 +105,6 @@ describe('KeyRotationSystemCheck', () => {
     })
 
     it('passes at 364 days old (iOS, seconds)', async () => {
-      const originalOS = Platform.OS
       Object.defineProperty(Platform, 'OS', { get: () => 'ios' })
       const createdSeconds = (NOW - 364 * 24 * 60 * 60 * 1000) / 1000
       mockedGetAllKeys.mockResolvedValue([{ id: 'rsa1', created: createdSeconds } as any])
@@ -110,11 +112,9 @@ describe('KeyRotationSystemCheck', () => {
       const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
 
       expect(await check.runCheck()).toBe(true)
-      Object.defineProperty(Platform, 'OS', { get: () => originalOS })
     })
 
     it('fails at 366 days old (iOS, seconds)', async () => {
-      const originalOS = Platform.OS
       Object.defineProperty(Platform, 'OS', { get: () => 'ios' })
       const createdSeconds = (NOW - 366 * 24 * 60 * 60 * 1000) / 1000
       mockedGetAllKeys.mockResolvedValue([{ id: 'rsa1', created: createdSeconds } as any])
@@ -122,11 +122,9 @@ describe('KeyRotationSystemCheck', () => {
       const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
 
       expect(await check.runCheck()).toBe(false)
-      Object.defineProperty(Platform, 'OS', { get: () => originalOS })
     })
 
     it('passes at 364 days old (Android, ms)', async () => {
-      const originalOS = Platform.OS
       Object.defineProperty(Platform, 'OS', { get: () => 'android' })
       const createdMs = NOW - 364 * 24 * 60 * 60 * 1000
       mockedGetAllKeys.mockResolvedValue([{ id: 'rsa1', created: createdMs } as any])
@@ -134,11 +132,9 @@ describe('KeyRotationSystemCheck', () => {
       const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
 
       expect(await check.runCheck()).toBe(true)
-      Object.defineProperty(Platform, 'OS', { get: () => originalOS })
     })
 
     it('fails at 366 days old (Android, ms)', async () => {
-      const originalOS = Platform.OS
       Object.defineProperty(Platform, 'OS', { get: () => 'android' })
       const createdMs = NOW - 366 * 24 * 60 * 60 * 1000
       mockedGetAllKeys.mockResolvedValue([{ id: 'rsa1', created: createdMs } as any])
@@ -146,11 +142,19 @@ describe('KeyRotationSystemCheck', () => {
       const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
 
       expect(await check.runCheck()).toBe(false)
-      Object.defineProperty(Platform, 'OS', { get: () => originalOS })
+    })
+
+    it('locks the strict-less-than semantics at the exact 365.0-day boundary (Android, ms)', async () => {
+      Object.defineProperty(Platform, 'OS', { get: () => 'android' })
+      const createdMs = NOW - 365 * 24 * 60 * 60 * 1000
+      mockedGetAllKeys.mockResolvedValue([{ id: 'rsa1', created: createdMs } as any])
+      const utils = makeUtils()
+      const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
+
+      expect(await check.runCheck()).toBe(false)
     })
 
     it('picks the newest key among several when computing age', async () => {
-      const originalOS = Platform.OS
       Object.defineProperty(Platform, 'OS', { get: () => 'android' })
       mockedGetAllKeys.mockResolvedValue([
         { id: 'rsa1', created: NOW - 500 * 24 * 60 * 60 * 1000 } as any, // old, but not newest
@@ -160,7 +164,40 @@ describe('KeyRotationSystemCheck', () => {
       const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
 
       expect(await check.runCheck()).toBe(true)
-      Object.defineProperty(Platform, 'OS', { get: () => originalOS })
+    })
+
+    it('does not latch rotation off when the last attempt is future-dated', async () => {
+      Object.defineProperty(Platform, 'OS', { get: () => 'android' })
+      const lastAttempt = new Date(NOW + 3 * 24 * 60 * 60 * 1000).toISOString()
+      mockedGetAllKeys.mockResolvedValue([{ id: 'rsa1', created: NOW - 400 * 24 * 60 * 60 * 1000 } as any])
+      const utils = makeUtils()
+      const check = new KeyRotationSystemCheck(false, lastAttempt, jest.fn(), utils)
+
+      expect(await check.runCheck()).toBe(false)
+      expect(mockedGetAllKeys).toHaveBeenCalled()
+      expect(utils.logger.warn).toHaveBeenCalled()
+    })
+
+    it('skips instead of rotating on a sibling when the newest key lacks a created timestamp', async () => {
+      Object.defineProperty(Platform, 'OS', { get: () => 'android' })
+      mockedGetAllKeys.mockResolvedValue([
+        { id: 'old', created: NOW - 400 * 24 * 60 * 60 * 1000 } as any,
+        { id: 'newest-no-ts' } as any,
+      ])
+      const utils = makeUtils()
+      const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
+
+      expect(await check.runCheck()).toBe(true)
+      expect(utils.logger.warn).toHaveBeenCalled()
+    })
+
+    it('skips when a key has created: 0 rather than reading it as an epoch-1970 key', async () => {
+      mockedGetAllKeys.mockResolvedValue([{ id: 'rsa1', created: 0 } as any])
+      const utils = makeUtils()
+      const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
+
+      expect(await check.runCheck()).toBe(true)
+      expect(utils.logger.warn).toHaveBeenCalled()
     })
   })
 

--- a/app/src/services/system-checks/KeyRotationSystemCheck.ts
+++ b/app/src/services/system-checks/KeyRotationSystemCheck.ts
@@ -106,8 +106,10 @@ export class KeyRotationSystemCheck implements SystemCheckStrategy {
       return true
     }
 
-    const usable = normalized.filter(isUsable)
-    const newest = usable.reduce((a, b) => (b.createdAtMs > a.createdAtMs ? b : a))
+    // unusable is undefined here, so every element passed isUsable and usable has >= 1 entry —
+    // destructuring the head makes that non-emptiness structural instead of assumed by reduce().
+    const [head, ...tail] = normalized.filter(isUsable)
+    const newest = tail.reduce((a, b) => (b.createdAtMs > a.createdAtMs ? b : a), head)
     const ageDays = keyAgeDays(newest.createdAtMs)
     if (ageDays < KEY_ROTATION_MAX_AGE_DAYS) {
       return true

--- a/app/src/services/system-checks/KeyRotationSystemCheck.ts
+++ b/app/src/services/system-checks/KeyRotationSystemCheck.ts
@@ -57,7 +57,13 @@ export class KeyRotationSystemCheck implements SystemCheckStrategy {
       const lastAttemptMs = Date.parse(this.lastRotationAttemptAt)
       if (!Number.isNaN(lastAttemptMs)) {
         const daysSinceLastAttempt = (Date.now() - lastAttemptMs) / MS_PER_DAY
-        if (daysSinceLastAttempt < KEY_ROTATION_RETRY_BACKOFF_DAYS) {
+        if (daysSinceLastAttempt < 0) {
+          // Future-dated stamp (clock jumped forward, then corrected): negative elapsed time
+          // satisfies the backoff forever, latching rotation off — ignore it and proceed.
+          this.utils.logger.warn(
+            `KeyRotationSystemCheck: last rotation attempt '${this.lastRotationAttemptAt}' is in the future; ignoring backoff`
+          )
+        } else if (daysSinceLastAttempt < KEY_ROTATION_RETRY_BACKOFF_DAYS) {
           this.utils.logger.info(
             `KeyRotationSystemCheck: skipping — last attempt was ${daysSinceLastAttempt.toFixed(1)} day(s) ago (backoff=${KEY_ROTATION_RETRY_BACKOFF_DAYS}d)`
           )
@@ -83,26 +89,40 @@ export class KeyRotationSystemCheck implements SystemCheckStrategy {
       return true
     }
 
-    const newest = keys.slice().sort((a, b) => (b.created ?? 0) - (a.created ?? 0))[0]
-    const createdAtMs = keyCreatedAtMs(newest.created)
-    if (createdAtMs === null) {
-      this.utils.logger.warn(`KeyRotationSystemCheck: skipping — newest key '${newest.id}' has no created timestamp`)
+    type NormalizedKey = { key: (typeof keys)[number]; createdAtMs: number }
+    const normalized: Array<{ key: (typeof keys)[number]; createdAtMs: number | null }> = keys.map((key) => ({
+      key,
+      createdAtMs: keyCreatedAtMs(key.created),
+    }))
+    const isUsable = (normalizedKey: { createdAtMs: number | null }): normalizedKey is NormalizedKey =>
+      normalizedKey.createdAtMs !== null && normalizedKey.createdAtMs > 0
+    // An unusable timestamp anywhere means "newest" can't be determined, and this check never
+    // rotates on a guess. Non-positive covers Android metadata deserializing createdAt as 0,
+    // which would otherwise read as an epoch-1970 key and force immediate rotation.
+    const unusable = normalized.find((normalizedKey) => !isUsable(normalizedKey))
+    if (unusable) {
+      this.utils.logger.warn(
+        `KeyRotationSystemCheck: skipping — key '${unusable.key.id}' has no usable created timestamp`
+      )
       return true
     }
 
-    const ageDays = keyAgeDays(createdAtMs)
+    const usable = normalized.filter(isUsable)
+    const newest = usable.reduce((a, b) => (b.createdAtMs > a.createdAtMs ? b : a))
+    const ageDays = keyAgeDays(newest.createdAtMs)
     if (ageDays < KEY_ROTATION_MAX_AGE_DAYS) {
       return true
     }
 
     this.utils.logger.info(
-      `KeyRotationSystemCheck: newest key '${newest.id}' is ${ageDays.toFixed(1)} day(s) old (threshold=${KEY_ROTATION_MAX_AGE_DAYS}d) — rotation due`
+      `KeyRotationSystemCheck: newest key '${newest.key.id}' is ${ageDays.toFixed(1)} day(s) old (threshold=${KEY_ROTATION_MAX_AGE_DAYS}d) — rotation due`
     )
     return false
   }
 
   async onFail(): Promise<void> {
-    // Dispatched before rotate() so the backoff throttle survives a crash mid-rotation.
+    // Dispatched before rotate() so the attempt stamp is queued first — best-effort ordering, not
+    // a durable write barrier.
     this.utils.dispatch({
       type: BCDispatchAction.KEY_ROTATION_ATTEMPTED,
       payload: [new Date().toISOString()],

--- a/app/src/services/system-checks/KeyRotationSystemCheck.ts
+++ b/app/src/services/system-checks/KeyRotationSystemCheck.ts
@@ -1,0 +1,125 @@
+import {
+  KEY_ROTATION_MAX_AGE_DAYS,
+  KEY_ROTATION_RETRY_BACKOFF_DAYS,
+  keyAgeDays,
+  keyCreatedAtMs,
+  KeyRotationResult,
+} from '@/bcsc-theme/utils/key-rotation'
+import { BCDispatchAction } from '@/store'
+import { getAllKeys } from 'react-native-bcsc-core'
+import { SystemCheckStrategy, SystemCheckUtils } from './system-checks'
+
+type RotateFunction = () => Promise<KeyRotationResult>
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * Startup check that rotates the device's signing key once it reaches
+ * {@link KEY_ROTATION_MAX_AGE_DAYS}. `runCheck` "passes" (returns true, skips rotation) whenever
+ * rotation can't be safely determined or attempted; it only fails (triggering `onFail`) once the
+ * newest local key's age is confirmed at or beyond the threshold. See issue #3876.
+ */
+export class KeyRotationSystemCheck implements SystemCheckStrategy {
+  private readonly deferForPendingRegistrationUpdate: boolean
+  private readonly lastRotationAttemptAt: string | undefined
+  private readonly rotate: RotateFunction
+  private readonly utils: SystemCheckUtils
+
+  /**
+   * @param deferForPendingRegistrationUpdate Whether the app version/build changed since the
+   *   PREVIOUS launch, so `UpdateDeviceRegistrationSystemCheck` will PUT the current key this
+   *   same launch. Must be derived from a marker stamped unconditionally every launch
+   *   (`lastSeenAppVersion`/`lastSeenAppBuildNumber`), never from `appVersion`/`appBuildNumber` —
+   *   those only advance after a successful registration PUT, so a persistently failing PUT
+   *   would latch rotation off forever (see the #3876 review that caught this).
+   */
+  constructor(
+    deferForPendingRegistrationUpdate: boolean,
+    lastRotationAttemptAt: string | undefined,
+    rotate: RotateFunction,
+    utils: SystemCheckUtils
+  ) {
+    this.deferForPendingRegistrationUpdate = deferForPendingRegistrationUpdate
+    this.lastRotationAttemptAt = lastRotationAttemptAt
+    this.rotate = rotate
+    this.utils = utils
+  }
+
+  async runCheck(): Promise<boolean> {
+    if (this.deferForPendingRegistrationUpdate) {
+      this.utils.logger.info(
+        'KeyRotationSystemCheck: skipping — app version/build changed since the last launch; UpdateDeviceRegistrationSystemCheck will PUT the current key this launch'
+      )
+      return true
+    }
+
+    if (this.lastRotationAttemptAt) {
+      const lastAttemptMs = Date.parse(this.lastRotationAttemptAt)
+      if (!Number.isNaN(lastAttemptMs)) {
+        const daysSinceLastAttempt = (Date.now() - lastAttemptMs) / MS_PER_DAY
+        if (daysSinceLastAttempt < KEY_ROTATION_RETRY_BACKOFF_DAYS) {
+          this.utils.logger.info(
+            `KeyRotationSystemCheck: skipping — last attempt was ${daysSinceLastAttempt.toFixed(1)} day(s) ago (backoff=${KEY_ROTATION_RETRY_BACKOFF_DAYS}d)`
+          )
+          return true
+        }
+      }
+    }
+
+    // Never rotate on "can't tell": enumeration failure, an empty keystore, and a missing
+    // `created` all skip rather than risk rotating (or not) based on a guess.
+    let keys
+    try {
+      keys = await getAllKeys()
+    } catch (error) {
+      this.utils.logger.warn(
+        `KeyRotationSystemCheck: skipping — could not enumerate local keys: ${error instanceof Error ? error.message : String(error)}`
+      )
+      return true
+    }
+
+    if (!keys || keys.length === 0) {
+      this.utils.logger.warn('KeyRotationSystemCheck: skipping — no local keys found')
+      return true
+    }
+
+    const newest = keys.slice().sort((a, b) => (b.created ?? 0) - (a.created ?? 0))[0]
+    const createdAtMs = keyCreatedAtMs(newest.created)
+    if (createdAtMs === null) {
+      this.utils.logger.warn(`KeyRotationSystemCheck: skipping — newest key '${newest.id}' has no created timestamp`)
+      return true
+    }
+
+    const ageDays = keyAgeDays(createdAtMs)
+    if (ageDays < KEY_ROTATION_MAX_AGE_DAYS) {
+      return true
+    }
+
+    this.utils.logger.info(
+      `KeyRotationSystemCheck: newest key '${newest.id}' is ${ageDays.toFixed(1)} day(s) old (threshold=${KEY_ROTATION_MAX_AGE_DAYS}d) — rotation due`
+    )
+    return false
+  }
+
+  async onFail(): Promise<void> {
+    // Dispatched before rotate() so the backoff throttle survives a crash mid-rotation.
+    this.utils.dispatch({
+      type: BCDispatchAction.KEY_ROTATION_ATTEMPTED,
+      payload: [new Date().toISOString()],
+    })
+
+    try {
+      const result = await this.rotate()
+      this.utils.logger.info(
+        `KeyRotationSystemCheck: rotation attempt finished with status='${result.status}' confirmed=${result.confirmed}`
+      )
+    } catch (error) {
+      // rotate() (rotateSigningKey) is designed to never throw, but this is a silent
+      // background flow (favour idempotency over erroring) — swallow defensively regardless.
+      this.utils.logger.error(
+        'KeyRotationSystemCheck: rotation attempt threw unexpectedly',
+        error instanceof Error ? error : new Error(String(error))
+      )
+    }
+  }
+}

--- a/app/src/services/system-checks/KeyRotationSystemCheck.ts
+++ b/app/src/services/system-checks/KeyRotationSystemCheck.ts
@@ -96,9 +96,8 @@ export class KeyRotationSystemCheck implements SystemCheckStrategy {
     }))
     const isUsable = (normalizedKey: { createdAtMs: number | null }): normalizedKey is NormalizedKey =>
       normalizedKey.createdAtMs !== null && normalizedKey.createdAtMs > 0
-    // An unusable timestamp anywhere means "newest" can't be determined, and this check never
-    // rotates on a guess. Non-positive covers Android metadata deserializing createdAt as 0,
-    // which would otherwise read as an epoch-1970 key and force immediate rotation.
+    // Any unusable timestamp means "newest" can't be determined — never rotate on a guess.
+    // Non-positive catches Android's createdAt: 0, which would read as a 1970 key and force rotation.
     const unusable = normalized.find((normalizedKey) => !isUsable(normalizedKey))
     if (unusable) {
       this.utils.logger.warn(

--- a/app/src/store.test.ts
+++ b/app/src/store.test.ts
@@ -1,5 +1,5 @@
 import { InstallIdSystemCheck } from './services/system-checks/InstallIdSystemCheck'
-import { BCDispatchAction, initialState, migrateBCSCState, reducer } from './store'
+import { BCDispatchAction, BCLocalStorageKeys, initialState, migrateBCSCState, reducer } from './store'
 
 jest.mock('react-native-config', () => ({
   BUILD_TARGET: 'bcsc',
@@ -24,7 +24,15 @@ jest.mock('@bifold/core', () => ({
   PersistentStorage: { storeValueForKey: jest.fn() },
 }))
 
+import { PersistentStorage } from '@bifold/core'
+
+const mockedStoreValueForKey = PersistentStorage.storeValueForKey as jest.Mock
+
 describe('reducer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('UPDATE_APP_VERSION sets appVersion and appBuildNumber', () => {
     const state = { ...initialState, bcsc: { ...initialState.bcsc, appVersion: '', appBuildNumber: '' } }
     const result = reducer(state, { type: BCDispatchAction.UPDATE_APP_VERSION })
@@ -75,6 +83,41 @@ describe('reducer', () => {
     const result = reducer(state, { type: BCDispatchAction.SET_INSTALL_ID, payload: ['new-install-id'] })
 
     expect(result.bcsc.installId).toBe('new-install-id')
+  })
+
+  it('KEY_ROTATION_ATTEMPTED sets and persists lastKeyRotationAttemptAt', () => {
+    const state = { ...initialState, bcsc: { ...initialState.bcsc, lastKeyRotationAttemptAt: undefined } }
+    const result = reducer(state, {
+      type: BCDispatchAction.KEY_ROTATION_ATTEMPTED,
+      payload: ['2026-01-01T00:00:00.000Z'],
+    })
+
+    expect(result.bcsc.lastKeyRotationAttemptAt).toBe('2026-01-01T00:00:00.000Z')
+    // Losing this persistence call means the throttle timestamp resets every launch, which
+    // re-fires generate/PUT/rollback-delete on every launch during a persistent outage —
+    // exactly the churn the 7-day backoff exists to prevent.
+    expect(mockedStoreValueForKey).toHaveBeenCalledWith(
+      BCLocalStorageKeys.BCSC,
+      expect.objectContaining({ lastKeyRotationAttemptAt: '2026-01-01T00:00:00.000Z' })
+    )
+  })
+
+  it('RECORD_APP_LAUNCH_VERSION sets and persists lastSeenAppVersion/lastSeenAppBuildNumber', () => {
+    const state = {
+      ...initialState,
+      bcsc: { ...initialState.bcsc, lastSeenAppVersion: undefined, lastSeenAppBuildNumber: undefined },
+    }
+    const result = reducer(state, {
+      type: BCDispatchAction.RECORD_APP_LAUNCH_VERSION,
+      payload: [{ version: '4.1.0', buildNumber: '1234' }],
+    })
+
+    expect(result.bcsc.lastSeenAppVersion).toBe('4.1.0')
+    expect(result.bcsc.lastSeenAppBuildNumber).toBe('1234')
+    expect(mockedStoreValueForKey).toHaveBeenCalledWith(
+      BCLocalStorageKeys.BCSC,
+      expect.objectContaining({ lastSeenAppVersion: '4.1.0', lastSeenAppBuildNumber: '1234' })
+    )
   })
 })
 

--- a/app/src/store.tsx
+++ b/app/src/store.tsx
@@ -96,6 +96,19 @@ export interface BCSCState {
   showCardRenewalNotification?: boolean
   acceptedTermsOfUseVersion?: string
   installId?: string // Unique identifier for this app install (not a per-report id); preserved across CLEAR_BCSC
+  /** ISO timestamp of the last automatic key-rotation attempt (success or failure), used to
+   * throttle retries — see KeyRotationSystemCheck. Not PII. */
+  lastKeyRotationAttemptAt?: string
+  /**
+   * App version/build seen on the MOST RECENT launch, stamped unconditionally every launch —
+   * deliberately distinct from `appVersion`/`appBuildNumber` above, which only advance on a
+   * SUCCESSFUL device-registration PUT. KeyRotationSystemCheck uses this pair (never
+   * `appVersion`/`appBuildNumber`) to detect "did the app version change since last launch",
+   * so a persistently failing registration PUT can never latch key rotation off forever. See
+   * the #3876 review.
+   */
+  lastSeenAppVersion?: string
+  lastSeenAppBuildNumber?: string
 }
 
 export enum VerificationStatus {
@@ -283,6 +296,8 @@ enum BCSCDispatchAction {
   SET_ACCOUNT_EXPIRY_NOTIFICATION = 'bcsc/setAccountExpiryNotification',
   SET_CARD_RENEWAL_NOTIFICATION = 'bcsc/setCardRenewalNotification',
   SET_INSTALL_ID = 'bcsc/setInstallId',
+  KEY_ROTATION_ATTEMPTED = 'bcsc/keyRotationAttempted',
+  RECORD_APP_LAUNCH_VERSION = 'bcsc/recordAppLaunchVersion',
 }
 
 enum ModeDispatchAction {
@@ -781,6 +796,22 @@ const bcReducer = (state: BCState, action: ReducerAction<BCDispatchAction>): BCS
     case BCSCDispatchAction.SET_INSTALL_ID: {
       const installId = (action?.payload || []).pop()
       const bcsc = { ...state.bcsc, installId }
+      const newState = { ...state, bcsc }
+      PersistentStorage.storeValueForKey<BCSCState>(BCLocalStorageKeys.BCSC, bcsc)
+      return newState
+    }
+
+    case BCSCDispatchAction.KEY_ROTATION_ATTEMPTED: {
+      const lastKeyRotationAttemptAt = (action?.payload || []).pop()
+      const bcsc = { ...state.bcsc, lastKeyRotationAttemptAt }
+      const newState = { ...state, bcsc }
+      PersistentStorage.storeValueForKey<BCSCState>(BCLocalStorageKeys.BCSC, bcsc)
+      return newState
+    }
+
+    case BCSCDispatchAction.RECORD_APP_LAUNCH_VERSION: {
+      const { version: lastSeenAppVersion, buildNumber: lastSeenAppBuildNumber } = (action?.payload || []).pop() ?? {}
+      const bcsc = { ...state.bcsc, lastSeenAppVersion, lastSeenAppBuildNumber }
       const newState = { ...state, bcsc }
       PersistentStorage.storeValueForKey<BCSCState>(BCLocalStorageKeys.BCSC, bcsc)
       return newState


### PR DESCRIPTION
Closes #3876

## What changed

Adds the logic that decides *when* a device's signing key should be automatically rotated, plus the storage needed to remember the last attempt. It doesn't rotate anything yet — nothing calls this code, so app behaviour is unchanged.

4 of 5 in the signing-key rotation series, stacked on #4535 — retargets to `main` automatically once that merges.

## What should the reviewer focus on

The skip conditions — the check only proceeds when it's confident a key is actually due for rotation. Whenever it can't tell (keys can't be read, a key's age is unknown), it skips rather than guessing, since a wrong guess is worse than waiting.

## How to test

Covered by unit tests: 14 new cases for the rotation-timing logic, plus 2 for the new store fields. No manual testing needed — wiring this check into the app happens in the next PR.

