### PR TITLE
feat: allow more options on rejected send video

### DIFF
--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.test.tsx
@@ -17,11 +17,13 @@ jest.mock('@/bcsc-theme/hooks/useVerificationReset', () => ({
 
 const mockCleanUpVerificationData = jest.fn()
 const mockResumeVerification = jest.fn()
+const mockRetryWithNewVideo = jest.fn()
 jest.mock('./CancelledReviewViewModel', () => ({
   __esModule: true,
   default: jest.fn(() => ({
     cleanUpVerificationData: mockCleanUpVerificationData,
     resumeVerification: mockResumeVerification,
+    retryWithNewVideo: mockRetryWithNewVideo,
   })),
 }))
 
@@ -110,8 +112,8 @@ describe('CancelledReview', () => {
       </BasicAppContext>
     )
 
-    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
-    fireEvent.press(okButton)
+    const restartButton = tree.getByText('BCSC.CancelledVerification.RestartButton')
+    fireEvent.press(restartButton)
 
     await waitFor(() => {
       expect(mockResumeVerification).toHaveBeenCalledTimes(1)
@@ -133,8 +135,8 @@ describe('CancelledReview', () => {
       </BasicAppContext>
     )
 
-    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
-    fireEvent.press(okButton)
+    const restartButton = tree.getByText('BCSC.CancelledVerification.RestartButton')
+    fireEvent.press(restartButton)
 
     expect(mockStartLoading).toHaveBeenCalledWith('Alerts.RestartVerification.Loading')
 
@@ -158,14 +160,14 @@ describe('CancelledReview', () => {
       </BasicAppContext>
     )
 
-    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
-    fireEvent.press(okButton)
+    const restartButton = tree.getByText('BCSC.CancelledVerification.RestartButton')
+    fireEvent.press(restartButton)
 
     await waitFor(() => {
       expect(mockResumeVerification).toHaveBeenCalledTimes(1)
     })
 
-    fireEvent.press(okButton)
+    fireEvent.press(restartButton)
 
     await waitFor(() => {
       expect(mockVerificationReset).toHaveBeenCalledTimes(2)
@@ -193,9 +195,9 @@ describe('CancelledReview', () => {
       </BasicAppContext>
     )
 
-    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
-    fireEvent.press(okButton)
-    fireEvent.press(okButton)
+    const restartButton = tree.getByText('BCSC.CancelledVerification.RestartButton')
+    fireEvent.press(restartButton)
+    fireEvent.press(restartButton)
 
     expect(mockVerificationReset).toHaveBeenCalledTimes(1)
     expect(mockStartLoading).toHaveBeenCalledTimes(1)
@@ -222,19 +224,19 @@ describe('CancelledReview', () => {
       </BasicAppContext>
     )
 
-    const okButton = tree.getByText('BCSC.CancelledVerification.Button')
-    fireEvent.press(okButton)
+    const restartButton = tree.getByText('BCSC.CancelledVerification.RestartButton')
+    fireEvent.press(restartButton)
 
     await waitFor(() => {
       expect(mockStopLoading).toHaveBeenCalledTimes(1)
     })
 
     expect(mockResumeVerification).not.toHaveBeenCalled()
-    const buttonTouchable = tree.getByTestId(testIdWithKey('SystemModalButton'))
+    const buttonTouchable = tree.getByTestId(testIdWithKey('RestartVerification'))
     expect(buttonTouchable.props.accessibilityState?.disabled).toBeFalsy()
   })
 
-  it('displays OK button', () => {
+  it('displays both retry and restart buttons', () => {
     const route = {
       params: {
         agentReason: 'Test reason',
@@ -247,14 +249,15 @@ describe('CancelledReview', () => {
       </BasicAppContext>
     )
 
-    expect(tree.getByText('BCSC.CancelledVerification.Button')).toBeTruthy()
+    expect(tree.getByTestId(testIdWithKey('RetryWithNewVideo'))).toBeTruthy()
+    expect(tree.getByTestId(testIdWithKey('RestartVerification'))).toBeTruthy()
   })
 
-  it('renders SystemModal component', () => {
-    const agentReason = 'Test reason'
+  // Retry keeps the ID, address and email steps — the reset belongs to the other button only.
+  it('retries with a new video without resetting verification', async () => {
     const route = {
       params: {
-        agentReason,
+        agentReason: 'Test reason',
       },
     } as any
 
@@ -264,7 +267,13 @@ describe('CancelledReview', () => {
       </BasicAppContext>
     )
 
-    // SystemModal should render with the header text
-    expect(tree.getByText('BCSC.CancelledVerification.Title')).toBeTruthy()
+    fireEvent.press(tree.getByText('BCSC.CancelledVerification.RetryButton'))
+
+    await waitFor(() => {
+      expect(mockRetryWithNewVideo).toHaveBeenCalledTimes(1)
+    })
+    expect(mockVerificationReset).not.toHaveBeenCalled()
+    expect(mockResumeVerification).not.toHaveBeenCalled()
+    expect(mockStartLoading).not.toHaveBeenCalled()
   })
 })

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -1,9 +1,20 @@
+import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import { useLoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
 import { useVerificationReset } from '@/bcsc-theme/hooks/useVerificationReset'
-import { usePreventDoublePress } from '@bifold/core'
+import usePreventGestureBack from '@/hooks/usePreventGestureBack'
+import {
+  Button,
+  ButtonType,
+  ScreenWrapper,
+  testIdWithKey,
+  ThemedText,
+  usePreventDoublePress,
+  useTheme,
+} from '@bifold/core'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { SystemModal } from '../../modal/components/SystemModal'
+import { StyleSheet } from 'react-native'
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 import useCancelledReviewViewModel from './CancelledReviewViewModel'
 
 interface CancelledReviewProps {
@@ -17,40 +28,82 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
   const { agentReason } = route.params
   const verificationReset = useVerificationReset()
   const { t } = useTranslation()
-  const { cleanUpVerificationData, resumeVerification } = useCancelledReviewViewModel()
+  const { ColorPalette, Spacing } = useTheme()
+  const { cleanUpVerificationData, resumeVerification, retryWithNewVideo } = useCancelledReviewViewModel()
   const { preventDoublePress, isPressing } = usePreventDoublePress()
   const loadingScreen = useLoadingScreen()
+
+  usePreventGestureBack()
 
   useEffect(() => {
     cleanUpVerificationData()
   }, [cleanUpVerificationData])
 
+  const styles = StyleSheet.create({
+    content: {
+      padding: Spacing.lg,
+      gap: Spacing.lg,
+    },
+    buttonIcon: {
+      marginRight: Spacing.sm,
+    },
+  })
+
+  const onPressRestart = preventDoublePress(async () => {
+    const stopLoading = loadingScreen.startLoading(t('Alerts.RestartVerification.Loading'))
+    try {
+      // Signals failure by returning false (with its own alert), never by throwing.
+      const success = await verificationReset()
+      if (success) {
+        // Leaves via store state, not navigation: each stack registers this screen under its
+        // own route name, so the RootStack swap drops it and lands on the new initialRouteName.
+        resumeVerification()
+      }
+    } finally {
+      stopLoading()
+    }
+  })
+
+  const controls = (
+    <ControlContainer>
+      <Button
+        title={t('BCSC.CancelledVerification.RetryButton')}
+        buttonType={ButtonType.Secondary}
+        onPress={preventDoublePress(retryWithNewVideo)}
+        disabled={isPressing}
+        accessibilityLabel={t('BCSC.CancelledVerification.RetryButton')}
+        testID={testIdWithKey('RetryWithNewVideo')}
+      >
+        <Icon name={'video-outline'} size={24} color={ColorPalette.brand.primary} style={styles.buttonIcon} />
+      </Button>
+      <Button
+        title={t('BCSC.CancelledVerification.RestartButton')}
+        buttonType={ButtonType.Secondary}
+        onPress={onPressRestart}
+        disabled={isPressing}
+        accessibilityLabel={t('BCSC.CancelledVerification.RestartButton')}
+        testID={testIdWithKey('RestartVerification')}
+      >
+        <Icon name={'restore'} size={24} color={ColorPalette.brand.primary} style={styles.buttonIcon} />
+      </Button>
+    </ControlContainer>
+  )
+
   return (
-    <SystemModal
-      headerText={t('BCSC.CancelledVerification.Title')}
-      contentText={[
-        t('BCSC.CancelledVerification.Label', {
+    <ScreenWrapper
+      padded={false}
+      controls={controls}
+      edges={['bottom', 'left', 'right']}
+      scrollViewContainerStyle={styles.content}
+    >
+      <ThemedText variant="headingThree">{t('BCSC.CancelledVerification.Title')}</ThemedText>
+      <ThemedText>
+        {t('BCSC.CancelledVerification.Label', {
           reason: agentReason ?? t('BCSC.CancelledVerification.NoReason'),
           interpolation: { escapeValue: false }, // this allows special characters to be rendered properly
-        }),
-      ]}
-      buttonText={t('BCSC.CancelledVerification.Button')}
-      buttonDisabled={isPressing}
-      onButtonPress={preventDoublePress(async () => {
-        const stopLoading = loadingScreen.startLoading(t('Alerts.RestartVerification.Loading'))
-        try {
-          // Signals failure by returning false (with its own alert), never by throwing.
-          const success = await verificationReset()
-          if (success) {
-            // Leaves via store state, not navigation: each stack registers this screen under its
-            // own route name, so the RootStack swap drops it and lands on the new initialRouteName.
-            resumeVerification()
-          }
-        } finally {
-          stopLoading()
-        }
-      })}
-    />
+        })}
+      </ThemedText>
+    </ScreenWrapper>
   )
 }
 

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.test.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.test.ts
@@ -1,6 +1,9 @@
 import useCancelledReviewViewModel from '@/bcsc-theme/features/verify/send-video/CancelledReviewViewModel'
+import { useVerificationStatus } from '@/bcsc-theme/hooks/useVerificationStatus'
+import { BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { BCDispatchAction } from '@/store'
 import * as Bifold from '@bifold/core'
+import { CommonActions, useNavigation } from '@mocks/@react-navigation/native'
 import { renderHook } from '@testing-library/react-native'
 
 jest.mock('@bifold/core', () => {
@@ -23,12 +26,22 @@ jest.mock('@/bcsc-theme/hooks/useSecureActions', () => ({
   })),
 }))
 
+jest.mock('@/bcsc-theme/hooks/useVerificationStatus', () => ({
+  useVerificationStatus: jest.fn(),
+}))
+
 describe('useCancelledReviewViewModel', () => {
   const mockDispatch = jest.fn()
 
   beforeEach(() => {
     jest.clearAllMocks()
     jest.mocked(Bifold).useStore.mockReturnValue([{} as any, mockDispatch])
+    jest.mocked(useVerificationStatus).mockReturnValue({
+      isVerified: false,
+      isVerificationInProgress: true,
+      isDeactivated: false,
+      needsVerification: false,
+    })
   })
 
   describe('cleanUpVerificationData', () => {
@@ -102,6 +115,50 @@ describe('useCancelledReviewViewModel', () => {
       result.current.resumeVerification()
 
       expect(mockContinueVerificationProcess).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('retryWithNewVideo', () => {
+    // Mounted in the VerifyStack the status already reads IN_PROGRESS, so the store swap the
+    // MainStack mount relies on would remount nothing — it has to reset in-stack instead.
+    it('resets to verification method selection when the verify flow is already mounted', () => {
+      const { result } = renderHook(() => useCancelledReviewViewModel())
+
+      result.current.retryWithNewVideo()
+
+      expect(CommonActions.reset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: BCSCScreens.VerificationMethodSelection }],
+      })
+      expect(useNavigation().dispatch).toHaveBeenCalledTimes(1)
+      expect(mockContinueVerificationProcess).not.toHaveBeenCalled()
+    })
+
+    // Reached from the home notification card, where there is no verify route to navigate to.
+    it('re-enters the verify flow via store state when mounted outside it', () => {
+      jest.mocked(useVerificationStatus).mockReturnValue({
+        isVerified: false,
+        isVerificationInProgress: false,
+        isDeactivated: false,
+        needsVerification: true,
+      })
+
+      const { result } = renderHook(() => useCancelledReviewViewModel())
+
+      result.current.retryWithNewVideo()
+
+      expect(mockContinueVerificationProcess).toHaveBeenCalledTimes(1)
+      expect(useNavigation().dispatch).not.toHaveBeenCalled()
+    })
+
+    // The full reset is the other button's job; retry keeps the ID, address and email steps.
+    it('does not clear verification data', () => {
+      const { result } = renderHook(() => useCancelledReviewViewModel())
+
+      result.current.retryWithNewVideo()
+
+      expect(mockUpdateVerificationRequest).not.toHaveBeenCalled()
+      expect(mockUpdateAccountFlags).not.toHaveBeenCalled()
     })
   })
 })

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.ts
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReviewViewModel.ts
@@ -1,11 +1,17 @@
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
+import { useVerificationStatus } from '@/bcsc-theme/hooks/useVerificationStatus'
+import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { BCDispatchAction, BCState } from '@/store'
 import { useStore } from '@bifold/core'
+import { CommonActions, useNavigation } from '@react-navigation/native'
+import { StackNavigationProp } from '@react-navigation/stack'
 import { useCallback } from 'react'
 
 /** ViewModel for CancelledReview: clears verification artifacts and re-enters the verify flow. */
 const useCancelledReviewViewModel = () => {
   const [, dispatch] = useStore<BCState>()
+  const navigation = useNavigation<StackNavigationProp<BCSCVerifyStackParams>>()
+  const { isVerificationInProgress } = useVerificationStatus()
   const { updateAccountFlags, updateVerificationRequest, continueVerificationProcess } = useSecureActions()
   const cleanUpVerificationData = useCallback(async () => {
     await updateVerificationRequest(undefined, null)
@@ -19,9 +25,27 @@ const useCancelledReviewViewModel = () => {
   // Not named for a screen: VerifyStack picks the landing step via getResumeStepRoute
   // (IdentitySelection after a full reset).
   const resumeVerification = () => continueVerificationProcess()
+
+  /**
+   * Keeps the user's ID, address and email — only the selfie photo and video are redone. Both routes
+   * land on Verification Method Selection, which opens the fresh verification request and purges the
+   * cached capture files before entering the photo steps.
+   */
+  const retryWithNewVideo = useCallback(() => {
+    if (isVerificationInProgress) {
+      navigation.dispatch(
+        CommonActions.reset({ index: 0, routes: [{ name: BCSCScreens.VerificationMethodSelection }] })
+      )
+      return
+    }
+
+    continueVerificationProcess()
+  }, [continueVerificationProcess, isVerificationInProgress, navigation])
+
   return {
     cleanUpVerificationData,
     resumeVerification,
+    retryWithNewVideo,
   }
 }
 

--- a/app/src/bcsc-theme/features/verify/send-video/__snapshots__/CancelledReview.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/send-video/__snapshots__/CancelledReview.test.tsx.snap
@@ -25,7 +25,6 @@ exports[`CancelledReview renders correctly with agent reason 1`] = `
       [
         false,
         {
-          "flexGrow": 1,
           "gap": 24,
           "padding": 24,
         },
@@ -125,7 +124,7 @@ exports[`CancelledReview renders correctly with agent reason 1`] = `
         }
       >
         <View
-          accessibilityLabel="BCSC.CancelledVerification.Button"
+          accessibilityLabel="BCSC.CancelledVerification.RetryButton"
           accessibilityRole="button"
           accessibilityState={
             {
@@ -156,13 +155,14 @@ exports[`CancelledReview renders correctly with agent reason 1`] = `
           onStartShouldSetResponder={[Function]}
           style={
             {
-              "backgroundColor": "#003366",
+              "borderColor": "#003366",
               "borderRadius": 4,
+              "borderWidth": 2,
               "opacity": 1,
               "padding": 16,
             }
           }
-          testID="com.ariesbifold:id/SystemModalButton"
+          testID="com.ariesbifold:id/RetryWithNewVideo"
         >
           <View
             style={
@@ -173,6 +173,29 @@ exports[`CancelledReview renders correctly with agent reason 1`] = `
               }
             }
           >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#003366",
+                    "fontSize": 24,
+                  },
+                  {
+                    "marginRight": 8,
+                  },
+                  {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              󰯜
+            </Text>
             <Text
               maxFontSizeMultiplier={2}
               style={
@@ -185,7 +208,7 @@ exports[`CancelledReview renders correctly with agent reason 1`] = `
                   },
                   [
                     {
-                      "color": "#FFFFFF",
+                      "color": "#003366",
                       "fontFamily": "BCSans-Regular",
                       "fontSize": 18,
                       "fontWeight": "bold",
@@ -197,7 +220,108 @@ exports[`CancelledReview renders correctly with agent reason 1`] = `
                 ]
               }
             >
-              BCSC.CancelledVerification.Button
+              BCSC.CancelledVerification.RetryButton
+            </Text>
+          </View>
+        </View>
+        <View
+          accessibilityLabel="BCSC.CancelledVerification.RestartButton"
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": false,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "borderColor": "#003366",
+              "borderRadius": 4,
+              "borderWidth": 2,
+              "opacity": 1,
+              "padding": 16,
+            }
+          }
+          testID="com.ariesbifold:id/RestartVerification"
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#003366",
+                    "fontSize": 24,
+                  },
+                  {
+                    "marginRight": 8,
+                  },
+                  {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              󰦛
+            </Text>
+            <Text
+              maxFontSizeMultiplier={2}
+              style={
+                [
+                  {
+                    "color": "#313132",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "normal",
+                  },
+                  [
+                    {
+                      "color": "#003366",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                      "textAlign": "center",
+                    },
+                    false,
+                    false,
+                  ],
+                ]
+              }
+            >
+              BCSC.CancelledVerification.RestartButton
             </Text>
           </View>
         </View>

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -1200,7 +1200,8 @@ const translation = {
     "CancelledVerification": {
       "Title": "Your identity couldn't be verified",
       "Label": "Details from Service BC agent: \n{{reason}}",
-      "Button": "Retry verification",
+      "RetryButton": "Retry with a new video",
+      "RestartButton": "Restart verification",
       "NoReason": "No reason provided"
     },
     "DualNonBCSCEvidence": {


### PR DESCRIPTION
Closes #4468

## What changed

Added second "Retry with new video" option to rejected send video result screen.
<img width="340" height="736" alt="rejected_send_video_options" src="https://github.com/user-attachments/assets/385c5e72-35e9-4e3f-bc7f-ab6baaa68ebe" />

## What should the reviewer focus on
The code changes are pretty simple, focus on manual testing the different permutations.

## How to test
Do a send-video request, reject it in IDCheck, try retrying and do another send-video ensuring it succeeds. Then repeat but this time choose to restart process, ensure that also works still.
