### PR TITLE
fix: stop flow on expired bcsc used as evidence

### DIFF
--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.tsx
@@ -173,6 +173,7 @@ const EvidenceCaptureScreen = ({ navigation, route }: EvidenceCaptureScreenProps
           )
           navigation.navigate(BCSCScreens.EvidenceTypeList, { cardProcess: BCSCCardProcess.NonBCSC })
           documentExpiredAlert()
+          return
         }
 
         // Note: Card not found is a valid error - continue with the evidence capture flow


### PR DESCRIPTION
Closes #4419

## What changed
Flow: Non-BCSC, choose birth cert as first evidence, continue, then choose BCID as second evidence, but instead take photos of an expired BCSC with clear barcodes.

In this situation, the missing `return` was allowing the flow to continue as if it was successful despite the BCSC being expired.

**Before:**

https://github.com/user-attachments/assets/faba2075-460e-4cbc-9d35-ceb6516fe799

**After:**

https://github.com/user-attachments/assets/97a5fb7f-fc89-4171-8266-ee2b230c068c

## What should the reviewer focus on
This is an easy one to review.

## How to test
See the flow mentioned above to reproduce the scenario.