### PR TITLE
fix: filter services properly

### DIFF
--- a/app/src/bcsc-theme/api/hooks/useMetadataApi.tsx
+++ b/app/src/bcsc-theme/api/hooks/useMetadataApi.tsx
@@ -25,6 +25,7 @@ export interface ClientMetadata {
   initiate_login_uri?: string
   client_description?: string
   policy_uri?: string
+  /** If omitted, the service should not be shown unless it is already bookmarked */
   service_listing_sort_order?: number
 }
 

--- a/app/src/bcsc-theme/features/home/components/SavedServices.tsx
+++ b/app/src/bcsc-theme/features/home/components/SavedServices.tsx
@@ -23,6 +23,7 @@ const SavedServices: React.FC = () => {
 
   const { serviceClients } = useFilterServiceClients({
     serviceClientIdsFilter: store.bcscSecure.savedServices,
+    savedServiceClientIds: store.bcscSecure.savedServices,
   })
 
   const styles = StyleSheet.create({

--- a/app/src/bcsc-theme/features/services/Services.tsx
+++ b/app/src/bcsc-theme/features/services/Services.tsx
@@ -48,11 +48,6 @@ const Services: React.FC = () => {
       onError: (error) => logger.error('Error loading card type', error as Error),
     }
   )
-  const { serviceClients, isLoading } = useFilterServiceClients({
-    cardProcessFilter: getCardProcessForCardType(idTokenMetadata?.bcsc_card_type ?? null),
-    partialNameFilter: !search ? '' : debouncedSearch, // if search is empty, avoid debounce delay
-  })
-
   const isBCSCMode = store.mode === Mode.BCSC // isDarkMode? or isBCSCMode?
 
   // Track the latest bookmarks via a ref so toggling a bookmark does not
@@ -69,6 +64,15 @@ const Services: React.FC = () => {
       setSortVersion((v) => v + 1)
     }, [])
   )
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const savedServicesSnapshot = useMemo(() => savedServicesRef.current, [sortVersion])
+
+  const { serviceClients, isLoading } = useFilterServiceClients({
+    cardProcessFilter: getCardProcessForCardType(idTokenMetadata?.bcsc_card_type ?? null),
+    partialNameFilter: !search ? '' : debouncedSearch, // if search is empty, avoid debounce delay
+    savedServiceClientIds: savedServicesSnapshot,
+  })
 
   const sortedServiceClients = useMemo(() => {
     const saved = new Set(savedServicesRef.current)

--- a/app/src/bcsc-theme/features/services/hooks/useFilterServiceClients.test.ts
+++ b/app/src/bcsc-theme/features/services/hooks/useFilterServiceClients.test.ts
@@ -19,7 +19,7 @@ const mockServiceClientA: ClientMetadata = {
   suppress_bookmark_prompt: false,
   allowed_identification_processes: [BCSCCardProcess.BCSCPhoto],
   bc_address: true,
-  service_listing_sort_order: undefined,
+  service_listing_sort_order: 2,
 }
 
 const mockServiceClientB: ClientMetadata = {
@@ -32,7 +32,7 @@ const mockServiceClientB: ClientMetadata = {
   suppress_bookmark_prompt: false,
   allowed_identification_processes: [BCSCCardProcess.NonBCSC],
   bc_address: false,
-  service_listing_sort_order: undefined,
+  service_listing_sort_order: 2,
 }
 
 const mockServiceClientC: ClientMetadata = {
@@ -46,6 +46,20 @@ const mockServiceClientC: ClientMetadata = {
   allowed_identification_processes: [BCSCCardProcess.NonBCSC],
   bc_address: false,
   service_listing_sort_order: 1,
+}
+
+// Not meant to be listed: no service_listing_sort_order
+const mockServiceClientD: ClientMetadata = {
+  client_ref_id: 'test-client-id-d',
+  client_name: 'TEST CLIENT DELTA',
+  client_uri: 'https://test.client.d',
+  application_type: 'web',
+  claims_description: 'claims',
+  suppress_confirmation_info: false,
+  suppress_bookmark_prompt: false,
+  allowed_identification_processes: [BCSCCardProcess.BCSCPhoto],
+  bc_address: true,
+  service_listing_sort_order: undefined,
 }
 
 describe('useFilterServiceClients', () => {
@@ -77,7 +91,7 @@ describe('useFilterServiceClients', () => {
       expect(hook.result.current.isLoading).toBe(false)
     })
 
-    it('should sort by sort order then name', async () => {
+    it('should sort by name when the sort order matches', async () => {
       const bifoldMock = jest.mocked(Bifold)
       const useApiMock = jest.mocked(useApi)
 
@@ -97,6 +111,79 @@ describe('useFilterServiceClients', () => {
       expect(hook.result.current.serviceClients[0].client_ref_id).toBe(mockServiceClientA.client_ref_id)
       expect(hook.result.current.serviceClients[1].client_ref_id).toBe(mockServiceClientB.client_ref_id)
       expect(hook.result.current.isLoading).toBe(false)
+    })
+  })
+
+  describe('service listing sort order filter', () => {
+    it('should filter out service clients without a service listing sort order', async () => {
+      const bifoldMock = jest.mocked(Bifold)
+      const useApiMock = jest.mocked(useApi)
+
+      useApiMock.default.mockReturnValue({
+        metadata: {
+          getClientMetadata: jest.fn().mockResolvedValue([mockServiceClientD, mockServiceClientC]),
+        },
+      } as any)
+      bifoldMock.useServices.mockReturnValue([{ error: jest.fn() }] as any)
+
+      const hook = renderHook(() => useFilterServiceClients({}))
+
+      expect(hook.result.current.isLoading).toBe(true)
+      await waitFor(() => {
+        expect(hook.result.current.serviceClients).toHaveLength(1)
+      })
+      expect(hook.result.current.serviceClients[0].client_ref_id).toBe(mockServiceClientC.client_ref_id)
+      expect(hook.result.current.isLoading).toBe(false)
+    })
+
+    it('should keep service clients without a service listing sort order when they are saved', async () => {
+      const bifoldMock = jest.mocked(Bifold)
+      const useApiMock = jest.mocked(useApi)
+
+      useApiMock.default.mockReturnValue({
+        metadata: {
+          getClientMetadata: jest.fn().mockResolvedValue([mockServiceClientD, mockServiceClientC]),
+        },
+      } as any)
+      bifoldMock.useServices.mockReturnValue([{ error: jest.fn() }] as any)
+
+      const hook = renderHook(() =>
+        useFilterServiceClients({ savedServiceClientIds: [mockServiceClientD.client_ref_id] })
+      )
+
+      expect(hook.result.current.isLoading).toBe(true)
+      await waitFor(() => {
+        expect(hook.result.current.serviceClients).toHaveLength(2)
+      })
+      // Unlisted services sort to the end
+      expect(hook.result.current.serviceClients[0].client_ref_id).toBe(mockServiceClientC.client_ref_id)
+      expect(hook.result.current.serviceClients[1].client_ref_id).toBe(mockServiceClientD.client_ref_id)
+      expect(hook.result.current.isLoading).toBe(false)
+    })
+
+    it('should still apply the other filters to saved service clients', async () => {
+      const bifoldMock = jest.mocked(Bifold)
+      const useApiMock = jest.mocked(useApi)
+
+      useApiMock.default.mockReturnValue({
+        metadata: {
+          getClientMetadata: jest.fn().mockResolvedValue([mockServiceClientD]),
+        },
+      } as any)
+      bifoldMock.useServices.mockReturnValue([{ error: jest.fn() }] as any)
+
+      const hook = renderHook(() =>
+        useFilterServiceClients({
+          cardProcessFilter: BCSCCardProcess.NonBCSC,
+          savedServiceClientIds: [mockServiceClientD.client_ref_id],
+        })
+      )
+
+      expect(hook.result.current.isLoading).toBe(true)
+      await waitFor(() => {
+        expect(hook.result.current.serviceClients).toHaveLength(0)
+        expect(hook.result.current.isLoading).toBe(false)
+      })
     })
   })
 

--- a/app/src/bcsc-theme/features/services/hooks/useFilterServiceClients.ts
+++ b/app/src/bcsc-theme/features/services/hooks/useFilterServiceClients.ts
@@ -50,6 +50,16 @@ export interface ServiceClientsFilter {
    */
   serviceClientIdsFilter?: string[]
   /**
+   * The ref ids of the service clients the user has saved (bookmarked).
+   *
+   * Services without a `service_listing_sort_order` are not meant to be listed, but they are
+   * still shown when the user has saved them.
+   *
+   * @format uuid
+   * @type {string[]}
+   */
+  savedServiceClientIds?: string[]
+  /**
    * If true, the hook will skip loading service clients and return an empty list.
    * @type {boolean}
    */
@@ -114,7 +124,11 @@ export const useFilterServiceClients = (filter: ServiceClientsFilter): FilterSer
       return []
     }
 
-    let serviceClientsCopy = serviceClients
+    // Services without a listing sort order are not meant to appear in the list, unless saved
+    const savedIdsSet = new Set(filter.savedServiceClientIds ?? [])
+    let serviceClientsCopy = serviceClients.filter(
+      (service) => service.service_listing_sort_order != null || savedIdsSet.has(service.client_ref_id)
+    )
 
     // Filter services based on the card process
     if (filter.cardProcessFilter) {
@@ -136,7 +150,13 @@ export const useFilterServiceClients = (filter: ServiceClientsFilter): FilterSer
 
     // Sort services by their listing order, then alphabetically by name
     return _sortServiceClients(serviceClientsCopy)
-  }, [serviceClients, filter.cardProcessFilter, filter.requireBCAddressFilter, filter.serviceClientIdsFilter])
+  }, [
+    serviceClients,
+    filter.cardProcessFilter,
+    filter.requireBCAddressFilter,
+    filter.serviceClientIdsFilter,
+    filter.savedServiceClientIds,
+  ])
 
   // Further filter services based on the partial name filter
   const queriedServiceClients = useMemo(() => {


### PR DESCRIPTION
Closes #4570

## What changed

Up until now, we weren't filtering our services list by an omitted service_listing_sort_order. The undocumented rule is that if that field is omitted, the service shouldn't be shown in the services list *unless* it's bookmarked.

## What should the reviewer focus on

Fairly simple change code-wise, manual testing should make the change obvious though.

## How to test

Verify yourself, check the services list, see that it is a lot cleaner (even in SIT environment). Message me on Teams for a more in-depth way to check the list is correct. Check bookmarking still works as expected.