### PR TITLE
feat: added verificationSkipped flag to automatically resume verification

### DIFF
--- a/app/container-imp.ts
+++ b/app/container-imp.ts
@@ -427,7 +427,7 @@ export class AppContainer implements Container {
         // after the scrub above so this one-shot write persists the scrubbed blob, not the transient
         // fields that were just nulled out. Failure is non-fatal - the same mapping re-runs next launch.
         PersistentStorage.storeValueForKey<BCSCState>(BCLocalStorageKeys.BCSC, bcsc).catch((error) => {
-          this.logger.error('Failed to write back migrated BCSC state (reportUUID -> installId)', error)
+          this.logger.error('Failed to write back migrated BCSC state', error)
         })
       }
 

--- a/app/container-imp.ts
+++ b/app/container-imp.ts
@@ -427,7 +427,7 @@ export class AppContainer implements Container {
         // after the scrub above so this one-shot write persists the scrubbed blob, not the transient
         // fields that were just nulled out. Failure is non-fatal - the same mapping re-runs next launch.
         PersistentStorage.storeValueForKey<BCSCState>(BCLocalStorageKeys.BCSC, bcsc).catch((error) => {
-          this.logger.error('Failed to write back migrated BCSC state', error)
+          this.logger.error('Failed to write back migrated BCSC state (reportUUID -> installId)', error)
         })
       }
 

--- a/app/src/bcsc-theme/features/notifications/StartVerificationNotification.tsx
+++ b/app/src/bcsc-theme/features/notifications/StartVerificationNotification.tsx
@@ -1,5 +1,6 @@
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
-import { useTheme } from '@bifold/core'
+import { BCDispatchAction, BCState } from '@/store'
+import { useStore, useTheme } from '@bifold/core'
 import { useTranslation } from 'react-i18next'
 import NotificationActionCard from './NotificationActionCard'
 
@@ -12,6 +13,7 @@ const StartVerificationNotification = () => {
   const { t } = useTranslation()
   const { ColorPalette } = useTheme()
   const secureActions = useSecureActions()
+  const [, dispatch] = useStore<BCState>()
 
   return (
     <NotificationActionCard
@@ -22,6 +24,7 @@ const StartVerificationNotification = () => {
       iconColor={ColorPalette.brand.primary}
       hideIconCircle={true}
       onPress={() => {
+        dispatch({ type: BCDispatchAction.SET_VERIFICATION_SKIPPED, payload: [false] })
         secureActions.continueVerificationProcess()
       }}
     />

--- a/app/src/bcsc-theme/features/onboarding/VerifyPromptScreen.test.tsx
+++ b/app/src/bcsc-theme/features/onboarding/VerifyPromptScreen.test.tsx
@@ -1,0 +1,58 @@
+import { BCLocalStorageKeys } from '@/store'
+import { PersistentStorage } from '@bifold/core'
+import { BasicAppContext } from '@mocks/helpers/app'
+import { act, fireEvent, render } from '@testing-library/react-native'
+import React from 'react'
+import { VerifyPromptScreen } from './VerifyPromptScreen'
+
+describe('VerifyPromptScreen', () => {
+  let storeSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    storeSpy = jest.spyOn(PersistentStorage, 'storeValueForKey').mockResolvedValue()
+  })
+
+  const renderScreen = (props: Partial<React.ComponentProps<typeof VerifyPromptScreen>> = {}) =>
+    render(
+      <BasicAppContext>
+        <VerifyPromptScreen {...props} />
+      </BasicAppContext>
+    )
+
+  const bcscWrites = () =>
+    storeSpy.mock.calls.filter(([key]) => key === BCLocalStorageKeys.BCSC).map(([, value]) => value)
+
+  it('persists verificationSkipped=false and advances when the user chooses to verify now', async () => {
+    const onAnswered = jest.fn()
+    const onContinue = jest.fn()
+    const tree = renderScreen({ onAnswered, onContinue })
+
+    await act(async () => {
+      fireEvent.press(tree.getByTestId('com.ariesbifold:id/Continue'))
+    })
+
+    expect(onAnswered).toHaveBeenCalledTimes(1)
+    expect(onContinue).toHaveBeenCalledTimes(1)
+    expect(bcscWrites()).toContainEqual(expect.objectContaining({ verificationSkipped: false }))
+  })
+
+  it('persists verificationSkipped=true when the user skips verification', async () => {
+    const onAnswered = jest.fn()
+    const tree = renderScreen({ onAnswered })
+
+    await act(async () => {
+      fireEvent.press(tree.getByTestId('com.ariesbifold:id/SkipVerification'))
+    })
+
+    expect(onAnswered).toHaveBeenCalledTimes(1)
+    expect(bcscWrites()).toContainEqual(expect.objectContaining({ verificationSkipped: true }))
+  })
+
+  it('hides the skip button when showSkip is false (main-app entry)', () => {
+    const tree = renderScreen({ showSkip: false })
+
+    expect(tree.queryByTestId('com.ariesbifold:id/SkipVerification')).toBeNull()
+    expect(tree.getByTestId('com.ariesbifold:id/Continue')).toBeTruthy()
+  })
+})

--- a/app/src/bcsc-theme/features/onboarding/VerifyPromptScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/VerifyPromptScreen.tsx
@@ -41,6 +41,9 @@ export const VerifyPromptScreen: React.FC<VerifyPromptScreenProps> = ({
 
   const handleVerifyNow = useCallback(() => {
     onAnswered?.()
+    // `false` = started verification, persisted until the user is verified.
+    // This will route the user into verification process until it is complete or the device is reset
+    dispatch({ type: BCDispatchAction.SET_VERIFICATION_SKIPPED, payload: [false] })
     dispatch({
       type: BCDispatchAction.UPDATE_SECURE_VERIFIED_STATUS,
       payload: [VerificationStatus.IN_PROGRESS],
@@ -52,7 +55,9 @@ export const VerifyPromptScreen: React.FC<VerifyPromptScreenProps> = ({
 
   const handleLater = useCallback(() => {
     onAnswered?.()
-  }, [onAnswered])
+    // `true` = verification is skipped, persisted, so subsequent launches go straight to the home stack
+    dispatch({ type: BCDispatchAction.SET_VERIFICATION_SKIPPED, payload: [true] })
+  }, [dispatch, onAnswered])
 
   const controls = (
     <ControlContainer>

--- a/app/src/bcsc-theme/features/onboarding/VerifyPromptScreen.tsx
+++ b/app/src/bcsc-theme/features/onboarding/VerifyPromptScreen.tsx
@@ -41,8 +41,6 @@ export const VerifyPromptScreen: React.FC<VerifyPromptScreenProps> = ({
 
   const handleVerifyNow = useCallback(() => {
     onAnswered?.()
-    // `false` = started verification, persisted until the user is verified.
-    // This will route the user into verification process until it is complete or the device is reset
     dispatch({ type: BCDispatchAction.SET_VERIFICATION_SKIPPED, payload: [false] })
     dispatch({
       type: BCDispatchAction.UPDATE_SECURE_VERIFIED_STATUS,
@@ -55,7 +53,6 @@ export const VerifyPromptScreen: React.FC<VerifyPromptScreenProps> = ({
 
   const handleLater = useCallback(() => {
     onAnswered?.()
-    // `true` = verification is skipped, persisted, so subsequent launches go straight to the home stack
     dispatch({ type: BCDispatchAction.SET_VERIFICATION_SKIPPED, payload: [true] })
   }, [dispatch, onAnswered])
 

--- a/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.test.tsx
@@ -746,6 +746,46 @@ describe('useSecureActions', () => {
     })
   })
 
+  describe('updateVerified', () => {
+    // Short-circuit after the dispatches; the credential-persistence branch is covered elsewhere.
+    beforeEach(() => {
+      jest.mocked(getAccount).mockResolvedValue(null as any)
+    })
+
+    it('dispatches UPDATE_SECURE_VERIFIED and latches SET_VERIFICATION_SKIPPED=true when verified', async () => {
+      const { result } = renderHook(() => useSecureActions())
+
+      await act(async () => {
+        await result.current.updateVerified(true)
+      })
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_SECURE_VERIFIED,
+        payload: [true],
+      })
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.SET_VERIFICATION_SKIPPED,
+        payload: [true],
+      })
+    })
+
+    it('leaves SET_VERIFICATION_SKIPPED alone when marking unverified', async () => {
+      const { result } = renderHook(() => useSecureActions())
+
+      await act(async () => {
+        await result.current.updateVerified(false)
+      })
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_SECURE_VERIFIED,
+        payload: [false],
+      })
+      expect(mockDispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: BCDispatchAction.SET_VERIFICATION_SKIPPED })
+      )
+    })
+  })
+
   describe('updateUserInfo', () => {
     beforeEach(() => {
       jest.mocked(getAuthorizationRequest).mockResolvedValue(null as any)

--- a/app/src/bcsc-theme/hooks/useSecureActions.tsx
+++ b/app/src/bcsc-theme/hooks/useSecureActions.tsx
@@ -467,6 +467,13 @@ export const useSecureActions = () => {
         type: BCDispatchAction.UPDATE_SECURE_VERIFIED,
         payload: [verified],
       })
+      if (verified) {
+        // set flag as "skipped" so the user isn't routed to reverify
+        dispatch({
+          type: BCDispatchAction.SET_VERIFICATION_SKIPPED,
+          payload: [true],
+        })
+      }
 
       const account = await getAccount()
       if (!account) {

--- a/app/src/bcsc-theme/navigators/RootStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.test.tsx
@@ -288,7 +288,10 @@ describe('BCSCRootStack', () => {
   })
 
   describe('verificationSkipped routing', () => {
-    const authedUnverified = (verificationSkipped: boolean | undefined, verifiedStatus = VerificationStatus.UNVERIFIED) =>
+    const authedUnverified = (
+      verificationSkipped: boolean | undefined,
+      verifiedStatus = VerificationStatus.UNVERIFIED
+    ) =>
       mockStore({
         bcsc: { hasAccount: true, verificationSkipped },
         authentication: { didAuthenticate: true },

--- a/app/src/bcsc-theme/navigators/RootStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.test.tsx
@@ -226,7 +226,9 @@ describe('BCSCRootStack', () => {
     const mockDispatch = jest.fn()
     jest.mocked(Bifold.useStore).mockReturnValue([
       mockStore({
-        bcsc: { hasAccount: true },
+        // verificationSkipped:true is what the load-time migration stamps on every already-onboarded
+        // install, so this "returning user" case never hits the undefined-means-show-the-prompt gate.
+        bcsc: { hasAccount: true, verificationSkipped: true },
         authentication: { didAuthenticate: true },
         bcscSecure: { verified: undefined },
       }),
@@ -268,11 +270,12 @@ describe('BCSCRootStack', () => {
 
   it('renders MainStack when an existing unverified account unlocks', () => {
     const mockDispatch = jest.fn()
-    // No OnboardingStack render this session — the user is returning, so the one-time prompt has
-    // passed them by. They start verification from the MainStack instead.
+    // The user is returning: the load-time migration stamped verificationSkipped:true on their
+    // already-onboarded state, so the prompt has passed them by. They start verification from the
+    // MainStack instead.
     jest.mocked(Bifold.useStore).mockReturnValue([
       mockStore({
-        bcsc: { hasAccount: true },
+        bcsc: { hasAccount: true, verificationSkipped: true },
         authentication: { didAuthenticate: true },
         bcscSecure: { verified: false },
       }),
@@ -282,6 +285,74 @@ describe('BCSCRootStack', () => {
     const { toJSON } = render(<BCSCRootStack />)
 
     expect(toJSON()).toBe('MainStack')
+  })
+
+  describe('verificationSkipped routing', () => {
+    const authedUnverified = (verificationSkipped: boolean | undefined, verifiedStatus = VerificationStatus.UNVERIFIED) =>
+      mockStore({
+        bcsc: { hasAccount: true, verificationSkipped },
+        authentication: { didAuthenticate: true },
+        bcscSecure: { verified: false, verifiedStatus },
+      })
+
+    it('shows the verify prompt (VerifyStack) when verificationSkipped is undefined', () => {
+      const mockDispatch = jest.fn()
+      jest.mocked(Bifold.useStore).mockReturnValue([authedUnverified(undefined), mockDispatch] as any)
+
+      const { toJSON } = render(<BCSCRootStack />)
+
+      expect(toJSON()).toBe('VerifyStack')
+      // "not answered yet" — the prompt records the choice; no resume dispatch here.
+      expect(mockDispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'bcsc/updateSecureVerifiedStatus' })
+      )
+    })
+
+    it('routes a skipped (true) unverified user straight to MainStack', () => {
+      const mockDispatch = jest.fn()
+      jest.mocked(Bifold.useStore).mockReturnValue([authedUnverified(true), mockDispatch] as any)
+
+      const { toJSON } = render(<BCSCRootStack />)
+
+      expect(toJSON()).toBe('MainStack')
+      expect(mockDispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'bcsc/updateSecureVerifiedStatus' })
+      )
+    })
+
+    it('re-enters verification on a cold start when verificationSkipped is false and unfinished', () => {
+      const mockDispatch = jest.fn()
+      jest.mocked(Bifold.useStore).mockReturnValue([authedUnverified(false), mockDispatch] as any)
+
+      const { toJSON, rerender } = render(<BCSCRootStack />)
+
+      // The one-shot effect restores IN_PROGRESS so VerifyStack takes over.
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'bcsc/updateSecureVerifiedStatus',
+        payload: [VerificationStatus.IN_PROGRESS],
+      })
+
+      // Simulate that dispatch landing in the store.
+      jest
+        .mocked(Bifold.useStore)
+        .mockReturnValue([authedUnverified(false, VerificationStatus.IN_PROGRESS), mockDispatch] as any)
+      rerender(<BCSCRootStack />)
+
+      expect(toJSON()).toBe('VerifyStack')
+    })
+
+    it('only re-enters verification once per session (a later re-render does not re-dispatch)', () => {
+      const mockDispatch = jest.fn()
+      jest.mocked(Bifold.useStore).mockReturnValue([authedUnverified(false), mockDispatch] as any)
+
+      const { rerender } = render(<BCSCRootStack />)
+      expect(mockDispatch).toHaveBeenCalledTimes(1)
+
+      // useLeaveVerification has moved status back out of IN_PROGRESS to show Home for the rest of
+      // the session; re-rendering in that state must not pull the user back into VerifyStack.
+      rerender(<BCSCRootStack />)
+      expect(mockDispatch).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('calls loadState when stateLoaded is false', () => {

--- a/app/src/bcsc-theme/navigators/RootStack.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.tsx
@@ -1,7 +1,7 @@
 import { useErrorAlert } from '@/contexts/ErrorAlertContext'
 import { useNavigationContainer } from '@/contexts/NavigationContainerContext'
 import { ErrorRegistry } from '@/errors'
-import { BCState } from '@/store'
+import { BCDispatchAction, BCState, VerificationStatus } from '@/store'
 import { TOKENS, useServices, useStore } from '@bifold/core'
 import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -46,8 +46,8 @@ const BCSCRootStack: React.FC = () => {
   const { isNavigationReady } = useNavigationContainer()
   const { initializingAccount } = useInitializeAccountStatus()
   const { needsVerification, isVerified, isVerificationInProgress } = useVerificationStatus()
-  const onboardedThisSession = useRef(false)
   const [verifyPromptAnswered, setVerifyPromptAnswered] = useState(false)
+  const resumeEvaluated = useRef(false)
   useSystemChecks(SystemCheckScope.STARTUP)
   useThirdPartyKeyboardWarning()
 
@@ -71,13 +71,48 @@ const BCSCRootStack: React.FC = () => {
     }
   }, [dispatch, loadState, store.stateLoaded, emitErrorModal, t])
 
+  // A user who chose "Skip" verification during onboarding and is not verified
+  // will be routed to continue verification where they left off
+  // Runs exactly once per session so the user isn't stuck in verification
+  useEffect(() => {
+    if (resumeEvaluated.current) {
+      return
+    }
+    if (!store.stateLoaded || !isClientReady || initializingAccount || !isNavigationReady) {
+      return
+    }
+    if (!store.bcsc.hasAccount || store.authentication.didAuthenticate === false) {
+      return
+    }
+    if (store.bcscSecure.sessionRecoveryRequired === true) {
+      return
+    }
+
+    resumeEvaluated.current = true
+
+    if (store.bcsc.verificationSkipped === false && !isVerified && !isVerificationInProgress) {
+      dispatch({ type: BCDispatchAction.UPDATE_SECURE_VERIFIED_STATUS, payload: [VerificationStatus.IN_PROGRESS] })
+    }
+  }, [
+    dispatch,
+    store.stateLoaded,
+    isClientReady,
+    initializingAccount,
+    isNavigationReady,
+    store.bcsc.hasAccount,
+    store.bcsc.verificationSkipped,
+    store.authentication.didAuthenticate,
+    store.bcscSecure.sessionRecoveryRequired,
+    isVerified,
+    isVerificationInProgress,
+  ])
+
   // Show loading screen if state, API client or navigation is not ready
   if (!store.stateLoaded || !isClientReady || initializingAccount || !isNavigationReady) {
     return <LoadingScreen message={t('BCSC.Loading.AppStartup')} />
   }
 
   if (store.bcsc.hasAccount === false) {
-    onboardedThisSession.current = true
     return <OnboardingStack />
   }
 
@@ -93,10 +128,9 @@ const BCSCRootStack: React.FC = () => {
     )
   }
 
-  // The prompt is a one-time hand-off from onboarding into verification: offer it only to a user who
-  // just finished onboarding, has yet to answer it, and has no verification to finish or resume.
-  // Everyone else reaches verification from the MainStack, which resumes them at their current step.
-  const showVerifyPrompt = onboardedThisSession.current && !verifyPromptAnswered && needsVerification
+  // This prompt controls if the user is sent back into the verification stack or can cotinue into the main app
+  // the value is only set when the user interacts with the prompt and is reset on a factory reset
+  const showVerifyPrompt = store.bcsc.verificationSkipped === undefined && !verifyPromptAnswered && needsVerification
 
   // Render the verify journey when the prompt is due, OR whenever verification is actively in
   // progress. Combining both into a single VerifyStack render keeps it mounted across the prompt →

--- a/app/src/bcsc-theme/navigators/RootStack.tsx
+++ b/app/src/bcsc-theme/navigators/RootStack.tsx
@@ -71,7 +71,7 @@ const BCSCRootStack: React.FC = () => {
     }
   }, [dispatch, loadState, store.stateLoaded, emitErrorModal, t])
 
-  // A user who chose "Skip" verification during onboarding and is not verified
+  // A user who chose to start verification during onboarding and is not verified
   // will be routed to continue verification where they left off
   // Runs exactly once per session so the user isn't stuck in verification
   useEffect(() => {

--- a/app/src/store.test.ts
+++ b/app/src/store.test.ts
@@ -1,5 +1,5 @@
 import { InstallIdSystemCheck } from './services/system-checks/InstallIdSystemCheck'
-import { BCDispatchAction, BCLocalStorageKeys, initialState, migrateBCSCState, reducer } from './store'
+import { BCDispatchAction, BCLocalStorageKeys, initialState, migrateBCSCState, reducer, VerificationStatus } from './store'
 
 jest.mock('react-native-config', () => ({
   BUILD_TARGET: 'bcsc',
@@ -119,6 +119,50 @@ describe('reducer', () => {
       expect.objectContaining({ lastSeenAppVersion: '4.1.0', lastSeenAppBuildNumber: '1234' })
     )
   })
+
+  it.each([
+    ['true (skipped)', true],
+    ['false (opted in, unfinished)', false],
+    ['undefined (reset)', undefined],
+  ])('SET_VERIFICATION_SKIPPED stores and persists %s', (_label, value) => {
+    const state = { ...initialState, bcsc: { ...initialState.bcsc, verificationSkipped: undefined } }
+    const result = reducer(state, { type: BCDispatchAction.SET_VERIFICATION_SKIPPED, payload: [value] })
+
+    expect(result.bcsc.verificationSkipped).toBe(value)
+    expect(mockedStoreValueForKey).toHaveBeenCalledWith(
+      BCLocalStorageKeys.BCSC,
+      expect.objectContaining({ verificationSkipped: value })
+    )
+  })
+
+  it('UPDATE_SECURE_VERIFIED with true also latches verificationSkipped and persists BCSC', () => {
+    const state = { ...initialState, bcsc: { ...initialState.bcsc, verificationSkipped: false } }
+    const result = reducer(state, { type: BCDispatchAction.UPDATE_SECURE_VERIFIED, payload: [true] })
+
+    expect(result.bcscSecure.verified).toBe(true)
+    expect(result.bcscSecure.verifiedStatus).toBe(VerificationStatus.VERIFIED)
+    expect(result.bcsc.verificationSkipped).toBe(true)
+    expect(mockedStoreValueForKey).toHaveBeenCalledWith(
+      BCLocalStorageKeys.BCSC,
+      expect.objectContaining({ verificationSkipped: true })
+    )
+  })
+
+  it('UPDATE_SECURE_VERIFIED with false leaves verificationSkipped untouched and does not persist BCSC', () => {
+    const state = { ...initialState, bcsc: { ...initialState.bcsc, verificationSkipped: false } }
+    const result = reducer(state, { type: BCDispatchAction.UPDATE_SECURE_VERIFIED, payload: [false] })
+
+    expect(result.bcscSecure.verified).toBe(false)
+    expect(result.bcsc.verificationSkipped).toBe(false)
+    expect(mockedStoreValueForKey).not.toHaveBeenCalledWith(BCLocalStorageKeys.BCSC, expect.anything())
+  })
+
+  it('CLEAR_BCSC resets verificationSkipped to undefined', () => {
+    const state = { ...initialState, bcsc: { ...initialState.bcsc, verificationSkipped: false } }
+    const result = reducer(state, { type: BCDispatchAction.CLEAR_BCSC })
+
+    expect(result.bcsc.verificationSkipped).toBeUndefined()
+  })
 })
 
 describe('migrateBCSCState', () => {
@@ -146,6 +190,34 @@ describe('migrateBCSCState', () => {
     const result = migrateBCSCState({})
 
     expect(result).toEqual({ bcsc: {}, migrated: false })
+  })
+
+  it('stamps verificationSkipped:true on an onboarded blob that predates the field', () => {
+    const result = migrateBCSCState({ hasAccount: true })
+
+    expect(result).toEqual({ bcsc: { hasAccount: true, verificationSkipped: true }, migrated: true })
+  })
+
+  it.each([true, false])('leaves an existing verificationSkipped (%s) untouched', (verificationSkipped) => {
+    const result = migrateBCSCState({ hasAccount: true, verificationSkipped })
+
+    expect(result).toEqual({ bcsc: { hasAccount: true, verificationSkipped }, migrated: false })
+  })
+
+  it('does not stamp verificationSkipped when there is no account yet (fresh install)', () => {
+    const result = migrateBCSCState({ hasAccount: false })
+
+    expect(result).toEqual({ bcsc: { hasAccount: false }, migrated: false })
+  })
+
+  it('applies both the reportUUID and verificationSkipped migrations together', () => {
+    const result = migrateBCSCState({ hasAccount: true, reportUUID: 'x' })
+
+    expect(result).toEqual({
+      bcsc: { hasAccount: true, installId: 'x', verificationSkipped: true },
+      migrated: true,
+    })
+    expect(result.bcsc).not.toHaveProperty('reportUUID')
   })
 
   it('composes with InstallIdSystemCheck so a migrated legacy id passes runCheck', () => {

--- a/app/src/store.test.ts
+++ b/app/src/store.test.ts
@@ -190,7 +190,7 @@ describe('migrateBCSCState', () => {
   it('stamps verificationSkipped:true on an onboarded blob that predates the field', () => {
     const result = migrateBCSCState({ hasAccount: true })
 
-    expect(result).toEqual({ bcsc: { hasAccount: true, verificationSkipped: true }, migrated: true })
+    expect(result).toEqual({ bcsc: { hasAccount: true, verificationSkipped: false }, migrated: true })
   })
 
   it.each([true, false])('leaves an existing verificationSkipped (%s) untouched', (verificationSkipped) => {
@@ -209,7 +209,7 @@ describe('migrateBCSCState', () => {
     const result = migrateBCSCState({ hasAccount: true, reportUUID: 'x' })
 
     expect(result).toEqual({
-      bcsc: { hasAccount: true, installId: 'x', verificationSkipped: true },
+      bcsc: { hasAccount: true, installId: 'x', verificationSkipped: false },
       migrated: true,
     })
     expect(result.bcsc).not.toHaveProperty('reportUUID')

--- a/app/src/store.test.ts
+++ b/app/src/store.test.ts
@@ -1,5 +1,12 @@
 import { InstallIdSystemCheck } from './services/system-checks/InstallIdSystemCheck'
-import { BCDispatchAction, BCLocalStorageKeys, initialState, migrateBCSCState, reducer, VerificationStatus } from './store'
+import {
+  BCDispatchAction,
+  BCLocalStorageKeys,
+  initialState,
+  migrateBCSCState,
+  reducer,
+  VerificationStatus,
+} from './store'
 
 jest.mock('react-native-config', () => ({
   BUILD_TARGET: 'bcsc',
@@ -135,24 +142,12 @@ describe('reducer', () => {
     )
   })
 
-  it('UPDATE_SECURE_VERIFIED with true also latches verificationSkipped and persists BCSC', () => {
+  it('UPDATE_SECURE_VERIFIED only touches secure state, leaving verificationSkipped to its own action', () => {
     const state = { ...initialState, bcsc: { ...initialState.bcsc, verificationSkipped: false } }
     const result = reducer(state, { type: BCDispatchAction.UPDATE_SECURE_VERIFIED, payload: [true] })
 
     expect(result.bcscSecure.verified).toBe(true)
     expect(result.bcscSecure.verifiedStatus).toBe(VerificationStatus.VERIFIED)
-    expect(result.bcsc.verificationSkipped).toBe(true)
-    expect(mockedStoreValueForKey).toHaveBeenCalledWith(
-      BCLocalStorageKeys.BCSC,
-      expect.objectContaining({ verificationSkipped: true })
-    )
-  })
-
-  it('UPDATE_SECURE_VERIFIED with false leaves verificationSkipped untouched and does not persist BCSC', () => {
-    const state = { ...initialState, bcsc: { ...initialState.bcsc, verificationSkipped: false } }
-    const result = reducer(state, { type: BCDispatchAction.UPDATE_SECURE_VERIFIED, payload: [false] })
-
-    expect(result.bcscSecure.verified).toBe(false)
     expect(result.bcsc.verificationSkipped).toBe(false)
     expect(mockedStoreValueForKey).not.toHaveBeenCalledWith(BCLocalStorageKeys.BCSC, expect.anything())
   })

--- a/app/src/store.tsx
+++ b/app/src/store.tsx
@@ -683,16 +683,6 @@ const bcReducer = (state: BCState, action: ReducerAction<BCDispatchAction>): BCS
         // QUESTION (MD): Should we handle DEACTIVATED here?
         verifiedStatus: verified ? VerificationStatus.VERIFIED : VerificationStatus.UNVERIFIED,
       }
-      // Becoming verified retires the "resume verification on next launch" state: from here on the
-      // user belongs on the home stack, same as if they'd skipped the post-onboarding prompt. This
-      // is the single choke point every verification method funnels through (updateVerified(true) in
-      // useVerificationResponseViewModel). Leave the flag untouched when verified is false so a
-      // transient unverify doesn't discard an in-progress "false" choice.
-      if (verified && state.bcsc.verificationSkipped !== true) {
-        const bcsc = { ...state.bcsc, verificationSkipped: true }
-        PersistentStorage.storeValueForKey<BCSCState>(BCLocalStorageKeys.BCSC, bcsc)
-        return { ...state, bcsc, bcscSecure }
-      }
       return { ...state, bcscSecure }
     }
     case BCSCDispatchAction.UPDATE_SECURE_VERIFIED_STATUS: {

--- a/app/src/store.tsx
+++ b/app/src/store.tsx
@@ -382,7 +382,7 @@ export const migrateBCSCState = <T extends Partial<BCSCState> & { reportUUID?: s
   }
 
   if (bcsc.hasAccount === true && bcsc.verificationSkipped === undefined) {
-    bcsc = { ...bcsc, verificationSkipped: true }
+    bcsc = { ...bcsc, verificationSkipped: false }
     migrated = true
   }
 

--- a/app/src/store.tsx
+++ b/app/src/store.tsx
@@ -109,6 +109,20 @@ export interface BCSCState {
    */
   lastSeenAppVersion?: string
   lastSeenAppBuildNumber?: string
+  /**
+   * The user's answer to the post-onboarding "verify your account now?" prompt, persisted so the
+   * choice survives an app restart:
+   * - `undefined` — not answered yet (fresh install, or after a factory reset). RootStack shows the
+   *   prompt.
+   * - `false` — the user chose to start verification but has not finished. RootStack routes straight
+   *   into VerifyStack on every launch until they verify.
+   * - `true` — the user chose to skip, OR verification completed. RootStack routes to the home stack.
+   *
+   * Set `true` automatically when `bcscSecure.verified` flips true (see UPDATE_SECURE_VERIFIED), and
+   * reset to `undefined` by CLEAR_BCSC. Intentionally on plain (AsyncStorage) state, not secure
+   * state, so an app uninstall clears it — iOS Keychain-backed secure state would survive a reinstall.
+   */
+  verificationSkipped?: boolean
 }
 
 export enum VerificationStatus {
@@ -298,6 +312,7 @@ enum BCSCDispatchAction {
   SET_INSTALL_ID = 'bcsc/setInstallId',
   KEY_ROTATION_ATTEMPTED = 'bcsc/keyRotationAttempted',
   RECORD_APP_LAUNCH_VERSION = 'bcsc/recordAppLaunchVersion',
+  SET_VERIFICATION_SKIPPED = 'bcsc/setVerificationSkipped',
 }
 
 enum ModeDispatchAction {
@@ -345,19 +360,33 @@ export const initialBCSCState: BCSCState = {
 }
 
 /**
- * Migrates a persisted BCSC state blob that may still carry the legacy `reportUUID` field
- * (added bcsc-v4.0.2, #4060). Safe to remove once all installs have launched on >= v4.1.
+ * Migrates a persisted BCSC state blob on load. Two idempotent, read-side migrations:
+ * - Legacy `reportUUID` (added bcsc-v4.0.2, #4060) → `installId`. Safe to remove once all installs
+ *   have launched on >= v4.1.
+ * - Onboarded installs that predate `verificationSkipped`: a missing value is treated as "skipped"
+ *   (`true`) so they keep landing on the home screen rather than the post-onboarding verify prompt.
  */
 export const migrateBCSCState = <T extends Partial<BCSCState> & { reportUUID?: string }>(
   persisted: T
-  // `& { installId?: string }` keeps installId in the return type even when T is inferred from a
-  // narrow literal that never mentions it (e.g. `{ reportUUID: 'x' }` in tests).
-): { bcsc: Omit<T, 'reportUUID'> & { installId?: string }; migrated: boolean } => {
+  // `& { installId?: string; verificationSkipped?: boolean }` keeps these fields in the return type
+  // even when T is inferred from a narrow literal that never mentions them (e.g. `{ reportUUID: 'x' }`
+  // in tests).
+): { bcsc: Omit<T, 'reportUUID'> & { installId?: string; verificationSkipped?: boolean }; migrated: boolean } => {
   const { reportUUID, ...rest } = persisted
-  if (reportUUID === undefined) {
-    return { bcsc: rest, migrated: false }
+  let bcsc: Omit<T, 'reportUUID'> & { installId?: string; verificationSkipped?: boolean } = rest
+  let migrated = false
+
+  if (reportUUID !== undefined) {
+    bcsc = { ...bcsc, installId: bcsc.installId ?? reportUUID }
+    migrated = true
   }
-  return { bcsc: { ...rest, installId: rest.installId ?? reportUUID }, migrated: true }
+
+  if (bcsc.hasAccount === true && bcsc.verificationSkipped === undefined) {
+    bcsc = { ...bcsc, verificationSkipped: true }
+    migrated = true
+  }
+
+  return { bcsc, migrated }
 }
 
 export enum BCLocalStorageKeys {
@@ -654,6 +683,16 @@ const bcReducer = (state: BCState, action: ReducerAction<BCDispatchAction>): BCS
         // QUESTION (MD): Should we handle DEACTIVATED here?
         verifiedStatus: verified ? VerificationStatus.VERIFIED : VerificationStatus.UNVERIFIED,
       }
+      // Becoming verified retires the "resume verification on next launch" state: from here on the
+      // user belongs on the home stack, same as if they'd skipped the post-onboarding prompt. This
+      // is the single choke point every verification method funnels through (updateVerified(true) in
+      // useVerificationResponseViewModel). Leave the flag untouched when verified is false so a
+      // transient unverify doesn't discard an in-progress "false" choice.
+      if (verified && state.bcsc.verificationSkipped !== true) {
+        const bcsc = { ...state.bcsc, verificationSkipped: true }
+        PersistentStorage.storeValueForKey<BCSCState>(BCLocalStorageKeys.BCSC, bcsc)
+        return { ...state, bcsc, bcscSecure }
+      }
       return { ...state, bcscSecure }
     }
     case BCSCDispatchAction.UPDATE_SECURE_VERIFIED_STATUS: {
@@ -812,6 +851,14 @@ const bcReducer = (state: BCState, action: ReducerAction<BCDispatchAction>): BCS
     case BCSCDispatchAction.RECORD_APP_LAUNCH_VERSION: {
       const { version: lastSeenAppVersion, buildNumber: lastSeenAppBuildNumber } = (action?.payload || []).pop() ?? {}
       const bcsc = { ...state.bcsc, lastSeenAppVersion, lastSeenAppBuildNumber }
+      const newState = { ...state, bcsc }
+      PersistentStorage.storeValueForKey<BCSCState>(BCLocalStorageKeys.BCSC, bcsc)
+      return newState
+    }
+
+    case BCSCDispatchAction.SET_VERIFICATION_SKIPPED: {
+      const verificationSkipped: boolean | undefined = (action?.payload || []).pop()
+      const bcsc = { ...state.bcsc, verificationSkipped }
       const newState = { ...state, bcsc }
       PersistentStorage.storeValueForKey<BCSCState>(BCLocalStorageKeys.BCSC, bcsc)
       return newState


### PR DESCRIPTION
Closes #4488 

## What changed
- added a `verificationSkipped` to the `BCSCStore` object to track if a user skips verification or decides to start it
- check added on start up to route user back into verification or to home screen based on flag and verification status

## What should the reviewer focus on
- `RootStack.tsx` has a one time run check if the user should continue verification or be brought to the home screen
- `store.tsx` added new dispatch action and case for handling the `verificationSkipped` flag
- migration logic modified to default a migrated user to "skipped" 

## How to test
- go through onboarding
- skip verification process
- restart app
- authenticate and see home screen

_________
- go through onboarding
- start verification process
- restart the app before completing verification
- authenticate and see verification process where you stopped


 