### PR TITLE
fix: bluetooth permissions on android

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
   
   <!-- Additional permissions for react-native-incall-manager (live call) -->
   <uses-permission android:name="android.permission.WAKE_LOCK" />
-  <uses-permission android:name="android.permission.BLUETOOTH" />
+  <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
+  <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
   <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
   <queries>


### PR DESCRIPTION
Closes #4556

<!-- Add the number above, like "Closes #1234", or link it in the Development
     panel. A bare "#1234" lower down doesn't count.
     No issue? Delete the line and add the `status/no-issue` label. -->

## What changed

<!-- Enough context to read the diff. The backstory lives in the issue.
     Drop in a screenshot or a short video if it shows what changed or how
     it's meant to work — often quicker than describing it. -->
- Mark bluetooth usage not required so devices that don't have bluetooth hardware can still see it in the Play Store.
- Add `maxSdkVersion="30"` to the `BLUETOOTH` permission since in API 31 `BLUETOOTH_CONNECT` is all that's needed

## What should the reviewer focus on

<!-- Point at the scary bit — or say there isn't one:
     "Copy change, quick skim is fine."
     "The cancel path in useEvidenceUpload — not sure it clears the timer."
     "iOS only, Android untouched." -->
     
 Android only, live call only.

## How to test

<!-- How someone else checks it. "Covered by unit tests" counts. -->
Try a live call, see it works as usual.