### PR TITLE
feat: e2e video call partial automation

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -654,7 +654,13 @@ e2e/
 │       │   ├── verified-photo.journey.ts    # photo card + send-video/live-call detours
 │       │   ├── verified-non-photo.journey.ts # non-photo card (+ additional photo ID)
 │       │   ├── verified-combined.journey.ts # combined card + login/deep-link/transfer/contacts/account
-│       │   └── verified-non-bcsc.journey.ts # non-BCSC (two IDs + address + email)
+│       │   ├── verified-non-bcsc.journey.ts # non-BCSC (two IDs + address + email)
+│       │   ├── send-video-approved.journey.ts # send-video end-to-end: record → upload → scripted approve → verified
+│       │   ├── send-video-cancelled.journey.ts # scripted reject + agent-reason round-trip (+ over-long recording)
+│       │   ├── send-video-non-photo.journey.ts # send-video from the card type that adds a photo ID first
+│       │   ├── send-video-non-bcsc.journey.ts # cardless send-video through the identity-match step (inbox-dependent)
+│       │   ├── video-call.journey.ts        # live call: WebRTC connect → answered by the SIT test harness (or queue-wait) → end → VerifyNotComplete (or busy/closed asserts)
+│       │   └── under-12.journey.ts          # under-12 persona: restricted method set + transfer age gate
 │       ├── main/
 │       │   ├── unverified-main.journey.ts   # unverified tab / QRCore gating
 │       │   └── settings.journey.ts          # settings rows, change-PIN, auto-lock, reset/remove account

--- a/e2e/src/flows/verify.ts
+++ b/e2e/src/flows/verify.ts
@@ -641,20 +641,20 @@ export async function exerciseInCallControls(): Promise<void> {
 }
 
 /**
- * Leave the live call from either settle outcome — Cancel on the loading/waiting view, EndCall once
- * connected — and ride the app's own exit: the CALL_ENDED processing view, a verification-status
- * re-check, then the stack reset to [VerificationMethodSelection, VerifyNotComplete] for an account
- * that is (as expected in CI) not verified.
+ * Leave the live call — Cancel on the loading/waiting view, EndCall once connected — and ride the
+ * app's own exit: the CALL_ENDED processing view, a verification-status re-check, then the stack
+ * reset to [VerificationMethodSelection, VerifyNotComplete] for an account that is (as expected in
+ * CI) not verified.
  */
 export async function leaveLiveCall(outcome: LiveCallOutcome): Promise<void> {
-  if (outcome === 'connected') {
-    // The far side owns the call too: if the harness agent hung up first, the app is already on its
-    // way out through the same reset this waits on — only tap EndCall while the call is still up.
-    if (await LiveCallScreen.isPresent(1_000)) {
-      await LiveCallScreen.tap('primary') // EndCall
-    }
-  } else {
-    await LiveCallLoadingScreen.tap('primary') // Cancel
+  // WHICH face is up is read here, not taken from `outcome`: the agent can answer (or hang up) in the
+  // gap since the settle. Neither up means the call is already leaving through the reset waited on below.
+  const [expected, other] =
+    outcome === 'connected' ? [LiveCallScreen, LiveCallLoadingScreen] : [LiveCallLoadingScreen, LiveCallScreen]
+  if (await expected.isPresent(1_000)) {
+    await expected.tap('primary') // EndCall / Cancel
+  } else if (await other.isPresent(1_000)) {
+    await other.tap('primary')
   }
   // Pexip disconnect + two session-status calls + the verification re-check run behind the processing
   // view before the reset lands, so the exit gets a launch-sized budget rather than a transition one.

--- a/e2e/src/flows/verify.ts
+++ b/e2e/src/flows/verify.ts
@@ -1,6 +1,6 @@
 import type { TestUser } from '../constants.js'
 import { COMBO_CARD_BARCODE_MASKS, Timeouts } from '../constants.js'
-import { tapAlertButton } from '../helpers/alerts.js'
+import { acceptSystemAlertsUntil, tapAlertButton } from '../helpers/alerts.js'
 import { isAppErrorShowing, throwIfAppErrorShowing } from '../helpers/app-error.js'
 import { ApproveInPersonInput, approveInPersonRequest } from '../helpers/approval.js'
 import type { ImageMaskRegion } from '../helpers/camera.js'
@@ -21,6 +21,7 @@ import { VerifyPromptScreen } from '../screens/onboarding.js'
 import {
   AccountSetupScreen,
   AdditionalIdentificationRequiredScreen,
+  CallBusyOrClosedScreen,
   CancelledReviewScreen,
   DualIdentificationRequiredScreen,
   EmailConfirmationScreen,
@@ -31,6 +32,9 @@ import {
   EvidenceIDCollectionScreen,
   IdentitySelectionScreen,
   IDPhotoInformationScreen,
+  LiveCallErrorScreen,
+  LiveCallLoadingScreen,
+  LiveCallScreen,
   ManualSerialScreen,
   PendingReviewScreen,
   PhotoInstructionsScreen,
@@ -38,11 +42,13 @@ import {
   ResidentialAddressScreen,
   ScanSerialScreen,
   SelfieCaptureScreen,
+  StartCallScreen,
   SuccessfullySentScreen,
   TakeVideoScreen,
   VerificationMethodSelectionScreen,
   VerificationSuccessScreen,
   VerifyInPersonScreen,
+  VerifyNotCompleteScreen,
   VideoInstructionsScreen,
   VideoReviewScreen,
   VideoTooLongScreen,
@@ -267,7 +273,11 @@ export async function submitSendVideoVerification(user: TestUser): Promise<void>
   await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
 }
 
-/** The selfie half: enter the front camera, inject when the session can, shoot, accept. Ends on VideoInstructions. */
+/**
+ * The selfie half: enter the front camera, inject when the session can, shoot, accept. UsePhoto RESETS
+ * to where the branch goes next — VideoInstructions (send-video) or StartCall (live-call) — so the
+ * caller asserts the destination.
+ */
 async function captureSelfie(user: TestUser): Promise<void> {
   await reachCameraScreen('TakePhoto (selfie)', () => SelfieCaptureScreen.isPresent(1_000))
   // The send-video lane runs without injection (it breaks the recorder) — the rack feed is fine
@@ -278,7 +288,7 @@ async function captureSelfie(user: TestUser): Promise<void> {
   }
   await SelfieCaptureScreen.tap('primary') // shutter — NOT tapToNavigate (not idempotent)
   await PhotoReviewScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
-  await PhotoReviewScreen.tapToNavigate('primary') // UsePhoto → RESETS to VideoInstructions
+  await PhotoReviewScreen.tapToNavigate('primary') // UsePhoto — its id is not on either reset destination
 }
 
 /**
@@ -480,6 +490,191 @@ export async function expectCancelledReviewReason(reason: string): Promise<void>
     throw new Error(
       `CancelledReview does not show the agent reason "${reason}". On screen: ${await describeCurrentScreen()}`
     )
+  }
+}
+
+/** Where the Video Call method button landed: open service hours → the selfie primer; otherwise the status screen. */
+export type LiveCallEntry = 'open' | 'busyOrClosed'
+
+/**
+ * Method selection → Video Call. The app routes on the agent-queue destinations and service hours:
+ * open lands on the shared PhotoInstructions (live-call flavour), busy/closed on CallBusyOrClosed.
+ * Which one is SIT's answer at this moment, so the branch is returned for the journey to dispatch on —
+ * both are legitimate outcomes for a suite that runs day and night.
+ */
+export async function chooseVideoCallMethod(): Promise<LiveCallEntry> {
+  await VerificationMethodSelectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  await VerificationMethodSelectionScreen.link('videoCall')
+  const deadline = Date.now() + Timeouts.SCREEN_TRANSITION
+  for (;;) {
+    if (await CallBusyOrClosedScreen.isPresent(1_000)) {
+      return 'busyOrClosed'
+    }
+    if (await PhotoInstructionsScreen.isPresent(1_000)) {
+      return 'open'
+    }
+    if (Date.now() > deadline) {
+      throw new Error(
+        `Video Call led to neither PhotoInstructions nor CallBusyOrClosed. On screen: ${await describeCurrentScreen()}`
+      )
+    }
+  }
+}
+
+/** The two CallBusyOrClosed title variants, keyed by the `busy` route param that selects them. */
+const CALL_STATUS_TITLES = {
+  busy: 'All agents are busy', // BCSC.VideoCall.CallBusyOrClosed.AllAgentsBusy
+  closed: 'Call us later', // BCSC.VideoCall.CallBusyOrClosed.CallUsLater
+} as const
+
+/**
+ * Assert CallBusyOrClosed is showing one of its two variants IN FULL — a status title matching a known
+ * variant, the hours-of-service block, and the add-your-card-again reminder — and return which.
+ *
+ * 'busy' means the destination list offered no usable queue (a config state, not live agent load);
+ * 'closed' covers outside-service-hours and the hours-fetch-failed fallback. SIT keeps a Test Harness
+ * queue destination, so 'closed' is what a night run deterministically gets.
+ */
+export async function expectCallBusyOrClosedVariant(): Promise<'busy' | 'closed'> {
+  await CallBusyOrClosedScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  const title = await CallBusyOrClosedScreen.read('callStatusTitle')
+  const variant = (Object.keys(CALL_STATUS_TITLES) as ('busy' | 'closed')[]).find(
+    (key) => CALL_STATUS_TITLES[key] === title
+  )
+  if (!variant) {
+    throw new Error(`CallBusyOrClosed shows an unknown status title: "${title}"`)
+  }
+  await CallBusyOrClosedScreen.waitFor('hoursOfServiceTitle', Timeouts.SCREEN_TRANSITION)
+  await CallBusyOrClosedScreen.waitFor('reminderTitle', Timeouts.SCREEN_TRANSITION)
+  return variant
+}
+
+/**
+ * The open-hours live-call arrange: PhotoInstructions → selfie capture (injected on Sauce, the rack or
+ * device camera otherwise) → StartCall. The UsePhoto accept RESETS the stack to [PhotoInstructions,
+ * StartCall], so backing out of StartCall returns to the instructions, not the review.
+ */
+export async function reachStartCallViaSelfie(user: TestUser): Promise<void> {
+  await PhotoInstructionsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  // Plain tap, NOT tapToNavigate: the camera's shutter carries the same testID as this CTA, so a
+  // confirm-and-retry would read the push as a miss and fire the shutter.
+  await PhotoInstructionsScreen.tap('primary')
+  await captureSelfie(user)
+  await StartCallScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+}
+
+/** How the live-call setup settled: queued at the human boundary, or actually answered by an agent. */
+export type LiveCallOutcome = 'waiting' | 'connected'
+
+/** BCSC.VideoCall.CallStates.WaitingForAgent — the loading state that proves the queue was reached. */
+const WAITING_FOR_AGENT_COPY = 'Waiting for an agent to join...'
+
+/** Budget for the whole call setup: selfie upload, session mint, Pexip WebRTC connect, queue entry. */
+const LIVE_CALL_SETUP_TIMEOUT_MS = 90_000
+
+/**
+ * StartCall → LiveCall → the agent queue. The Start press requests microphone permission (Android adds
+ * Bluetooth on 12+, and WebRTC can raise iOS's local-network prompt mid-connect), so the whole wait
+ * accepts system dialogs until the call settles on one of three outcomes:
+ *
+ * - 'waiting' — evidence uploaded, session minted, WebRTC connected as the Pexip guest, queued until
+ *   a host (agent) joins. The human boundary — where a run stops when nobody answers.
+ * - 'connected' — an agent ANSWERED (the in-call controls are up). SIT's Test Harness queue does this
+ *   (observed 2026-08-27: it auto-answers within seconds), so on SIT this is the common outcome; it
+ *   converges on the same exit (`leaveLiveCall` handles both) and does NOT approve the verification.
+ * - CallErrorView → throws, surfacing the app's own error where a bare wait would report a timeout.
+ */
+export async function startLiveCall(): Promise<LiveCallOutcome> {
+  await StartCallScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  await StartCallScreen.tapWhenEnabled('primary')
+
+  let outcome: LiveCallOutcome | 'error' | null = null
+  const settled = await acceptSystemAlertsUntil(
+    async () => {
+      if (await LiveCallScreen.isPresent(500)) {
+        outcome = 'connected'
+        return true
+      }
+      if (await engine.isTextDisplayed(WAITING_FOR_AGENT_COPY)) {
+        outcome = 'waiting'
+        return true
+      }
+      if (await LiveCallErrorScreen.isPresent(500)) {
+        outcome = 'error'
+        return true
+      }
+      return false
+    },
+    { timeoutMs: LIVE_CALL_SETUP_TIMEOUT_MS }
+  )
+
+  if (!settled || outcome === null) {
+    throw new Error(
+      `The live call did not reach the agent queue within ${LIVE_CALL_SETUP_TIMEOUT_MS}ms. ` +
+        `On screen: ${await describeCurrentScreen()}`
+    )
+  }
+  if (outcome === 'error') {
+    throw new Error(
+      `The live-call setup failed — CallErrorView is showing. On screen: ${await describeCurrentScreen()}`
+    )
+  }
+  console.log(`[live-call] Settled: ${outcome === 'waiting' ? 'queued, waiting for an agent' : 'an agent ANSWERED'}`)
+  return outcome
+}
+
+/**
+ * In-call checkpoint, reachable whenever the Test Harness agent answers: the control row is usable.
+ * Mute and video each get a there-and-back toggle (each tap flips the local track state), and the
+ * having-trouble affordance must be offered. Kept SHORT on purpose — the far side owns the call's
+ * lifetime, so this must not dwell in it.
+ */
+export async function exerciseInCallControls(): Promise<void> {
+  await LiveCallScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  await LiveCallScreen.link('mute')
+  await LiveCallScreen.link('mute')
+  await LiveCallScreen.link('video')
+  await LiveCallScreen.link('video')
+  if (!(await LiveCallScreen.isVisible('havingTrouble'))) {
+    throw new Error('The in-call HavingTrouble control is missing')
+  }
+}
+
+/**
+ * Leave the live call from either settle outcome — Cancel on the loading/waiting view, EndCall once
+ * connected — and ride the app's own exit: the CALL_ENDED processing view, a verification-status
+ * re-check, then the stack reset to [VerificationMethodSelection, VerifyNotComplete] for an account
+ * that is (as expected in CI) not verified.
+ */
+export async function leaveLiveCall(outcome: LiveCallOutcome): Promise<void> {
+  if (outcome === 'connected') {
+    // The far side owns the call too: if the harness agent hung up first, the app is already on its
+    // way out through the same reset this waits on — only tap EndCall while the call is still up.
+    if (await LiveCallScreen.isPresent(1_000)) {
+      await LiveCallScreen.tap('primary') // EndCall
+    }
+  } else {
+    await LiveCallLoadingScreen.tap('primary') // Cancel
+  }
+  // Pexip disconnect + two session-status calls + the verification re-check run behind the processing
+  // view before the reset lands, so the exit gets a launch-sized budget rather than a transition one.
+  const deadline = Date.now() + Timeouts.APP_LAUNCH
+  for (;;) {
+    if (await VerifyNotCompleteScreen.isPresent(1_000)) {
+      return
+    }
+    if (await VerificationSuccessScreen.isPresent(1_000)) {
+      throw new Error(
+        'The live call ended VERIFIED (VerificationSuccess) — an SIT agent approved the request. ' +
+          'Record the Test Harness queue behavior in the UAT-3 notes and extend the journey to full completion.'
+      )
+    }
+    if (Date.now() > deadline) {
+      throw new Error(
+        `Leaving the live call reached neither VerifyNotComplete nor VerificationSuccess. ` +
+          `On screen: ${await describeCurrentScreen()}`
+      )
+    }
   }
 }
 

--- a/e2e/src/screens/verify.ts
+++ b/e2e/src/screens/verify.ts
@@ -322,6 +322,74 @@ export const CallBusyOrClosedScreen = defineScreen({
 })
 
 /**
+ * `StartCall` — the live-call primer reached after the selfie (open hours only). `primary` (Start call)
+ * requests microphone permission and pushes LiveCall, so drive it through `startLiveCall`, which
+ * accepts the permission dialogs on the way. The post-selfie stack is [PhotoInstructions, StartCall],
+ * so `back` returns to the instructions.
+ */
+export const StartCallScreen = defineScreen({
+  self: bcsc(v.startCall.start),
+  primary: bcsc(v.startCall.start),
+  back: bcsc(common.back),
+  elements: {
+    hoursOfServiceTitle: bcsc(v.startCall.hoursOfServiceTitle),
+  },
+})
+
+/**
+ * LiveCall's pre-connect face (`CallLoadingView`) — up through the evidence upload, session mint,
+ * WebRTC connect, and the wait for an agent. `self`/`primary` (Cancel) is its only control; WHICH
+ * state it is in is copy-only, so the waiting state is matched by text (see `startLiveCall`).
+ */
+export const LiveCallLoadingScreen = defineScreen({
+  self: bcsc(v.liveCall.cancel),
+  primary: bcsc(v.liveCall.cancel),
+})
+
+/**
+ * LiveCall's connected face — rendered only once an agent (the Pexip chair host) joins. `self`/
+ * `primary` is EndCall; `mute`/`video` toggle the local tracks; `havingTrouble` raises a confirm alert.
+ */
+export const LiveCallScreen = defineScreen({
+  self: bcsc(v.liveCall.endCall),
+  primary: bcsc(v.liveCall.endCall),
+  links: {
+    mute: bcsc(v.liveCall.mute),
+    video: bcsc(v.liveCall.video),
+    havingTrouble: bcsc(v.liveCall.havingTrouble),
+  },
+})
+
+/**
+ * LiveCall's failed face (`CallErrorView`). `self`/`secondary` (GoBack, pops to StartCall) is the
+ * marker — its TryAgain renders only for retryable errors, and the id also belongs to
+ * VerifyNotComplete. Probed by `startLiveCall` so a failed setup reports the app's error, not a timeout.
+ */
+export const LiveCallErrorScreen = defineScreen({
+  self: bcsc(v.liveCall.errorGoBack),
+  primary: bcsc(v.liveCall.errorTryAgain),
+  secondary: bcsc(v.liveCall.errorGoBack),
+})
+
+/**
+ * `VerifyNotComplete` — where an ended call that did not verify lands (the LiveCall exit resets the
+ * stack to [VerificationMethodSelection, this]). `self` is the having-trouble link, the only id UNIQUE
+ * to this screen; it opens the external help centre, so it is asserted but never tapped. `primary`
+ * (SendVideo) and `secondary` (TryAgain) BOTH reset to method selection — confirm-and-retry only
+ * TryAgain: the SendVideo id is also method selection's own send-video button, so a retry after the
+ * reset would enter the send-video flow.
+ */
+export const VerifyNotCompleteScreen = defineScreen({
+  self: bcsc(v.verifyNotComplete.trouble),
+  primary: bcsc(v.verifyNotComplete.sendVideo),
+  secondary: bcsc(v.verifyNotComplete.tryAgain),
+  elements: {
+    sendVideo: bcsc(v.verifyNotComplete.sendVideo),
+    tryAgain: bcsc(v.verifyNotComplete.tryAgain),
+  },
+})
+
+/**
  * Email confirmation (`'Email Verification'`) — enter the 6-digit code emailed to the address from
  * EnterEmail. `self`/`code` is the OTP field; `primary` (Continue) validates the code and RESETS the
  * stack to EmailVerified (a wrong code keeps the screen with an inline error).

--- a/e2e/src/test-ids/registry.ts
+++ b/e2e/src/test-ids/registry.ts
@@ -263,6 +263,33 @@ export const TestIds = {
       reminderTitle: 'ReminderTitle',
       sendVideo: 'SendVideo',
     },
+    /** `StartCall` — the live-call primer after the selfie (open hours only): user photo, call tips,
+     *  the hours list, and the Start button, which requests mic permission and pushes LiveCall. */
+    startCall: {
+      start: 'StartCall',
+      hoursOfServiceTitle: 'HoursOfServiceTitle',
+    },
+    /** `LiveCall` (headerless) — one route, three faces. CallLoadingView through every pre-connect
+     *  state (`cancel` is its only control; WHICH state is copy-only), the in-call controls once an
+     *  agent answers, and CallErrorView's pair on a failed setup. The "Call ended" processing view
+     *  has no ids. */
+    liveCall: {
+      cancel: 'Cancel',
+      mute: 'Mute',
+      video: 'Video',
+      endCall: 'EndCall',
+      havingTrouble: 'HavingTrouble',
+      errorTryAgain: 'TryAgain',
+      errorGoBack: 'GoBack',
+    },
+    /** `VerifyNotComplete` — where an ended-but-unverified live call lands. `sendVideo` and `tryAgain`
+     *  BOTH reset to method selection; `trouble` (external help centre) is the screen's only unique id —
+     *  `SendVideo` also renders on method selection and CallBusyOrClosed, `TryAgain` on CallErrorView. */
+    verifyNotComplete: {
+      sendVideo: 'SendVideo',
+      tryAgain: 'TryAgain',
+      trouble: 'Trouble',
+    },
     /** Email confirmation (`'Email Verification'`) — the 6-digit code emailed to the entered address.
      *  A correct `continue` RESETS the stack to EmailVerified. (`ResendCodeLink` / `GoToMyEmailLink`
      *  are BARE testIDs — add them as raw strings, not `bcsc()`-wrapped, if a resend detour needs

--- a/e2e/test/bcsc/verify/video-call.journey.ts
+++ b/e2e/test/bcsc/verify/video-call.journey.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict'
+import { TestUsers, Timeouts } from '../../../src/constants.js'
+import { completeOnboarding } from '../../../src/flows/onboarding.js'
+import {
+  chooseAddAccount,
+  chooseVideoCallMethod,
+  enterBirthdate,
+  enterSerialManually,
+  exerciseInCallControls,
+  expectCallBusyOrClosedVariant,
+  leaveLiveCall,
+  reachStartCallViaSelfie,
+  reachVerificationMethod,
+  startLiveCall,
+  startVerification,
+} from '../../../src/flows/verify.js'
+import {
+  CallBusyOrClosedScreen,
+  StartCallScreen,
+  VerificationMethodSelectionScreen,
+  VerifyNotCompleteScreen,
+} from '../../../src/screens/verify.js'
+import { getTestUser, setTestUser } from '../../../src/support/context.js'
+
+/**
+ * Verify journey: video call — the live-call method driven through a REAL call and back, stopping
+ * only at the approval boundary.
+ *
+ * The app joins the Pexip room as a WebRTC guest; SIT's Test Harness queue AUTO-ANSWERS as the chair
+ * host (observed 2026-08-27 — within seconds), which puts a genuine two-way call in CI reach: remote
+ * stream up, in-call controls live. What it does NOT do is approve — the verification stays pending,
+ * so ending the call lands on VerifyNotComplete (an ending that reaches VerificationSuccess fails
+ * loudly: an auto-approving agent would mean extending this journey to full completion — see UAT-3).
+ * SIT's service hours decide at runtime which half runs; the other half's checkpoints skip.
+ *
+ * - OPEN: selfie → StartCall → the real setup chain (evidence upload → session mint → WebRTC guest
+ *   connect) settles as answered (usual on SIT) or waiting at the queue — answered exercises the
+ *   in-call controls then EndCall, waiting cancels from the loading view — → VerifyNotComplete →
+ *   Try Again back to method selection.
+ * - CLOSED/BUSY: CallBusyOrClosed asserted in full (known variant title, hours, reminder) and its
+ *   SendVideo reset back to method selection. The nightly runs at midnight PT, so it deterministically
+ *   gets 'closed'.
+ *
+ * The open half is CAMERA-ONLY (the selfie: Sauce injection, a real device, or the emulator's
+ * emulated camera) and submits nothing for review — no queue hygiene rules apply. Ends unverified,
+ * like the send-video reject journey.
+ */
+describe('Verify journey: video call to the approval boundary', () => {
+  let entry: 'open' | 'busyOrClosed' | undefined
+  let callOutcome: 'waiting' | 'connected' | undefined
+
+  before(() => {
+    setTestUser(TestUsers.photo)
+  })
+
+  it('onboards to the verify prompt', async () => {
+    await completeOnboarding()
+  })
+
+  it('enters the photo serial and submits the birthdate', async () => {
+    await startVerification()
+    await chooseAddAccount()
+    await enterSerialManually(getTestUser())
+    await enterBirthdate(getTestUser())
+    await reachVerificationMethod()
+  })
+
+  it('chooses the video-call method and branches on service availability', async () => {
+    entry = await chooseVideoCallMethod()
+    console.log(`[video-call-journey] Service availability branch: ${entry}`)
+  })
+
+  it('closed: asserts the busy/closed status screen in full and recovers', async function () {
+    if (entry !== 'busyOrClosed') {
+      return this.skip()
+    }
+    const variant = await expectCallBusyOrClosedVariant()
+    console.log(`[video-call-journey] CallBusyOrClosed variant: ${variant}`)
+    // Plain tap: SendVideo's id is ALSO method selection's send-video button, so a confirm-and-retry
+    // after the reset would enter the send-video flow. Arrival is proven by an id the status screen
+    // does not render (its hours heading matches method selection's, so `expectVisible` cannot).
+    await CallBusyOrClosedScreen.tap('primary')
+    await VerificationMethodSelectionScreen.waitFor('videoCall', Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('open: takes the selfie and reaches StartCall', async function () {
+    if (entry !== 'open') {
+      return this.skip()
+    }
+    await reachStartCallViaSelfie(getTestUser())
+    // The screen's own copy of the hours block — the same list the busy/closed branch asserts.
+    assert.ok(
+      await StartCallScreen.isVisible('hoursOfServiceTitle'),
+      'StartCall should show the hours-of-service block'
+    )
+  })
+
+  it('open: starts the call and reaches the agent queue', async function () {
+    if (entry !== 'open') {
+      return this.skip()
+    }
+    callOutcome = await startLiveCall()
+  })
+
+  it('open: exercises the in-call controls when the harness agent answers', async function () {
+    if (entry !== 'open' || callOutcome !== 'connected') {
+      return this.skip()
+    }
+    await exerciseInCallControls()
+  })
+
+  it('open: leaves the call at the approval boundary and lands on VerifyNotComplete', async function () {
+    if (entry !== 'open') {
+      return this.skip()
+    }
+    assert.ok(callOutcome, 'the call checkpoint must have settled before leaving')
+    await leaveLiveCall(callOutcome)
+  })
+
+  it('open: recovers from VerifyNotComplete back to method selection', async function () {
+    if (entry !== 'open') {
+      return this.skip()
+    }
+    // Both recovery actions must be offered before one is taken.
+    assert.ok(await VerifyNotCompleteScreen.isVisible('sendVideo'), 'VerifyNotComplete should offer Send Video')
+    assert.ok(await VerifyNotCompleteScreen.isVisible('tryAgain'), 'VerifyNotComplete should offer Try Again')
+    // TryAgain is safe to confirm-and-retry (its id is not on method selection, unlike SendVideo's).
+    await VerifyNotCompleteScreen.tapToNavigate('secondary')
+    await VerificationMethodSelectionScreen.waitFor('videoCall', Timeouts.SCREEN_TRANSITION)
+  })
+})


### PR DESCRIPTION
Closes #4350

## What changed

Adds an e2e journey for the BCSC live video-call verification method, with the flow helpers, screen definitions and test-id registry entries it needs. E2e-only — no app code is touched, and the new registry entries map to testIDs the app already renders.

- `test/bcsc/verify/video-call.journey.ts` — drives the method to the approval boundary. Suites glob the directory, so `verify` and the nightly `full` pick it up with no config change.
- The journey branches at runtime on SIT service hours: **open** takes the selfie → StartCall → real WebRTC connect to the Test Harness queue → in-call controls → end → `VerifyNotComplete`; **closed/busy** asserts `CallBusyOrClosed` in full and recovers to method selection. The other half's checkpoints skip.
- `src/flows/verify.ts` — `chooseVideoCallMethod`, `reachStartCallViaSelfie`, `startLiveCall`, `exerciseInCallControls`, `leaveLiveCall`, `expectCallBusyOrClosedVariant`; `captureSelfie` is now shared with the send-video branch.
- `README.md` — the verify journey list was several files behind; brought up to date.

## What should the reviewer focus on

- `startLiveCall` in `src/flows/verify.ts` — the three-way settle (connected / waiting-for-agent / `CallErrorView`) inside `acceptSystemAlertsUntil`, on a 90s budget covering evidence upload, session mint and WebRTC connect. Permission dialogs land mid-connect.
- `leaveLiveCall` — two exits (EndCall vs Cancel on the loading view), and the deliberate hard failure if the call ends on `VerificationSuccess`: that would mean an SIT agent auto-approves, and the journey should then be extended to full completion.
- Shared testIDs force several plain `tap`s where `tapToNavigate` would misfire: `SendVideo` and `TryAgain` render on more than one screen, and PhotoInstructions' CTA shares its id with the camera shutter.

## How to test

```
cd e2e
yarn test:ios:sauce --spec test/bcsc/verify/video-call.journey.ts
yarn test:android:sauce --spec test/bcsc/verify/video-call.journey.ts
```

