### PR TITLE
fix: system check wait before home screen

### DIFF
--- a/app/src/bcsc-theme/hooks/useCreateSystemChecks.test.tsx
+++ b/app/src/bcsc-theme/hooks/useCreateSystemChecks.test.tsx
@@ -693,6 +693,19 @@ describe('useGetSystemChecks', () => {
       jest.spyOn(React, 'useContext').mockReturnValue({ account: {} })
     }
 
+    it('should be applicable only once the account has loaded', () => {
+      jest.spyOn(DeviceInfo, 'getBundleId').mockReturnValue('ca.bc.gov.id.servicescard')
+      mockHydratedStore()
+
+      const { result: withAccount } = renderHook(() => useCreateSystemChecks())
+      expect(withAccount.current[SystemCheckScope.ACCOUNT].isApplicable).toBe(true)
+
+      jest.spyOn(React, 'useContext').mockReturnValue({ account: null })
+
+      const { result: withoutAccount } = renderHook(() => useCreateSystemChecks())
+      expect(withoutAccount.current[SystemCheckScope.ACCOUNT].isApplicable).toBe(false)
+    })
+
     it('should return no AccountSystemChecks with no accountExpirationDate', async () => {
       jest.spyOn(DeviceInfo, 'getBundleId').mockReturnValue('ca.bc.gov.id.servicescard')
       mockHydratedStore()

--- a/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
+++ b/app/src/bcsc-theme/hooks/useCreateSystemChecks.tsx
@@ -51,6 +51,11 @@ type UseGetSystemChecksReturn = Record<
      * Indicates if the system checks for the scope are ready to be run
      */
     isReady: boolean
+    /**
+     * Indicates if the scope will ever run in the current app state. False means callers waiting on
+     * the scope (see the loading gate in MainStack) should stop waiting — `isReady` will never flip.
+     */
+    isApplicable: boolean
   }
 >
 
@@ -273,18 +278,24 @@ export const useCreateSystemChecks = (): UseGetSystemChecksReturn => {
       [SystemCheckScope.STARTUP]: {
         getSystemChecks: getStartupSystemChecks,
         isReady: Boolean(defaultReadiness && store.stateLoaded),
+        isApplicable: true,
       },
       [SystemCheckScope.MAIN_STACK]: {
         getSystemChecks: getMainSystemChecks,
         isReady: Boolean(defaultReadiness && store.bcscSecure.isHydrated),
+        isApplicable: true,
       },
       [SystemCheckScope.VERIFY]: {
         getSystemChecks: getVerifySystemChecks,
         isReady: Boolean(defaultReadiness && store.bcscSecure.isHydrated),
+        isApplicable: true,
       },
       [SystemCheckScope.ACCOUNT]: {
         getSystemChecks: getAccountSystemChecks,
         isReady: Boolean(defaultReadiness && store.bcscSecure.isHydrated && !!accountContext?.account),
+        // Account metadata is only fetched for verified users, and a failed fetch leaves `account`
+        // null for good — so without an account in hand this scope has nothing to wait for.
+        isApplicable: Boolean(accountContext?.account),
       },
     }
   }, [

--- a/app/src/bcsc-theme/hooks/useSystemChecks.tsx
+++ b/app/src/bcsc-theme/hooks/useSystemChecks.tsx
@@ -12,7 +12,7 @@ import { BCState } from '@/store'
 import { TOKENS, useServices, useStore } from '@bifold/core'
 import NetInfo from '@react-native-community/netinfo'
 import { useNavigation } from '@react-navigation/native'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AppState, DeviceEventEmitter } from 'react-native'
 import { useTokenService } from '../services/hooks/useTokenService'
@@ -35,9 +35,10 @@ export enum SystemCheckScope {
  *   - VERIFY: Checks that run within the verification flow (VerifyStack) for an unverified, authenticated user ie: expired verification session
  *
  * @param {SystemCheckScope} scope - The scope of the system checks to run
- * @returns {*} {void}
+ * @returns Whether the scope has settled, i.e. its checks have finished running (or will never run).
+ *   Callers that paint state the checks can change (see MainStack's loading gate) wait on this.
  */
-export const useSystemChecks = (scope: SystemCheckScope) => {
+export const useSystemChecks = (scope: SystemCheckScope): { hasSettled: boolean } => {
   const { t } = useTranslation()
   const [store, dispatch] = useStore<BCState>()
   const { client, isClientReady } = useBCSCApiClientState()
@@ -46,6 +47,7 @@ export const useSystemChecks = (scope: SystemCheckScope) => {
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const navigation = useNavigation()
   const ranSystemChecksRef = useRef(false)
+  const [hasRun, setHasRun] = useState(false)
   const systemChecks = useCreateSystemChecks()
   const appStateRef = useRef(AppState.currentState)
   const credentialMetadataRef = useRef(store.bcsc.credentialMetadata)
@@ -182,9 +184,16 @@ export const useSystemChecks = (scope: SystemCheckScope) => {
         )
       } catch (error) {
         logger.error(`[useSystemChecks]: Error running system checks for scope: ${scope}:`, error as Error)
+      } finally {
+        setHasRun(true)
       }
     }
 
     runSystemChecksByScope()
   }, [logger, scope, scopeSystemCheck])
+
+  return useMemo(
+    () => ({ hasSettled: hasRun || !scopeSystemCheck.isApplicable }),
+    [hasRun, scopeSystemCheck.isApplicable]
+  )
 }

--- a/app/src/bcsc-theme/navigators/MainStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.test.tsx
@@ -4,9 +4,9 @@ import { useNavigation } from '@react-navigation/native'
 import { act, render } from '@testing-library/react-native'
 import React from 'react'
 import { useAccount } from '../contexts/BCSCAccountContext'
-import { useSystemChecks } from '../hooks/useSystemChecks'
 import * as PairingModule from '../features/pairing'
 import { PairingNavigationListener, PairingPayload } from '../features/pairing/types'
+import { useSystemChecks } from '../hooks/useSystemChecks'
 import { BCSCScreens } from '../types/navigators'
 import MainStack from './MainStack'
 
@@ -145,8 +145,7 @@ describe('MainStack', () => {
     jest.mocked(useSystemChecks).mockReturnValue({ hasSettled: true })
   })
 
-  const queryLoadingScreens = (view: ReturnType<typeof render>) =>
-    view.UNSAFE_queryAllByType('LoadingScreen' as any)
+  const queryLoadingScreens = (view: ReturnType<typeof render>) => view.UNSAFE_queryAllByType('LoadingScreen' as any)
 
   it('renders correctly', () => {
     const { toJSON } = render(<MainStack />)

--- a/app/src/bcsc-theme/navigators/MainStack.test.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.test.tsx
@@ -1,8 +1,10 @@
+import { SYSTEM_CHECK_LOADING_GATE_MAX_WAIT_MS } from '@/constants'
 import * as Bifold from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
-import { render } from '@testing-library/react-native'
+import { act, render } from '@testing-library/react-native'
 import React from 'react'
 import { useAccount } from '../contexts/BCSCAccountContext'
+import { useSystemChecks } from '../hooks/useSystemChecks'
 import * as PairingModule from '../features/pairing'
 import { PairingNavigationListener, PairingPayload } from '../features/pairing/types'
 import { BCSCScreens } from '../types/navigators'
@@ -46,6 +48,7 @@ jest.mock('@/constants', () => ({
   DEFAULT_HEADER_TITLE_CONTAINER_STYLE: {},
   HelpCentreUrl: { COMPUTER_LOGIN: 'https://example.com' },
   Mode: { BCWallet: 'bcwallet', BCSC: 'bcsc' },
+  SYSTEM_CHECK_LOADING_GATE_MAX_WAIT_MS: 10000,
 }))
 jest.mock('../contexts/BCSCStackContext', () => ({
   useBCSCStack: jest.fn(),
@@ -54,8 +57,8 @@ jest.mock('../contexts/BCSCLoadingContext', () => ({
   LoadingScreen: 'LoadingScreen',
 }))
 jest.mock('../hooks/useSystemChecks', () => ({
-  SystemCheckScope: { MAIN_STACK: 'MAIN_STACK' },
-  useSystemChecks: jest.fn(),
+  SystemCheckScope: { MAIN_STACK: 'MAIN_STACK', ACCOUNT: 'ACCOUNT' },
+  useSystemChecks: jest.fn(() => ({ hasSettled: true })),
 }))
 jest.mock('../features/pairing', () => ({
   usePairingService: jest.fn(),
@@ -139,7 +142,11 @@ describe('MainStack', () => {
     jest.mocked(Bifold.testIdWithKey).mockImplementation((key: string) => key)
     jest.mocked(PairingModule.usePairingService).mockReturnValue(makePairingService() as any)
     jest.mocked(PairingModule.pairingPayloadToServiceLoginParams).mockReturnValue({ pairingCode: 'code' } as any)
+    jest.mocked(useSystemChecks).mockReturnValue({ hasSettled: true })
   })
+
+  const queryLoadingScreens = (view: ReturnType<typeof render>) =>
+    view.UNSAFE_queryAllByType('LoadingScreen' as any)
 
   it('renders correctly', () => {
     const { toJSON } = render(<MainStack />)
@@ -210,5 +217,33 @@ describe('MainStack', () => {
     const { toJSON } = render(<MainStack />)
 
     expect(toJSON()).toMatchObject({ type: 'LoadingScreen' })
+  })
+
+  it('holds the loading screen over the stack while system checks are still settling', () => {
+    jest.mocked(useSystemChecks).mockReturnValue({ hasSettled: false })
+
+    expect(queryLoadingScreens(render(<MainStack />))).toHaveLength(1)
+  })
+
+  it('drops the loading screen once the system checks have settled', () => {
+    expect(queryLoadingScreens(render(<MainStack />))).toHaveLength(0)
+  })
+
+  it('releases the loading screen when the system checks never settle', () => {
+    jest.useFakeTimers()
+    jest.mocked(useSystemChecks).mockReturnValue({ hasSettled: false })
+
+    try {
+      const view = render(<MainStack />)
+      expect(queryLoadingScreens(view)).toHaveLength(1)
+
+      act(() => {
+        jest.advanceTimersByTime(SYSTEM_CHECK_LOADING_GATE_MAX_WAIT_MS)
+      })
+
+      expect(queryLoadingScreens(view)).toHaveLength(0)
+    } finally {
+      jest.useRealTimers()
+    }
   })
 })

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -1,4 +1,8 @@
-import { DEFAULT_HEADER_TITLE_CONTAINER_STYLE, HelpCentreUrl } from '@/constants'
+import {
+  DEFAULT_HEADER_TITLE_CONTAINER_STYLE,
+  HelpCentreUrl,
+  SYSTEM_CHECK_LOADING_GATE_MAX_WAIT_MS,
+} from '@/constants'
 import {
   CredentialDetails,
   Screens,
@@ -96,6 +100,31 @@ const ScopedContactDetails = withAgentReadyGate(ContactDetailsScreen, testIdWith
 const ScopedEditContactName = withAgentReadyGate(EditContactNameScreen, testIdWithKey('EditContactName.Loading'))
 const ScopedRemoveContact = withAgentReadyGate(RemoveContactScreen, testIdWithKey('RemoveContact.Loading'))
 
+/**
+ * Holds the startup loading screen until the system checks that decide the Home notification card
+ * have settled. Home renders that card straight out of the store, so a check resolving after paint
+ * swaps the card in front of the user (e.g. "Start verification" flipping to "Verified"). Capped by
+ * {@link SYSTEM_CHECK_LOADING_GATE_MAX_WAIT_MS} so a hung request can't strand the app.
+ *
+ * @param hasSettled - Whether every tracked system check scope has finished running.
+ * @returns Whether the loading screen should still be shown.
+ */
+const useSystemCheckLoadingGate = (hasSettled: boolean) => {
+  const [waitedTooLong, setWaitedTooLong] = useState(false)
+
+  useEffect(() => {
+    if (hasSettled) {
+      return
+    }
+
+    const timeoutId = setTimeout(() => setWaitedTooLong(true), SYSTEM_CHECK_LOADING_GATE_MAX_WAIT_MS)
+
+    return () => clearTimeout(timeoutId)
+  }, [hasSettled])
+
+  return !hasSettled && !waitedTooLong
+}
+
 const MainStack: React.FC = () => {
   const { currentStep } = useTour()
   const { isLoadingAccount } = useAccount()
@@ -130,8 +159,9 @@ const MainStack: React.FC = () => {
 
   const initialRouteName = pairingInitialParams ? BCSCScreens.ServiceLogin : BCSCStacks.Tab
 
-  useSystemChecks(SystemCheckScope.MAIN_STACK)
-  useSystemChecks(SystemCheckScope.ACCOUNT)
+  const mainStackChecks = useSystemChecks(SystemCheckScope.MAIN_STACK)
+  const accountChecks = useSystemChecks(SystemCheckScope.ACCOUNT)
+  const isAwaitingSystemChecks = useSystemCheckLoadingGate(mainStackChecks.hasSettled && accountChecks.hasSettled)
   useBCSCStack(BCSCStacks.Main)
 
   // Accept connection-invitation deep links (e.g. from the showcase) once the
@@ -156,6 +186,9 @@ const MainStack: React.FC = () => {
 
   return (
     <View style={{ flex: 1 }} importantForAccessibility={hideElements}>
+      {/* Overlays rather than replaces the stack: the checks themselves navigate to screens
+          registered below (terms of use, service outage), so the navigator has to stay mounted. */}
+      {isAwaitingSystemChecks ? <LoadingScreen message={t('BCSC.Loading.AppStartup')} /> : null}
       <BifoldScope>
         <Stack.Navigator
           initialRouteName={initialRouteName}

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -1,8 +1,4 @@
-import {
-  DEFAULT_HEADER_TITLE_CONTAINER_STYLE,
-  HelpCentreUrl,
-  SYSTEM_CHECK_LOADING_GATE_MAX_WAIT_MS,
-} from '@/constants'
+import { DEFAULT_HEADER_TITLE_CONTAINER_STYLE, HelpCentreUrl, SYSTEM_CHECK_LOADING_GATE_MAX_WAIT_MS } from '@/constants'
 import {
   CredentialDetails,
   Screens,

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -112,6 +112,12 @@ export const ACCOUNT_EXPIRATION_DATE_FORMAT = 'MMMM D, YYYY'
 export const ACCOUNT_EXPIRATION_WARNING_DAYS = 30
 export const FIVE_MINUTES_IN_SECONDS = 5 * 60
 export const SERVER_STATUS_RECHECK_INTERVAL_MS = 60 * 1000
+/**
+ * Ceiling on how long the main stack holds its startup loading screen waiting for system checks to
+ * complete. An unreachable or hung endpoint must not be able to strand the app behind the loading
+ * screen indefinitely.
+ */
+export const SYSTEM_CHECK_LOADING_GATE_MAX_WAIT_MS = 3 * 1000
 
 // Notification constants
 /**

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -117,7 +117,7 @@ export const SERVER_STATUS_RECHECK_INTERVAL_MS = 60 * 1000
  * complete. An unreachable or hung endpoint must not be able to strand the app behind the loading
  * screen indefinitely.
  */
-export const SYSTEM_CHECK_LOADING_GATE_MAX_WAIT_MS = 3 * 1000
+export const SYSTEM_CHECK_LOADING_GATE_MAX_WAIT_MS = 4 * 1000
 
 // Notification constants
 /**


### PR DESCRIPTION
Closes #4539

## What changed
Wait for system checks to complete before showing home screen, up to a maximum wait time. This is to prevent a jumpy UI.

## What should the reviewer focus on
No regressions introduced, only waiting as much as necessary up until the max wait time.

## How to test
Restart the app to the home screen in a variety of states, especially when verified but needing renewal (`CustomNotificationId.AccountRenewalAvailable`). Inspect that there is no UI jumpiness unless for some reason loading takes longer than the max weight time.
