### PR TITLE
ci: default Publish to ring-2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ on:
       ring:
         description: 'How far to publish. ring-0 (the team) always goes; this picks how much further, and needs approval.'
         required: false
-        default: ring-1
+        default: ring-2
         type: choice
         options:
           - ring-1

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -57,8 +57,9 @@ wider and needs an approval. Publishing to a ring publishes every ring below it.
 A build is uploaded once at ring-0. Later rings widen who can see that same
 build rather than uploading it again, so publishing is safe to repeat.
 
-Approvals come from three teams: `bcsc-approvers-ring-1` for QA,
-`bcsc-approvers-ring-2` for UAT, and `bcsc-approvers-ring-3-plus` beyond that.
+QA (ring-1) and UAT (ring-2) are separate rings with separate gates. Approvals
+come from three teams: `bcsc-approvers-ring-1` for QA, `bcsc-approvers-ring-2`
+for UAT, and `bcsc-approvers-ring-3-plus` beyond that.
 
 ## Variants
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -57,8 +57,8 @@ wider and needs an approval. Publishing to a ring publishes every ring below it.
 A build is uploaded once at ring-0. Later rings widen who can see that same
 build rather than uploading it again, so publishing is safe to repeat.
 
-Approvals come from two teams: `bcsc-approvers-ring-1` for QA builds, and
-`bcsc-approvers-ring-2-plus` for anything wider.
+Approvals come from three teams: `bcsc-approvers-ring-1` for QA,
+`bcsc-approvers-ring-2` for UAT, and `bcsc-approvers-ring-3-plus` beyond that.
 
 ## Variants
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -60,7 +60,7 @@ one; only an approver can take it past ring-0.
 
 | Input | Leave it alone to | Use it to |
 |---|---|---|
-| `ring` | Publish to QA | Go further |
+| `ring` | Publish to UAT | Stop at QA, or go further |
 | `build_number` | Publish the newest usable build | Publish an older build |
 | `targets` | Publish to all three stores | Retry one store after a failure |
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -13,8 +13,8 @@ A ring is an audience. Each one is wider than the last.
 | Ring | Who gets the build | Who approves it |
 |---|---|---|
 | `ring-0` | The team | Nobody, it always publishes |
-| `ring-1` | QA | `bcsc-approvers-ring-1` |
-| `ring-2` | UAT | `bcsc-approvers-ring-2` |
+| `ring-1` | QA testers | `bcsc-approvers-ring-1` |
+| `ring-2` | UAT testers | `bcsc-approvers-ring-2` |
 | `ring-3` | Early adopters | `bcsc-approvers-ring-3-plus` |
 | `ring-4` | Everyone | `bcsc-approvers-ring-3-plus` |
 
@@ -41,14 +41,18 @@ is the one case where a build can knock another off a track.
 
 ## Who approves
 
-Three teams, so signing off on a QA or UAT build doesn't also let you release
-to everyone.
+QA and UAT are separate rings with separate gates. ring-1 goes to QA testers,
+ring-2 to UAT testers, and each has its own approval even though the same
+people sit on both teams today.
 
-| Team | Approves | Members |
+| Team | Approves | Who is on it |
 |---|---|---|
-| `bcsc-approvers-ring-1` | ring-1 | UAT, the PO and the dev team |
-| `bcsc-approvers-ring-2` | ring-2 | UAT, the PO and the dev team |
+| `bcsc-approvers-ring-1` | ring-1 | The UAT team, the PO and the dev team |
+| `bcsc-approvers-ring-2` | ring-2 | The UAT team, the PO and the dev team |
 | `bcsc-approvers-ring-3-plus` | ring-3 and ring-4 | The PO and the dev team |
+
+Approving is separate from receiving: being on an approver team does not put
+you in that ring's tester group, and vice versa.
 
 Anyone in the team can approve, and membership is managed in the team, so
 nothing here changes when someone joins or leaves. You cannot approve your own

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -47,7 +47,7 @@ people sit on both teams today.
 
 | Team | Approves | Who is on it |
 |---|---|---|
-| `bcsc-approvers-ring-1` | ring-1 | The UAT team, the PO and the dev team |
+| `bcsc-approvers-ring-1` | ring-1 | The QA team, the PO and the dev team |
 | `bcsc-approvers-ring-2` | ring-2 | The UAT team, the PO and the dev team |
 | `bcsc-approvers-ring-3-plus` | ring-3 and ring-4 | The PO and the dev team |
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -14,9 +14,9 @@ A ring is an audience. Each one is wider than the last.
 |---|---|---|
 | `ring-0` | The team | Nobody, it always publishes |
 | `ring-1` | QA | `bcsc-approvers-ring-1` |
-| `ring-2` | UAT | `bcsc-approvers-ring-2-plus` |
-| `ring-3` | Early adopters | `bcsc-approvers-ring-2-plus` |
-| `ring-4` | Everyone | `bcsc-approvers-ring-2-plus` |
+| `ring-2` | UAT | `bcsc-approvers-ring-2` |
+| `ring-3` | Early adopters | `bcsc-approvers-ring-3-plus` |
+| `ring-4` | Everyone | `bcsc-approvers-ring-3-plus` |
 
 Publishing to a ring publishes every ring below it, so `ring-2` sends the build
 to ring-0, ring-1 and ring-2. The team gets it straight away; everything above
@@ -41,13 +41,14 @@ is the one case where a build can knock another off a track.
 
 ## Who approves
 
-Two teams, so signing off on a QA build doesn't also let you release to
-everyone.
+Three teams, so signing off on a QA or UAT build doesn't also let you release
+to everyone.
 
 | Team | Approves | Members |
 |---|---|---|
 | `bcsc-approvers-ring-1` | ring-1 | UAT, the PO and the dev team |
-| `bcsc-approvers-ring-2-plus` | ring-2 to ring-4 | The PO and the dev team |
+| `bcsc-approvers-ring-2` | ring-2 | UAT, the PO and the dev team |
+| `bcsc-approvers-ring-3-plus` | ring-3 and ring-4 | The PO and the dev team |
 
 Anyone in the team can approve, and membership is managed in the team, so
 nothing here changes when someone joins or leaves. You cannot approve your own


### PR DESCRIPTION
Closes #4522

## What changed

Publish now defaults to `ring-2` (UAT) instead of `ring-1` (QA). ring-1 was a placeholder nobody picks, so the default had to be changed by hand every time.

## What should the reviewer focus on

ring-1 stays in the dropdown. Choosing ring-2 publishes through it anyway, so the entry only matters for stopping short at QA.

ring-2 also gets its own approver team. Sharing one with ring-3 and ring-4 would have put the new default under the PO and devs only; `bcsc-approvers-ring-2` has the same members as ring-1, so UAT approvers stay on the everyday path. The old `bcsc-approvers-ring-2-plus` is renamed `bcsc-approvers-ring-3-plus` and keeps its team id, so those environments were untouched.

## How to test

The default is a valid option, and `actionlint` is clean apart from the known `queue:` false positive. Nothing else in the workflow or resolver assumed ring-1.

## Note for the team

Running Publish with the defaults now goes to UAT, and to the team and QA on the way. Pick ring-1 if you want it to stop at QA.

