### PR TITLE
ci: build only when something can change the build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -241,8 +241,13 @@ jobs:
             # it, so adding actions on either side needs no upkeep here. The
             # match is one level deep: no build-side action nests another
             # today, and one that did would need adding by hand.
+            #
+            # The trailing group is a word boundary spelled out in plain ERE,
+            # so it does not depend on \b being a GNU extension. Without it,
+            # "setup" would match "setup-node" and count an action the build
+            # does not use.
             if [[ "$file" =~ ^\.github/workflows/actions/([^/]+)/ ]]; then
-              grep -qR "actions/${BASH_REMATCH[1]}\b" \
+              grep -qER "actions/${BASH_REMATCH[1]}([^A-Za-z0-9_-]|$)" \
                 .github/workflows/main.yaml .github/workflows/e2e.yml 2>/dev/null && return 0
             fi
             return 1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,13 +6,23 @@ env:
 on:
   workflow_dispatch:
   push:
+    # A coarse pre-filter only. early-exit-check decides for real, and this
+    # list has to stay a superset of it or a build would be missed entirely.
     branches: [main, 'release/**']
     paths:
       - app/**
-      - .yarn/**
+      - packages/**
       - variants/**
       - scripts/**
-      - .github/workflows/**
+      - patch/**
+      - .yarn/**
+      - .github/workflows/main.yaml
+      - .github/workflows/e2e.yml
+      - .github/workflows/actions/**
+  # Deliberately unfiltered. Native Tests and build-summary are required
+  # checks, and a workflow skipped by a paths filter never reports them, so
+  # the PR could not merge. early-exit-check skips the expensive jobs instead,
+  # which still lets those checks report.
   pull_request:
     branches: [main, 'release/**']
   merge_group:
@@ -201,9 +211,40 @@ jobs:
           echo "Comparing ${parent_ref} with ${child_ref}"
 
           diff_output=$(git diff --name-only ${parent_ref}..${child_ref})
-          change_count=$(echo "$diff_output" | (grep -E '^(app/.*)|(.yarn/.*)|(variants/.*)|(scripts/.*)|(patch/.*)|(.github/workflows/.*)' || true) | wc -l | awk '{$1=$1};1')
 
-          echo "$change_count files changed in app, .yarn, or .github/workflows"
+          # A file matters if it can change what the app is built from, or how.
+          # Everything under .github/workflows is deliberately NOT enough on its
+          # own: editing publish.yml or a publish-only composite action cannot
+          # affect a native build, and rebuilding five variants for it is waste.
+          build_relevant() {
+            local file="$1"
+            # Source, native modules, dependencies, variant config, build scripts.
+            if [[ "$file" =~ ^(app|packages|variants|scripts|patch|\.yarn)/ ]]; then
+              return 0
+            fi
+            # This workflow, and the E2E suite it calls.
+            if [[ "$file" =~ ^\.github/workflows/(main\.yaml|e2e\.yml)$ ]]; then
+              return 0
+            fi
+            # A composite action counts only if the build actually uses it, so
+            # this needs no upkeep when actions are added on either side.
+            if [[ "$file" =~ ^\.github/workflows/actions/([^/]+)/ ]]; then
+              grep -qR "actions/${BASH_REMATCH[1]}\b" \
+                .github/workflows/main.yaml .github/workflows/e2e.yml 2>/dev/null && return 0
+            fi
+            return 1
+          }
+
+          change_count=0
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            if build_relevant "$file"; then
+              echo "  build-relevant: $file"
+              change_count=$((change_count + 1))
+            fi
+          done <<< "$diff_output"
+
+          echo "$change_count build-relevant file(s) changed"
 
           if [ $change_count -gt 0 ]; then
             # A result greater than 0 means there are changes

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,11 @@ on:
       - variants/**
       - scripts/**
       - patch/**
+      - e2e/**
       - .yarn/**
+      - package.json
+      - yarn.lock
+      - .yarnrc.yml
       - .github/workflows/main.yaml
       - .github/workflows/e2e.yml
       - .github/workflows/actions/**
@@ -218,16 +222,25 @@ jobs:
           # affect a native build, and rebuilding five variants for it is waste.
           build_relevant() {
             local file="$1"
-            # Source, native modules, dependencies, variant config, build scripts.
-            if [[ "$file" =~ ^(app|packages|variants|scripts|patch|\.yarn)/ ]]; then
+            # Source, native modules, variant config, build scripts, and the
+            # E2E specs, which the smoke run exercises against this build.
+            if [[ "$file" =~ ^(app|packages|variants|scripts|patch|e2e|\.yarn)/ ]]; then
               return 0
             fi
-            # This workflow, and the E2E suite it calls.
+            # Dependency truth. resolutions in the root manifest pin the React
+            # Native version and bind the yarn patches, so a change here can
+            # alter the binary without touching a line of app source.
+            if [[ "$file" =~ ^(package\.json|yarn\.lock|\.yarnrc\.yml)$ ]]; then
+              return 0
+            fi
+            # This workflow, and the E2E workflow it calls.
             if [[ "$file" =~ ^\.github/workflows/(main\.yaml|e2e\.yml)$ ]]; then
               return 0
             fi
-            # A composite action counts only if the build actually uses it, so
-            # this needs no upkeep when actions are added on either side.
+            # A composite action counts only if the build actually references
+            # it, so adding actions on either side needs no upkeep here. The
+            # match is one level deep: no build-side action nests another
+            # today, and one that did would need adding by hand.
             if [[ "$file" =~ ^\.github/workflows/actions/([^/]+)/ ]]; then
               grep -qR "actions/${BASH_REMATCH[1]}\b" \
                 .github/workflows/main.yaml .github/workflows/e2e.yml 2>/dev/null && return 0


### PR DESCRIPTION
Closes #4522

## What changed

Editing anything under `.github/workflows` triggered a full native build of five variants on both platforms. Changing `publish.yml` or a publish-only action cannot affect what the app is built from, so most of those builds were waste. The build now runs when app source, native modules, variant config, build scripts, dependencies, this workflow or the E2E suite change.

## What should the reviewer focus on

PRs stay unfiltered on purpose: `Native Tests` and `build-summary` are required, and a workflow skipped by `paths:` never reports them, so the PR could not merge. The skipping happens inside the run instead.

`e2e/` now counts, which costs something: it changed in 42 of the last 300 commits, so those will build where they didn't.

Three older gaps closed on the way. Dependency files were never counted, so a bump could skip the build. `packages/` was never listed, so native module changes rebuilt only by accident. And the old pattern anchored just its first alternative, so `docs/scripts/anything` matched.

## How to test

The rule was run against real commits from this repo: the publish-rings merge builds (it touched `variants/`), a publish.yml-and-docs commit skips, a docs commit skips, and an app-code commit builds. The push filter was checked to be a superset of the runtime rule, so it cannot filter out a build the check would have wanted. `shellcheck` is clean on the changed step, and `main.yaml` has one fewer warning than before.

## Note for the team

Docs and workflow-only PRs stop spending twenty minutes building apps that did not change. Required checks still report, so nothing about merging changes.


