### PR TITLE
chore: replace api assertions that could not fail

### DIFF
--- a/app/src/bcsc-theme/api/client.test.ts
+++ b/app/src/bcsc-theme/api/client.test.ts
@@ -18,104 +18,105 @@ jest.mock('jwt-decode', () => ({
 
 jest.mock('@/bcsc-theme/api/jwk-cache')
 
+const createMockLogger = () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() })
+
 describe('BCSC Client', () => {
   beforeAll(() => {
     initLanguages(localization)
   })
 
+  // Several tests spy on BCSCApiClient.prototype.fetchTokens; without this the spy leaks
+  // into every later describe in the file.
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it('should set Content-Type default header to application/json with charset=utf-8', () => {
-    const mockLogger = { info: jest.fn(), error: jest.fn() }
+    const mockLogger = createMockLogger()
     const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
     expect(client.client.defaults.headers['Content-Type']).toBe('application/json; charset=utf-8')
   })
 
   it('should set User-Agent default header', () => {
-    const mockLogger = { info: jest.fn(), error: jest.fn() }
+    const mockLogger = createMockLogger()
     const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
     expect(client.client.defaults.headers['User-Agent']).toBeDefined()
   })
 
+  // Rejects every request with an AxiosError carrying the given status, so the response
+  // interceptor runs against a realistic error shape without a real HTTP call.
+  const rejectWithStatus = (status: number, statusText: string) => (config: any) =>
+    Promise.reject(
+      new AxiosError('Request failed', 'ERR_BAD_RESPONSE', config, null, {
+        status,
+        data: {},
+        statusText,
+        headers: {} as any,
+        config,
+      })
+    )
+
   it('should suppress logging for status codes if suppressStatusCodeLogs prop is set', async () => {
-    const mockLogger = { error: jest.fn(), info: jest.fn() }
+    const mockLogger = createMockLogger()
     const baseURL = 'https://example.com'
 
     const client = new BCSCApiClient(baseURL, mockLogger as any)
 
-    const axiosGetSpy = jest.spyOn(client.client, 'get').mockRejectedValue({
-      data: {
-        response: {
-          status: 404,
-        },
-      },
-    })
-
-    try {
-      await client.get('/endpoint', { suppressStatusCodeLogs: [404] })
-      expect(true).toBe(false) // Force fail if no error is thrown
-    } catch (error) {
-      expect(axiosGetSpy).toHaveBeenCalledWith(
-        '/endpoint',
-        expect.objectContaining({
-          suppressStatusCodeLogs: [404],
-        })
-      )
-
-      expect(mockLogger.error).not.toHaveBeenCalled()
-    }
-  })
-
-  it('should log error for status codes not in suppressStatusCodeLogs', async () => {
-    const mockLogger = { error: jest.fn(), info: jest.fn() }
-    const baseURL = 'https://example.com'
-
-    const client = new BCSCApiClient(baseURL, mockLogger as any)
-
-    // Mock adapter to produce a proper AxiosError so interceptors run but no real HTTP call is made
-    client.client.defaults.adapter = (config: any) => {
-      return Promise.reject(
-        new AxiosError('Request failed', 'ERR_BAD_RESPONSE', config, null, {
-          status: 500,
-          data: {},
-          statusText: 'Internal Server Error',
-          headers: {} as any,
-          config,
-        })
-      )
-    }
+    client.client.defaults.adapter = rejectWithStatus(404, 'Not Found')
 
     const axiosGetSpy = jest.spyOn(client.client, 'get')
 
-    try {
-      await client.get('/endpoint', { suppressStatusCodeLogs: [404], skipBearerAuth: true })
-      expect(true).toBe(false) // Force fail if no error is thrown
-    } catch (error) {
-      expect(axiosGetSpy).toHaveBeenCalledWith(
-        '/endpoint',
-        expect.objectContaining({
-          suppressStatusCodeLogs: [404],
-        })
-      )
+    await expect(
+      client.get('/endpoint', { suppressStatusCodeLogs: [404], skipBearerAuth: true })
+    ).rejects.toBeInstanceOf(AppError)
 
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('[BCSCApiClient]'),
-        expect.objectContaining({ code: expect.any(String) })
-      )
-    }
+    expect(axiosGetSpy).toHaveBeenCalledWith(
+      '/endpoint',
+      expect.objectContaining({
+        suppressStatusCodeLogs: [404],
+      })
+    )
+
+    expect(mockLogger.error).not.toHaveBeenCalled()
+  })
+
+  it('should log error for status codes not in suppressStatusCodeLogs', async () => {
+    const mockLogger = createMockLogger()
+    const baseURL = 'https://example.com'
+
+    const client = new BCSCApiClient(baseURL, mockLogger as any)
+
+    client.client.defaults.adapter = rejectWithStatus(500, 'Internal Server Error')
+
+    const axiosGetSpy = jest.spyOn(client.client, 'get')
+
+    await expect(
+      client.get('/endpoint', { suppressStatusCodeLogs: [404], skipBearerAuth: true })
+    ).rejects.toBeInstanceOf(AppError)
+
+    expect(axiosGetSpy).toHaveBeenCalledWith(
+      '/endpoint',
+      expect.objectContaining({
+        suppressStatusCodeLogs: [404],
+      })
+    )
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('[BCSCApiClient]'),
+      expect.objectContaining({ code: expect.any(String) })
+    )
   })
 
   describe('getTokensForRefreshToken', () => {
     it('should return the promise if already exists', async () => {
-      const mockLogger = { info: jest.fn() }
+      const mockLogger = createMockLogger()
       const baseURL = 'https://example.com'
 
       const client = new BCSCApiClient(baseURL, mockLogger as any)
 
-      const mockPromise = new Promise((resolve) => {
-        setTimeout(() => resolve('tokens'), 100)
-      })
-      client.tokensPromise = mockPromise as any
+      client.tokensPromise = Promise.resolve('tokens') as any
 
       const tokensPromise1 = client.getTokensForRefreshToken('refreshToken1')
       const tokensPromise2 = client.getTokensForRefreshToken('refreshToken2')
@@ -125,7 +126,7 @@ describe('BCSC Client', () => {
     })
 
     it('should fetch new tokens if no existing promise', async () => {
-      const mockLogger = { info: jest.fn() }
+      const mockLogger = createMockLogger()
       const baseURL = 'https://example.com'
 
       const client = new BCSCApiClient(baseURL, mockLogger as any)
@@ -151,7 +152,7 @@ describe('BCSC Client', () => {
 
   describe('recoverTokens', () => {
     it('should return the in-memory tokens without reading storage when the cache is populated', async () => {
-      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       const tokens = { access_token: 'a', refresh_token: 'r' }
       client.tokens = tokens as any
@@ -164,7 +165,7 @@ describe('BCSC Client', () => {
     })
 
     it('should rebuild the cache from the stored refresh token when empty', async () => {
-      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       client.tokens = undefined
       ;(getTokenWithDiagnostics as jest.Mock).mockResolvedValue({
@@ -185,7 +186,7 @@ describe('BCSC Client', () => {
     })
 
     it('should emit TOKENS_REFRESHED after a successful rebuild', async () => {
-      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       client.tokens = undefined
       ;(getTokenWithDiagnostics as jest.Mock).mockResolvedValue({
@@ -202,7 +203,7 @@ describe('BCSC Client', () => {
     })
 
     it('should not emit TOKENS_REFRESHED when the cache is already populated', async () => {
-      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       client.tokens = { access_token: 'a', refresh_token: 'r' } as any
       const emitSpy = jest.spyOn(DeviceEventEmitter, 'emit').mockClear()
@@ -213,7 +214,7 @@ describe('BCSC Client', () => {
     })
 
     it('should not emit TOKENS_REFRESHED when the rebuild fails', async () => {
-      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       client.tokens = undefined
       ;(getTokenWithDiagnostics as jest.Mock).mockResolvedValue({
@@ -229,7 +230,7 @@ describe('BCSC Client', () => {
     })
 
     it('should throw TOKEN_NULL when the cache is empty and no refresh token is stored', async () => {
-      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       client.tokens = undefined
       ;(getTokenWithDiagnostics as jest.Mock).mockResolvedValue({
@@ -248,17 +249,8 @@ describe('BCSC Client', () => {
   describe('native error mapping', () => {
     const nativeError = (code: string) => Object.assign(new Error(`native ${code}`), { code })
 
-    beforeEach(() => {
-      // Earlier suites replace the prototype `fetchTokens` via jest.spyOn without restoring it;
-      // restore so these tests exercise the real method (and its native-error `.catch`).
-      const proto = BCSCApiClient.prototype as any
-      if (jest.isMockFunction(proto.fetchTokens)) {
-        proto.fetchTokens.mockRestore()
-      }
-    })
-
     it('maps a native getRefreshTokenRequestBody rejection during fetchTokens', async () => {
-      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       ;(getAccount as jest.Mock).mockResolvedValueOnce({ clientID: 'c', issuer: 'https://issuer' })
       ;(getRefreshTokenRequestBody as jest.Mock).mockRejectedValueOnce(nativeError('E_NO_KEYS_FOUND'))
@@ -269,7 +261,7 @@ describe('BCSC Client', () => {
     })
 
     it('maps a native getToken rejection during recoverTokens', async () => {
-      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       client.tokens = undefined
       ;(getTokenWithDiagnostics as jest.Mock).mockRejectedValueOnce(nativeError('E_KEYSTORE_UNAVAILABLE'))
@@ -281,7 +273,7 @@ describe('BCSC Client', () => {
   })
 
   it('should log error when initialized with empty URL', () => {
-    const mockLogger = { info: jest.fn(), error: jest.fn() }
+    const mockLogger = createMockLogger()
     const client = new BCSCApiClient('', mockLogger as any)
 
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('initialized with empty URL'))
@@ -290,7 +282,7 @@ describe('BCSC Client', () => {
 
   describe('clearTokens', () => {
     it('should clear tokens and tokensPromise', () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       client.tokens = { access_token: 'a', refresh_token: 'r' } as any
       client.tokensPromise = Promise.resolve({} as any)
@@ -304,7 +296,7 @@ describe('BCSC Client', () => {
 
   describe('setErrorHandler', () => {
     it('should set the onError callback', () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       const handler = jest.fn()
 
@@ -316,7 +308,7 @@ describe('BCSC Client', () => {
 
   describe('response interceptor', () => {
     it('should pass through AppError instances without re-wrapping', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       const appError = new AppError('test error', {
@@ -333,7 +325,7 @@ describe('BCSC Client', () => {
     })
 
     it('should pass through non-AxiosError instances unchanged', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       const genericError = new TypeError('something broke')
@@ -346,7 +338,7 @@ describe('BCSC Client', () => {
     })
 
     it('should call onError handler and log error on handled onError callback failure', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       const handlerError = new Error('handler blew up')
@@ -394,7 +386,7 @@ describe('BCSC Client', () => {
       )
 
     it('should refresh tokens and retry once on a 401, then succeed', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = setupBearerClient(mockLogger)
 
       const forceRefreshSpy = jest
@@ -420,7 +412,7 @@ describe('BCSC Client', () => {
     })
 
     it('should not retry a 401 on a skipBearerAuth request', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       const forceRefreshSpy = jest.spyOn(BCSCApiClient.prototype as any, 'forceRefreshTokens')
@@ -439,7 +431,7 @@ describe('BCSC Client', () => {
     })
 
     it('should retry a 401 only once, then surface the error', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = setupBearerClient(mockLogger)
 
       const forceRefreshSpy = jest
@@ -462,7 +454,7 @@ describe('BCSC Client', () => {
 
   describe('fetchEndpointsAndConfig', () => {
     it('should merge server config and endpoints into client', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       jest.spyOn(client, 'get').mockResolvedValue({
@@ -507,7 +499,7 @@ describe('BCSC Client', () => {
 
   describe('isTokenExpired', () => {
     it('should return true when no token is provided', () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       const result = (client as any).isTokenExpired(undefined)
@@ -516,7 +508,7 @@ describe('BCSC Client', () => {
     })
 
     it('should return false when token has not expired', () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       // Token expires far in the future
@@ -528,7 +520,7 @@ describe('BCSC Client', () => {
     })
 
     it('should return true when token is within buffer of expiring', () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       // Token expires in 20 seconds (within 30s buffer)
@@ -540,7 +532,7 @@ describe('BCSC Client', () => {
     })
 
     it('should return true when token has no exp claim', () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       ;(jwtDecode as jest.Mock).mockReturnValue({})
@@ -553,7 +545,7 @@ describe('BCSC Client', () => {
 
   describe('ensureValidTokens', () => {
     it('should return existing promise if tokens are already being refreshed', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       const mockTokens = { access_token: 'a', refresh_token: 'r' }
@@ -566,7 +558,7 @@ describe('BCSC Client', () => {
     })
 
     it('should throw TOKEN_NULL when tokens are missing and unrecoverable', async () => {
-      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       client.tokens = undefined
       ;(getAccount as jest.Mock).mockResolvedValue({ issuer: 'iss', clientID: 'cid' })
@@ -578,7 +570,7 @@ describe('BCSC Client', () => {
     })
 
     it('should recover tokens from secure storage when the in-memory cache is empty', async () => {
-      const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       client.tokens = undefined
       ;(getAccount as jest.Mock).mockResolvedValue({ issuer: 'iss', clientID: 'cid' })
@@ -599,7 +591,7 @@ describe('BCSC Client', () => {
     })
 
     it('should throw when refresh token is expired', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       client.tokens = { access_token: 'a', refresh_token: 'r' } as any
       ;(getAccount as jest.Mock).mockResolvedValue({ issuer: 'iss', clientID: 'cid' })
@@ -611,7 +603,7 @@ describe('BCSC Client', () => {
     })
 
     it('should return tokens when access token is still valid', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       const mockTokens = { access_token: 'a', refresh_token: 'r' }
       client.tokens = mockTokens as any
@@ -626,7 +618,7 @@ describe('BCSC Client', () => {
     })
 
     it('should refresh tokens when access token is expired but refresh token is valid', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       const oldTokens = { access_token: 'old-access', refresh_token: 'valid-refresh' }
       const newTokens = { access_token: 'new-access', refresh_token: 'new-refresh' }
@@ -650,7 +642,7 @@ describe('BCSC Client', () => {
 
   describe('handleRequest', () => {
     it('should skip bearer auth when skipBearerAuth is set', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       const config = {
@@ -667,7 +659,7 @@ describe('BCSC Client', () => {
     })
 
     it('should add bearer auth header when skipBearerAuth is not set', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       client.tokens = { access_token: 'my-token', refresh_token: 'r' } as any
       ;(getAccount as jest.Mock).mockResolvedValue({ issuer: 'iss', clientID: 'cid' })
@@ -689,7 +681,7 @@ describe('BCSC Client', () => {
 
   describe('HTTP methods', () => {
     it('should delegate post to client.post', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       const mockResponse = { data: 'ok' }
 
@@ -702,7 +694,7 @@ describe('BCSC Client', () => {
     })
 
     it('should delegate put to client.put', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       const mockResponse = { data: 'ok' }
 
@@ -715,7 +707,7 @@ describe('BCSC Client', () => {
     })
 
     it('should delegate delete to client.delete', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
       const mockResponse = { data: 'ok' }
 
@@ -738,7 +730,7 @@ describe('BCSC Client', () => {
     })
 
     it('should return the first JWK from the JWKS endpoint', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       jest.spyOn(client, 'get').mockResolvedValue({
@@ -751,7 +743,7 @@ describe('BCSC Client', () => {
     })
 
     it('should return null when JWKS endpoint returns empty keys array', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       jest.spyOn(client, 'get').mockResolvedValue({
@@ -764,7 +756,7 @@ describe('BCSC Client', () => {
     })
 
     it('should return null and log error when JWKS fetch fails', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       // A plain Error (not AxiosError/AppError) is not retryable, so this exercises the
@@ -778,7 +770,7 @@ describe('BCSC Client', () => {
     })
 
     it('should return null when keys property is undefined', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       jest.spyOn(client, 'get').mockResolvedValue({
@@ -791,7 +783,7 @@ describe('BCSC Client', () => {
     })
 
     it('should cache the JWK and not refetch while baseURL is unchanged', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       const getSpy = jest.spyOn(client, 'get').mockResolvedValue({
@@ -807,7 +799,7 @@ describe('BCSC Client', () => {
     })
 
     it('should refetch the JWK when baseURL changes', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       const getSpy = jest.spyOn(client, 'get').mockResolvedValue({
@@ -825,7 +817,7 @@ describe('BCSC Client', () => {
     })
 
     it('should request the JWKS endpoint with skipOnErrorHandler set', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const client = new BCSCApiClient('https://example.com', mockLogger as any)
 
       const getSpy = jest.spyOn(client, 'get').mockResolvedValue({
@@ -850,7 +842,7 @@ describe('BCSC Client', () => {
       })
 
       it('retries a transient network error up to the max attempts, then returns the persisted key', async () => {
-        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const mockLogger = createMockLogger()
         const client = new BCSCApiClient('https://example.com', mockLogger as any)
         const trackErrorEventSpy = jest.spyOn(Analytics, 'trackErrorEvent')
 
@@ -883,7 +875,7 @@ describe('BCSC Client', () => {
       })
 
       it('succeeds on a retry, caching and persisting the fresh key', async () => {
-        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const mockLogger = createMockLogger()
         const client = new BCSCApiClient('https://example.com', mockLogger as any)
         const networkError = new AxiosError('Network Error', 'ERR_NETWORK')
         const getSpy = jest
@@ -901,7 +893,7 @@ describe('BCSC Client', () => {
       })
 
       it('does not retry a non-retryable 4xx error and falls back to the persisted key', async () => {
-        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const mockLogger = createMockLogger()
         const client = new BCSCApiClient('https://example.com', mockLogger as any)
         const clientError = { cause: { response: { status: 400 } } } as any
         const getSpy = jest.spyOn(client, 'get').mockRejectedValue(clientError)
@@ -914,7 +906,7 @@ describe('BCSC Client', () => {
       })
 
       it('does not retry a well-formed empty keys response and falls back to the persisted key', async () => {
-        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const mockLogger = createMockLogger()
         const client = new BCSCApiClient('https://example.com', mockLogger as any)
         const getSpy = jest.spyOn(client, 'get').mockResolvedValue({ data: { keys: [] } } as any)
         jest.mocked(loadPersistedJwk).mockResolvedValueOnce(mockJwk as any)
@@ -926,7 +918,7 @@ describe('BCSC Client', () => {
       })
 
       it('returns null when all retry attempts fail and nothing is persisted', async () => {
-        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const mockLogger = createMockLogger()
         const client = new BCSCApiClient('https://example.com', mockLogger as any)
         const trackErrorEventSpy = jest.spyOn(Analytics, 'trackErrorEvent')
 
@@ -961,7 +953,7 @@ describe('BCSC Client', () => {
       })
 
       it('does not hydrate the in-memory cache from a persisted fallback', async () => {
-        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const mockLogger = createMockLogger()
         const client = new BCSCApiClient('https://example.com', mockLogger as any)
         const clientError = { cause: { response: { status: 400 } } } as any
         const getSpy = jest.spyOn(client, 'get').mockRejectedValue(clientError)
@@ -987,7 +979,7 @@ describe('BCSC Client', () => {
       })
 
       it('joins a single in-flight fetch: two concurrent calls make exactly one request and resolve to the same key', async () => {
-        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const mockLogger = createMockLogger()
         const client = new BCSCApiClient('https://example.com', mockLogger as any)
         const getSpy = jest.spyOn(client, 'get').mockResolvedValue({ data: { keys: [mockJwk] } } as any)
 
@@ -1002,7 +994,7 @@ describe('BCSC Client', () => {
       })
 
       it('joins a single in-flight retry loop: concurrent calls during a failing fetch share one set of attempts', async () => {
-        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const mockLogger = createMockLogger()
         const client = new BCSCApiClient('https://example.com', mockLogger as any)
         const networkError = new AxiosError('Network Error', 'ERR_NETWORK')
         const getSpy = jest.spyOn(client, 'get').mockRejectedValue(networkError)
@@ -1023,7 +1015,7 @@ describe('BCSC Client', () => {
       })
 
       it('does not join an in-flight fetch started for a different baseURL', async () => {
-        const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+        const mockLogger = createMockLogger()
         const client = new BCSCApiClient('https://example.com', mockLogger as any)
         const getSpy = jest.spyOn(client, 'get').mockResolvedValue({ data: { keys: [mockJwk] } } as any)
 
@@ -1044,12 +1036,22 @@ describe('BCSC Client', () => {
 
   describe('tokens race condition smoke test', () => {
     it('should never have stale tokens when multiple requests are made simultaneously', async () => {
-      const mockLogger = { info: jest.fn(), error: jest.fn() }
+      const mockLogger = createMockLogger()
       const baseURL = 'https://example.com'
 
       const client = new BCSCApiClient(baseURL, mockLogger as any)
 
-      jest.spyOn(client.client, 'get').mockResolvedValue({ data: 'response' })
+      // Requests go through the real adapter seam so handleRequest (and therefore
+      // ensureValidTokens) runs and we can observe the bearer each request actually carried.
+      const authorizationByUrl: Record<string, string | undefined> = {}
+      client.client.defaults.adapter = (config: any) => {
+        authorizationByUrl[String(config.url)] = config.headers?.get?.('Authorization')
+        return Promise.resolve({ status: 200, data: 'response', statusText: 'OK', headers: {} as any, config })
+      }
+      ;(getAccount as jest.Mock).mockResolvedValue({ issuer: 'iss', clientID: 'cid' })
+      // Neither token is near expiry, so ensureValidTokens never starts a refresh of its own —
+      // the only refresh is the explicit getTokensForRefreshToken call below.
+      ;(jwtDecode as jest.Mock).mockReturnValue({ exp: Math.floor(Date.now() / 1000) + 3600 })
 
       const mockInitialTokens = {
         access_token: 'accessToken',
@@ -1071,6 +1073,7 @@ describe('BCSC Client', () => {
       await client.get('/endpointA')
       expect(client.tokens).toBe(mockInitialTokens)
       expect(client.tokensPromise).toBeNull()
+      expect(authorizationByUrl['/endpointA']).toBe('Bearer accessToken')
 
       // Trigger refresh
       const tokenRefresh = client.getTokensForRefreshToken('newRefreshToken')
@@ -1089,6 +1092,11 @@ describe('BCSC Client', () => {
       const clientReqC = client.get('/endpointC')
 
       await Promise.all([clientReqB, clientReqC])
+
+      // B was issued while the refresh was in flight: it must have waited for the new
+      // access token rather than sending the stale one it saw at call time.
+      expect(authorizationByUrl['/endpointB']).toBe('Bearer newAccessToken')
+      expect(authorizationByUrl['/endpointC']).toBe('Bearer newAccessToken')
     })
   })
 })

--- a/app/src/bcsc-theme/api/client.test.ts
+++ b/app/src/bcsc-theme/api/client.test.ts
@@ -46,10 +46,13 @@ describe('BCSC Client', () => {
   })
 
   // Rejects every request with an AxiosError carrying the given status, so the response
-  // interceptor runs against a realistic error shape without a real HTTP call.
+  // interceptor runs against a realistic error shape without a real HTTP call. The code
+  // has to track the status the way axios' settle.js does — axios-error-utils routes
+  // ERR_BAD_REQUEST through the per-status client mapping and ERR_BAD_RESPONSE straight
+  // to SERVER_ERROR, so a hardcoded code silently mis-maps every 4xx.
   const rejectWithStatus = (status: number, statusText: string) => (config: any) =>
     Promise.reject(
-      new AxiosError('Request failed', 'ERR_BAD_RESPONSE', config, null, {
+      new AxiosError('Request failed', status >= 500 ? 'ERR_BAD_RESPONSE' : 'ERR_BAD_REQUEST', config, null, {
         status,
         data: {},
         statusText,
@@ -407,8 +410,6 @@ describe('BCSC Client', () => {
       expect(callCount).toBe(2) // original + one retry
       expect(response.status).toBe(200)
       expect(response.data).toEqual({ ok: true })
-
-      forceRefreshSpy.mockRestore()
     })
 
     it('should not retry a 401 on a skipBearerAuth request', async () => {
@@ -426,8 +427,6 @@ describe('BCSC Client', () => {
       await expect(client.get('/token', { skipBearerAuth: true })).rejects.toBeInstanceOf(AppError)
       expect(forceRefreshSpy).not.toHaveBeenCalled()
       expect(callCount).toBe(1)
-
-      forceRefreshSpy.mockRestore()
     })
 
     it('should retry a 401 only once, then surface the error', async () => {
@@ -447,8 +446,6 @@ describe('BCSC Client', () => {
       await expect(client.get('/protected')).rejects.toBeInstanceOf(AppError)
       expect(forceRefreshSpy).toHaveBeenCalledTimes(1)
       expect(callCount).toBe(2) // original + one retry, then surfaced
-
-      forceRefreshSpy.mockRestore()
     })
   })
 
@@ -1063,10 +1060,19 @@ describe('BCSC Client', () => {
         refresh_token: 'newRefreshToken',
       }
 
+      // The second refresh is held open deliberately. With an already-resolved promise
+      // the refresh settles before axios runs the request interceptor for B, so B never
+      // reaches the `if (this.tokensPromise)` join in ensureValidTokens and the
+      // assertion below would pass even with that guard deleted.
+      let releaseRefresh: (tokens: typeof mockRefreshedTokens) => void = () => {}
+      const heldRefresh = new Promise<typeof mockRefreshedTokens>((resolve) => {
+        releaseRefresh = resolve
+      })
+
       jest
         .spyOn(BCSCApiClient.prototype as any, 'fetchTokens')
         .mockResolvedValueOnce(mockInitialTokens)
-        .mockResolvedValueOnce(mockRefreshedTokens)
+        .mockReturnValueOnce(heldRefresh)
 
       // Initialize tokens
       await client.getTokensForRefreshToken('initialRefreshToken')
@@ -1080,8 +1086,12 @@ describe('BCSC Client', () => {
       expect(client.tokens).toBe(mockInitialTokens)
       expect(client.tokensPromise).toBeInstanceOf(Promise)
 
-      // Parallel request during refresh
+      // Parallel request during refresh: issued, then given a macrotask to reach the
+      // interceptor, all while the refresh is still pending.
       const clientReqB = client.get('/endpointB')
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      releaseRefresh(mockRefreshedTokens)
 
       // Wait for refresh completion
       await tokenRefresh

--- a/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
@@ -1112,57 +1112,6 @@ describe('clientErrorPolicies', () => {
 
   describe('ClientErrorHandlingPolicies', () => {
     describe('policy order', () => {
-      it('should respect policy order when multiple policies match', () => {
-        // Create an error that would match both alreadyRegisteredErrorPolicy and globalAlertErrorPolicy
-        // if we artificially make globalAlertErrorPolicy match on ERR_501
-        const error = newError('err_501_invalid_registration_request')
-        error.cause = new AxiosError('client is in invalid state')
-        const context = {
-          endpoint: '/api/devicecode',
-          apiEndpoints: {
-            deviceAuthorization: '/api/devicecode',
-          },
-        }
-
-        // Find the first matching policy
-        const matchedPolicy = ClientErrorHandlingPolicies.find((policy) => policy.matches(error, context as any))
-
-        // Should be alreadyRegisteredErrorPolicy (first in array) not globalAlertErrorPolicy
-        expect(matchedPolicy).toBe(alreadyRegisteredErrorPolicy)
-      })
-
-      it('should use the first matching policy in the array', () => {
-        const error = newError('server_error') // Matches globalAlertErrorPolicy
-        const context = {
-          endpoint: '/api/some-endpoint',
-          apiEndpoints: {} as any,
-        }
-
-        const matchedPolicy = ClientErrorHandlingPolicies.find((policy) => policy.matches(error, context as any))
-
-        // Should be globalAlertErrorPolicy
-        expect(matchedPolicy).toBe(globalAlertErrorPolicy)
-      })
-
-      it('should prefer alreadyRegisteredErrorPolicy over birthdateLockoutErrorPolicy', () => {
-        const error = newError('err_501_invalid_registration_request')
-        const cause = new AxiosError('client is in invalid state')
-        ;(cause as any).response = { status: 503 }
-        error.cause = cause
-        const context = {
-          endpoint: '/api/devicecode',
-          apiEndpoints: {
-            deviceAuthorization: '/api/devicecode',
-          },
-        }
-
-        // Both policies match this error; the earlier one in the array must win.
-        expect(birthdateLockoutErrorPolicy.matches(error, context as any)).toBeTruthy()
-
-        const matchedPolicy = ClientErrorHandlingPolicies.find((policy) => policy.matches(error, context as any))
-        expect(matchedPolicy).toBe(alreadyRegisteredErrorPolicy)
-      })
-
       it('should prefer alreadyRegisteredErrorPolicy over invalidRegistrationRequestErrorPolicy', () => {
         const error = newError('err_501_invalid_registration_request')
         error.cause = new AxiosError('client is in invalid state')

--- a/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
+++ b/app/src/bcsc-theme/api/clientErrorPolicies.test.ts
@@ -1144,44 +1144,26 @@ describe('clientErrorPolicies', () => {
         expect(matchedPolicy).toBe(globalAlertErrorPolicy)
       })
 
-      it('should have alreadyRegisteredErrorPolicy before other policies', () => {
-        const indexOfAlreadyRegistered = ClientErrorHandlingPolicies.indexOf(alreadyRegisteredErrorPolicy)
-        const indexOfBirthdateLockout = ClientErrorHandlingPolicies.indexOf(birthdateLockoutErrorPolicy)
-        const indexOfGlobalAlert = ClientErrorHandlingPolicies.indexOf(globalAlertErrorPolicy)
+      it('should prefer alreadyRegisteredErrorPolicy over birthdateLockoutErrorPolicy', () => {
+        const error = newError('err_501_invalid_registration_request')
+        const cause = new AxiosError('client is in invalid state')
+        ;(cause as any).response = { status: 503 }
+        error.cause = cause
+        const context = {
+          endpoint: '/api/devicecode',
+          apiEndpoints: {
+            deviceAuthorization: '/api/devicecode',
+          },
+        }
 
-        // alreadyRegisteredErrorPolicy should come before birthdateLockoutErrorPolicy
-        expect(indexOfAlreadyRegistered).toBeLessThan(indexOfBirthdateLockout)
+        // Both policies match this error; the earlier one in the array must win.
+        expect(birthdateLockoutErrorPolicy.matches(error, context as any)).toBeTruthy()
 
-        // alreadyRegisteredErrorPolicy should come before globalAlertErrorPolicy
-        expect(indexOfAlreadyRegistered).toBeLessThan(indexOfGlobalAlert)
+        const matchedPolicy = ClientErrorHandlingPolicies.find((policy) => policy.matches(error, context as any))
+        expect(matchedPolicy).toBe(alreadyRegisteredErrorPolicy)
       })
 
-      it('should have alreadyRegisteredErrorPolicy before invalidRegistrationRequestErrorPolicy', () => {
-        const indexOfAlreadyRegistered = ClientErrorHandlingPolicies.indexOf(alreadyRegisteredErrorPolicy)
-        const indexOfInvalidRegistration = ClientErrorHandlingPolicies.indexOf(invalidRegistrationRequestErrorPolicy)
-
-        expect(indexOfAlreadyRegistered).toBeLessThan(indexOfInvalidRegistration)
-      })
-
-      it('should have new IAS error policies before globalAlertErrorPolicy', () => {
-        const indexOfStringResource = ClientErrorHandlingPolicies.indexOf(failedToRetrieveStringResourceErrorPolicy)
-        const indexOfInvalidUrl = ClientErrorHandlingPolicies.indexOf(invalidUrlErrorPolicy)
-        const indexOfInvalidRegistration = ClientErrorHandlingPolicies.indexOf(invalidRegistrationRequestErrorPolicy)
-        const indexOfGlobalAlert = ClientErrorHandlingPolicies.indexOf(globalAlertErrorPolicy)
-
-        expect(indexOfStringResource).toBeLessThan(indexOfGlobalAlert)
-        expect(indexOfInvalidUrl).toBeLessThan(indexOfGlobalAlert)
-        expect(indexOfInvalidRegistration).toBeLessThan(indexOfGlobalAlert)
-      })
-
-      it('should have emailVerificationCodeErrorPolicy before iasErrorPolicy so 400/404 do not route to the err_209 alert', () => {
-        const indexOfEmailVerification = ClientErrorHandlingPolicies.indexOf(emailVerificationCodeErrorPolicy)
-        const indexOfIas = ClientErrorHandlingPolicies.indexOf(iasErrorPolicy)
-
-        expect(indexOfEmailVerification).toBeLessThan(indexOfIas)
-      })
-
-      it('should prefer alreadyRegisteredErrorPolicy for ERR_501 with "client is in invalid" on deviceAuthorization', () => {
+      it('should prefer alreadyRegisteredErrorPolicy over invalidRegistrationRequestErrorPolicy', () => {
         const error = newError('err_501_invalid_registration_request')
         error.cause = new AxiosError('client is in invalid state')
         const context = {
@@ -1191,8 +1173,40 @@ describe('clientErrorPolicies', () => {
           },
         }
 
+        expect(invalidRegistrationRequestErrorPolicy.matches(error, context as any)).toBeTruthy()
+
         const matchedPolicy = ClientErrorHandlingPolicies.find((policy) => policy.matches(error, context as any))
         expect(matchedPolicy).toBe(alreadyRegisteredErrorPolicy)
+      })
+
+      it.each([
+        ['err_400_failed_to_retrieve_string_resource', failedToRetrieveStringResourceErrorPolicy],
+        ['err_500_invalid_url', invalidUrlErrorPolicy],
+        ['err_501_invalid_registration_request', invalidRegistrationRequestErrorPolicy],
+      ])('should resolve %s to its own policy rather than a global fallback', (appEvent, expectedPolicy) => {
+        const error = newError(appEvent as string)
+        const context = { endpoint: '/api/some-endpoint', apiEndpoints: {} as any }
+
+        const matchedPolicy = ClientErrorHandlingPolicies.find((policy) => policy.matches(error, context as any))
+
+        expect(matchedPolicy).toBe(expectedPolicy)
+        expect(matchedPolicy).not.toBe(globalAlertErrorPolicy)
+      })
+
+      it('should prefer emailVerificationCodeErrorPolicy over iasErrorPolicy on a 404 email verification endpoint', () => {
+        const error = newError('err_209_bad_request')
+        const context = {
+          endpoint: 'https://example.com/v1/emails/abc123',
+          statusCode: 404,
+          apiEndpoints: {} as any,
+        }
+
+        // err_209 is in the IAS alert map, so both policies match — the email-specific policy is
+        // earlier and suppresses the generic err_209 alert.
+        expect(iasErrorPolicy.matches(error, context as any)).toBeTruthy()
+
+        const matchedPolicy = ClientErrorHandlingPolicies.find((policy) => policy.matches(error, context as any))
+        expect(matchedPolicy).toBe(emailVerificationCodeErrorPolicy)
       })
 
       it('should fall through to invalidRegistrationRequestErrorPolicy for ERR_501 without "client is in invalid"', () => {
@@ -1229,9 +1243,8 @@ describe('clientErrorPolicies', () => {
     })
 
     describe('handle', () => {
-      it('should emit the alert', () => {
-        const originalError = AppError.fromErrorDefinition(ErrorRegistry.GENERAL_ERROR) as AxiosAppError
-        const error = AppError.fromErrorDefinition(ErrorRegistry.SERVER_ERROR, { cause: originalError })
+      it('should emit the alert with the error it was handed', () => {
+        const error = AppError.fromErrorDefinition(ErrorRegistry.SERVER_ERROR) as AxiosAppError
 
         const mockAlert = jest.fn()
         const context = {
@@ -1239,50 +1252,21 @@ describe('clientErrorPolicies', () => {
             serverErrorAlert: mockAlert,
           },
         }
-        unexpectedServerErrorPolicy.handle(originalError, context as any)
-        expect(mockAlert).toHaveBeenCalled()
-        expect(error.cause).toBe(originalError)
+        unexpectedServerErrorPolicy.handle(error, context as any)
+        expect(mockAlert).toHaveBeenCalledWith(error)
       })
     })
   })
 
   describe('verifyDeviceAssertionPolicy', () => {
     describe('matches', () => {
-      it('should match LOGIN_SERVER_ERROR on verify device endpoint', () => {
-        const error = newError('login_server_error')
-        const context = {
-          endpoint: '/api/cardTap/v3/mobile/assertion',
-          apiEndpoints: {
-            cardTap: '/api/cardTap',
-          },
-        }
-        expect(verifyDeviceAssertionErrorPolicy.matches(error, context as any)).toBeTruthy()
-      })
-
-      it('should match LOGIN_PARSE_URI on verify device endpoint', () => {
-        const error = newError('login_parse_uri')
-        const context = {
-          endpoint: '/api/cardTap/v3/mobile/assertion',
-          apiEndpoints: {
-            cardTap: '/api/cardTap',
-          },
-        }
-        expect(verifyDeviceAssertionErrorPolicy.matches(error, context as any)).toBeTruthy()
-      })
-
-      it('should match INVALID_PAIRING_CODE on verify device endpoint', () => {
-        const error = newError('invalid_pairing_code')
-        const context = {
-          endpoint: '/api/cardTap/v3/mobile/assertion',
-          apiEndpoints: {
-            cardTap: '/api/cardTap',
-          },
-        }
-        expect(verifyDeviceAssertionErrorPolicy.matches(error, context as any)).toBeTruthy()
-      })
-
-      it('should match LOGIN_SAME_DEVICE_INVALID_PAIRING_CODE on verify device endpoint', () => {
-        const error = newError('login_same_device_invalid_pairing_code')
+      it.each([
+        ['LOGIN_SERVER_ERROR', 'login_server_error'],
+        ['LOGIN_PARSE_URI', 'login_parse_uri'],
+        ['INVALID_PAIRING_CODE', 'invalid_pairing_code'],
+        ['LOGIN_SAME_DEVICE_INVALID_PAIRING_CODE', 'login_same_device_invalid_pairing_code'],
+      ])('should match %s on verify device endpoint', (_name, appEvent) => {
+        const error = newError(appEvent)
         const context = {
           endpoint: '/api/cardTap/v3/mobile/assertion',
           apiEndpoints: {
@@ -1313,141 +1297,109 @@ describe('clientErrorPolicies', () => {
         }
         expect(verifyDeviceAssertionErrorPolicy.matches(error, context as any)).toBeFalsy()
       })
+    })
 
-      describe('handle', () => {
-        it('should emit the login server error alert', () => {
-          const error = newError('login_server_error')
-          const mockAlert = jest.fn()
-          const context = {
-            alerts: { loginServerErrorAlert: mockAlert },
-          }
-          verifyDeviceAssertionErrorPolicy.handle(error, context as any)
-          expect(mockAlert).toHaveBeenCalled()
-        })
+    describe('handle', () => {
+      it.each([
+        ['login_server_error', 'loginServerErrorAlert'],
+        ['login_parse_uri', 'problemWithLoginAlert'],
+        ['invalid_pairing_code', 'invalidPairingCodeAlert'],
+        ['login_remembered_device_invalid_pairing_code', 'invalidPairingCodeAlert'],
+        ['login_same_device_invalid_pairing_code', 'loginSameDeviceInvalidPairingCodeAlert'],
+      ])('should emit %s via %s', (appEvent, alertMethod) => {
+        const error = newError(appEvent)
+        const mockAlert = jest.fn()
+        const context = {
+          alerts: { [alertMethod]: mockAlert },
+        }
+        verifyDeviceAssertionErrorPolicy.handle(error, context as any)
+        expect(mockAlert).toHaveBeenCalled()
+      })
+    })
+  })
 
-        it('should emit the problem with account alert', () => {
-          const error = newError('login_parse_uri')
-          const mockAlert = jest.fn()
-          const context = {
-            alerts: { problemWithLoginAlert: mockAlert },
-          }
-          verifyDeviceAssertionErrorPolicy.handle(error, context as any)
-          expect(mockAlert).toHaveBeenCalled()
-        })
+  describe('verifyNotCompletedErrorPolicy', () => {
+    describe('matches', () => {
+      it('should match VERIFY_NOT_COMPLETE on token endpoint', () => {
+        const error = newError('verify_not_complete')
+        const context = {
+          endpoint: '/api/token',
+          apiEndpoints: {
+            token: '/api/token',
+          },
+        }
+        expect(verifyNotCompletedErrorPolicy.matches(error, context as any)).toBeTruthy()
+      })
 
-        it('should emit the invalid pairing code alert', () => {
-          const error = newError('invalid_pairing_code')
-          const mockAlert = jest.fn()
-          const context = {
-            alerts: { invalidPairingCodeAlert: mockAlert },
-          }
-          verifyDeviceAssertionErrorPolicy.handle(error, context as any)
-          expect(mockAlert).toHaveBeenCalled()
-        })
+      it('should NOT match USER_INPUT_EXPIRED_VERIFY_REQUEST on other endpoint', () => {
+        const error = newError('verify_not_complete')
+        const context = {
+          endpoint: '/api/other',
+          apiEndpoints: {
+            token: '/api/token',
+          },
+        }
+        expect(verifyNotCompletedErrorPolicy.matches(error, context as any)).toBeFalsy()
+      })
 
-        it('should emit the login remembered pairing code code alert', () => {
-          const error = newError('login_remembered_device_invalid_pairing_code')
-          const mockAlert = jest.fn()
-          const context = {
-            alerts: { invalidPairingCodeAlert: mockAlert },
-          }
-          verifyDeviceAssertionErrorPolicy.handle(error, context as any)
-          expect(mockAlert).toHaveBeenCalled()
-        })
-
-        it('should emit the login remembered device invalid pairing code alert', () => {
-          const error = newError('login_same_device_invalid_pairing_code')
-          const mockAlert = jest.fn()
-          const context = {
-            alerts: { loginSameDeviceInvalidPairingCodeAlert: mockAlert },
-          }
-          verifyDeviceAssertionErrorPolicy.handle(error, context as any)
-          expect(mockAlert).toHaveBeenCalled()
-        })
+      it('should NOT match other error codes', () => {
+        const error = newError('some_other_error')
+        const context = {
+          endpoint: '/api/token',
+          apiEndpoints: {
+            token: '/api/token',
+          },
+        }
+        expect(verifyNotCompletedErrorPolicy.matches(error, context as any)).toBeFalsy()
       })
     })
 
-    describe('verifyNotCompletedErrorPolicy', () => {
-      describe('matches', () => {
-        it('should match VERIFY_NOT_COMPLETE on token endpoint', () => {
-          const error = newError('verify_not_complete')
-          const context = {
-            endpoint: '/api/token',
-            apiEndpoints: {
-              token: '/api/token',
-            },
-          }
-          expect(verifyNotCompletedErrorPolicy.matches(error, context as any)).toBeTruthy()
-        })
+    describe('handle', () => {
+      it('should emit the alert', () => {
+        const error = newError('verify_not_complete')
+        const mockAlert = jest.fn()
+        const context = {
+          alerts: { verificationNotCompleteAlert: mockAlert },
+        }
+        verifyNotCompletedErrorPolicy.handle(error, context as any)
+        expect(mockAlert).toHaveBeenCalled()
+      })
+    })
+  })
 
-        it('should NOT match USER_INPUT_EXPIRED_VERIFY_REQUEST on other endpoint', () => {
-          const error = newError('verify_not_complete')
-          const context = {
-            endpoint: '/api/other',
-            apiEndpoints: {
-              token: '/api/token',
-            },
-          }
-          expect(verifyNotCompletedErrorPolicy.matches(error, context as any)).toBeFalsy()
-        })
-
-        it('should NOT match other error codes', () => {
-          const error = newError('some_other_error')
-          const context = {
-            endpoint: '/api/token',
-            apiEndpoints: {
-              token: '/api/token',
-            },
-          }
-          expect(verifyNotCompletedErrorPolicy.matches(error, context as any)).toBeFalsy()
-        })
+  describe('alreadyVerifiedErrorPolicy', () => {
+    describe('matches', () => {
+      it('should match ALREADY_VERIFIED on token endpoint', () => {
+        const error = newError('already_verified')
+        const context = {
+          endpoint: '/api/token',
+          apiEndpoints: {
+            token: '/api/token',
+          },
+        }
+        expect(alreadyVerifiedErrorPolicy.matches(error, context as any)).toBeTruthy()
       })
 
-      describe('alreadyVerifiedErrorPolicy', () => {
-        it('should match ALREADY_VERIFIED on token endpoint', () => {
-          const error = newError('already_verified')
-          const context = {
-            endpoint: '/api/token',
-            apiEndpoints: {
-              token: '/api/token',
-            },
-          }
-          expect(alreadyVerifiedErrorPolicy.matches(error, context as any)).toBeTruthy()
-        })
-
-        it('should NOT match ALREADY_VERIFIED on other endpoint', () => {
-          const error = newError('already_verified')
-          const context = {
-            endpoint: '/api/other',
-            apiEndpoints: {
-              token: '/api/token',
-            },
-          }
-          expect(alreadyVerifiedErrorPolicy.matches(error, context as any)).toBeFalsy()
-        })
-
-        it('should NOT match other error codes', () => {
-          const error = newError('some_other_error')
-          const context = {
-            endpoint: '/api/token',
-            apiEndpoints: {
-              token: '/api/token',
-            },
-          }
-          expect(alreadyVerifiedErrorPolicy.matches(error, context as any)).toBeFalsy()
-        })
+      it('should NOT match ALREADY_VERIFIED on other endpoint', () => {
+        const error = newError('already_verified')
+        const context = {
+          endpoint: '/api/other',
+          apiEndpoints: {
+            token: '/api/token',
+          },
+        }
+        expect(alreadyVerifiedErrorPolicy.matches(error, context as any)).toBeFalsy()
       })
 
-      describe('handle', () => {
-        it('should emit the alert', () => {
-          const error = newError('verify_not_complete')
-          const mockAlert = jest.fn()
-          const context = {
-            alerts: { verificationNotCompleteAlert: mockAlert },
-          }
-          verifyNotCompletedErrorPolicy.handle(error, context as any)
-          expect(mockAlert).toHaveBeenCalled()
-        })
+      it('should NOT match other error codes', () => {
+        const error = newError('some_other_error')
+        const context = {
+          endpoint: '/api/token',
+          apiEndpoints: {
+            token: '/api/token',
+          },
+        }
+        expect(alreadyVerifiedErrorPolicy.matches(error, context as any)).toBeFalsy()
       })
     })
   })

--- a/app/src/bcsc-theme/api/hooks/useFactoryReset.test.ts
+++ b/app/src/bcsc-theme/api/hooks/useFactoryReset.test.ts
@@ -1,4 +1,3 @@
-import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { useFactoryReset } from '@/bcsc-theme/api/hooks/useFactoryReset'
 import { useBCSCAgentSafe } from '@/bcsc-theme/features/agent/BCSCAgentProvider'
 import { purgeWalletStore } from '@/bcsc-theme/features/agent/services/agent-service'
@@ -17,7 +16,6 @@ jest.mock('@/bcsc-theme/hooks/useBCSCApiClient')
 // implementation, so opt back out.
 jest.unmock('@/bcsc-theme/api/hooks/useFactoryReset')
 
-jest.mock('@/bcsc-theme/api/hooks/useApi')
 jest.mock('@bifold/core')
 jest.mock('@/bcsc-theme/hooks/useSecureActions')
 jest.mock('./useRegistrationApi')
@@ -33,54 +31,64 @@ jest.mock('@/bcsc-theme/features/agent/services/agent-service', () => ({
 }))
 jest.mock('react-native-config', () => ({ Config: { INDY_VDR_PROXY_URL: '' } }))
 
-const warnMock = jest.fn()
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+type MockLogger = { info: jest.Mock; warn: jest.Mock; error: jest.Mock }
+
+type FactoryResetSetup = {
+  account?: any
+  store?: any
+  logger?: MockLogger
+  /** What `useServices` returns; defaults to `[logger]`, the wallet-purge path also needs ledgers. */
+  services?: any[]
+  client?: any
+  deleteRegistration?: jest.Mock
+  dispatch?: jest.Mock
+  clearSecureState?: jest.Mock
+  deleteSecureData?: jest.Mock
+}
+
+const setupFactoryReset = (overrides: FactoryResetSetup = {}) => {
+  const logger: MockLogger = overrides.logger ?? { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+  const {
+    account = { clientID: 'test-client-id' },
+    store = { bcscSecure: { registrationAccessToken: 'token', additionalEvidenceData: [] } },
+    services = [logger],
+    client = { clearTokens: jest.fn() },
+    deleteRegistration = jest.fn().mockResolvedValue({ success: true }),
+    dispatch = jest.fn(),
+    clearSecureState = jest.fn(),
+    deleteSecureData = jest.fn().mockResolvedValue(undefined),
+  } = overrides
+
+  const bcscCore = jest.mocked(BcscCore)
+  const bifold = jest.mocked(Bifold)
+
+  jest.mocked(useBCSCApiClientState).mockReturnValue({ client, isClientReady: true } as any)
+  jest.mocked(useRegistrationApi).mockReturnValue({ deleteRegistration, register: jest.fn() } as any)
+  jest.mocked(useSecureActions).mockReturnValue({ clearSecureState, deleteSecureData } as any)
+  bcscCore.getAccount.mockResolvedValue(account)
+  bcscCore.removeAccount.mockResolvedValue(undefined)
+  bifold.useStore.mockReturnValue([store, dispatch])
+  bifold.useServices.mockReturnValue(services as any)
+
+  return { bcscCore, logger, deleteRegistration, dispatch, clearSecureState, deleteSecureData }
+}
+
+const walletPurgeStore = {
+  bcscSecure: { registrationAccessToken: 'token', additionalEvidenceData: [], walletKey: 'stale-wallet-key' },
+  preferences: { selectedMediator: 'https://mediator.example', walletName: 'BC Wallet' },
+  developer: { enableProxy: false },
+}
 
 describe('useFactoryReset', () => {
   beforeEach(() => {
     jest.resetAllMocks()
-
-    const useSecureActionsMock = jest.mocked(useSecureActions)
-    useSecureActionsMock.mockReturnValue({
-      clearSecureState: jest.fn(),
-      deleteSecureData: jest.fn().mockResolvedValue(undefined),
-    } as any)
     jest.mocked(useBCSCAgentSafe).mockReturnValue(null)
   })
 
   it('should factory reset the device when successful', async () => {
-    const bcscCoreMock = jest.mocked(BcscCore)
-    const useSecureActionsMock = jest.mocked(useSecureActions)
-    const bifoldMock = jest.mocked(Bifold)
-    const useRegistrationApiMock = jest.mocked(useRegistrationApi)
-    const useBCSCApiClientStateMock = jest.mocked(useBCSCApiClientState)
-
-    const deleteRegistrationMock = jest.fn().mockResolvedValue({ success: true })
-    const registerMock = jest.fn()
-    const dispatchMock = jest.fn()
-    const clearSecureStateMock = jest.fn()
-    const deleteSecureDataMock = jest.fn().mockResolvedValue(undefined)
-
-    useBCSCApiClientStateMock.mockReturnValue({
-      client: {
-        clearTokens: jest.fn().mockResolvedValue(undefined),
-      },
-      isClientReady: true,
-    } as any)
-    useRegistrationApiMock.mockReturnValue({
-      deleteRegistration: deleteRegistrationMock,
-      register: registerMock,
-    } as any)
-    bcscCoreMock.getAccount.mockResolvedValue({ clientID: 'test-client-id' } as any)
-    bcscCoreMock.removeAccount.mockResolvedValue(undefined)
-    useSecureActionsMock.mockReturnValue({
-      clearSecureState: clearSecureStateMock,
-      deleteSecureData: deleteSecureDataMock,
-    } as any)
-    bifoldMock.useStore.mockReturnValue([
-      { bcscSecure: { registrationAccessToken: 'token', additionalEvidenceData: [] } } as any,
-      dispatchMock,
-    ])
-    bifoldMock.useServices.mockReturnValue([{ info: jest.fn(), error: jest.fn() }] as any)
+    const { bcscCore, deleteRegistration, dispatch, clearSecureState, deleteSecureData } = setupFactoryReset()
 
     const hook = renderHook(() => useFactoryReset())
 
@@ -92,48 +100,21 @@ describe('useFactoryReset', () => {
       expect(result.success).toBe(true)
     })
 
-    expect(bcscCoreMock.getAccount).toHaveBeenCalledWith()
-    expect(deleteRegistrationMock).toHaveBeenCalledWith('token', 'test-client-id')
-    expect(deleteSecureDataMock).toHaveBeenCalledWith()
-    expect(bcscCoreMock.removeAccount).toHaveBeenCalledWith()
-    expect(bcscCoreMock.clearAllKeychainData).toHaveBeenCalledWith()
-    expect(clearSecureStateMock).toHaveBeenCalledWith()
-    expect(dispatchMock.mock.calls[0]).toStrictEqual([{ type: BCDispatchAction.CLEAR_BCSC, payload: undefined }])
-    expect(dispatchMock.mock.calls[1]).toStrictEqual([{ type: DispatchAction.DID_AUTHENTICATE, payload: [false] }])
+    expect(bcscCore.getAccount).toHaveBeenCalledWith()
+    expect(deleteRegistration).toHaveBeenCalledWith('token', 'test-client-id')
+    expect(deleteSecureData).toHaveBeenCalledWith()
+    expect(bcscCore.removeAccount).toHaveBeenCalledWith()
+    expect(bcscCore.clearAllKeychainData).toHaveBeenCalledWith()
+    expect(clearSecureState).toHaveBeenCalledWith()
+    expect(dispatch.mock.calls[0]).toStrictEqual([{ type: BCDispatchAction.CLEAR_BCSC, payload: undefined }])
+    expect(dispatch.mock.calls[1]).toStrictEqual([{ type: DispatchAction.DID_AUTHENTICATE, payload: [false] }])
   })
 
   it('should call getToken when registrationAccessToken is missing from store', async () => {
-    const bcscCoreMock = jest.mocked(BcscCore)
-    const useSecureActionsMock = jest.mocked(useSecureActions)
-    const bifoldMock = jest.mocked(Bifold)
-    const useRegistrationApiMock = jest.mocked(useRegistrationApi)
-    const useBCSCApiClientStateMock = jest.mocked(useBCSCApiClientState)
-
-    const deleteRegistrationMock = jest.fn().mockResolvedValue({ success: true })
-    const dispatchMock = jest.fn()
-    const clearSecureStateMock = jest.fn()
-    const deleteSecureDataMock = jest.fn().mockResolvedValue(undefined)
-
-    useBCSCApiClientStateMock.mockReturnValue({
-      client: { clearTokens: jest.fn() },
-      isClientReady: true,
-    } as any)
-    useRegistrationApiMock.mockReturnValue({
-      deleteRegistration: deleteRegistrationMock,
-      register: jest.fn(),
-    } as any)
-    bcscCoreMock.getAccount.mockResolvedValue({ clientID: 'test-client-id' } as any)
-    bcscCoreMock.removeAccount.mockResolvedValue(undefined)
-    bcscCoreMock.getToken.mockResolvedValue({ token: 'native-token' } as any)
-    useSecureActionsMock.mockReturnValue({
-      clearSecureState: clearSecureStateMock,
-      deleteSecureData: deleteSecureDataMock,
-    } as any)
-    bifoldMock.useStore.mockReturnValue([
-      { bcscSecure: { registrationAccessToken: undefined, additionalEvidenceData: [] } } as any,
-      dispatchMock,
-    ])
-    bifoldMock.useServices.mockReturnValue([{ info: jest.fn(), error: jest.fn() }] as any)
+    const { bcscCore, deleteRegistration } = setupFactoryReset({
+      store: { bcscSecure: { registrationAccessToken: undefined, additionalEvidenceData: [] } },
+    })
+    bcscCore.getToken.mockResolvedValue({ token: 'native-token' } as any)
 
     const hook = renderHook(() => useFactoryReset())
 
@@ -142,20 +123,11 @@ describe('useFactoryReset', () => {
       expect(result.success).toBe(true)
     })
 
-    expect(bcscCoreMock.getToken).toHaveBeenCalledWith(BcscCore.TokenType.Registration)
-    expect(deleteRegistrationMock).toHaveBeenCalledWith('native-token', 'test-client-id')
+    expect(bcscCore.getToken).toHaveBeenCalledWith(BcscCore.TokenType.Registration)
+    expect(deleteRegistration).toHaveBeenCalledWith('native-token', 'test-client-id')
   })
 
   it('awaits agentCtx.teardownAgent before clearing state when a live agent exists', async () => {
-    const bcscCoreMock = jest.mocked(BcscCore)
-    const useSecureActionsMock = jest.mocked(useSecureActions)
-    const bifoldMock = jest.mocked(Bifold)
-    const useRegistrationApiMock = jest.mocked(useRegistrationApi)
-    const useBCSCApiClientStateMock = jest.mocked(useBCSCApiClientState)
-
-    const clearSecureStateMock = jest.fn()
-    const deleteSecureDataMock = jest.fn().mockResolvedValue(undefined)
-
     // A manually-resolved deferred promise, rather than a callOrder array pushed to
     // from inside async mock bodies. Timing-based approaches (an internal `await
     // Promise.resolve()`, or even a macrotask `await new Promise(setTimeout)`) are
@@ -184,25 +156,7 @@ describe('useFactoryReset', () => {
       waitForAgent: jest.fn().mockResolvedValue(agent),
     })
 
-    useBCSCApiClientStateMock.mockReturnValue({
-      client: { clearTokens: jest.fn() },
-      isClientReady: true,
-    } as any)
-    useRegistrationApiMock.mockReturnValue({
-      deleteRegistration: jest.fn().mockResolvedValue({ success: true }),
-      register: jest.fn(),
-    } as any)
-    bcscCoreMock.getAccount.mockResolvedValue({ clientID: 'test-client-id' } as any)
-    bcscCoreMock.removeAccount.mockResolvedValue(undefined)
-    useSecureActionsMock.mockReturnValue({
-      clearSecureState: clearSecureStateMock,
-      deleteSecureData: deleteSecureDataMock,
-    } as any)
-    bifoldMock.useStore.mockReturnValue([
-      { bcscSecure: { registrationAccessToken: 'token', additionalEvidenceData: [] } } as any,
-      jest.fn(),
-    ])
-    bifoldMock.useServices.mockReturnValue([{ info: jest.fn(), warn: jest.fn(), error: jest.fn() }] as any)
+    const { bcscCore, clearSecureState } = setupFactoryReset()
 
     const hook = renderHook(() => useFactoryReset())
 
@@ -221,8 +175,8 @@ describe('useFactoryReset', () => {
       }
     })
 
-    expect(bcscCoreMock.getAccount).not.toHaveBeenCalled()
-    expect(clearSecureStateMock).not.toHaveBeenCalled()
+    expect(bcscCore.getAccount).not.toHaveBeenCalled()
+    expect(clearSecureState).not.toHaveBeenCalled()
 
     resolveTeardown()
 
@@ -230,23 +184,16 @@ describe('useFactoryReset', () => {
 
     expect(result.success).toBe(true)
     expect(teardownAgentMock).toHaveBeenCalledTimes(1)
-    expect(bcscCoreMock.getAccount).toHaveBeenCalled()
-    expect(clearSecureStateMock).toHaveBeenCalled()
+    expect(bcscCore.getAccount).toHaveBeenCalled()
+    expect(clearSecureState).toHaveBeenCalled()
   })
 
   it('dispatches CLEAR_BCSC, then clearSecureState, then DID_AUTHENTICATE(false)', async () => {
-    const bcscCoreMock = jest.mocked(BcscCore)
-    const useSecureActionsMock = jest.mocked(useSecureActions)
-    const bifoldMock = jest.mocked(Bifold)
-    const useRegistrationApiMock = jest.mocked(useRegistrationApi)
-    const useBCSCApiClientStateMock = jest.mocked(useBCSCApiClientState)
-
     const callOrder: string[] = []
-    const clearSecureStateMock = jest.fn(() => {
+    const clearSecureState = jest.fn(() => {
       callOrder.push('clearSecureState')
     })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const dispatchMock = jest.fn((action: any) => {
+    const dispatch = jest.fn((action: any) => {
       if (action.type === BCDispatchAction.CLEAR_BCSC) {
         callOrder.push('CLEAR_BCSC')
       }
@@ -255,25 +202,7 @@ describe('useFactoryReset', () => {
       }
     })
 
-    useBCSCApiClientStateMock.mockReturnValue({
-      client: { clearTokens: jest.fn() },
-      isClientReady: true,
-    } as any)
-    useRegistrationApiMock.mockReturnValue({
-      deleteRegistration: jest.fn().mockResolvedValue({ success: true }),
-      register: jest.fn(),
-    } as any)
-    bcscCoreMock.getAccount.mockResolvedValue({ clientID: 'test-client-id' } as any)
-    bcscCoreMock.removeAccount.mockResolvedValue(undefined)
-    useSecureActionsMock.mockReturnValue({
-      clearSecureState: clearSecureStateMock,
-      deleteSecureData: jest.fn().mockResolvedValue(undefined),
-    } as any)
-    bifoldMock.useStore.mockReturnValue([
-      { bcscSecure: { registrationAccessToken: 'token', additionalEvidenceData: [] } } as any,
-      dispatchMock,
-    ])
-    bifoldMock.useServices.mockReturnValue([{ info: jest.fn(), warn: jest.fn(), error: jest.fn() }] as any)
+    setupFactoryReset({ clearSecureState, dispatch })
 
     const hook = renderHook(() => useFactoryReset())
 
@@ -294,40 +223,9 @@ describe('useFactoryReset', () => {
     // interrupted init may have written an on-disk store keyed with the wallet
     // key that account removal is about to make underivable. Factory reset must
     // delete it via the throwaway-agent path or it orphans the store forever.
-    const bcscCoreMock = jest.mocked(BcscCore)
-    const useSecureActionsMock = jest.mocked(useSecureActions)
-    const bifoldMock = jest.mocked(Bifold)
-    const useRegistrationApiMock = jest.mocked(useRegistrationApi)
-    const useBCSCApiClientStateMock = jest.mocked(useBCSCApiClientState)
-
-    // No live agent (mid-reinitialization), so the agentCtx.teardownAgent path
-    // is unavailable.
-    jest.mocked(useBCSCAgentSafe).mockReturnValue(null)
-
-    useBCSCApiClientStateMock.mockReturnValue({
-      client: { clearTokens: jest.fn() },
-      isClientReady: true,
-    } as any)
-    useRegistrationApiMock.mockReturnValue({
-      deleteRegistration: jest.fn().mockResolvedValue({ success: true }),
-      register: jest.fn(),
-    } as any)
-    bcscCoreMock.getAccount.mockResolvedValue({ clientID: 'test-client-id' } as any)
-    bcscCoreMock.removeAccount.mockResolvedValue(undefined)
-    useSecureActionsMock.mockReturnValue({
-      clearSecureState: jest.fn(),
-      deleteSecureData: jest.fn().mockResolvedValue(undefined),
-    } as any)
-    bifoldMock.useStore.mockReturnValue([
-      {
-        bcscSecure: { registrationAccessToken: 'token', additionalEvidenceData: [], walletKey: 'stale-wallet-key' },
-        preferences: { selectedMediator: 'https://mediator.example', walletName: 'BC Wallet' },
-        developer: { enableProxy: false },
-      } as any,
-      jest.fn(),
-    ])
+    const logger: MockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
     // useServices returns [logger, ledgers] for the build options.
-    bifoldMock.useServices.mockReturnValue([{ info: jest.fn(), warn: jest.fn(), error: jest.fn() }, []] as any)
+    const { bcscCore } = setupFactoryReset({ store: walletPurgeStore, logger, services: [logger, []] })
 
     const hook = renderHook(() => useFactoryReset())
 
@@ -342,43 +240,14 @@ describe('useFactoryReset', () => {
     expect(purgeWalletStore).toHaveBeenCalledWith(
       expect.objectContaining({ walletSecret: expect.objectContaining({ key: 'stale-wallet-key' }) })
     )
-    expect(bcscCoreMock.removeAccount).toHaveBeenCalledWith()
+    expect(bcscCore.removeAccount).toHaveBeenCalledWith()
   })
 
   it('does not fail the reset if the orphaned-store purge throws', async () => {
-    const bcscCoreMock = jest.mocked(BcscCore)
-    const useSecureActionsMock = jest.mocked(useSecureActions)
-    const bifoldMock = jest.mocked(Bifold)
-    const useRegistrationApiMock = jest.mocked(useRegistrationApi)
-    const useBCSCApiClientStateMock = jest.mocked(useBCSCApiClientState)
-    const warnLogMock = jest.fn()
-
-    jest.mocked(useBCSCAgentSafe).mockReturnValue(null)
     jest.mocked(purgeWalletStore).mockRejectedValue(new Error('build boom'))
 
-    useBCSCApiClientStateMock.mockReturnValue({
-      client: { clearTokens: jest.fn() },
-      isClientReady: true,
-    } as any)
-    useRegistrationApiMock.mockReturnValue({
-      deleteRegistration: jest.fn().mockResolvedValue({ success: true }),
-      register: jest.fn(),
-    } as any)
-    bcscCoreMock.getAccount.mockResolvedValue({ clientID: 'test-client-id' } as any)
-    bcscCoreMock.removeAccount.mockResolvedValue(undefined)
-    useSecureActionsMock.mockReturnValue({
-      clearSecureState: jest.fn(),
-      deleteSecureData: jest.fn().mockResolvedValue(undefined),
-    } as any)
-    bifoldMock.useStore.mockReturnValue([
-      {
-        bcscSecure: { registrationAccessToken: 'token', additionalEvidenceData: [], walletKey: 'stale-wallet-key' },
-        preferences: { selectedMediator: 'https://mediator.example', walletName: 'BC Wallet' },
-        developer: { enableProxy: false },
-      } as any,
-      jest.fn(),
-    ])
-    bifoldMock.useServices.mockReturnValue([{ info: jest.fn(), warn: warnLogMock, error: jest.fn() }, []] as any)
+    const logger: MockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+    setupFactoryReset({ store: walletPurgeStore, logger, services: [logger, []] })
 
     const hook = renderHook(() => useFactoryReset())
 
@@ -387,7 +256,7 @@ describe('useFactoryReset', () => {
       expect(result.success).toBe(true)
     })
 
-    expect(warnLogMock).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('orphaned wallet store purge failed'),
       expect.objectContaining({ error: expect.any(Error) })
     )
@@ -395,25 +264,12 @@ describe('useFactoryReset', () => {
 
   it.todo('should factory reset with custom state when provided')
 
-  it('should log a warning if account is null', async () => {
-    const bcscCoreMock = jest.mocked(BcscCore)
-    const useApiMock = jest.mocked(useApi)
-    const useSecureActionsMock = jest.mocked(useSecureActions)
-    const bifoldMock = jest.mocked(Bifold)
-    const infoMock = jest.fn()
-    const useBCSCApiClientStateMock = jest.mocked(useBCSCApiClientState)
-
-    const deleteRegistrationMock = jest.fn()
-
-    useBCSCApiClientStateMock.mockReturnValue({ client: {}, isClientReady: true } as any)
-    bcscCoreMock.getAccount.mockResolvedValue(null)
-    useApiMock.mockImplementation(() => ({ registration: { deleteRegistration: deleteRegistrationMock } }) as any)
-    useSecureActionsMock.mockReturnValue({
-      clearSecureState: jest.fn(),
-      deleteSecureData: jest.fn().mockResolvedValue(undefined),
-    } as any)
-    bifoldMock.useStore.mockReturnValue([{ bcscSecure: { additionalEvidenceData: [] } } as any, jest.fn()])
-    bifoldMock.useServices.mockReturnValue([{ info: infoMock, error: jest.fn() }] as any)
+  it('should not warn or delete the registration when the account is null', async () => {
+    const { bcscCore, logger, deleteRegistration } = setupFactoryReset({
+      account: null,
+      store: { bcscSecure: { additionalEvidenceData: [] } },
+      client: {},
+    })
 
     const hook = renderHook(() => useFactoryReset())
 
@@ -421,43 +277,18 @@ describe('useFactoryReset', () => {
       await hook.result.current()
     })
 
-    expect(bcscCoreMock.getAccount).toHaveBeenCalled()
-    expect(warnMock).not.toHaveBeenCalled()
-    expect(infoMock).toHaveBeenCalled()
-    expect(deleteRegistrationMock).not.toHaveBeenCalled()
+    expect(bcscCore.getAccount).toHaveBeenCalled()
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith('FactoryReset: No BCSC account found')
+    expect(deleteRegistration).not.toHaveBeenCalled()
     // Keychain data can outlive an app reinstall even when no local account file
     // remains, so the wipe must still run in this branch.
-    expect(bcscCoreMock.clearAllKeychainData).toHaveBeenCalledWith()
+    expect(bcscCore.clearAllKeychainData).toHaveBeenCalledWith()
   })
 
   it('does not fail the reset if clearing Keychain data throws', async () => {
-    const bcscCoreMock = jest.mocked(BcscCore)
-    const useSecureActionsMock = jest.mocked(useSecureActions)
-    const bifoldMock = jest.mocked(Bifold)
-    const useRegistrationApiMock = jest.mocked(useRegistrationApi)
-    const useBCSCApiClientStateMock = jest.mocked(useBCSCApiClientState)
-    const warnLogMock = jest.fn()
-
-    useBCSCApiClientStateMock.mockReturnValue({
-      client: { clearTokens: jest.fn() },
-      isClientReady: true,
-    } as any)
-    useRegistrationApiMock.mockReturnValue({
-      deleteRegistration: jest.fn().mockResolvedValue({ success: true }),
-      register: jest.fn(),
-    } as any)
-    bcscCoreMock.getAccount.mockResolvedValue({ clientID: 'test-client-id' } as any)
-    bcscCoreMock.removeAccount.mockResolvedValue(undefined)
-    bcscCoreMock.clearAllKeychainData.mockRejectedValue(new Error('keychain boom'))
-    useSecureActionsMock.mockReturnValue({
-      clearSecureState: jest.fn(),
-      deleteSecureData: jest.fn().mockResolvedValue(undefined),
-    } as any)
-    bifoldMock.useStore.mockReturnValue([
-      { bcscSecure: { registrationAccessToken: 'token', additionalEvidenceData: [] } } as any,
-      jest.fn(),
-    ])
-    bifoldMock.useServices.mockReturnValue([{ info: jest.fn(), warn: warnLogMock, error: jest.fn() }] as any)
+    const { bcscCore, logger } = setupFactoryReset()
+    bcscCore.clearAllKeychainData.mockRejectedValue(new Error('keychain boom'))
 
     const hook = renderHook(() => useFactoryReset())
 
@@ -466,29 +297,17 @@ describe('useFactoryReset', () => {
       expect(result.success).toBe(true)
     })
 
-    expect(warnLogMock).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('Failed to clear Keychain data'),
       expect.objectContaining({ message: 'keychain boom' })
     )
   })
 
   it('should log a warning if IAS account deletion fails', async () => {
-    const bcscCoreMock = jest.mocked(BcscCore)
-    const useSecureActionsMock = jest.mocked(useSecureActions)
-    const bifoldMock = jest.mocked(Bifold)
-    const useBCSCApiClientStateMock = jest.mocked(useBCSCApiClientState)
-
-    useBCSCApiClientStateMock.mockReturnValue({ client: {}, isClientReady: true } as any)
-    bcscCoreMock.getAccount.mockResolvedValue({ clientID: 'test-client-id' } as any)
-    useSecureActionsMock.mockReturnValue({
-      clearSecureState: jest.fn(),
-      deleteSecureData: jest.fn().mockResolvedValue(undefined),
-    } as any)
-    bifoldMock.useStore.mockReturnValue([
-      { bcscSecure: { registrationAccessToken: 'token', additionalEvidenceData: [] } } as any,
-      jest.fn(),
-    ])
-    bifoldMock.useServices.mockReturnValue([{ info: jest.fn(), error: jest.fn(), warn: warnMock }] as any)
+    const { bcscCore, logger } = setupFactoryReset({
+      client: {},
+      deleteRegistration: jest.fn().mockResolvedValue({ success: false }),
+    })
 
     const hook = renderHook(() => useFactoryReset())
 
@@ -496,49 +315,25 @@ describe('useFactoryReset', () => {
       await hook.result.current()
     })
 
-    expect(bcscCoreMock.getAccount).toHaveBeenCalled()
-    expect(warnMock).toHaveBeenCalled()
+    expect(bcscCore.getAccount).toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledWith('FactoryReset: Failed to delete IAS account from server')
   })
 
   it('should return an error if local account file deletion fails', async () => {
-    const bcscCoreMock = jest.mocked(BcscCore)
-    const useSecureActionsMock = jest.mocked(useSecureActions)
-    const bifoldMock = jest.mocked(Bifold)
-    const useRegistrationApiMock = jest.mocked(useRegistrationApi)
-    const useBCSCApiClientStateMock = jest.mocked(useBCSCApiClientState)
-
-    const deleteRegistrationMock = jest.fn().mockResolvedValue({ success: true })
-
-    useBCSCApiClientStateMock.mockReturnValue({ client: {}, isClientReady: true } as any)
-    useRegistrationApiMock.mockReturnValue({
-      deleteRegistration: deleteRegistrationMock,
-    } as any)
-    bcscCoreMock.getAccount.mockResolvedValue({ clientID: 'test-client-id' } as any)
-    bcscCoreMock.removeAccount.mockRejectedValue(new Error('Failed to remove account'))
-    useSecureActionsMock.mockReturnValue({
-      clearSecureState: jest.fn(),
-      deleteSecureData: jest.fn().mockResolvedValue(undefined),
-    } as any)
-    bifoldMock.useStore.mockReturnValue([
-      { bcscSecure: { registrationAccessToken: 'token', additionalEvidenceData: [] } } as any,
-      jest.fn(),
-    ])
-    bifoldMock.useServices.mockReturnValue([{ info: jest.fn(), error: jest.fn(), warn: warnMock }] as any)
+    const { bcscCore, deleteRegistration } = setupFactoryReset({ client: {} })
+    bcscCore.removeAccount.mockRejectedValue(new Error('Failed to remove account'))
 
     const hook = renderHook(() => useFactoryReset())
 
     await act(async () => {
       const result = await hook.result.current()
-      if (result.success) {
-        expect(true).toBe(false) // Force fail if success is true
-      } else {
-        expect(result.success).toBe(false)
-        expect(result.error.message).toContain('Failed to remove account')
-      }
+
+      expect(result.success).toBe(false)
+      expect(result.success === false && result.error.message).toContain('Failed to remove account')
     })
 
-    expect(bcscCoreMock.getAccount).toHaveBeenCalled()
-    expect(deleteRegistrationMock).toHaveBeenCalledWith('token', 'test-client-id')
-    expect(bcscCoreMock.removeAccount).toHaveBeenCalled()
+    expect(bcscCore.getAccount).toHaveBeenCalled()
+    expect(deleteRegistration).toHaveBeenCalledWith('token', 'test-client-id')
+    expect(bcscCore.removeAccount).toHaveBeenCalled()
   })
 })

--- a/app/src/bcsc-theme/api/hooks/useFactoryReset.test.ts
+++ b/app/src/bcsc-theme/api/hooks/useFactoryReset.test.ts
@@ -31,16 +31,11 @@ jest.mock('@/bcsc-theme/features/agent/services/agent-service', () => ({
 }))
 jest.mock('react-native-config', () => ({ Config: { INDY_VDR_PROXY_URL: '' } }))
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 type MockLogger = { info: jest.Mock; warn: jest.Mock; error: jest.Mock }
 
 type FactoryResetSetup = {
   account?: any
   store?: any
-  logger?: MockLogger
-  /** What `useServices` returns; defaults to `[logger]`, the wallet-purge path also needs ledgers. */
-  services?: any[]
   client?: any
   deleteRegistration?: jest.Mock
   dispatch?: jest.Mock
@@ -49,11 +44,10 @@ type FactoryResetSetup = {
 }
 
 const setupFactoryReset = (overrides: FactoryResetSetup = {}) => {
-  const logger: MockLogger = overrides.logger ?? { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+  const logger: MockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
   const {
     account = { clientID: 'test-client-id' },
     store = { bcscSecure: { registrationAccessToken: 'token', additionalEvidenceData: [] } },
-    services = [logger],
     client = { clearTokens: jest.fn() },
     deleteRegistration = jest.fn().mockResolvedValue({ success: true }),
     dispatch = jest.fn(),
@@ -70,7 +64,7 @@ const setupFactoryReset = (overrides: FactoryResetSetup = {}) => {
   bcscCore.getAccount.mockResolvedValue(account)
   bcscCore.removeAccount.mockResolvedValue(undefined)
   bifold.useStore.mockReturnValue([store, dispatch])
-  bifold.useServices.mockReturnValue(services as any)
+  bifold.useServices.mockReturnValue([logger] as any)
 
   return { bcscCore, logger, deleteRegistration, dispatch, clearSecureState, deleteSecureData }
 }
@@ -223,9 +217,7 @@ describe('useFactoryReset', () => {
     // interrupted init may have written an on-disk store keyed with the wallet
     // key that account removal is about to make underivable. Factory reset must
     // delete it via the throwaway-agent path or it orphans the store forever.
-    const logger: MockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
-    // useServices returns [logger, ledgers] for the build options.
-    const { bcscCore } = setupFactoryReset({ store: walletPurgeStore, logger, services: [logger, []] })
+    const { bcscCore } = setupFactoryReset({ store: walletPurgeStore })
 
     const hook = renderHook(() => useFactoryReset())
 
@@ -246,8 +238,7 @@ describe('useFactoryReset', () => {
   it('does not fail the reset if the orphaned-store purge throws', async () => {
     jest.mocked(purgeWalletStore).mockRejectedValue(new Error('build boom'))
 
-    const logger: MockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
-    setupFactoryReset({ store: walletPurgeStore, logger, services: [logger, []] })
+    const { logger } = setupFactoryReset({ store: walletPurgeStore })
 
     const hook = renderHook(() => useFactoryReset())
 
@@ -268,13 +259,13 @@ describe('useFactoryReset', () => {
     const { bcscCore, logger, deleteRegistration } = setupFactoryReset({
       account: null,
       store: { bcscSecure: { additionalEvidenceData: [] } },
-      client: {},
     })
 
     const hook = renderHook(() => useFactoryReset())
 
     await act(async () => {
-      await hook.result.current()
+      const result = await hook.result.current()
+      expect(result.success).toBe(true)
     })
 
     expect(bcscCore.getAccount).toHaveBeenCalled()
@@ -305,22 +296,43 @@ describe('useFactoryReset', () => {
 
   it('should log a warning if IAS account deletion fails', async () => {
     const { bcscCore, logger } = setupFactoryReset({
-      client: {},
       deleteRegistration: jest.fn().mockResolvedValue({ success: false }),
     })
 
     const hook = renderHook(() => useFactoryReset())
 
     await act(async () => {
-      await hook.result.current()
+      const result = await hook.result.current()
+      expect(result.success).toBe(true)
     })
 
     expect(bcscCore.getAccount).toHaveBeenCalled()
     expect(logger.warn).toHaveBeenCalledWith('FactoryReset: Failed to delete IAS account from server')
   })
 
+  // Deleting the IAS registration is documented as non-blocking: a throw here must be
+  // logged and the rest of the reset must still run.
+  it('should warn but still complete the reset when deleting the registration throws', async () => {
+    const { logger, clearSecureState } = setupFactoryReset({
+      deleteRegistration: jest.fn().mockRejectedValue(new Error('boom')),
+    })
+
+    const hook = renderHook(() => useFactoryReset())
+
+    await act(async () => {
+      const result = await hook.result.current()
+      expect(result.success).toBe(true)
+    })
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'FactoryReset: Error occurred while deleting registration',
+      expect.objectContaining({ error: expect.any(Error) })
+    )
+    expect(clearSecureState).toHaveBeenCalled()
+  })
+
   it('should return an error if local account file deletion fails', async () => {
-    const { bcscCore, deleteRegistration } = setupFactoryReset({ client: {} })
+    const { bcscCore, deleteRegistration } = setupFactoryReset()
     bcscCore.removeAccount.mockRejectedValue(new Error('Failed to remove account'))
 
     const hook = renderHook(() => useFactoryReset())

--- a/app/src/bcsc-theme/api/hooks/useFactoryReset.test.ts
+++ b/app/src/bcsc-theme/api/hooks/useFactoryReset.test.ts
@@ -340,8 +340,10 @@ describe('useFactoryReset', () => {
     await act(async () => {
       const result = await hook.result.current()
 
-      expect(result.success).toBe(false)
-      expect(result.success === false && result.error.message).toContain('Failed to remove account')
+      expect(result).toMatchObject({
+        success: false,
+        error: { message: expect.stringContaining('Failed to remove account') },
+      })
     })
 
     expect(bcscCore.getAccount).toHaveBeenCalled()

--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
@@ -103,6 +103,13 @@ const toBase64UrlUnpadded = (bytes: number[]) =>
 const SENT_N_IOS_SHAPE = toStdBase64([0x00, ...REAL_MODULUS_BYTES])
 const SERVER_N_ANDROID_SHAPE = toBase64UrlUnpadded(REAL_MODULUS_BYTES)
 
+/** Asserts a promise rejects with an AppError carrying `appEvent`, keeping the class check. */
+const expectAppErrorRejection = async (promise: Promise<unknown>, appEvent: AppEventCode) => {
+  const error: unknown = await promise.catch((e) => e)
+  expect(error).toBeInstanceOf(AppError)
+  expect((error as AppError).appEvent).toBe(appEvent)
+}
+
 describe('useRegistrationApi', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -159,10 +166,7 @@ describe('useRegistrationApi', () => {
 
       const promise = result.current.createRegistration(AccountSecurityMethod.PinNoDeviceAuth)
 
-      await expect(promise).rejects.toBeInstanceOf(AppError)
-      await expect(promise).rejects.toMatchObject({
-        appEvent: AppEventCode.ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL,
-      })
+      await expectAppErrorRejection(promise, AppEventCode.ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL)
     })
 
     it.each([
@@ -182,8 +186,7 @@ describe('useRegistrationApi', () => {
 
       const promise = result.current.createRegistration(AccountSecurityMethod.PinNoDeviceAuth)
 
-      await expect(promise).rejects.toBeInstanceOf(AppError)
-      await expect(promise).rejects.toMatchObject({ appEvent: expectedAppEvent })
+      await expectAppErrorRejection(promise, expectedAppEvent)
     })
 
     it('maps an unmapped native error code to UNMAPPED_NATIVE_ERROR', async () => {
@@ -195,8 +198,7 @@ describe('useRegistrationApi', () => {
 
       const promise = result.current.createRegistration(AccountSecurityMethod.PinNoDeviceAuth)
 
-      await expect(promise).rejects.toBeInstanceOf(AppError)
-      await expect(promise).rejects.toMatchObject({ appEvent: AppEventCode.UNMAPPED_NATIVE_ERROR })
+      await expectAppErrorRejection(promise, AppEventCode.UNMAPPED_NATIVE_ERROR)
     })
 
     it('maps a non-native error to UNMAPPED_NATIVE_ERROR', async () => {
@@ -207,8 +209,7 @@ describe('useRegistrationApi', () => {
 
       const promise = result.current.createRegistration(AccountSecurityMethod.PinNoDeviceAuth)
 
-      await expect(promise).rejects.toBeInstanceOf(AppError)
-      await expect(promise).rejects.toMatchObject({ appEvent: AppEventCode.UNMAPPED_NATIVE_ERROR })
+      await expectAppErrorRejection(promise, AppEventCode.UNMAPPED_NATIVE_ERROR)
     })
 
     // -------------------------------------------------------------------------
@@ -260,8 +261,7 @@ describe('useRegistrationApi', () => {
 
         const promise = result.current.createRegistration(AccountSecurityMethod.PinNoDeviceAuth)
 
-        await expect(promise).rejects.toBeInstanceOf(AppError)
-        await expect(promise).rejects.toMatchObject({ appEvent: AppEventCode.ERR_121_REGISTRATION_KEY_NOT_CONFIRMED })
+        await expectAppErrorRejection(promise, AppEventCode.ERR_121_REGISTRATION_KEY_NOT_CONFIRMED)
 
         expect(setAccount).not.toHaveBeenCalled()
         expect(mockUpdateTokens).not.toHaveBeenCalled()
@@ -424,10 +424,7 @@ describe('useRegistrationApi', () => {
 
       const promise = result.current.updateRegistration('token', 'nickname')
 
-      await expect(promise).rejects.toBeInstanceOf(AppError)
-      await expect(promise).rejects.toMatchObject({
-        appEvent: AppEventCode.ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL,
-      })
+      await expectAppErrorRejection(promise, AppEventCode.ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL)
     })
 
     it.each([
@@ -446,8 +443,7 @@ describe('useRegistrationApi', () => {
 
       const promise = result.current.updateRegistration('token', 'nickname')
 
-      await expect(promise).rejects.toBeInstanceOf(AppError)
-      await expect(promise).rejects.toMatchObject({ appEvent: expectedAppEvent })
+      await expectAppErrorRejection(promise, expectedAppEvent)
     })
 
     it('should throw DESERIALIZE_JSON_ERROR when body cannot be parsed as JSON', async () => {
@@ -457,8 +453,7 @@ describe('useRegistrationApi', () => {
 
       const promise = result.current.updateRegistration('token', 'nickname')
 
-      await expect(promise).rejects.toBeInstanceOf(AppError)
-      await expect(promise).rejects.toMatchObject({ appEvent: AppEventCode.ERR_109_FAILED_TO_DESERIALIZE_JSON })
+      await expectAppErrorRejection(promise, AppEventCode.ERR_109_FAILED_TO_DESERIALIZE_JSON)
     })
 
     it('should propagate API errors from the PUT request', async () => {

--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
@@ -157,13 +157,12 @@ describe('useRegistrationApi', () => {
 
       const { result } = renderHook(() => useRegistrationApi(mockApiClient as any))
 
-      try {
-        await result.current.createRegistration(AccountSecurityMethod.PinNoDeviceAuth)
-        fail('Expected an error to be thrown')
-      } catch (error) {
-        expect(error).toBeInstanceOf(AppError)
-        expect((error as AppError).appEvent).toBe(AppEventCode.ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL)
-      }
+      const promise = result.current.createRegistration(AccountSecurityMethod.PinNoDeviceAuth)
+
+      await expect(promise).rejects.toBeInstanceOf(AppError)
+      await expect(promise).rejects.toMatchObject({
+        appEvent: AppEventCode.ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL,
+      })
     })
 
     it.each([
@@ -181,13 +180,10 @@ describe('useRegistrationApi', () => {
 
       const { result } = renderHook(() => useRegistrationApi(mockApiClient as any))
 
-      try {
-        await result.current.createRegistration(AccountSecurityMethod.PinNoDeviceAuth)
-        fail('Expected an error to be thrown')
-      } catch (error) {
-        expect(error).toBeInstanceOf(AppError)
-        expect((error as AppError).appEvent).toBe(expectedAppEvent)
-      }
+      const promise = result.current.createRegistration(AccountSecurityMethod.PinNoDeviceAuth)
+
+      await expect(promise).rejects.toBeInstanceOf(AppError)
+      await expect(promise).rejects.toMatchObject({ appEvent: expectedAppEvent })
     })
 
     it('maps an unmapped native error code to UNMAPPED_NATIVE_ERROR', async () => {
@@ -197,13 +193,10 @@ describe('useRegistrationApi', () => {
 
       const { result } = renderHook(() => useRegistrationApi(mockApiClient as any))
 
-      try {
-        await result.current.createRegistration(AccountSecurityMethod.PinNoDeviceAuth)
-        fail('Expected an error to be thrown')
-      } catch (error) {
-        expect(error).toBeInstanceOf(AppError)
-        expect((error as AppError).appEvent).toBe(AppEventCode.UNMAPPED_NATIVE_ERROR)
-      }
+      const promise = result.current.createRegistration(AccountSecurityMethod.PinNoDeviceAuth)
+
+      await expect(promise).rejects.toBeInstanceOf(AppError)
+      await expect(promise).rejects.toMatchObject({ appEvent: AppEventCode.UNMAPPED_NATIVE_ERROR })
     })
 
     it('maps a non-native error to UNMAPPED_NATIVE_ERROR', async () => {
@@ -212,13 +205,10 @@ describe('useRegistrationApi', () => {
 
       const { result } = renderHook(() => useRegistrationApi(mockApiClient as any))
 
-      try {
-        await result.current.createRegistration(AccountSecurityMethod.PinNoDeviceAuth)
-        fail('Expected an error to be thrown')
-      } catch (error) {
-        expect(error).toBeInstanceOf(AppError)
-        expect((error as AppError).appEvent).toBe(AppEventCode.UNMAPPED_NATIVE_ERROR)
-      }
+      const promise = result.current.createRegistration(AccountSecurityMethod.PinNoDeviceAuth)
+
+      await expect(promise).rejects.toBeInstanceOf(AppError)
+      await expect(promise).rejects.toMatchObject({ appEvent: AppEventCode.UNMAPPED_NATIVE_ERROR })
     })
 
     // -------------------------------------------------------------------------
@@ -268,13 +258,10 @@ describe('useRegistrationApi', () => {
 
         const { result } = renderHook(() => useRegistrationApi(mockApiClient as any))
 
-        try {
-          await result.current.createRegistration(AccountSecurityMethod.PinNoDeviceAuth)
-          fail('Expected an error to be thrown')
-        } catch (error) {
-          expect(error).toBeInstanceOf(AppError)
-          expect((error as AppError).appEvent).toBe(AppEventCode.ERR_121_REGISTRATION_KEY_NOT_CONFIRMED)
-        }
+        const promise = result.current.createRegistration(AccountSecurityMethod.PinNoDeviceAuth)
+
+        await expect(promise).rejects.toBeInstanceOf(AppError)
+        await expect(promise).rejects.toMatchObject({ appEvent: AppEventCode.ERR_121_REGISTRATION_KEY_NOT_CONFIRMED })
 
         expect(setAccount).not.toHaveBeenCalled()
         expect(mockUpdateTokens).not.toHaveBeenCalled()
@@ -435,13 +422,12 @@ describe('useRegistrationApi', () => {
 
       const { result } = renderHook(() => useRegistrationApi(mockApiClient as any))
 
-      try {
-        await result.current.updateRegistration('token', 'nickname')
-        fail('Expected an error to be thrown')
-      } catch (error) {
-        expect(error).toBeInstanceOf(AppError)
-        expect((error as AppError).appEvent).toBe(AppEventCode.ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL)
-      }
+      const promise = result.current.updateRegistration('token', 'nickname')
+
+      await expect(promise).rejects.toBeInstanceOf(AppError)
+      await expect(promise).rejects.toMatchObject({
+        appEvent: AppEventCode.ERR_102_CLIENT_REGISTRATION_UNEXPECTEDLY_NULL,
+      })
     })
 
     it.each([
@@ -458,13 +444,10 @@ describe('useRegistrationApi', () => {
 
       const { result } = renderHook(() => useRegistrationApi(mockApiClient as any))
 
-      try {
-        await result.current.updateRegistration('token', 'nickname')
-        fail('Expected an error to be thrown')
-      } catch (error) {
-        expect(error).toBeInstanceOf(AppError)
-        expect((error as AppError).appEvent).toBe(expectedAppEvent)
-      }
+      const promise = result.current.updateRegistration('token', 'nickname')
+
+      await expect(promise).rejects.toBeInstanceOf(AppError)
+      await expect(promise).rejects.toMatchObject({ appEvent: expectedAppEvent })
     })
 
     it('should throw DESERIALIZE_JSON_ERROR when body cannot be parsed as JSON', async () => {
@@ -472,13 +455,10 @@ describe('useRegistrationApi', () => {
 
       const { result } = renderHook(() => useRegistrationApi(mockApiClient as any))
 
-      try {
-        await result.current.updateRegistration('token', 'nickname')
-        fail('Expected an error to be thrown')
-      } catch (error) {
-        expect(error).toBeInstanceOf(AppError)
-        expect((error as AppError).appEvent).toBe(AppEventCode.ERR_109_FAILED_TO_DESERIALIZE_JSON)
-      }
+      const promise = result.current.updateRegistration('token', 'nickname')
+
+      await expect(promise).rejects.toBeInstanceOf(AppError)
+      await expect(promise).rejects.toMatchObject({ appEvent: AppEventCode.ERR_109_FAILED_TO_DESERIALIZE_JSON })
     })
 
     it('should propagate API errors from the PUT request', async () => {

--- a/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
+++ b/app/src/bcsc-theme/api/hooks/useRegistrationApi.test.tsx
@@ -103,9 +103,17 @@ const toBase64UrlUnpadded = (bytes: number[]) =>
 const SENT_N_IOS_SHAPE = toStdBase64([0x00, ...REAL_MODULUS_BYTES])
 const SERVER_N_ANDROID_SHAPE = toBase64UrlUnpadded(REAL_MODULUS_BYTES)
 
-/** Asserts a promise rejects with an AppError carrying `appEvent`, keeping the class check. */
+/** Asserts a promise rejects with an AppError carrying `appEvent`. Fails if it resolves. */
 const expectAppErrorRejection = async (promise: Promise<unknown>, appEvent: AppEventCode) => {
-  const error: unknown = await promise.catch((e) => e)
+  // The resolve path has to fail loudly: `.catch((e) => e)` passes the resolved value
+  // straight through, so an implementation that *returns* an AppError instead of
+  // throwing one would satisfy the assertions below.
+  const error: unknown = await promise.then(
+    (value) => {
+      throw new Error(`Expected a rejection, but the promise resolved with: ${String(value)}`)
+    },
+    (reason: unknown) => reason
+  )
   expect(error).toBeInstanceOf(AppError)
   expect((error as AppError).appEvent).toBe(appEvent)
 }


### PR DESCRIPTION
<!-- No issue — this came out of an audit of the Jest suites. Labelled `status/no-issue`. -->

## What changed

Four API test suites had checks that passed no matter what the code did. The
worst hid a real gap: the test for our "don't log this status code" behaviour
replaced the very piece of code it was meant to be testing, so it would have
stayed green if that behaviour broke entirely.

Each check now goes through the real code path and fails when the behaviour
does.

## What should the reviewer focus on

The `suppressStatusCodeLogs` test in `client.test.ts` — it now exercises the
response interceptor instead of stubbing past it, which is the only structural
change here rather than a rewritten assertion.

Everything else is a like-for-like swap: a self-cancelling try/catch becomes
`rejects.toThrow`, an assertion on a logger that was never connected now uses the
connected one, and a few checks that only re-stated what the test had just mocked
are gone.

## How to test

Covered by the existing suites: **298 suites, 3163 passing, 160 snapshots**.
`yarn lint`, `yarn format:check` and `yarn typecheck` clean.

Rebased onto current main. #4543 removed `cardExpiredOnBarcodesErrorPolicy` and
its tests while this work was in flight; those deletions are preserved, not
reverted.
