### PR TITLE
fix: prevent double press on other id selection

### DIFF
--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.test.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.test.tsx
@@ -7,7 +7,7 @@ import { useNavigation } from '@mocks/custom/@react-navigation/core'
 import { BasicAppContext } from '@mocks/helpers/app'
 import * as Navigation from '@react-navigation/native'
 import { RouteProp } from '@react-navigation/native'
-import { fireEvent, render } from '@testing-library/react-native'
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 import { BCSCCardProcess, EvidenceMetadata, EvidenceType } from 'react-native-bcsc-core'
 import EvidenceTypeListScreen from './EvidenceTypeListScreen'
@@ -63,7 +63,7 @@ describe('EvidenceTypeList', () => {
     mockUseSecureActions.mockReturnValue({
       removeIncompleteEvidence: jest.fn().mockResolvedValue([]),
       truncateEvidence: jest.fn().mockResolvedValue([]),
-      addEvidenceType: jest.fn(),
+      addEvidenceType: jest.fn().mockResolvedValue(undefined),
     })
     mockUseDataLoader.mockReturnValue({
       data: undefined,
@@ -455,7 +455,7 @@ describe('EvidenceTypeList', () => {
       mockUseSecureActions.mockReturnValue({
         removeIncompleteEvidence: removeIncompleteEvidenceMock,
         truncateEvidence: jest.fn().mockResolvedValue([]),
-        addEvidenceType: jest.fn(),
+        addEvidenceType: jest.fn().mockResolvedValue(undefined),
       })
 
       render(
@@ -479,7 +479,7 @@ describe('EvidenceTypeList', () => {
       mockUseSecureActions.mockReturnValue({
         removeIncompleteEvidence: removeIncompleteEvidenceMock,
         truncateEvidence: jest.fn().mockResolvedValue([]),
-        addEvidenceType: jest.fn(),
+        addEvidenceType: jest.fn().mockResolvedValue(undefined),
       })
 
       const existingEvidence: EvidenceMetadata = {
@@ -502,6 +502,166 @@ describe('EvidenceTypeList', () => {
       )
 
       expect(removeIncompleteEvidenceMock).toHaveBeenCalledWith([existingEvidence])
+    })
+  })
+
+  describe('double press handling', () => {
+    const cardA = makeEvidenceType({ evidence_type: 'card_a', evidence_type_label: 'Card A' })
+    const cardB = makeEvidenceType({ evidence_type: 'card_b', evidence_type_label: 'Card B' })
+
+    const testIdFor = (card: EvidenceType) => `com.ariesbifold:id/EvidenceTypeListItem-${card.evidence_type}`
+
+    const renderList = (addEvidenceType: jest.Mock) => {
+      mockUseSecureActions.mockReturnValue({
+        removeIncompleteEvidence: jest.fn().mockResolvedValue([]),
+        truncateEvidence: jest.fn().mockResolvedValue([]),
+        addEvidenceType,
+      })
+      mockUseDataLoader.mockReturnValue({
+        data: mockMetadata([cardA, cardB], BCSCCardProcess.None as string),
+        load: jest.fn(),
+        isLoading: false,
+      })
+
+      return render(
+        <BasicAppContext>
+          <EvidenceTypeListScreen
+            navigation={mockNavigation as never}
+            route={{ params: { cardProcess: BCSCCardProcess.None } } as EvidenceTypeListRoute}
+          />
+        </BasicAppContext>
+      )
+    }
+
+    it('ignores a second press on the same row after the first has settled', async () => {
+      const addEvidenceType = jest.fn().mockResolvedValue(undefined)
+      const { getByTestId } = renderList(addEvidenceType)
+
+      const row = getByTestId(testIdFor(cardA))
+      await act(async () => {
+        fireEvent.press(row)
+      })
+      await act(async () => {
+        fireEvent.press(row)
+      })
+
+      expect(addEvidenceType).toHaveBeenCalledTimes(1)
+      expect(mockNavigation.push).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores a press on a different row while the first selection is in flight', async () => {
+      const addEvidenceType = jest.fn().mockResolvedValue(undefined)
+      const { getByTestId } = renderList(addEvidenceType)
+
+      await act(async () => {
+        fireEvent.press(getByTestId(testIdFor(cardA)))
+        fireEvent.press(getByTestId(testIdFor(cardB)))
+      })
+
+      expect(addEvidenceType).toHaveBeenCalledTimes(1)
+      expect(addEvidenceType).toHaveBeenCalledWith(cardA)
+      expect(mockNavigation.push).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores a card press while "Other Options" is navigating', async () => {
+      const addEvidenceType = jest.fn().mockResolvedValue(undefined)
+      mockUseSecureActions.mockReturnValue({
+        removeIncompleteEvidence: jest.fn().mockResolvedValue([]),
+        truncateEvidence: jest.fn().mockResolvedValue([]),
+        addEvidenceType,
+      })
+      mockUseDataLoader.mockReturnValue({
+        data: mockMetadata([cardA], BCSCCardProcess.BCSCNonPhoto as string),
+        load: jest.fn(),
+        isLoading: false,
+      })
+
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <EvidenceTypeListScreen
+            navigation={mockNavigation as never}
+            route={
+              { params: { cardProcess: BCSCCardProcess.BCSCNonPhoto, photoFilter: 'photo' } } as EvidenceTypeListRoute
+            }
+          />
+        </BasicAppContext>
+      )
+
+      await act(async () => {
+        fireEvent.press(getByTestId('com.ariesbifold:id/EvidenceTypeListOtherOptions'))
+        fireEvent.press(getByTestId(testIdFor(cardA)))
+      })
+
+      expect(mockNavigation.replace).toHaveBeenCalledTimes(1)
+      expect(addEvidenceType).not.toHaveBeenCalled()
+      expect(mockNavigation.push).not.toHaveBeenCalled()
+    })
+
+    it('re-arms selection when the screen regains focus', async () => {
+      let focusCallback: (() => void) | undefined
+      jest.spyOn(Navigation, 'useFocusEffect').mockImplementation((callback) => {
+        focusCallback = callback as () => void
+        callback()
+      })
+
+      const addEvidenceType = jest.fn().mockResolvedValue(undefined)
+      const { getByTestId } = renderList(addEvidenceType)
+
+      await act(async () => {
+        fireEvent.press(getByTestId(testIdFor(cardA)))
+      })
+      expect(mockNavigation.push).toHaveBeenCalledTimes(1)
+
+      // Simulate navigating back to the list.
+      await act(async () => {
+        focusCallback?.()
+      })
+
+      await act(async () => {
+        fireEvent.press(getByTestId(testIdFor(cardA)))
+      })
+      expect(mockNavigation.push).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('failed evidence persistence', () => {
+    const card = makeEvidenceType({ evidence_type: 'card_a', evidence_type_label: 'Card A' })
+    const cardTestId = 'com.ariesbifold:id/EvidenceTypeListItem-card_a'
+
+    it('logs and re-arms selection when the evidence write fails', async () => {
+      const addEvidenceType = jest.fn().mockRejectedValue(new Error('native write failed'))
+      mockUseSecureActions.mockReturnValue({
+        removeIncompleteEvidence: jest.fn().mockResolvedValue([]),
+        truncateEvidence: jest.fn().mockResolvedValue([]),
+        addEvidenceType,
+      })
+      mockUseDataLoader.mockReturnValue({
+        data: mockMetadata([card], BCSCCardProcess.None as string),
+        load: jest.fn(),
+        isLoading: false,
+      })
+
+      const { getByTestId } = render(
+        <BasicAppContext>
+          <EvidenceTypeListScreen
+            navigation={mockNavigation as never}
+            route={{ params: { cardProcess: BCSCCardProcess.None } } as EvidenceTypeListRoute}
+          />
+        </BasicAppContext>
+      )
+
+      await act(async () => {
+        fireEvent.press(getByTestId(cardTestId))
+      })
+
+      await waitFor(() =>
+        expect(defaultLogger.error).toHaveBeenCalledWith(expect.stringContaining('native write failed'))
+      )
+
+      await act(async () => {
+        fireEvent.press(getByTestId(cardTestId))
+      })
+      expect(addEvidenceType).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.tsx
@@ -94,9 +94,11 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
   // stack (the first-ID list and the second-ID list) keeps its own baseline, so backing to one only
   // releases the ID chosen from it.
   const baselineCountRef = useRef<number | null>(null)
+  const isNavigatingRef = useRef(false)
 
   useFocusEffect(
     useCallback(() => {
+      isNavigatingRef.current = false
       const evidence = storeRef.current.bcscSecure.additionalEvidenceData
       if (baselineCountRef.current === null) {
         // First (forward) visit: the baseline is how many IDs are already fully collected before this
@@ -254,6 +256,33 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
    */
   const showOtherOptions = photoFilter === 'photo' && store.bcscSecure.additionalEvidenceData.length === 0
 
+  const handleSelectEvidenceType = useCallback(
+    (item: EvidenceType) => {
+      if (isNavigatingRef.current) {
+        return
+      }
+      isNavigatingRef.current = true
+
+      addEvidenceType(item).catch((error) => {
+        logger.error(`Error adding evidence type: ${error}`)
+        isNavigatingRef.current = false
+      })
+      // push (not navigate) so the second ID opens a fresh instructions screen instead of
+      // popping back to the first ID's IDPhotoInformation already in the stack.
+      navigation.push(BCSCScreens.IDPhotoInformation, { cardType: item })
+    },
+    [addEvidenceType, navigation, logger]
+  )
+
+  const handleShowOtherOptions = useCallback(() => {
+    if (isNavigatingRef.current) {
+      return
+    }
+    isNavigatingRef.current = true
+
+    navigation.replace(BCSCScreens.EvidenceTypeList, { cardProcess, photoFilter: 'nonPhoto' })
+  }, [navigation, cardProcess])
+
   if (isLoading) {
     return <ActivityIndicator size={'large'} style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }} />
   }
@@ -281,12 +310,7 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
             {section.data.map((item) => (
               <ListButton
                 key={item.evidence_type_label}
-                onPress={() => {
-                  addEvidenceType(item)
-                  // push (not navigate) so the second ID opens a fresh instructions screen instead of
-                  // popping back to the first ID's IDPhotoInformation already in the stack.
-                  navigation.push(BCSCScreens.IDPhotoInformation, { cardType: item })
-                }}
+                onPress={() => handleSelectEvidenceType(item)}
                 testID={testIdWithKey(`EvidenceTypeListItem-${item.evidence_type}`)}
                 accessibilityLabel={a11yShortLabel(item.evidence_type_label)}
               >
@@ -305,12 +329,7 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
           <ThemedText style={styles.sectionTitle}>{t('BCSC.EvidenceTypeList.OtherOptions')}</ThemedText>
           <ListButtonGroup>
             <ListButton
-              onPress={() => {
-                navigation.replace(BCSCScreens.EvidenceTypeList, {
-                  cardProcess,
-                  photoFilter: 'nonPhoto',
-                })
-              }}
+              onPress={handleShowOtherOptions}
               testID={testIdWithKey('EvidenceTypeListOtherOptions')}
               accessibilityLabel={a11yLabel(t('BCSC.EvidenceTypeList.ShowMoreOptions'))}
             >


### PR DESCRIPTION
Closes #4548

## What changed

This PR prevents double press on the evidence / other id selection screen. The previous usePreventDoublePress implementation didn't work because it was only per-item, so double pressing would cause that item to be removed and a second press to register on the item below it.

## What should the reviewer focus on

Check that the functions extracted haven't changed beyond the double tap prevention.

## How to test

Other ID, evidence selection screen, double press list items as fast as you can