### PR TITLE
fix: use server kid in response to better select decrypt key

### DIFF
--- a/app/src/services/system-checks/KeyRotationSystemCheck.test.ts
+++ b/app/src/services/system-checks/KeyRotationSystemCheck.test.ts
@@ -178,26 +178,55 @@ describe('KeyRotationSystemCheck', () => {
       expect(utils.logger.warn).toHaveBeenCalled()
     })
 
-    it('skips instead of rotating on a sibling when the newest key lacks a created timestamp', async () => {
+    it('ignores a sibling with no created timestamp and rotates based on the remaining usable key', async () => {
       Object.defineProperty(Platform, 'OS', { get: () => 'android' })
       mockedGetAllKeys.mockResolvedValue([
         { id: 'old', created: NOW - 400 * 24 * 60 * 60 * 1000 } as any,
-        { id: 'newest-no-ts' } as any,
+        { id: 'untracked-no-ts' } as any,
       ])
       const utils = makeUtils()
       const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
 
-      expect(await check.runCheck()).toBe(true)
-      expect(utils.logger.warn).toHaveBeenCalled()
+      expect(await check.runCheck()).toBe(false)
+      expect(utils.logger.warn).toHaveBeenCalledWith(expect.stringContaining("ignoring key 'untracked-no-ts'"))
     })
 
-    it('skips when a key has created: 0 rather than reading it as an epoch-1970 key', async () => {
+    it('ignores a sibling with created: 0 and passes based on the remaining usable key', async () => {
+      Object.defineProperty(Platform, 'OS', { get: () => 'android' })
+      mockedGetAllKeys.mockResolvedValue([
+        { id: 'rsa2', created: NOW - 10 * 24 * 60 * 60 * 1000 } as any,
+        { id: 'rsa3', created: 0 } as any,
+      ])
+      const utils = makeUtils()
+      const rotate = jest.fn()
+      const check = new KeyRotationSystemCheck(false, undefined, rotate, utils)
+
+      expect(await check.runCheck()).toBe(true)
+      expect(rotate).not.toHaveBeenCalled()
+      expect(utils.logger.warn).toHaveBeenCalledWith(expect.stringContaining("ignoring key 'rsa3'"))
+    })
+
+    it('skips when the only key has created: 0 rather than reading it as an epoch-1970 key', async () => {
       mockedGetAllKeys.mockResolvedValue([{ id: 'rsa1', created: 0 } as any])
       const utils = makeUtils()
       const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
 
       expect(await check.runCheck()).toBe(true)
-      expect(utils.logger.warn).toHaveBeenCalled()
+      expect(utils.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('no local key has a usable created timestamp')
+      )
+    })
+
+    it('skips when every key lacks a usable created timestamp', async () => {
+      Object.defineProperty(Platform, 'OS', { get: () => 'android' })
+      mockedGetAllKeys.mockResolvedValue([{ id: 'rsa1', created: 0 } as any, { id: 'rsa2' } as any])
+      const utils = makeUtils()
+      const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
+
+      expect(await check.runCheck()).toBe(true)
+      expect(utils.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('no local key has a usable created timestamp')
+      )
     })
   })
 

--- a/app/src/services/system-checks/KeyRotationSystemCheck.test.ts
+++ b/app/src/services/system-checks/KeyRotationSystemCheck.test.ts
@@ -198,11 +198,9 @@ describe('KeyRotationSystemCheck', () => {
         { id: 'rsa3', created: 0 } as any,
       ])
       const utils = makeUtils()
-      const rotate = jest.fn()
-      const check = new KeyRotationSystemCheck(false, undefined, rotate, utils)
+      const check = new KeyRotationSystemCheck(false, undefined, jest.fn(), utils)
 
       expect(await check.runCheck()).toBe(true)
-      expect(rotate).not.toHaveBeenCalled()
       expect(utils.logger.warn).toHaveBeenCalledWith(expect.stringContaining("ignoring key 'rsa3'"))
     })
 

--- a/app/src/services/system-checks/KeyRotationSystemCheck.ts
+++ b/app/src/services/system-checks/KeyRotationSystemCheck.ts
@@ -72,8 +72,8 @@ export class KeyRotationSystemCheck implements SystemCheckStrategy {
       }
     }
 
-    // Never rotate on "can't tell": enumeration failure, an empty keystore, and a missing
-    // `created` all skip rather than risk rotating (or not) based on a guess.
+    // Never rotate on "can't tell": enumeration failure and an empty keystore skip. A key with
+    // no usable `created` is ignored below rather than blocking the check on its own.
     let keys
     try {
       keys = await getAllKeys()
@@ -96,19 +96,20 @@ export class KeyRotationSystemCheck implements SystemCheckStrategy {
     }))
     const isUsable = (normalizedKey: { createdAtMs: number | null }): normalizedKey is NormalizedKey =>
       normalizedKey.createdAtMs !== null && normalizedKey.createdAtMs > 0
-    // Any unusable timestamp means "newest" can't be determined — never rotate on a guess.
-    // Non-positive catches Android's createdAt: 0, which would read as a 1970 key and force rotation.
-    const unusable = normalized.find((normalizedKey) => !isUsable(normalizedKey))
-    if (unusable) {
-      this.utils.logger.warn(
-        `KeyRotationSystemCheck: skipping — key '${unusable.key.id}' has no usable created timestamp`
-      )
+    // Log and ignore keys with no usable timestamp rather than skipping the whole check: signing
+    // always uses the metadata-newest key, so an untracked key (Android reports createdAt: 0 for
+    // one, which would otherwise read as a 1970 key and force rotation) is never the active key
+    // whose age this check is about.
+    for (const unusable of normalized.filter((normalizedKey) => !isUsable(normalizedKey))) {
+      this.utils.logger.warn(`KeyRotationSystemCheck: ignoring key '${unusable.key.id}' — no usable created timestamp`)
+    }
+    const usable = normalized.filter(isUsable)
+    if (usable.length === 0) {
+      this.utils.logger.warn('KeyRotationSystemCheck: skipping — no local key has a usable created timestamp')
       return true
     }
 
-    // unusable is undefined here, so every element passed isUsable and usable has >= 1 entry —
-    // destructuring the head makes that non-emptiness structural instead of assumed by reduce().
-    const [head, ...tail] = normalized.filter(isUsable)
+    const [head, ...tail] = usable
     const newest = tail.reduce((a, b) => (b.createdAtMs > a.createdAtMs ? b : a), head)
     const ageDays = keyAgeDays(newest.createdAtMs)
     if (ageDays < KEY_ROTATION_MAX_AGE_DAYS) {

--- a/app/src/services/system-checks/KeyRotationSystemCheck.ts
+++ b/app/src/services/system-checks/KeyRotationSystemCheck.ts
@@ -72,8 +72,8 @@ export class KeyRotationSystemCheck implements SystemCheckStrategy {
       }
     }
 
-    // Never rotate on "can't tell": enumeration failure and an empty keystore skip. A key with
-    // no usable `created` is ignored below rather than blocking the check on its own.
+    // Never rotate when we can't tell: skip if the keys can't be listed, or there are none. A key
+    // with no usable creation date is ignored below instead of stopping the check.
     let keys
     try {
       keys = await getAllKeys()
@@ -96,10 +96,9 @@ export class KeyRotationSystemCheck implements SystemCheckStrategy {
     }))
     const isUsable = (normalizedKey: { createdAtMs: number | null }): normalizedKey is NormalizedKey =>
       normalizedKey.createdAtMs !== null && normalizedKey.createdAtMs > 0
-    // Log and ignore keys with no usable timestamp rather than skipping the whole check: signing
-    // always uses the metadata-newest key, so an untracked key (Android reports createdAt: 0 for
-    // one, which would otherwise read as a 1970 key and force rotation) is never the active key
-    // whose age this check is about.
+    // Signing always uses the newest key we have a record of, so a key without a creation date is
+    // never the active one this check is about — ignore those rather than skipping the whole check.
+    // Zero counts as missing, so it isn't read as a 1970 key that would force rotation.
     for (const unusable of normalized.filter((normalizedKey) => !isUsable(normalizedKey))) {
       this.utils.logger.warn(`KeyRotationSystemCheck: ignoring key '${unusable.key.id}' — no usable created timestamp`)
     }

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -140,7 +140,7 @@ private enum class AccountFileName(
 @ReactModule(name = BcscCoreModule.NAME)
 class BcscCoreModule internal constructor(
     reactContext: ReactApplicationContext,
-    // Test seam: lets unit tests inject a keystore-free BcscKeyPairSource.
+    // Lets tests supply their own key source, so the decrypt path can run without a device keystore.
     private val keyPairSourceOverride: BcscKeyPairSource? = null,
 ) : BcscCoreSpec(reactContext) {
     companion object {
@@ -1833,8 +1833,8 @@ class BcscCoreModule internal constructor(
         // makes 2507 reports self-classifying in the field.
         val diagnostics = decodeDiagnosticsSummary(jweString)
         try {
-            // The server keeps encrypting to the previous key until it has seen the new one, so
-            // the response's own kid wins when we hold that key; otherwise newest, as before.
+            // The server keeps encrypting to the previous key until it has seen the new one, so use
+            // the key the response names when we hold it. Otherwise fall back to newest, as before.
             val kid = incomingJWEHeader(jweString).kid.takeIf { it.isNotEmpty() }
             val decryptKeyPair =
                 kid?.let { keyPairSource.getBcscKeyPair(it) }

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/BcscCoreModule.kt
@@ -138,8 +138,10 @@ private enum class AccountFileName(
  * for BC Services Card integration in React Native applications.
  */
 @ReactModule(name = BcscCoreModule.NAME)
-class BcscCoreModule(
+class BcscCoreModule internal constructor(
     reactContext: ReactApplicationContext,
+    // Test seam: lets unit tests inject a keystore-free BcscKeyPairSource.
+    private val keyPairSourceOverride: BcscKeyPairSource? = null,
 ) : BcscCoreSpec(reactContext) {
     companion object {
         const val NAME = "BcscCore"
@@ -174,8 +176,7 @@ class BcscCoreModule(
 
     // Initialize the BC Services Card KeyPair functionality
     private val keyPairSource: BcscKeyPairSource by lazy {
-        val keyPairInfoSource = SimpleKeyPairInfoSource(reactApplicationContext)
-        BcscKeyPairRepo(keyPairInfoSource)
+        keyPairSourceOverride ?: BcscKeyPairRepo(SimpleKeyPairInfoSource(reactApplicationContext))
     }
 
     // Initialize native-compatible storage for rollback support
@@ -1766,9 +1767,9 @@ class BcscCoreModule(
     )
 
     /**
-     * Best-effort read of the *incoming* JWE protected header for diagnostics. Reads the
-     * real `kid` straight off the wire so we can tell whether the server encrypted to a key
-     * this device actually holds. Never throws — unreadable fields come back as "?".
+     * Best-effort read of the *incoming* JWE protected header for diagnostics and decrypt-key
+     * selection. Reads the real `kid` straight off the wire so we can tell whether the server
+     * encrypted to a key this device actually holds. Never throws — unreadable fields come back as "?".
      */
     private fun incomingJWEHeader(jweString: String): JweHeaderInfo {
         val parts = jweString.split(".")
@@ -1832,10 +1833,14 @@ class BcscCoreModule(
         // makes 2507 reports self-classifying in the field.
         val diagnostics = decodeDiagnosticsSummary(jweString)
         try {
-            // Get the current (latest) key pair for decryption
-            val currentKeyPair = keyPairSource.getCurrentBcscKeyPair()
+            // The server keeps encrypting to the previous key until it has seen the new one, so
+            // the response's own kid wins when we hold that key; otherwise newest, as before.
+            val kid = incomingJWEHeader(jweString).kid.takeIf { it.isNotEmpty() }
+            val decryptKeyPair =
+                kid?.let { keyPairSource.getBcscKeyPair(it) }
+                    ?: keyPairSource.getCurrentBcscKeyPair()
 
-            if (currentKeyPair.getKeyPair()?.private == null) {
+            if (decryptKeyPair.getKeyPair()?.private == null) {
                 promise.reject("E_NO_KEYS_FOUND", "No private key available for decryption $diagnostics")
                 return
             }
@@ -1844,7 +1849,7 @@ class BcscCoreModule(
             val jweObject = JWEObject.parse(jweString)
 
             // Create RSA decrypter with the private key
-            val rsaDecrypter = RSADecrypter(currentKeyPair.getKeyPair()!!.private)
+            val rsaDecrypter = RSADecrypter(decryptKeyPair.getKeyPair()!!.private)
 
             // Decrypt the JWE to get the inner JWT (compact JWS)
             jweObject.decrypt(rsaDecrypter)

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
@@ -165,8 +165,8 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
 
       KeyPairInfo info = keyPairInfoSource.getKeyPairInfo(kid);
       if (info == null) {
-        // Untracked alias: createdAt 0, same as getAllBcscKeyPairInfos(). Never persisted here —
-        // a bare read must not promote an orphan to "newest" and derail signing/rotation (#4595).
+        // A key the keystore holds but our records don't: report no creation date, and don't save
+        // one. Recording a date here would make a stray key look newest and take over signing (#4595).
         info = new KeyPairInfo(kid, 0L);
       }
 

--- a/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
+++ b/packages/bcsc-core/android/src/main/java/com/bcsccore/bcsc-keypair-port/repos/key/BcscKeyPairRepo.java
@@ -165,8 +165,9 @@ public class BcscKeyPairRepo implements BcscKeyPairSource {
 
       KeyPairInfo info = keyPairInfoSource.getKeyPairInfo(kid);
       if (info == null) {
-        info = new KeyPairInfo(kid, System.currentTimeMillis());
-        keyPairInfoSource.saveKeyPairInfo(info);
+        // Untracked alias: createdAt 0, same as getAllBcscKeyPairInfos(). Never persisted here —
+        // a bare read must not promote an orphan to "newest" and derail signing/rotation (#4595).
+        info = new KeyPairInfo(kid, 0L);
       }
 
       final KeyPair keyPair = getKeyPair(keyStore, kid);

--- a/packages/bcsc-core/android/src/test/java/com/bcsccore/BcscCoreModuleDecodePayloadTest.kt
+++ b/packages/bcsc-core/android/src/test/java/com/bcsccore/BcscCoreModuleDecodePayloadTest.kt
@@ -56,7 +56,9 @@ class BcscCoreModuleDecodePayloadTest {
         private val KEYS: Map<String, KeyPair> = listOf("rsa1", "rsa2", "rsa3").associateWith { rsa() }
     }
 
-    private class InMemoryKeyPairInfoSource(initial: Map<String, KeyPairInfo>) : KeyPairInfoSource {
+    private class InMemoryKeyPairInfoSource(
+        initial: Map<String, KeyPairInfo>,
+    ) : KeyPairInfoSource {
         val store = HashMap<String, KeyPairInfo>(initial)
 
         override fun getKeyPairInfo(kid: String): KeyPairInfo? = store[kid]
@@ -73,7 +75,9 @@ class BcscCoreModuleDecodePayloadTest {
     }
 
     /** Real repo over a fake keystore whose aliases are exactly [KEYS]. */
-    private class InMemoryKeyStoreRepo(infoSource: KeyPairInfoSource) : BcscKeyPairRepo(infoSource) {
+    private class InMemoryKeyStoreRepo(
+        infoSource: KeyPairInfoSource,
+    ) : BcscKeyPairRepo(infoSource) {
         private val keyStore: KeyStore =
             mockk<KeyStore>(relaxed = true).also {
                 every { it.aliases() } answers { Collections.enumeration(KEYS.keys.toList()) }
@@ -119,7 +123,8 @@ class BcscCoreModuleDecodePayloadTest {
         encryptTo: KeyPair,
         kid: String?,
     ): String {
-        val inner = SignedJWT(JWSHeader.Builder(JWSAlgorithm.RS512).build(), JWTClaimsSet.Builder().subject("user-123").build())
+        val inner =
+            SignedJWT(JWSHeader.Builder(JWSAlgorithm.RS512).build(), JWTClaimsSet.Builder().subject("user-123").build())
         inner.sign(RSASSASigner(encryptTo.private))
         val header = JWEHeader.Builder(JWEAlgorithm.RSA1_5, EncryptionMethod.A256CBC_HS512)
         if (kid != null) header.keyID(kid)

--- a/packages/bcsc-core/android/src/test/java/com/bcsccore/BcscCoreModuleDecodePayloadTest.kt
+++ b/packages/bcsc-core/android/src/test/java/com/bcsccore/BcscCoreModuleDecodePayloadTest.kt
@@ -1,0 +1,171 @@
+package com.bcsccore
+
+import com.bcsccore.keypair.core.interfaces.KeyPairInfoSource
+import com.bcsccore.keypair.core.models.KeyPairInfo
+import com.bcsccore.keypair.repos.key.BcscKeyPairRepo
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.JavaOnlyMap
+import com.facebook.react.bridge.Promise
+import com.nimbusds.jose.EncryptionMethod
+import com.nimbusds.jose.JWEAlgorithm
+import com.nimbusds.jose.JWEHeader
+import com.nimbusds.jose.JWEObject
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.Payload
+import com.nimbusds.jose.crypto.RSAEncrypter
+import com.nimbusds.jose.crypto.RSASSASigner
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.interfaces.RSAPublicKey
+import java.util.Collections
+
+/**
+ * Covers the decrypt-key selection rule behind issue #4595: a response's own JWE `kid` wins
+ * over "newest" when we hold that key, falling back to newest exactly as before otherwise.
+ * Drives the real [BcscCoreModule.decodePayload] through the constructor test seam with a real
+ * [BcscKeyPairRepo] over a mocked [KeyStore], so the metadata-write contract (case 4) is
+ * exercised against the real repo code, not a fake.
+ */
+@RunWith(RobolectricTestRunner::class)
+class BcscCoreModuleDecodePayloadTest {
+    companion object {
+        private fun rsa(): KeyPair = KeyPairGenerator.getInstance("RSA").also { it.initialize(2048) }.generateKeyPair()
+
+        // One DISTINCT key per alias so the tests can tell which key decrypted: rsa1 = previous
+        // key, rsa2 = tracked newest, rsa3 = held in the keystore but untracked in metadata.
+        // Sharing one JVM key across aliases would let a wrong-key fallback still decrypt.
+        private val KEYS: Map<String, KeyPair> = listOf("rsa1", "rsa2", "rsa3").associateWith { rsa() }
+    }
+
+    private class InMemoryKeyPairInfoSource(initial: Map<String, KeyPairInfo>) : KeyPairInfoSource {
+        val store = HashMap<String, KeyPairInfo>(initial)
+
+        override fun getKeyPairInfo(kid: String): KeyPairInfo? = store[kid]
+
+        override fun getKeyPairInfo(): HashMap<String, KeyPairInfo> = HashMap(store)
+
+        override fun saveKeyPairInfo(info: KeyPairInfo) {
+            store[info.alias] = info
+        }
+
+        override fun deleteKeyPairInfo(alias: String) {
+            store.remove(alias)
+        }
+    }
+
+    /** Real repo over a fake keystore whose aliases are exactly [KEYS]. */
+    private class InMemoryKeyStoreRepo(infoSource: KeyPairInfoSource) : BcscKeyPairRepo(infoSource) {
+        private val keyStore: KeyStore =
+            mockk<KeyStore>(relaxed = true).also {
+                every { it.aliases() } answers { Collections.enumeration(KEYS.keys.toList()) }
+                every { it.containsAlias(any()) } answers { firstArg<String>() in KEYS }
+            }
+
+        override fun loadAndroidKeyStore(): KeyStore = keyStore
+
+        // AssertionError is an Error, not an Exception, so it escapes every catch in
+        // getCurrentBcscKeyPair/decodePayload and fails the test loudly. Do NOT throw
+        // KeypairGenerationException here — that would be swallowed into a confusing reject.
+        override fun generateKeyPair(alias: String) = fail("decodePayload must never mint a key (tried '$alias')")
+
+        override fun getKeyPair(
+            keyStore: KeyStore,
+            kid: String,
+        ): KeyPair = KEYS.getValue(kid)
+    }
+
+    private lateinit var infoSource: InMemoryKeyPairInfoSource
+    private lateinit var module: BcscCoreModule
+
+    @Before
+    fun setUp() {
+        mockkStatic(Arguments::class)
+        every { Arguments.createMap() } answers { JavaOnlyMap() }
+        // rsa2 is the tracked newest; rsa3 exists only in the keystore (no metadata row).
+        infoSource =
+            InMemoryKeyPairInfoSource(
+                mapOf(
+                    "rsa1" to KeyPairInfo("rsa1", 1_000L),
+                    "rsa2" to KeyPairInfo("rsa2", 2_000L),
+                ),
+            )
+        module = BcscCoreModule(mockk(relaxed = true), InMemoryKeyStoreRepo(infoSource))
+    }
+
+    @After
+    fun tearDown() = unmockkStatic(Arguments::class)
+
+    /** What the server sends: inner RS512 JWT, outer RSA1_5 JWE (the app's own JWE alg), labelled [kid] when non-null. */
+    private fun serverJwe(
+        encryptTo: KeyPair,
+        kid: String?,
+    ): String {
+        val inner = SignedJWT(JWSHeader.Builder(JWSAlgorithm.RS512).build(), JWTClaimsSet.Builder().subject("user-123").build())
+        inner.sign(RSASSASigner(encryptTo.private))
+        val header = JWEHeader.Builder(JWEAlgorithm.RSA1_5, EncryptionMethod.A256CBC_HS512)
+        if (kid != null) header.keyID(kid)
+        return JWEObject(header.build(), Payload(inner.serialize()))
+            .also { it.encrypt(RSAEncrypter(encryptTo.public as RSAPublicKey)) }
+            .serialize()
+    }
+
+    /** Runs decodePayload (no JWK, so `verified` is false and irrelevant) and returns the resolved map. */
+    private fun decode(jwe: String): JavaOnlyMap {
+        val promise = mockk<Promise>(relaxed = true)
+        val result = slot<JavaOnlyMap>()
+        module.decodePayload(jwe, null, promise)
+        // on failure MockK prints the reject(code, message) call, diagnostics included
+        verify { promise.resolve(capture(result)) }
+        return result.captured
+    }
+
+    @Test
+    fun `a response labelled with the previous key opens while both keys are held`() {
+        val result = decode(serverJwe(KEYS.getValue("rsa1"), kid = "rsa1"))
+
+        assertTrue(result.getString("claims")!!.contains("user-123"))
+    }
+
+    @Test
+    fun `a response with no label opens with the newest key`() {
+        val result = decode(serverJwe(KEYS.getValue("rsa2"), kid = null))
+
+        assertTrue(result.getString("claims")!!.contains("user-123"))
+    }
+
+    @Test
+    fun `a label naming a key this device does not hold falls back to the newest key`() {
+        val result = decode(serverJwe(KEYS.getValue("rsa2"), kid = "rsa9"))
+
+        assertTrue(result.getString("claims")!!.contains("user-123"))
+    }
+
+    @Test
+    fun `a label hit on an untracked keystore alias opens the response without writing key metadata`() {
+        val result = decode(serverJwe(KEYS.getValue("rsa3"), kid = "rsa3"))
+
+        assertTrue(result.getString("claims")!!.contains("user-123"))
+        assertFalse(infoSource.store.containsKey("rsa3"))
+        assertEquals(setOf("rsa1", "rsa2"), infoSource.store.keys)
+        assertEquals(2_000L, infoSource.store["rsa2"]!!.createdAt)
+    }
+}

--- a/packages/bcsc-core/android/src/test/java/com/bcsccore/BcscCoreModuleDecodePayloadTest.kt
+++ b/packages/bcsc-core/android/src/test/java/com/bcsccore/BcscCoreModuleDecodePayloadTest.kt
@@ -39,20 +39,18 @@ import java.security.interfaces.RSAPublicKey
 import java.util.Collections
 
 /**
- * Covers the decrypt-key selection rule behind issue #4595: a response's own JWE `kid` wins
- * over "newest" when we hold that key, falling back to newest exactly as before otherwise.
- * Drives the real [BcscCoreModule.decodePayload] through the constructor test seam with a real
- * [BcscKeyPairRepo] over a mocked [KeyStore], so the metadata-write contract (case 4) is
- * exercised against the real repo code, not a fake.
+ * Covers how the decrypt key is chosen (issue #4595): use the key a response names when we hold it,
+ * and the newest key otherwise. Runs the real [BcscCoreModule.decodePayload] against a real
+ * [BcscKeyPairRepo] over a stand-in [KeyStore], so the last test checks real code, not a substitute.
  */
 @RunWith(RobolectricTestRunner::class)
 class BcscCoreModuleDecodePayloadTest {
     companion object {
         private fun rsa(): KeyPair = KeyPairGenerator.getInstance("RSA").also { it.initialize(2048) }.generateKeyPair()
 
-        // One DISTINCT key per alias so the tests can tell which key decrypted: rsa1 = previous
-        // key, rsa2 = tracked newest, rsa3 = held in the keystore but untracked in metadata.
-        // Sharing one JVM key across aliases would let a wrong-key fallback still decrypt.
+        // A different key per alias so a test can tell which one decrypted: rsa1 is the previous
+        // key, rsa2 the newest, rsa3 one the keystore holds but our records don't. Reusing a single
+        // key across aliases would let the wrong choice still decrypt and hide a failure.
         private val KEYS: Map<String, KeyPair> = listOf("rsa1", "rsa2", "rsa3").associateWith { rsa() }
     }
 
@@ -74,7 +72,7 @@ class BcscCoreModuleDecodePayloadTest {
         }
     }
 
-    /** Real repo over a fake keystore whose aliases are exactly [KEYS]. */
+    /** The real repository, over a stand-in keystore holding exactly the [KEYS] aliases. */
     private class InMemoryKeyStoreRepo(
         infoSource: KeyPairInfoSource,
     ) : BcscKeyPairRepo(infoSource) {
@@ -86,9 +84,9 @@ class BcscCoreModuleDecodePayloadTest {
 
         override fun loadAndroidKeyStore(): KeyStore = keyStore
 
-        // AssertionError is an Error, not an Exception, so it escapes every catch in
-        // getCurrentBcscKeyPair/decodePayload and fails the test loudly. Do NOT throw
-        // KeypairGenerationException here — that would be swallowed into a confusing reject.
+        // fail() throws an Error, which escapes the catch blocks in getCurrentBcscKeyPair and
+        // decodePayload, so the test fails clearly. Don't throw KeypairGenerationException here —
+        // it would be caught and reported as a confusing decrypt failure instead.
         override fun generateKeyPair(alias: String) = fail("decodePayload must never mint a key (tried '$alias')")
 
         override fun getKeyPair(
@@ -104,7 +102,7 @@ class BcscCoreModuleDecodePayloadTest {
     fun setUp() {
         mockkStatic(Arguments::class)
         every { Arguments.createMap() } answers { JavaOnlyMap() }
-        // rsa2 is the tracked newest; rsa3 exists only in the keystore (no metadata row).
+        // rsa2 is the newest key on record; rsa3 is in the keystore but has no record.
         infoSource =
             InMemoryKeyPairInfoSource(
                 mapOf(
@@ -118,7 +116,7 @@ class BcscCoreModuleDecodePayloadTest {
     @After
     fun tearDown() = unmockkStatic(Arguments::class)
 
-    /** What the server sends: inner RS512 JWT, outer RSA1_5 JWE (the app's own JWE alg), labelled [kid] when non-null. */
+    /** Builds what the server sends: a signed token wrapped in an encrypted one, labelled [kid]. */
     private fun serverJwe(
         encryptTo: KeyPair,
         kid: String?,

--- a/packages/bcsc-core/ios/BcscCore.swift
+++ b/packages/bcsc-core/ios/BcscCore.swift
@@ -208,9 +208,9 @@ class BcscCore: NSObject {
     return Data(base64Encoded: base64)
   }
 
-  /// Best-effort read of the *incoming* JWE protected header for diagnostics. Reads the
-  /// real `kid` straight off the wire — NOT `JWEHeader.kid`, which the parser overwrites
-  /// with the server's own public-key id. Unreadable fields come back as "?".
+  /// Best-effort read of the *incoming* JWE protected header for diagnostics and decrypt-key
+  /// selection. Reads the real `kid` straight off the wire — NOT `JWEHeader.kid`, which the
+  /// parser overwrites with the server's own public-key id. Unreadable fields come back as "?".
   private func incomingJWEHeader(_ jweString: String) -> (alg: String, enc: String, kid: String, parts: Int) {
     let parts = jweString.components(separatedBy: ".")
     guard parts.count == 5, let headerSegment = parts.first,
@@ -1517,7 +1517,8 @@ class BcscCore: NSObject {
     // key. This is what makes 2507 reports self-classifying in the field.
     let diagnostics = decodeDiagnosticsSummary(keys: keys, jweString: jweString)
 
-    guard let latestKeyInfo = keys.sorted(by: { $0.created > $1.created }).first else {
+    guard let decryptKeyInfo = KeyPairManager.decryptKeyInfo(matching: incomingJWEHeader(jweString).kid, in: keys)
+    else {
       reject(
         "E_NO_KEYS_FOUND",
         "No keys available to decrypt JWE \(diagnostics)",
@@ -1528,7 +1529,7 @@ class BcscCore: NSObject {
 
     let keyPair: (public: SecKey, private: SecKey)
     do {
-      keyPair = try keyPairManager.getKeyPair(with: latestKeyInfo.tag)
+      keyPair = try keyPairManager.getKeyPair(with: decryptKeyInfo.tag)
     } catch let KeychainError.keychainUnavailable(status) {
       // The key likely exists but can't be read right now (device locked, auth
       // failure, or launched in the background before first unlock). Distinct,

--- a/packages/bcsc-core/ios/BcscCoreTests/KeyPairManagerTests.swift
+++ b/packages/bcsc-core/ios/BcscCoreTests/KeyPairManagerTests.swift
@@ -80,7 +80,12 @@ final class KeyPairManagerEnumerationClassifierTests: XCTestCase {
 /// only, no keychain — so these run in the entitlement-less SPM runner.
 final class KeyPairManagerDecryptKeySelectionTests: XCTestCase {
   private func key(_ tag: String, createdSecondsAgo: TimeInterval) -> PrivateKeyInfo {
-    PrivateKeyInfo(keyType: KeyType.RSA, keySize: 2048, tag: tag, created: Date(timeIntervalSinceNow: -createdSecondsAgo))
+    PrivateKeyInfo(
+      keyType: KeyType.RSA,
+      keySize: 2048,
+      tag: tag,
+      created: Date(timeIntervalSinceNow: -createdSecondsAgo)
+    )
   }
 
   func testKidNamingThePreviousKeySelectsItOverNewest() {

--- a/packages/bcsc-core/ios/BcscCoreTests/KeyPairManagerTests.swift
+++ b/packages/bcsc-core/ios/BcscCoreTests/KeyPairManagerTests.swift
@@ -76,6 +76,39 @@ final class KeyPairManagerEnumerationClassifierTests: XCTestCase {
   }
 }
 
+/// Pins the decrypt-key selection rule behind issue #4595. Pure and synchronous — fixtures
+/// only, no keychain — so these run in the entitlement-less SPM runner.
+final class KeyPairManagerDecryptKeySelectionTests: XCTestCase {
+  private func key(_ tag: String, createdSecondsAgo: TimeInterval) -> PrivateKeyInfo {
+    PrivateKeyInfo(keyType: KeyType.RSA, keySize: 2048, tag: tag, created: Date(timeIntervalSinceNow: -createdSecondsAgo))
+  }
+
+  func testKidNamingThePreviousKeySelectsItOverNewest() {
+    let previous = key("rsa1", createdSecondsAgo: 100)
+    let newest = key("rsa2", createdSecondsAgo: 0)
+    let result = KeyPairManager.decryptKeyInfo(matching: "rsa1", in: [previous, newest])
+    XCTAssertEqual(result?.tag, "rsa1")
+  }
+
+  func testEmptyKidFallsBackToNewest() {
+    let previous = key("rsa1", createdSecondsAgo: 100)
+    let newest = key("rsa2", createdSecondsAgo: 0)
+    let result = KeyPairManager.decryptKeyInfo(matching: "", in: [previous, newest])
+    XCTAssertEqual(result?.tag, "rsa2")
+  }
+
+  func testKidHeldByNoLocalKeyFallsBackToNewest() {
+    let previous = key("rsa1", createdSecondsAgo: 100)
+    let newest = key("rsa2", createdSecondsAgo: 0)
+    let result = KeyPairManager.decryptKeyInfo(matching: "rsa9", in: [previous, newest])
+    XCTAssertEqual(result?.tag, "rsa2")
+  }
+
+  func testEmptyKeysReturnsNil() {
+    XCTAssertNil(KeyPairManager.decryptKeyInfo(matching: "rsa1", in: []))
+  }
+}
+
 /// Exercises the real simulator keychain. Covers the key lifecycle relied on by
 /// dynamic client registration (issue #4032 / error 2603): generation, discovery
 /// via `findAllPrivateKeys`, and retrieval via `getKeyPair`.

--- a/packages/bcsc-core/ios/BcscCoreTests/KeyPairManagerTests.swift
+++ b/packages/bcsc-core/ios/BcscCoreTests/KeyPairManagerTests.swift
@@ -76,8 +76,8 @@ final class KeyPairManagerEnumerationClassifierTests: XCTestCase {
   }
 }
 
-/// Pins the decrypt-key selection rule behind issue #4595. Pure and synchronous — fixtures
-/// only, no keychain — so these run in the entitlement-less SPM runner.
+/// Covers how the decrypt key is chosen (issue #4595). These use plain test data rather than the
+/// keychain, so they run everywhere, including CI, where the keychain is not available.
 final class KeyPairManagerDecryptKeySelectionTests: XCTestCase {
   private func key(_ tag: String, createdSecondsAgo: TimeInterval) -> PrivateKeyInfo {
     PrivateKeyInfo(

--- a/packages/bcsc-core/ios/KeyPairManager.swift
+++ b/packages/bcsc-core/ios/KeyPairManager.swift
@@ -244,6 +244,15 @@ class KeyPairManager: KeyPairManagerProtocol {
     }
   }
 
+  /// During rotation the server keeps encrypting to the previous key until it sees the new
+  /// one, so the JWE's own `kid` beats "newest" when we hold that key. Nil only for empty `keys`.
+  static func decryptKeyInfo(matching kid: String, in keys: [PrivateKeyInfo]) -> PrivateKeyInfo? {
+    if !kid.isEmpty, let match = keys.first(where: { $0.tag == kid }) {
+      return match
+    }
+    return keys.sorted(by: { $0.created > $1.created }).first
+  }
+
   func generateKeyPair(
     withLabel label: String,
     keyType: KeyType = KeyType.RSA,

--- a/packages/bcsc-core/ios/KeyPairManager.swift
+++ b/packages/bcsc-core/ios/KeyPairManager.swift
@@ -244,8 +244,8 @@ class KeyPairManager: KeyPairManagerProtocol {
     }
   }
 
-  /// During rotation the server keeps encrypting to the previous key until it sees the new
-  /// one, so the JWE's own `kid` beats "newest" when we hold that key. Nil only for empty `keys`.
+  /// The server keeps encrypting to the previous key until it has seen the new one, so use the key
+  /// the response names when we hold it, and the newest key otherwise. Nil only when there are none.
   static func decryptKeyInfo(matching kid: String, in keys: [PrivateKeyInfo]) -> PrivateKeyInfo? {
     if !kid.isEmpty, let match = keys.first(where: { $0.tag == kid }) {
       return match


### PR DESCRIPTION
Closes #4595 

## What changed

Encrypted responses name the key they were locked with. The app ignored that and always used its newest key, so during yearly key rotation it could not open its own response — the user saw an error and an empty Home screen. It now uses the key the response names, falling back to the newest one, which is what v3 did.

Supporting change on Android: reading a key by name no longer records it as the newest key, so a stray key cannot take over signing.

## What should the reviewer focus on

The four Android tests drive the real decrypt path, and two of them fail without the fix — reverting either production change on its own confirms that. The iOS tests cover the key choice only, so the decrypt path there was verified by hand on a device.

## How to test

Rotation is not wired up yet — that is #4549 — so nothing on this branch alone can trigger it. What you can check here:

1. Unit tests, both platforms: `cd packages/bcsc-core && yarn test:android && yarn test:ios`.
2. Run app normally, do a fresh install. Restart, all works as expected (like it does now).