### PR TITLE
fix: send each store the ring name it actually uses

### DIFF
--- a/.github/scripts/resolve_publishable_build.py
+++ b/.github/scripts/resolve_publishable_build.py
@@ -20,6 +20,17 @@ WORKFLOW = "main.yaml"
 RUN_PAGE_SIZE = 100
 # ring-0 always publishes; the input picks how much further to go.
 RINGS = ["ring-0", "ring-1", "ring-2", "ring-3", "ring-4"]
+
+
+def spaced(ring):
+    """The name TestFlight and Play know a ring by.
+
+    Firebase matches on a group alias, which cannot contain spaces, so it keeps
+    the hyphen. TestFlight matches on the group's display name and Play on the
+    track name, and both of those are written with a space. Same ring, three
+    services, two spellings.
+    """
+    return ring.replace("-", " ")
 KINDS = {
     "ipa": re.compile(r"^ios-(?P<variant>.+)\.ipa$"),
     "aab": re.compile(r"^android-(?P<variant>.+)\.aab$"),
@@ -142,10 +153,13 @@ if widen_rings:
     print(f"  after {RING} is approved: {', '.join(widen_rings)}")
 
 with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+    # Firebase group aliases keep the hyphen.
     output.write(f"widen_rings_csv={','.join(widen_rings)}\n")
-    # TestFlight takes one group per line, so this one needs the heredoc form.
-    output.write("widen_rings_lines<<__RINGS_EOF__\n")
-    output.write("\n".join(widen_rings) + "\n")
+    # Play track names use the spaced form.
+    output.write(f"widen_tracks_csv={','.join(spaced(r) for r in widen_rings)}\n")
+    # TestFlight takes one group per line, spaced, so it needs the heredoc form.
+    output.write("widen_groups_lines<<__RINGS_EOF__\n")
+    output.write("\n".join(spaced(r) for r in widen_rings) + "\n")
     output.write("__RINGS_EOF__\n")
     output.write(f"run_id={run['id']}\n")
     output.write(f"run_number={run['run_number']}\n")

--- a/.github/scripts/resolve_publishable_build.py
+++ b/.github/scripts/resolve_publishable_build.py
@@ -20,6 +20,10 @@ WORKFLOW = "main.yaml"
 RUN_PAGE_SIZE = 100
 # ring-0 always publishes; the input picks how much further to go.
 RINGS = ["ring-0", "ring-1", "ring-2", "ring-3", "ring-4"]
+# BC Wallet is being retired after v4.1, so its ring groups and tracks were
+# never created past ring-0. It still publishes to the team; it is left out of
+# everything above that rather than failing the run on a missing group.
+RING_0_ONLY = {"bcwallet-prod"}
 
 
 def spaced(ring):
@@ -149,10 +153,16 @@ widen_rings = RINGS[1 : RINGS.index(RING) + 1]
 print(f"  ring:   {RING}")
 print(f"  reaches: {', '.join(RINGS[: RINGS.index(RING) + 1])}")
 print("  ring-0 publishes now, without approval")
+held_back = sorted(set(all_variants(by_kind)) & RING_0_ONLY)
+if held_back and widen_rings:
+    print(f"  ring-0 only for: {', '.join(held_back)}")
 if widen_rings:
     print(f"  after {RING} is approved: {', '.join(widen_rings)}")
 
 with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+    for kind, variants in by_kind.items():
+        widening = [v for v in variants if v not in RING_0_ONLY]
+        output.write(f"widen_{kind}_variants={json.dumps(widening)}\n")
     # Firebase group aliases keep the hyphen.
     output.write(f"widen_rings_csv={','.join(widen_rings)}\n")
     # Play track names use the spaced form.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,8 @@ jobs:
       aab_variants: ${{ steps.resolve.outputs.aab_variants }}
       apk_variants: ${{ steps.resolve.outputs.apk_variants }}
       widen_rings_csv: ${{ steps.resolve.outputs.widen_rings_csv }}
-      widen_rings_lines: ${{ steps.resolve.outputs.widen_rings_lines }}
+      widen_tracks_csv: ${{ steps.resolve.outputs.widen_tracks_csv }}
+      widen_groups_lines: ${{ steps.resolve.outputs.widen_groups_lines }}
     steps:
       # A feature branch can produce a perfectly good build, but shipping one
       # to real testers is almost always a mistake. Releases come off main or
@@ -228,7 +229,7 @@ jobs:
           bundle_id: ${{ env.IOS_BUNDLE_ID }}
           version_code: ${{ needs.resolve-build.outputs.run_number }}
           version_name: ${{ env.APP_VERSION }}
-          beta_groups: ring-0
+          beta_groups: ring 0
 
   google-upload:
     name: 'Google Play internal - ${{ matrix.variant }}'
@@ -498,7 +499,7 @@ jobs:
           bundle_id: ${{ env.IOS_BUNDLE_ID }}
           version_code: ${{ needs.resolve-build.outputs.run_number }}
           version_name: ${{ env.APP_VERSION }}
-          beta_groups: ${{ needs.resolve-build.outputs.widen_rings_lines }}
+          beta_groups: ${{ needs.resolve-build.outputs.widen_groups_lines }}
 
   google-promote:
     name: 'Google Play closed - ${{ matrix.variant }}'
@@ -549,7 +550,7 @@ jobs:
           version_code: ${{ needs.resolve-build.outputs.run_number }}
           version_name: ${{ env.APP_VERSION }}
           build_number: ${{ needs.resolve-build.outputs.run_number }}
-          target_tracks: ${{ needs.resolve-build.outputs.widen_rings_csv }}
+          target_tracks: ${{ needs.resolve-build.outputs.widen_tracks_csv }}
 
   firebase-ios-widen:
     name: 'Firebase iOS widen - ${{ matrix.variant }}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,6 +78,9 @@ jobs:
       ipa_variants: ${{ steps.resolve.outputs.ipa_variants }}
       aab_variants: ${{ steps.resolve.outputs.aab_variants }}
       apk_variants: ${{ steps.resolve.outputs.apk_variants }}
+      widen_ipa_variants: ${{ steps.resolve.outputs.widen_ipa_variants }}
+      widen_aab_variants: ${{ steps.resolve.outputs.widen_aab_variants }}
+      widen_apk_variants: ${{ steps.resolve.outputs.widen_apk_variants }}
       widen_rings_csv: ${{ steps.resolve.outputs.widen_rings_csv }}
       widen_tracks_csv: ${{ steps.resolve.outputs.widen_tracks_csv }}
       widen_groups_lines: ${{ steps.resolve.outputs.widen_groups_lines }}
@@ -467,7 +470,7 @@ jobs:
       always() && !cancelled() &&
       needs.resolve-build.result == 'success' &&
       needs.approval.result == 'success' &&
-      needs.resolve-build.outputs.ipa_variants != '[]' &&
+      needs.resolve-build.outputs.widen_ipa_variants != '[]' &&
       (inputs.targets == 'all' || inputs.targets == 'apple-store')
     runs-on: ubuntu-22.04
     permissions:
@@ -476,7 +479,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: ${{ fromJSON(needs.resolve-build.outputs.ipa_variants) }}
+        variant: ${{ fromJSON(needs.resolve-build.outputs.widen_ipa_variants) }}
     steps:
       - uses: actions/checkout@v7
 
@@ -508,7 +511,7 @@ jobs:
       always() && !cancelled() &&
       needs.resolve-build.result == 'success' &&
       needs.approval.result == 'success' &&
-      needs.resolve-build.outputs.aab_variants != '[]' &&
+      needs.resolve-build.outputs.widen_aab_variants != '[]' &&
       (inputs.targets == 'all' || inputs.targets == 'google-store')
     runs-on: ubuntu-22.04
     permissions:
@@ -517,7 +520,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: ${{ fromJSON(needs.resolve-build.outputs.aab_variants) }}
+        variant: ${{ fromJSON(needs.resolve-build.outputs.widen_aab_variants) }}
     steps:
       - uses: actions/checkout@v7
 
@@ -559,7 +562,7 @@ jobs:
       always() && !cancelled() &&
       needs.resolve-build.result == 'success' &&
       needs.approval.result == 'success' &&
-      needs.resolve-build.outputs.ipa_variants != '[]' &&
+      needs.resolve-build.outputs.widen_ipa_variants != '[]' &&
       (inputs.targets == 'all' || inputs.targets == 'firebase')
     runs-on: ubuntu-22.04
     permissions:
@@ -568,7 +571,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: ${{ fromJSON(needs.resolve-build.outputs.ipa_variants) }}
+        variant: ${{ fromJSON(needs.resolve-build.outputs.widen_ipa_variants) }}
     steps:
       - name: Download IPA
         uses: actions/download-artifact@v8
@@ -621,7 +624,7 @@ jobs:
       always() && !cancelled() &&
       needs.resolve-build.result == 'success' &&
       needs.approval.result == 'success' &&
-      needs.resolve-build.outputs.apk_variants != '[]' &&
+      needs.resolve-build.outputs.widen_apk_variants != '[]' &&
       (inputs.targets == 'all' || inputs.targets == 'firebase')
     runs-on: ubuntu-22.04
     permissions:
@@ -630,7 +633,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: ${{ fromJSON(needs.resolve-build.outputs.apk_variants) }}
+        variant: ${{ fromJSON(needs.resolve-build.outputs.widen_apk_variants) }}
     steps:
       - name: Download APK
         uses: actions/download-artifact@v8

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -86,8 +86,15 @@ what a tester installs is exactly what CI made.
 | Firebase | The `ring-0` group | That ring's group |
 
 Each service has its own name for "the team", and ring-0 uses whatever that
-service already provides. Only TestFlight needs a `ring-0` group created by
+service already provides. Only TestFlight needs a `ring 0` group created by
 hand; Play's Internal testing track is built in.
+
+The rings are spelled differently on each service, so create them carefully.
+TestFlight groups and Play tracks are named with a space (`ring 1`). Firebase
+matches on a group alias, which cannot contain a space, so its groups are
+`ring-1`. Firebase generates that alias from the display name, so a group shown
+as "ring 1" there is still addressed as `ring-1`. Publish sends each service
+the form it expects.
 
 Approving a ring does not always mean iOS testers have it straight away. Apple
 runs a Beta App Review on the first build of each version before external
@@ -146,14 +153,15 @@ hand, and there is one app per variant.
 
 For each variant:
 
-- **Google Play**: four closed testing tracks named `ring-1` to `ring-4` (Test
+- **Google Play**: four closed testing tracks named `ring 1` to `ring 4` (Test
   and release → Testing → Closed testing → Create track). Tracks cannot be
   created through the API. Use a Google Group for testers so membership changes
   don't need a Play Console edit.
-- **App Store Connect**: five TestFlight beta groups, `ring-0` to `ring-4`.
-  `ring-0` is an internal group (up to 100 App Store Connect users, no Apple
+- **App Store Connect**: five TestFlight beta groups, `ring 0` to `ring 4`.
+  `ring 0` is an internal group (up to 100 App Store Connect users, no Apple
   review). The rest are external groups.
-- **Firebase App Distribution**: five tester groups, `ring-0` to `ring-4`.
+- **Firebase App Distribution**: five tester groups with the aliases `ring-0`
+  to `ring-4`.
 
 The repository side is done. The `ring-1` to `ring-4` environments exist under
 Settings → Environments with their approver team set. If a ring is ever added,

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -18,6 +18,11 @@ A ring is an audience. Each one is wider than the last.
 | `ring-3` | Early adopters | `bcsc-approvers-ring-2-plus` |
 | `ring-4` | Everyone | `bcsc-approvers-ring-2-plus` |
 
+BC Wallet is the exception. It is being retired after v4.1, so its ring groups
+and tracks were never created past ring-0. It still publishes to the team on
+every run, and is left out of the wider rings rather than failing them on a
+missing group. The **Resolve build** log says so when it applies.
+
 Publishing to a ring publishes every ring below it. Choosing `ring-2` sends the
 build to ring-0, ring-1 and ring-2.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -86,13 +86,17 @@ what a tester installs is exactly what CI made.
 | | ring-0 (the team) | ring-1 to ring-4 |
 |---|---|---|
 | App Store Connect | Uploaded | |
-| TestFlight | Internal testing, the `ring-0` group | External testing, that ring's group |
+| TestFlight | Internal testing, the `ring 0` group | External testing, that ring's group |
 | Google Play | Internal testing | Closed testing, that ring's track |
 | Firebase | The `ring-0` group | That ring's group |
 
 Each service has its own name for "the team", and ring-0 uses whatever that
 service already provides. Only TestFlight needs a `ring 0` group created by
 hand; Play's Internal testing track is built in.
+
+Throughout this page, `ring-0` written with a hyphen is the ring itself, which
+is what you pick when running Publish. A name in backticks next to a service is
+what that service calls the group or track.
 
 The rings are spelled differently on each service, so create them carefully.
 TestFlight groups and Play tracks are named with a space (`ring 1`). Firebase


### PR DESCRIPTION
Closes #4522

## What changed

Publish now sends each store the ring name that store actually uses. Play and TestFlight name their rings with a space ("ring 1"), while Firebase matches on a group alias, which cannot contain a space, so it stays "ring-1". The workflow previously sent the hyphenated form everywhere, so Play and TestFlight would have matched nothing.

BC Wallet is also held at ring-0. It is being retired after v4.1 and its ring groups were never created past ring-0, so it publishes to the team and drops out of the wider rings instead of failing them.

## What should the reviewer focus on

The three ring spellings were confirmed against the live Play and Firebase APIs, not inferred. Firebase generates its alias from the display name, so a group shown as "ring 1" is addressed as "ring-1".

The rings themselves now exist on all three services for the four BCSC variants, so a publish should reach every ring. BC Wallet is the deliberate exception, and the Resolve build log names it when it applies.

## How to test

The resolver was run against this repo at ring-2 and emits the right forms: `ring-1,ring-2` for Firebase, `ring 1,ring 2` for Play, and a spaced list for TestFlight. It also drops `bcwallet-prod` from the widen lists while keeping it in ring-0.

After merge: publish at ring-1 and confirm QA receives it on all three services, and that BC Wallet appears in ring-0 only.

## Note for the team

No change to how you run Publish. This makes the ring names line up with what is actually configured in the stores, so widening past the team works.
