### PR TITLE
fix: stop trying to give internal testers a build they already have

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,6 +119,11 @@ jobs:
   # These run without approval. ring-0 is also the only upload: Apple rejects
   # a duplicate binary and Play rejects a duplicate version code, so every
   # higher ring can only widen who sees what these jobs put there.
+  #
+  # There is no TestFlight job for ring-0. `ring 0` is an internal group, and
+  # Apple hands internal testers every build once it finishes processing, so
+  # assigning one is rejected outright: "Cannot add internal group to a
+  # build". Export compliance comes from Info.plist, so nothing is left to do.
 
   apple-upload:
     name: 'Apple upload - ${{ matrix.variant }}'
@@ -190,49 +195,6 @@ jobs:
           app_store_connect_issuer_id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           app_store_connect_key_identifier: ${{ secrets.APP_STORE_CONNECT_KEY_IDENTIFIER_95 }}
           ipa_path: ${{ runner.temp }}/artifact/BCWallet.ipa
-
-  # always() so one variant's failed upload cannot skip the other variants.
-  # It also disables the implicit success() the other jobs rely on, so the
-  # check on resolve-build has to be spelled out here.
-  testflight:
-    name: 'TestFlight ring-0 - ${{ matrix.variant }}'
-    needs: [resolve-build, apple-upload]
-    if: >-
-      always() && !cancelled() &&
-      needs.resolve-build.result == 'success' &&
-      needs.resolve-build.outputs.ipa_variants != '[]' &&
-      (inputs.targets == 'all' || inputs.targets == 'apple-store')
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-      actions: read
-    strategy:
-      fail-fast: false
-      matrix:
-        variant: ${{ fromJSON(needs.resolve-build.outputs.ipa_variants) }}
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Use the build's variant config
-        uses: ./.github/workflows/actions/use-build-variant-config
-        with:
-          head_sha: ${{ needs.resolve-build.outputs.head_sha }}
-
-      - name: Load variant config
-        uses: ./.github/workflows/actions/load-variant-config
-        with:
-          variant: ${{ matrix.variant }}
-
-      - name: Distribute to TestFlight
-        uses: ./.github/workflows/actions/distribute-testflight
-        with:
-          app_store_connect_issuer_id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-          app_store_connect_key_identifier: ${{ secrets.APP_STORE_CONNECT_KEY_IDENTIFIER_95 }}
-          app_store_connect_private_key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY_95 }}
-          bundle_id: ${{ env.IOS_BUNDLE_ID }}
-          version_code: ${{ needs.resolve-build.outputs.run_number }}
-          version_name: ${{ env.APP_VERSION }}
-          beta_groups: ring 0
 
   google-upload:
     name: 'Google Play internal - ${{ matrix.variant }}'
@@ -439,7 +401,6 @@ jobs:
       [
         resolve-build,
         apple-upload,
-        testflight,
         google-upload,
         firebase-ios,
         firebase-android,
@@ -465,7 +426,7 @@ jobs:
 
   testflight-widen:
     name: 'TestFlight widen - ${{ matrix.variant }}'
-    needs: [resolve-build, approval, testflight]
+    needs: [resolve-build, approval, apple-upload]
     if: >-
       always() && !cancelled() &&
       needs.resolve-build.result == 'success' &&

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -86,7 +86,7 @@ what a tester installs is exactly what CI made.
 | | ring-0 (the team) | ring-1 to ring-4 |
 |---|---|---|
 | App Store Connect | Uploaded | |
-| TestFlight | Internal testing, the `ring 0` group | External testing, that ring's group |
+| TestFlight | Internal testing, automatic | External testing, that ring's group |
 | Google Play | Internal testing | Closed testing, that ring's track |
 | Firebase | The `ring-0` group | That ring's group |
 
@@ -97,6 +97,11 @@ hand; Play's Internal testing track is built in.
 Throughout this page, `ring-0` written with a hyphen is the ring itself, which
 is what you pick when running Publish. A name in backticks next to a service is
 what that service calls the group or track.
+
+On TestFlight, ring-0 needs nothing from Publish. Apple gives internal testers
+every build as soon as it finishes processing, and it refuses a request to
+assign a build to an internal group at all. So the `ring 0` group exists for
+the people in it, not for the workflow, and Publish never touches it.
 
 The rings are spelled differently on each service, so create them carefully.
 TestFlight groups and Play tracks are named with a space (`ring 1`). Firebase
@@ -166,9 +171,9 @@ For each variant:
   and release → Testing → Closed testing → Create track). Tracks cannot be
   created through the API. Use a Google Group for testers so membership changes
   don't need a Play Console edit.
-- **App Store Connect**: five TestFlight beta groups, `ring 0` to `ring 4`.
-  `ring 0` is an internal group (up to 100 App Store Connect users, no Apple
-  review). The rest are external groups.
+- **App Store Connect**: `ring 0` as an internal group (up to 100 App Store
+  Connect users, no Apple review, and it receives builds automatically), plus
+  `ring 1` to `ring 4` as external groups.
 - **Firebase App Distribution**: five tester groups with the aliases `ring-0`
   to `ring-4`.
 


### PR DESCRIPTION
Closes #4522

## What changed

Publish no longer tries to hand the build to TestFlight's `ring 0` group. Apple gives internal testers every build as soon as it finishes processing, and rejects any attempt to assign one, so that job could only ever fail. Rings 1 and up are unaffected; those groups are external and the assignment is real.

## What should the reviewer focus on

This is the fix for the failed run on main, where four of five variants failed with `HTTP 422 — Cannot add internal group to a build`. `bcsc-test` passed only because its `ring 0` was created as an external group rather than an internal one.

The job is deleted rather than made conditional, because nothing in it applied to ring-0: export compliance already comes from `Info.plist`, and the only other action was the assignment Apple refuses.

## How to test

`actionlint` is clean apart from the known `queue:` false positive, and the job graph was checked for dangling references after the removal. Widening now depends on the upload rather than on the deleted job.

After merge: run Publish and confirm the team receives the iOS build through TestFlight with no job attempting to assign it, then approve a ring and confirm the external groups still get it.

## Note for the team

Nothing changes for testers. Internal testers were already getting every build automatically; the workflow was just failing while trying to do it a second time.
