### PR TITLE
chore: make the four production-module mocks opt-in per suite

### DIFF
--- a/app/jestSetup.js
+++ b/app/jestSetup.js
@@ -130,57 +130,6 @@ jest.mock('react-native/Libraries/Image/resolveAssetSource', () => {
   }))
 })
 
-jest.mock('./src/bcsc-theme/hooks/useBCSCApiClient', () => ({
-  useBCSCApiClient: jest.fn(() => ({})),
-  useBCSCApiClientState: jest.fn(() => ({})),
-}))
-
-jest.mock('./src/bcsc-theme/api/hooks/useApi', () => ({
-  __esModule: true,
-  default: jest.fn(() => ({
-    registration: {
-      updateRegistration: jest.fn(),
-    },
-    authorization: {
-      authorizeDevice: jest.fn().mockResolvedValue({
-        device_code: 'mock-device-code',
-        user_code: 'mock-user-code',
-        verified_email: 'test@example.com',
-        expires_in: 3600,
-      }),
-    },
-    deviceAttestation: {
-      verifyAttestation: jest.fn().mockResolvedValue({ success: true }),
-    },
-    token: {
-      deviceToken: jest.fn().mockResolvedValue({
-        access_token: 'mock-access-token',
-        refresh_token: 'mock-refresh-token',
-        token_type: 'Bearer',
-        expires_in: 3600,
-      }),
-    },
-  })),
-}))
-
-jest.mock('./src/bcsc-theme/api/hooks/useFactoryReset', () => ({
-  useFactoryReset: jest.fn(() => jest.fn()),
-}))
-
-jest.mock('./src/bcsc-theme/contexts/BCSCAccountContext', () => ({
-  useAccount: jest.fn(() => ({
-    given_name: 'John',
-    family_name: 'Doe',
-    birthdate: '1990-01-01',
-    card_expiry: '2025-12-31',
-    email: 'john.doe@example.com',
-    picture: null,
-    fullname_formatted: 'Doe, John',
-    account_expiration_date: new Date('2025-12-31'),
-  })),
-  BCSCAccountProvider: jest.fn(({ children }) => children),
-}))
-
 jest.mock('react-native-webview', () => {
   const { View } = jest.requireActual('react-native')
 

--- a/app/src/bcsc-theme/api/hooks/__mocks__/useApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/__mocks__/useApi.tsx
@@ -1,0 +1,29 @@
+// Opt in with `jest.mock('@/bcsc-theme/api/hooks/useApi')`, then override the calls a
+// test cares about via `jest.mocked(useApi).mockReturnValue(...)`. These defaults resolve
+// successfully, so a suite that needs an error path must say so explicitly.
+const useApi = jest.fn(() => ({
+  registration: {
+    updateRegistration: jest.fn(),
+  },
+  authorization: {
+    authorizeDevice: jest.fn().mockResolvedValue({
+      device_code: 'mock-device-code',
+      user_code: 'mock-user-code',
+      verified_email: 'test@example.com',
+      expires_in: 3600,
+    }),
+  },
+  deviceAttestation: {
+    verifyAttestation: jest.fn().mockResolvedValue({ success: true }),
+  },
+  token: {
+    deviceToken: jest.fn().mockResolvedValue({
+      access_token: 'mock-access-token',
+      refresh_token: 'mock-refresh-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+    }),
+  },
+}))
+
+export default useApi

--- a/app/src/bcsc-theme/api/hooks/__mocks__/useFactoryReset.tsx
+++ b/app/src/bcsc-theme/api/hooks/__mocks__/useFactoryReset.tsx
@@ -1,0 +1,1 @@
+export const useFactoryReset = jest.fn(() => jest.fn())

--- a/app/src/bcsc-theme/api/hooks/useFactoryReset.test.ts
+++ b/app/src/bcsc-theme/api/hooks/useFactoryReset.test.ts
@@ -11,6 +11,10 @@ import { act, renderHook } from '@testing-library/react-native'
 import * as BcscCore from 'react-native-bcsc-core'
 import useRegistrationApi from './useRegistrationApi'
 
+jest.mock('@/bcsc-theme/hooks/useBCSCApiClient')
+
+// Other suites opt into __mocks__/useFactoryReset.tsx; this one tests the real
+// implementation, so opt back out.
 jest.unmock('@/bcsc-theme/api/hooks/useFactoryReset')
 
 jest.mock('@/bcsc-theme/api/hooks/useApi')

--- a/app/src/bcsc-theme/contexts/__mocks__/BCSCAccountContext.tsx
+++ b/app/src/bcsc-theme/contexts/__mocks__/BCSCAccountContext.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+export const useAccount = jest.fn(() => ({
+  given_name: 'John',
+  family_name: 'Doe',
+  birthdate: '1990-01-01',
+  card_expiry: '2025-12-31',
+  email: 'john.doe@example.com',
+  picture: null,
+  fullname_formatted: 'Doe, John',
+  account_expiration_date: new Date('2025-12-31'),
+}))
+
+export const BCSCAccountProvider = jest.fn(({ children }: { children: React.ReactNode }) => children)

--- a/app/src/bcsc-theme/features/account-transfer/transferee/TransferQRScannerScreen.test.tsx
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/TransferQRScannerScreen.test.tsx
@@ -3,6 +3,8 @@ import { render } from '@testing-library/react-native'
 import React from 'react'
 import TransferQRScannerScreen from './TransferQRScannerScreen'
 
+jest.mock('@/bcsc-theme/hooks/useBCSCApiClient')
+
 const mockNavigation = {
   navigate: jest.fn(),
   dispatch: jest.fn(),

--- a/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.test.ts
+++ b/app/src/bcsc-theme/features/account-transfer/transferee/useTransferQRScannerViewModel.test.ts
@@ -8,6 +8,8 @@ import { act, renderHook, waitFor } from '@testing-library/react-native'
 import { createDeviceSignedJWT, getAccount } from 'react-native-bcsc-core'
 import useTransferQRScannerViewModel from './useTransferQRScannerViewModel'
 
+jest.mock('@/bcsc-theme/api/hooks/useApi')
+
 const mockAuthorizeDevice = jest.fn().mockResolvedValue(null)
 const mockVerifyAttestation = jest.fn().mockResolvedValue({ success: true })
 const mockDeviceToken = jest.fn().mockResolvedValue({

--- a/app/src/bcsc-theme/features/home/Home.test.tsx
+++ b/app/src/bcsc-theme/features/home/Home.test.tsx
@@ -8,6 +8,8 @@ import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 import DefaultHome, { HomeV4_0_x as Home } from './Home'
 
+jest.mock('@/bcsc-theme/contexts/BCSCAccountContext')
+
 jest.mock('@/bcsc-theme/hooks/useBCSCApiClient', () => ({
   useBCSCApiClient: jest.fn(() => ({
     endpoints: {

--- a/app/src/bcsc-theme/features/modal/TermsOfUseUpdated.test.tsx
+++ b/app/src/bcsc-theme/features/modal/TermsOfUseUpdated.test.tsx
@@ -8,6 +8,8 @@ import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import { TermsOfUseUpdated } from './TermsOfUseUpdated'
 
+jest.mock('@/bcsc-theme/hooks/useBCSCApiClient')
+
 jest.mock('@/bcsc-theme/api/hooks/useApi')
 
 const mockTermsOfUseResponse = {

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.test.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseContent.test.tsx
@@ -5,6 +5,8 @@ import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import { TermsOfUseContent } from './TermsOfUseContent'
 
+jest.mock('@/bcsc-theme/hooks/useBCSCApiClient')
+
 jest.mock('@/bcsc-theme/api/hooks/useApi')
 
 const mockTermsOfUseResponse = {

--- a/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.test.tsx
+++ b/app/src/bcsc-theme/features/onboarding/TermsOfUseScreen.test.tsx
@@ -8,6 +8,8 @@ import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import { TermsOfUseScreen } from './TermsOfUseScreen'
 
+jest.mock('@/bcsc-theme/hooks/useBCSCApiClient')
+
 jest.mock('@/bcsc-theme/api/hooks/useApi')
 
 const mockTermsOfUseResponse = {

--- a/app/src/bcsc-theme/features/settings/ForgetAllPairingsScreen.test.tsx
+++ b/app/src/bcsc-theme/features/settings/ForgetAllPairingsScreen.test.tsx
@@ -4,6 +4,8 @@ import { render } from '@testing-library/react-native'
 import React from 'react'
 import { ForgetAllPairingsScreen } from './ForgetAllPairingsScreen'
 
+jest.mock('@/bcsc-theme/api/hooks/useApi')
+
 describe('ForgetAllPairings', () => {
   let mockNavigation: any
 

--- a/app/src/bcsc-theme/features/settings/MainSettingsScreen.test.tsx
+++ b/app/src/bcsc-theme/features/settings/MainSettingsScreen.test.tsx
@@ -7,6 +7,9 @@ import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 import { MainSettingsScreen } from './MainSettingsScreen'
 
+jest.mock('@/bcsc-theme/hooks/useBCSCApiClient')
+jest.mock('@/bcsc-theme/contexts/BCSCAccountContext')
+
 describe('MainSettings', () => {
   let mockNavigation: any
 

--- a/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.test.tsx
@@ -4,6 +4,8 @@ import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 import EnterBirthdateScreen from './EnterBirthdateScreen'
 
+jest.mock('@/bcsc-theme/api/hooks/useApi')
+
 describe('EnterBirthdate', () => {
   let mockNavigation: any
 

--- a/app/src/bcsc-theme/features/verify/ResidentialAddressScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/ResidentialAddressScreen.test.tsx
@@ -3,6 +3,8 @@ import { render } from '@testing-library/react-native'
 import React from 'react'
 import { ResidentialAddressScreen } from './ResidentialAddressScreen'
 
+jest.mock('@/bcsc-theme/api/hooks/useApi')
+
 describe('ResidentialAddress', () => {
   let mockNavigation: any
   let mockRoute: any

--- a/app/src/bcsc-theme/features/verify/ScanSerialScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/ScanSerialScreen.test.tsx
@@ -6,6 +6,8 @@ import React from 'react'
 import { useCameraPermission } from 'react-native-vision-camera'
 import ScanSerialScreen from './ScanSerialScreen'
 
+jest.mock('@/bcsc-theme/api/hooks/useApi')
+
 /** testID on the mocked Camera host element, so tests can drive its props directly. */
 const VISION_CAMERA_TEST_ID = 'vision-camera'
 

--- a/app/src/bcsc-theme/features/verify/in-person/VerifyInPersonScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/in-person/VerifyInPersonScreen.test.tsx
@@ -6,6 +6,8 @@ import React from 'react'
 import { BCSCCardProcess } from 'react-native-bcsc-core'
 import VerifyInPersonScreen from './VerifyInPersonScreen'
 
+jest.mock('@/bcsc-theme/api/hooks/useApi')
+
 describe('VerifyInPerson', () => {
   let mockNavigation: any
 

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.test.tsx
@@ -7,6 +7,8 @@ import { render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import EvidenceCaptureScreen from './EvidenceCaptureScreen'
 
+jest.mock('@/bcsc-theme/api/hooks/useApi')
+
 // MaskedCamera reads appStateStatus from BCSCActivityContext, which BasicAppContext doesn't provide.
 jest.mock('@/bcsc-theme/contexts/BCSCActivityContext', () => ({
   useBCSCActivity: jest.fn().mockReturnValue({

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.test.tsx
@@ -12,6 +12,8 @@ import React from 'react'
 import { BCSCCardProcess, EvidenceMetadata, EvidenceType } from 'react-native-bcsc-core'
 import EvidenceTypeListScreen from './EvidenceTypeListScreen'
 
+jest.mock('@/bcsc-theme/api/hooks/useApi')
+
 jest.mock('@/bcsc-theme/hooks/useDataLoader')
 jest.mock('@/bcsc-theme/hooks/useSecureActions')
 

--- a/app/src/bcsc-theme/features/webview/WebViewScreen.test.tsx
+++ b/app/src/bcsc-theme/features/webview/WebViewScreen.test.tsx
@@ -3,6 +3,8 @@ import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 import { WebViewScreen } from './WebViewScreen'
 
+jest.mock('@/bcsc-theme/hooks/useBCSCApiClient')
+
 describe('WebViewScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks()

--- a/app/src/bcsc-theme/hooks/__mocks__/useBCSCApiClient.tsx
+++ b/app/src/bcsc-theme/hooks/__mocks__/useBCSCApiClient.tsx
@@ -1,0 +1,2 @@
+export const useBCSCApiClient = jest.fn(() => ({}))
+export const useBCSCApiClientState = jest.fn(() => ({}))

--- a/app/src/bcsc-theme/hooks/useCreateSystemChecks.test.tsx
+++ b/app/src/bcsc-theme/hooks/useCreateSystemChecks.test.tsx
@@ -4,6 +4,8 @@ import * as DeviceInfo from 'react-native-device-info'
 import { useCreateSystemChecks } from './useCreateSystemChecks'
 import { SystemCheckScope } from './useSystemChecks'
 
+jest.mock('@/bcsc-theme/api/hooks/useFactoryReset')
+
 // --------------------
 // Mock functions
 // --------------------

--- a/app/src/bcsc-theme/navigators/MainStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.test.tsx
@@ -8,6 +8,8 @@ import { PairingNavigationListener, PairingPayload } from '../features/pairing/t
 import { BCSCScreens } from '../types/navigators'
 import MainStack from './MainStack'
 
+jest.mock('@/bcsc-theme/contexts/BCSCAccountContext')
+
 let capturedNavigationListener: PairingNavigationListener | undefined
 
 const mockUnsubscribe = jest.fn()

--- a/app/src/bcsc-theme/services/hooks/useAuthorizationService.test.tsx
+++ b/app/src/bcsc-theme/services/hooks/useAuthorizationService.test.tsx
@@ -6,6 +6,8 @@ import { AppError, ErrorCategory } from '@/errors'
 import { AppEventCode } from '@/events/appEventCode'
 import { renderHook } from '@testing-library/react-native'
 
+jest.mock('@/bcsc-theme/api/hooks/useApi')
+
 jest.mock('@bifold/core', () => ({
   __esModule: true,
   TOKENS: { UTIL_LOGGER: 'UTIL_LOGGER' },

--- a/app/src/bcsc-theme/services/hooks/useEvidenceService.test.tsx
+++ b/app/src/bcsc-theme/services/hooks/useEvidenceService.test.tsx
@@ -10,6 +10,8 @@ import { renderHook } from '@testing-library/react-native'
 import { AxiosError } from 'axios'
 import { useEvidenceService } from './useEvidenceService'
 
+jest.mock('@/bcsc-theme/api/hooks/useFactoryReset')
+
 jest.mock('@/bcsc-theme/api/hooks/useEvidenceApi')
 jest.mock('@/bcsc-theme/hooks/useBCSCApiClient')
 jest.mock('@bifold/core', () => ({

--- a/app/src/hooks/useAlerts.test.tsx
+++ b/app/src/hooks/useAlerts.test.tsx
@@ -9,6 +9,8 @@ import { renderHook } from '@testing-library/react-native'
 import RN, { Platform } from 'react-native'
 import { showErrorAlert, useAlerts } from './useAlerts'
 
+jest.mock('@/bcsc-theme/api/hooks/useFactoryReset')
+
 jest.mock('@bifold/core', () => ({
   useStore: () => mockUseStore(),
   useServices: () => mockUseServices(),


### PR DESCRIPTION
<!-- No issue — this came out of an audit of the Jest suites. Labelled `status/no-issue`. -->

> **Stacked on #4518.** Base is `chore/jest-config-and-dead-mocks`, so review that
> one first. GitHub will retarget this to `main` once #4518 merges.

## What changed

The shared test setup was standing in for four of our own modules in every suite,
and its stand-in for `useApi` always returned success. Any suite that didn't
override it could only ever test the happy path — error handling was unreachable.

Those stand-ins now sit next to the modules they replace, and the 21 suites that
need them ask for them by name.

## What should the reviewer focus on

That the 21 suites are the right 21. I measured it: removing the shared setup
broke exactly 21 suites, and I then dropped each opt-in one at a time, keeping
only the ones a suite actually needed — 37 of 84 turned out to be unnecessary.

Worth knowing for later: a stand-in file's extension must match the module it
replaces, or jest silently ignores it.

## How to test

Covered by the existing suites, and the counts are the point: **295 suites, 3072
passing, 161 snapshots** — identical to #4518 and to `main`. No test was added,
removed or rewritten here; only mock plumbing moved. `yarn lint`, `yarn
format:check` and `yarn typecheck` clean.

