### PR TITLE
feat: which services? buttons

### DIFF
--- a/app/src/bcsc-theme/components/BulletedInstructionsScreen.tsx
+++ b/app/src/bcsc-theme/components/BulletedInstructionsScreen.tsx
@@ -122,7 +122,6 @@ const SectionLinkView = ({ link }: { link: SectionLink }) => {
     },
     externalButtonText: {
       ...Buttons.secondaryText,
-      flexWrap: 'wrap',
       flexShrink: 1,
     },
   })

--- a/app/src/bcsc-theme/components/BulletedInstructionsScreen.tsx
+++ b/app/src/bcsc-theme/components/BulletedInstructionsScreen.tsx
@@ -2,17 +2,25 @@ import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import BulletPointList from '@/components/BulletPointList'
 import { Button, ButtonType, Link, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { useTranslation } from 'react-i18next'
+import { StyleSheet, View } from 'react-native'
+import Icon from 'react-native-vector-icons/MaterialIcons'
+
+export type SectionLink = {
+  label: string
+  onPress: () => void
+  testID?: string
+  /** Renders an external link icon and button that announces that the link leaves the app. */
+  externalButton?: boolean
+}
 
 export type InstructionsSection = {
   heading: string
   paragraph?: string
   bullets?: string[]
   /** Optional inline link rendered before the section heading (e.g. "See accepted ID"). */
-  link?: {
-    label: string
-    onPress: () => void
-    testID?: string
-  }
+  link?: SectionLink
+  /** Optional inline link rendered after the section content (e.g. "Which services?"). */
+  footerLink?: SectionLink
 }
 
 type BulletedInstructionsScreenProps = {
@@ -84,17 +92,60 @@ type SectionProps = {
 
 const Section = ({ section, iconColor, iconSize }: SectionProps) => (
   <>
-    {section.link ? (
-      <Link
-        testID={section.link.testID ?? testIdWithKey(section.link.label)}
-        linkText={section.link.label}
-        onPress={section.link.onPress}
-      />
-    ) : null}
+    {section.link ? <SectionLinkView link={section.link} /> : null}
     <ThemedText variant={'headingFour'}>{section.heading}</ThemedText>
     {section.paragraph ? <ThemedText>{section.paragraph}</ThemedText> : null}
     {section.bullets && section.bullets.length > 0 ? (
       <BulletPointList translationKeys={section.bullets} iconColor={iconColor} iconSize={iconSize} />
     ) : null}
+    {section.footerLink ? <SectionLinkView link={section.footerLink} /> : null}
   </>
 )
+
+const SectionLinkView = ({ link }: { link: SectionLink }) => {
+  const { Buttons, Spacing } = useTheme()
+  const { t } = useTranslation()
+  const testID = link.testID ?? testIdWithKey(link.label)
+
+  const styles = StyleSheet.create({
+    // The button has no intrinsic width, so an inline wrapper keeps it from stretching to the section width.
+    externalButtonWrapper: {
+      alignSelf: 'flex-start',
+      maxWidth: '100%',
+    },
+    externalButtonContent: {
+      paddingHorizontal: Spacing.md,
+      alignItems: 'center',
+      flexDirection: 'row',
+      justifyContent: 'center',
+      gap: Spacing.sm,
+    },
+    externalButtonText: {
+      ...Buttons.secondaryText,
+      flexWrap: 'wrap',
+      flexShrink: 1,
+    },
+  })
+
+  if (!link.externalButton) {
+    return <Link testID={testID} linkText={link.label} onPress={link.onPress} />
+  }
+
+  return (
+    <View style={styles.externalButtonWrapper}>
+      <Button
+        buttonType={ButtonType.Secondary}
+        title={''}
+        accessibilityLabel={link.label}
+        accessibilityHint={t('Global.A11y.OpensInBrowser')}
+        testID={testID}
+        onPress={link.onPress}
+      >
+        <View style={styles.externalButtonContent}>
+          <ThemedText style={styles.externalButtonText}>{link.label}</ThemedText>
+          <Icon name={'open-in-new'} size={24} color={Buttons.secondaryText.color} />
+        </View>
+      </Button>
+    </View>
+  )
+}

--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
@@ -339,7 +339,6 @@ export const ServiceLoginScreen: React.FC<ServiceLoginScreenProps> = ({
     },
     externalButtonText: {
       ...Buttons.primaryText,
-      flexWrap: 'wrap',
       flexShrink: 1,
     },
   })

--- a/app/src/bcsc-theme/features/verify/non-photo/AdditionalIdentificationRequiredScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/AdditionalIdentificationRequiredScreen.tsx
@@ -1,7 +1,9 @@
 import { BulletedInstructionsScreen } from '@/bcsc-theme/components/BulletedInstructionsScreen'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
+import { ACCOUNT_SERVICES_URL } from '@/constants'
 import { BCState } from '@/store'
-import { useStore } from '@bifold/core'
+import { openLink } from '@/utils/links'
+import { testIdWithKey, useStore } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useTranslation } from 'react-i18next'
 import { BCSCCardProcess } from 'react-native-bcsc-core'
@@ -32,6 +34,12 @@ const AdditionalIdentificationRequiredScreen: React.FC<AdditionalIdentificationR
         {
           heading: t('BCSC.AdditionalEvidence.LimitedAccess'),
           paragraph: t('BCSC.AdditionalEvidence.LimitedAccessDescription'),
+          footerLink: {
+            label: t('BCSC.AdditionalEvidence.WhichServices'),
+            testID: testIdWithKey('WhichServices'),
+            externalButton: true,
+            onPress: () => openLink(ACCOUNT_SERVICES_URL),
+          },
         },
       ]}
       primaryAction={{

--- a/app/src/bcsc-theme/features/verify/non-photo/DualIdentificationRequiredScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/DualIdentificationRequiredScreen.tsx
@@ -1,6 +1,7 @@
 import { BulletedInstructionsScreen } from '@/bcsc-theme/components/BulletedInstructionsScreen'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
-import { HelpCentreUrl } from '@/constants'
+import { ACCOUNT_SERVICES_URL, HelpCentreUrl } from '@/constants'
+import { openLink } from '@/utils/links'
 import { testIdWithKey } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useTranslation } from 'react-i18next'
@@ -46,6 +47,12 @@ const DualIdentificationRequiredScreen: React.FC<DualIdentificationRequiredScree
         {
           heading: t('BCSC.AdditionalEvidence.LimitedAccess'),
           paragraph: t('BCSC.AdditionalEvidence.LimitedAccessDescription'),
+          footerLink: {
+            label: t('BCSC.AdditionalEvidence.WhichServices'),
+            testID: testIdWithKey('WhichServices'),
+            externalButton: true,
+            onPress: () => openLink(ACCOUNT_SERVICES_URL),
+          },
         },
       ]}
       primaryAction={{

--- a/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/AdditionalIdentificationRequiredScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/AdditionalIdentificationRequiredScreen.test.tsx.snap
@@ -391,7 +391,6 @@ exports[`AdditionalIdentificationRequired renders correctly 1`] = `
                     {
                       "color": "#003366",
                       "flexShrink": 1,
-                      "flexWrap": "wrap",
                       "fontFamily": "BCSans-Regular",
                       "fontSize": 18,
                       "fontWeight": "bold",

--- a/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/AdditionalIdentificationRequiredScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/AdditionalIdentificationRequiredScreen.test.tsx.snap
@@ -308,6 +308,149 @@ exports[`AdditionalIdentificationRequired renders correctly 1`] = `
       >
         BCSC.AdditionalEvidence.LimitedAccessDescription
       </Text>
+      <View
+        style={
+          {
+            "alignSelf": "flex-start",
+            "maxWidth": "100%",
+          }
+        }
+      >
+        <View
+          accessibilityHint="Global.A11y.OpensInBrowser"
+          accessibilityLabel="BCSC.AdditionalEvidence.WhichServices"
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": false,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "borderColor": "#003366",
+              "borderRadius": 4,
+              "borderWidth": 2,
+              "opacity": 1,
+              "padding": 16,
+            }
+          }
+          testID="com.ariesbifold:id/WhichServices"
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 8,
+                  "justifyContent": "center",
+                  "paddingHorizontal": 16,
+                }
+              }
+            >
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "normal",
+                    },
+                    {
+                      "color": "#003366",
+                      "flexShrink": 1,
+                      "flexWrap": "wrap",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                      "textAlign": "center",
+                    },
+                  ]
+                }
+              >
+                BCSC.AdditionalEvidence.WhichServices
+              </Text>
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": "#003366",
+                      "fontSize": 24,
+                    },
+                    undefined,
+                    {
+                      "fontFamily": "Material Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                
+              </Text>
+            </View>
+            <Text
+              maxFontSizeMultiplier={2}
+              style={
+                [
+                  {
+                    "color": "#313132",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "normal",
+                  },
+                  [
+                    {
+                      "color": "#003366",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                      "textAlign": "center",
+                    },
+                    false,
+                    false,
+                  ],
+                ]
+              }
+            />
+          </View>
+        </View>
+      </View>
     </View>
   </RCTScrollView>
   <View

--- a/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/DualIdentificationRequiredScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/DualIdentificationRequiredScreen.test.tsx.snap
@@ -483,7 +483,6 @@ exports[`DualIdentificationRequired renders correctly 1`] = `
                     {
                       "color": "#003366",
                       "flexShrink": 1,
-                      "flexWrap": "wrap",
                       "fontFamily": "BCSans-Regular",
                       "fontSize": 18,
                       "fontWeight": "bold",

--- a/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/DualIdentificationRequiredScreen.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/non-photo/__snapshots__/DualIdentificationRequiredScreen.test.tsx.snap
@@ -400,6 +400,149 @@ exports[`DualIdentificationRequired renders correctly 1`] = `
       >
         BCSC.AdditionalEvidence.LimitedAccessDescription
       </Text>
+      <View
+        style={
+          {
+            "alignSelf": "flex-start",
+            "maxWidth": "100%",
+          }
+        }
+      >
+        <View
+          accessibilityHint="Global.A11y.OpensInBrowser"
+          accessibilityLabel="BCSC.AdditionalEvidence.WhichServices"
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": false,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "borderColor": "#003366",
+              "borderRadius": 4,
+              "borderWidth": 2,
+              "opacity": 1,
+              "padding": 16,
+            }
+          }
+          testID="com.ariesbifold:id/WhichServices"
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 8,
+                  "justifyContent": "center",
+                  "paddingHorizontal": 16,
+                }
+              }
+            >
+              <Text
+                maxFontSizeMultiplier={2}
+                style={
+                  [
+                    {
+                      "color": "#313132",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "normal",
+                    },
+                    {
+                      "color": "#003366",
+                      "flexShrink": 1,
+                      "flexWrap": "wrap",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                      "textAlign": "center",
+                    },
+                  ]
+                }
+              >
+                BCSC.AdditionalEvidence.WhichServices
+              </Text>
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": "#003366",
+                      "fontSize": 24,
+                    },
+                    undefined,
+                    {
+                      "fontFamily": "Material Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                
+              </Text>
+            </View>
+            <Text
+              maxFontSizeMultiplier={2}
+              style={
+                [
+                  {
+                    "color": "#313132",
+                    "fontFamily": "BCSans-Regular",
+                    "fontSize": 18,
+                    "fontWeight": "normal",
+                  },
+                  [
+                    {
+                      "color": "#003366",
+                      "fontFamily": "BCSans-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                      "textAlign": "center",
+                    },
+                    false,
+                    false,
+                  ],
+                ]
+              }
+            />
+          </View>
+        </View>
+      </View>
     </View>
   </RCTScrollView>
   <View

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -54,6 +54,7 @@ export const BCThemeNames = {
 export const BCSC_EMAIL_NOT_PROVIDED = 'Not provided'
 export const BCSC_APPLE_STORE_URL = 'https://apps.apple.com/us/app/id1234298467'
 export const BCSC_GOOGLE_PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=ca.bc.gov.id.servicescard'
+export const ACCOUNT_SERVICES_URL = 'https://id.gov.bc.ca/account/services'
 export const TERMS_OF_USE_URL = 'https://id.gov.bc.ca/static/termsOfUse.html'
 export const FEEDBACK_URL = 'https://id.gov.bc.ca/static/feedback.html'
 export const ACCESSIBILITY_URL =

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -823,7 +823,7 @@ const translation = {
       "CheckYourIDBullet3": "Is not expired",
       "LimitedAccess": "Limited access to services",
       "LimitedAccessDescription": "Some services only accept the app when it's set up with a BC Services Card with a photo.",
-      "OpenAccountServices": "Open account services",
+      "WhichServices": "Which services?",
     },
     "AccountSetup": {
       "Title": "Have you verified before?",


### PR DESCRIPTION
Closes #4500

## What changed
Adds the two missing "Which services?" buttons on the non-photo and non-bcsc flows.

## What should the reviewer focus on
Do the links work? Do they look like the wireframes?

## How to test
Go through the first steps of the non-bcsc and non-photo flows, see the two screens, confirm the link buttons are there and work.