### PR TITLE
fix: button titles on cancelled review screen

### DIFF
--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -14,7 +14,8 @@ import {
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet } from 'react-native'
-import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
+import CommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons'
+import MaterialIcon from 'react-native-vector-icons/MaterialIcons'
 import useCancelledReviewViewModel from './CancelledReviewViewModel'
 
 interface CancelledReviewProps {
@@ -74,7 +75,7 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
         accessibilityLabel={t('BCSC.CancelledVerification.RetryButton')}
         testID={testIdWithKey('RetryWithNewVideo')}
       >
-        <Icon name={'video-outline'} size={24} color={ColorPalette.brand.primary} style={styles.buttonIcon} />
+        <MaterialIcon name={'sensor-occupied'} size={24} color={ColorPalette.brand.primary} style={styles.buttonIcon} />
       </Button>
       <Button
         title={t('BCSC.CancelledVerification.RestartButton')}
@@ -84,7 +85,7 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
         accessibilityLabel={t('BCSC.CancelledVerification.RestartButton')}
         testID={testIdWithKey('RestartVerification')}
       >
-        <Icon name={'restore'} size={24} color={ColorPalette.brand.primary} style={styles.buttonIcon} />
+        <CommunityIcon name={'restore'} size={24} color={ColorPalette.brand.primary} style={styles.buttonIcon} />
       </Button>
     </ControlContainer>
   )

--- a/app/src/bcsc-theme/features/verify/send-video/__snapshots__/CancelledReview.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/send-video/__snapshots__/CancelledReview.test.tsx.snap
@@ -186,7 +186,7 @@ exports[`CancelledReview renders correctly with agent reason 1`] = `
                     "marginRight": 8,
                   },
                   {
-                    "fontFamily": "Material Design Icons",
+                    "fontFamily": "Material Icons",
                     "fontStyle": "normal",
                     "fontWeight": "normal",
                   },
@@ -194,7 +194,7 @@ exports[`CancelledReview renders correctly with agent reason 1`] = `
                 ]
               }
             >
-              󰯜
+              
             </Text>
             <Text
               maxFontSizeMultiplier={2}

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -1200,8 +1200,8 @@ const translation = {
     "CancelledVerification": {
       "Title": "Your identity couldn't be verified",
       "Label": "Details from Service BC agent: \n{{reason}}",
-      "RetryButton": "Retry with a new video",
-      "RestartButton": "Restart verification",
+      "RetryButton": "Try again",
+      "RestartButton": "Restart from beginning",
       "NoReason": "No reason provided"
     },
     "DualNonBCSCEvidence": {


### PR DESCRIPTION
Closes #4419

## What changed

Just button titles / content, as per UX guidance

## What should the reviewer focus on
Look at this screenshot
<img width="585" height="1266" alt="IMG_0005" src="https://github.com/user-attachments/assets/6a228917-050f-4002-91a6-dae622faf88f" />


## How to test
No testing required
