### PR TITLE
chore: connect analytics spies and cover the onFail path in system checks

### DIFF
--- a/app/src/contexts/ErrorAlertContext.test.tsx
+++ b/app/src/contexts/ErrorAlertContext.test.tsx
@@ -32,11 +32,6 @@ jest.mock('react-native', () => ({
   },
 }))
 
-jest.mock('../errors/errorHandler', () => {
-  const actual = jest.requireActual('../errors/errorHandler')
-  return { ...actual }
-})
-
 jest.mock('@bifold/core', () => ({
   testIdWithKey: (key: string) => `com.aries.bifold:id/${key}`,
   useStore: jest.fn().mockReturnValue([
@@ -112,22 +107,11 @@ jest.mock('react-native-device-info', () => ({
 jest.mock('react-native-vector-icons/MaterialIcons', () => 'Icon')
 
 describe('ErrorAlertContext', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
-
   const wrapper = ({ children }: { children: React.ReactNode }) => <ErrorAlertProvider>{children}</ErrorAlertProvider>
 
   describe('useErrorAlert hook', () => {
     it('should throw error when used outside ErrorAlertProvider', () => {
       expect(() => renderHook(() => useErrorAlert())).toThrow('useErrorAlert must be used within an ErrorAlertProvider')
-    })
-
-    it('should return context with emitErrorModal, and emitAlert', () => {
-      const { result } = renderHook(() => useErrorAlert(), { wrapper })
-
-      expect(result.current).toHaveProperty('emitErrorModal')
-      expect(result.current).toHaveProperty('emitAlert')
     })
   })
 
@@ -246,12 +230,14 @@ describe('ErrorAlertContext', () => {
         result.current.emitErrorModal('Title 1', 'Desc 1', appError)
       })
 
+      expect(mockBCSCErrorModal).toHaveBeenLastCalledWith(expect.objectContaining({ errorKey: 1 }))
+
       act(() => {
         result.current.emitErrorModal('Title 2', 'Desc 2', appError)
       })
 
-      // Two calls should have triggered two trackAlertDisplayEvent calls
-      expect(Analytics.trackAlertDisplayEvent).toHaveBeenCalledTimes(2)
+      // A repeated error must bump the key, otherwise the modal never re-opens.
+      expect(mockBCSCErrorModal).toHaveBeenLastCalledWith(expect.objectContaining({ errorKey: 2 }))
     })
   })
 

--- a/app/src/errors/appError.test.ts
+++ b/app/src/errors/appError.test.ts
@@ -8,154 +8,112 @@ jest.mock('@/contexts/NavigationContainerContext', () => ({
   navigationRef: { isReady: () => false, getCurrentRoute: () => undefined },
 }))
 
-describe('AppError', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
+const GENERAL_IDENTITY = {
+  category: ErrorCategory.GENERAL,
+  appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
+  statusCode: 1234,
+}
 
+const BAD_REQUEST_IDENTITY = {
+  category: ErrorCategory.NETWORK,
+  appEvent: AppEventCode.ERR_209_BAD_REQUEST,
+  statusCode: 2107,
+}
+
+describe('AppError', () => {
   describe('constructor', () => {
     it('should create an AppError with correct properties', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
       const message = 'Detailed technical message'
-      const error = new AppError(message, identity, { cause: new Error(message) })
+      const error = new AppError(message, GENERAL_IDENTITY, { cause: new Error(message) })
 
       expect(error.message).toBe(message)
       expect(error.code).toBe('general.unknown_server_error.1234')
       expect(error.appEvent).toBe('unknown_server_error')
       expect(error.technicalMessage).toBe(message)
       expect(error.cause).toBeInstanceOf(Error)
-      expect(error.timestamp).toBeDefined()
+      expect(error.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
       expect(error.handled).toBe(false)
     })
   })
 
   describe('technicalMessage', () => {
     it('should return null if there is no cause', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Something went wrong', identity)
+      const error = new AppError('Something went wrong', GENERAL_IDENTITY)
 
       expect(error.technicalMessage).toBeNull()
     })
 
     it('should return null if cause is not an Error', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Something went wrong', identity, { cause: 'Not an error' as any })
+      const error = new AppError('Something went wrong', GENERAL_IDENTITY, { cause: 'Not an error' as any })
 
       expect(error.technicalMessage).toBeNull()
     })
 
     it('should prefix the native error code when present on the cause', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
       const cause = Object.assign(new Error("Key pair with alias 'abc' not found."), { code: 'E_KEY_NOT_FOUND' })
-      const error = new AppError('Something went wrong', identity, { cause })
+      const error = new AppError('Something went wrong', GENERAL_IDENTITY, { cause })
 
       expect(error.technicalMessage).toBe("E_KEY_NOT_FOUND: Key pair with alias 'abc' not found.")
     })
 
     it('should append the server response body for AxiosErrors when it is a short string', () => {
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { data: 'email_address is invalid' },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       expect(error.technicalMessage).toBe('Request failed with status code 400: email_address is invalid')
     })
 
     it('should not append the response body for objects without a string message', () => {
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { data: { error: 'bad_request' } },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       expect(error.technicalMessage).toBe('Request failed with status code 400')
     })
 
     it('should not append the response body when the JSON message field is not a string', () => {
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { data: { message: 42 } },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       expect(error.technicalMessage).toBe('Request failed with status code 400')
     })
 
     it('should append the JSON message field for AxiosErrors when the response body is an object (e.g. IAS 4xx evidence rejections)', () => {
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { data: { message: 'unexpected images count' } },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       expect(error.technicalMessage).toBe('Request failed with status code 400: unexpected images count')
     })
 
     it('should truncate a JSON message field longer than 500 chars', () => {
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const longMessage = 'x'.repeat(600)
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { data: { message: longMessage } },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       expect(error.technicalMessage).toBe(`Request failed with status code 400: ${'x'.repeat(500)}`)
     })
 
     it('should truncate a string response body longer than 500 chars', () => {
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const longBody = 'y'.repeat(600)
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { data: longBody },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       expect(error.technicalMessage).toBe(`Request failed with status code 400: ${'y'.repeat(500)}`)
     })
@@ -187,24 +145,14 @@ describe('AppError', () => {
 
   describe('fullMessage', () => {
     it('should return message without technicalMessage', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Something went wrong', identity)
+      const error = new AppError('Something went wrong', GENERAL_IDENTITY)
 
       expect(error.fullMessage).toBe('Something went wrong\nDebug: [general.unknown_server_error.1234]')
     })
 
     it('should return message with technicalMessage if cause is present', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
       const technicalMessage = 'Technical details about the error'
-      const error = new AppError('Something went wrong', identity, { cause: new Error(technicalMessage) })
+      const error = new AppError('Something went wrong', GENERAL_IDENTITY, { cause: new Error(technicalMessage) })
 
       expect(error.fullMessage).toBe(
         'Something went wrong\nDebug: [general.unknown_server_error.1234] Technical details about the error'
@@ -217,16 +165,11 @@ describe('AppError', () => {
       // fullMessage is what ErrorAlertContext.emitErrorModal forwards as `message` to
       // ErrorModal.handleReport -> logger.reportProblem, which is what reaches Loki when the
       // user taps "Report a problem". The server's real reason must survive that whole path.
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { data: { message: 'unexpected images count' } },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       expect(error.fullMessage).toBe(
         'Bad request\nDebug: [network.err_209_bad_request.2107] Request failed with status code 400: unexpected images count'
@@ -282,12 +225,7 @@ describe('AppError', () => {
       // Screen/Request are intentionally kept out of fullMessage (the "Show details" string)
       // so infra context never alarms the user. They ride along in toJSON() (screen + context)
       // when the full error is handed to reportProblem.
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Something went wrong', identity)
+      const error = new AppError('Something went wrong', GENERAL_IDENTITY)
       error.addContext({ url: 'https://example.com/device/token', method: 'POST' })
 
       expect(error.fullMessage).toBe('Something went wrong\nDebug: [general.unknown_server_error.1234]')
@@ -300,12 +238,7 @@ describe('AppError', () => {
     it('should track error event in analytics', () => {
       const trackErrorEventSpy = jest.spyOn(Analytics, 'trackErrorEvent')
 
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Something went wrong', identity)
+      const error = new AppError('Something went wrong', GENERAL_IDENTITY)
 
       error.track()
 
@@ -387,16 +320,17 @@ describe('AppError', () => {
   })
 
   describe('toJSON', () => {
-    it('should serialize AppError to JSON', () => {
+    beforeEach(() => {
       jest.useFakeTimers().setSystemTime(new Date('2024-01-01T00:00:00Z'))
+    })
 
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('should serialize AppError to JSON', () => {
       const cause = new Error('Technical message')
-      const error = new AppError('Something went wrong', identity, { cause })
+      const error = new AppError('Something went wrong', GENERAL_IDENTITY, { cause })
       const json = error.toJSON()
 
       expect(json).toEqual({
@@ -411,8 +345,6 @@ describe('AppError', () => {
         handled: false,
         context: {},
       })
-
-      jest.useRealTimers()
     })
 
     it('summarizes the cause so a large request body is never serialized', () => {
@@ -436,17 +368,12 @@ describe('AppError', () => {
     })
 
     it('includes the server response body in the summarized cause for AxiosErrors', () => {
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         code: 'ERR_BAD_REQUEST',
         response: { status: 400, data: 'email_address is invalid' },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       const json = error.toJSON()
 
@@ -462,16 +389,11 @@ describe('AppError', () => {
       // toJSON().technicalMessage is what client.ts and ErrorAlertContext auto-log to Loki for
       // every AppError (not just user-initiated "Report a problem"), so the lifted JSON `message`
       // must survive serialization too.
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { status: 400, data: { message: 'unexpected images count' } },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       const json = error.toJSON()
 
@@ -504,24 +426,14 @@ describe('AppError', () => {
 
   describe('isHandledAppError', () => {
     it('should return true for handled AppError', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Error', identity)
+      const error = new AppError('Error', GENERAL_IDENTITY)
       error.handled = true
 
       expect(isHandledAppError(error)).toBe(true)
     })
 
     it('should return false for unhandled AppError', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Error', identity)
+      const error = new AppError('Error', GENERAL_IDENTITY)
 
       expect(isHandledAppError(error)).toBe(false)
     })
@@ -535,34 +447,19 @@ describe('AppError', () => {
 
   describe('isAppError', () => {
     it('should return true for AppError', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Error', identity)
+      const error = new AppError('Error', GENERAL_IDENTITY)
 
       expect(isAppError(error)).toBe(true)
     })
 
     it('should return true for AppError with matching appEvent code', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Error', identity)
+      const error = new AppError('Error', GENERAL_IDENTITY)
 
       expect(isAppError(error, AppEventCode.UNKNOWN_SERVER_ERROR)).toBe(true)
     })
 
     it('should return false for AppError with non-matching appEvent code', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Error', identity)
+      const error = new AppError('Error', GENERAL_IDENTITY)
 
       expect(isAppError(error, AppEventCode.ADD_CARD_CAMERA_BROKEN)).toBe(false)
     })
@@ -570,25 +467,13 @@ describe('AppError', () => {
 
   describe('isAxiosAppError', () => {
     it('should return true for AppError with AxiosError cause', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-
-      const axiosAppError = new AppError('Error', identity, { cause: new AxiosError() })
+      const axiosAppError = new AppError('Error', GENERAL_IDENTITY, { cause: new AxiosError() })
 
       expect(isAxiosAppError(axiosAppError)).toBe(true)
     })
 
     it('should return false for AppError without AxiosError cause', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-
-      const appError = new AppError('Error', identity)
+      const appError = new AppError('Error', GENERAL_IDENTITY)
       expect(isAxiosAppError(appError)).toBe(false)
     })
   })

--- a/app/src/errors/errorRegistry.test.ts
+++ b/app/src/errors/errorRegistry.test.ts
@@ -1,29 +1,31 @@
 import { ErrorCategory, ErrorRegistry, ErrorRegistryKey, ErrorSeverity } from './errorRegistry'
 
 describe('errorRegistry', () => {
+  // These strings are serialized into AppError.code and shipped to analytics/Loki, so the
+  // exact set is a wire contract — asserting the whole set catches additions as well as renames.
   describe('ErrorSeverity', () => {
     it('should have all expected severity levels', () => {
-      expect(ErrorSeverity.INFO).toBe('info')
-      expect(ErrorSeverity.WARNING).toBe('warning')
-      expect(ErrorSeverity.ERROR).toBe('error')
-      expect(ErrorSeverity.CRITICAL).toBe('critical')
+      expect(Object.values(ErrorSeverity).sort()).toEqual(['critical', 'error', 'info', 'warning'])
     })
   })
 
   describe('ErrorCategory', () => {
     it('should have all expected categories', () => {
-      expect(ErrorCategory.CAMERA).toBe('camera')
-      expect(ErrorCategory.NETWORK).toBe('network')
-      expect(ErrorCategory.AUTHENTICATION).toBe('auth')
-      expect(ErrorCategory.CREDENTIAL).toBe('credential')
-      expect(ErrorCategory.PROOF).toBe('proof')
-      expect(ErrorCategory.CONNECTION).toBe('connection')
-      expect(ErrorCategory.WALLET).toBe('wallet')
-      expect(ErrorCategory.VERIFICATION).toBe('verification')
-      expect(ErrorCategory.DEVICE).toBe('device')
-      expect(ErrorCategory.STORAGE).toBe('storage')
-      expect(ErrorCategory.TOKEN).toBe('token')
-      expect(ErrorCategory.GENERAL).toBe('general')
+      expect(Object.values(ErrorCategory).sort()).toEqual([
+        'auth',
+        'camera',
+        'connection',
+        'credential',
+        'device',
+        'general',
+        'network',
+        'proof',
+        'storage',
+        'token',
+        'unknown',
+        'verification',
+        'wallet',
+      ])
     })
   })
 
@@ -40,55 +42,38 @@ describe('errorRegistry', () => {
       expect(uniqueAppEvents.size).toBe(appEvents.length)
     })
 
+    // Deliberately untyped strings: a typed `ErrorRegistryKey[]` would only fail the TS build,
+    // whereas plain strings make a rename or removal fail here with the offending key named.
     it('should contain all expected error keys', () => {
-      // Camera errors
-      expect(ErrorRegistry.CAMERA_BROKEN).toBeDefined()
-      expect(ErrorRegistry.INVALID_QR_CODE).toBeDefined()
+      const expectedKeys = [
+        'CAMERA_BROKEN',
+        'INVALID_QR_CODE',
+        'NO_INTERNET',
+        'SERVER_ERROR',
+        'SERVER_TIMEOUT',
+        'LOGIN_PARSE_URI',
+        'LOGIN_REJECTED_401',
+        'CARD_EXPIRED_WILL_REMOVE',
+        'VERIFY_NOT_COMPLETE',
+        'VIDEO_VERIFY_NOT_COMPLETE',
+        'INVALID_TOKEN',
+        'TOKEN_NULL',
+        'STORAGE_WRITE_ERROR',
+        'STORAGE_READ_ERROR',
+        'ANDROID_APP_UPDATE_REQUIRED',
+        'IOS_APP_UPDATE_REQUIRED',
+        'GENERAL_ERROR',
+        'DYNAMIC_REGISTRATION_ERROR',
+        'STATE_LOAD_ERROR',
+        'AGENT_INITIALIZATION_ERROR',
+        'WALLET_SECRET_NOT_FOUND',
+        'PARSE_INVITATION_ERROR',
+        'RECEIVE_INVITATION_ERROR',
+        'ATTESTATION_BAD_INVITATION',
+        'ATTESTATION_CONNECTION_ERROR',
+      ]
 
-      // Network errors
-      expect(ErrorRegistry.NO_INTERNET).toBeDefined()
-      expect(ErrorRegistry.SERVER_ERROR).toBeDefined()
-      expect(ErrorRegistry.SERVER_TIMEOUT).toBeDefined()
-
-      // Auth errors
-      expect(ErrorRegistry.LOGIN_PARSE_URI).toBeDefined()
-      expect(ErrorRegistry.LOGIN_REJECTED_401).toBeDefined()
-
-      // Credential errors
-      expect(ErrorRegistry.CARD_EXPIRED_WILL_REMOVE).toBeDefined()
-
-      // Verification errors
-      expect(ErrorRegistry.VERIFY_NOT_COMPLETE).toBeDefined()
-      expect(ErrorRegistry.VIDEO_VERIFY_NOT_COMPLETE).toBeDefined()
-
-      // Token errors
-      expect(ErrorRegistry.INVALID_TOKEN).toBeDefined()
-      expect(ErrorRegistry.TOKEN_NULL).toBeDefined()
-
-      // Storage errors
-      expect(ErrorRegistry.STORAGE_WRITE_ERROR).toBeDefined()
-      expect(ErrorRegistry.STORAGE_READ_ERROR).toBeDefined()
-
-      // Device errors
-      expect(ErrorRegistry.ANDROID_APP_UPDATE_REQUIRED).toBeDefined()
-      expect(ErrorRegistry.IOS_APP_UPDATE_REQUIRED).toBeDefined()
-
-      // General errors
-      expect(ErrorRegistry.GENERAL_ERROR).toBeDefined()
-      expect(ErrorRegistry.DYNAMIC_REGISTRATION_ERROR).toBeDefined()
-
-      // Wallet errors
-      expect(ErrorRegistry.STATE_LOAD_ERROR).toBeDefined()
-      expect(ErrorRegistry.AGENT_INITIALIZATION_ERROR).toBeDefined()
-      expect(ErrorRegistry.WALLET_SECRET_NOT_FOUND).toBeDefined()
-
-      // Connection errors
-      expect(ErrorRegistry.PARSE_INVITATION_ERROR).toBeDefined()
-      expect(ErrorRegistry.RECEIVE_INVITATION_ERROR).toBeDefined()
-
-      // Attestation errors
-      expect(ErrorRegistry.ATTESTATION_BAD_INVITATION).toBeDefined()
-      expect(ErrorRegistry.ATTESTATION_CONNECTION_ERROR).toBeDefined()
+      expect(Object.keys(ErrorRegistry)).toEqual(expect.arrayContaining(expectedKeys))
     })
 
     it('should have valid error definitions with all required fields', () => {

--- a/app/src/services/system-checks/EventReasonAlertsSystemCheck.test.ts
+++ b/app/src/services/system-checks/EventReasonAlertsSystemCheck.test.ts
@@ -1,4 +1,5 @@
 import { tokenToCredentialMetadata } from '@/bcsc-theme/contexts/BCSCIdTokenContext'
+import { BCSCModals } from '@/bcsc-theme/types/navigators'
 import { BCSCEvent, BCSCReason, IdToken } from '@/bcsc-theme/utils/id-token'
 import { AppEventCode } from '@/events/appEventCode'
 import { EventReasonAlertsSystemCheck } from '@/services/system-checks/EventReasonAlertsSystemCheck'
@@ -176,9 +177,27 @@ describe('EventReasonAlertsSystemCheck', () => {
       const getIdToken = jest.fn().mockResolvedValue(mockIdToken)
       const check = new EventReasonAlertsSystemCheck(getIdToken, emitAlert, undefined, mockUtils, mockNavigation)
 
-      const result = await check.runCheck()
+      await check.runCheck()
+      check.onFail()
 
-      expect(result).toBe(false)
+      expect(mockUtils.dispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_CREDENTIAL_METADATA,
+        payload: [expect.objectContaining({ bcscReason: BCSCReason.Cancel })],
+      })
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCModals.DeviceInvalidated, {
+        invalidationReason: BCSCReason.Cancel,
+      })
+    })
+
+    it('should do nothing when onFail runs before runCheck', () => {
+      const getIdToken = jest.fn()
+      const check = new EventReasonAlertsSystemCheck(getIdToken, emitAlert, undefined, mockUtils, mockNavigation)
+
+      check.onFail()
+
+      expect(mockUtils.dispatch).not.toHaveBeenCalled()
+      expect(emitAlert).not.toHaveBeenCalled()
+      expect(mockNavigation.navigate).not.toHaveBeenCalled()
     })
     it('should render an alert with CARD_STATUS_UPDATED event when reason Renew', async () => {
       const mockIdToken = createMockIdToken({

--- a/app/src/services/system-checks/system-checks.test.ts
+++ b/app/src/services/system-checks/system-checks.test.ts
@@ -10,7 +10,24 @@ import { MockLogger } from '@bifold/core'
 
 const devGlobal = global as typeof global & { __DEV__: boolean }
 
-jest.mock('react-native-bcsc-core')
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const makeUtils = (translation: jest.Mock = jest.fn()) => ({
+  dispatch: jest.fn(),
+  translation: translation as any,
+  logger: {} as any,
+})
+
+// Built per test rather than shared: the outer `jest.resetAllMocks()` strips
+// `mockReturnValue` implementations, which would silently turn getState() into undefined.
+const makeNavigation = (currentRoute = 'SomeScreen', overrides: Record<string, unknown> = {}) => ({
+  navigate: jest.fn(),
+  canGoBack: jest.fn().mockReturnValue(false),
+  goBack: jest.fn(),
+  getState: jest.fn().mockReturnValue({ routes: [{ name: currentRoute }], index: 0 }),
+  ...overrides,
+})
+
 describe('System Checks', () => {
   beforeEach(() => {
     jest.resetAllMocks()
@@ -147,11 +164,7 @@ describe('System Checks', () => {
   describe('DeviceCountSystemCheck', () => {
     describe('runCheck', () => {
       it('should return true when device count is within limit', async () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn() as any,
-          logger: {} as any,
-        }
+        const mockUtils = makeUtils()
         const getIdToken = jest.fn().mockResolvedValue({
           bcsc_devices_count: 3,
           bcsc_max_devices: 5,
@@ -166,11 +179,7 @@ describe('System Checks', () => {
       })
 
       it('should return false when device count exceeds limit', async () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn() as any,
-          logger: {} as any,
-        }
+        const mockUtils = makeUtils()
         const getIdToken = jest.fn().mockResolvedValue({
           bcsc_devices_count: 6,
           bcsc_max_devices: 5,
@@ -185,11 +194,7 @@ describe('System Checks', () => {
       })
 
       it('should return false when device count is equal to limit', async () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn() as any,
-          logger: {} as any,
-        }
+        const mockUtils = makeUtils()
         const getIdToken = jest.fn().mockResolvedValue({
           bcsc_devices_count: 5,
           bcsc_max_devices: 5,
@@ -207,11 +212,7 @@ describe('System Checks', () => {
         const devReplacement = jest.replaceProperty(devGlobal, '__DEV__', true)
 
         try {
-          const mockUtils = {
-            dispatch: jest.fn(),
-            translation: jest.fn() as any,
-            logger: {} as any,
-          }
+          const mockUtils = makeUtils()
           const getIdToken = jest.fn()
           const dismissedAt = new Date(Date.now() - 29 * 60 * 1000).getTime() // 29 minute ago
 
@@ -228,11 +229,7 @@ describe('System Checks', () => {
       it('should run the check when dismissed for longer than cooldown time', async () => {
         const devReplacement = jest.replaceProperty(devGlobal, '__DEV__', true)
         try {
-          const mockUtils = {
-            dispatch: jest.fn(),
-            translation: jest.fn() as any,
-            logger: {} as any,
-          }
+          const mockUtils = makeUtils()
           const getIdToken = jest.fn().mockResolvedValue({
             bcsc_devices_count: 6,
             bcsc_max_devices: 5,
@@ -252,11 +249,7 @@ describe('System Checks', () => {
 
     describe('onFail', () => {
       it('should dispatch a warning banner message', async () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn().mockReturnValue('Device limit reached') as any,
-          logger: {} as any,
-        }
+        const mockUtils = makeUtils(jest.fn().mockReturnValue('Device limit reached'))
         const getIdToken = jest.fn()
 
         const deviceCountCheck = new DeviceCountSystemCheck(getIdToken, mockUtils)
@@ -281,11 +274,7 @@ describe('System Checks', () => {
 
     describe('onSuccess', () => {
       it('should dispatch action to remove the banner message', async () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn() as any,
-          logger: {} as any,
-        }
+        const mockUtils = makeUtils()
         const getIdToken = jest.fn()
 
         const deviceCountCheck = new DeviceCountSystemCheck(getIdToken, mockUtils)
@@ -302,28 +291,15 @@ describe('System Checks', () => {
   })
 
   describe('ServerStatusSystemCheck', () => {
-    const mockNavigation = {
-      navigate: jest.fn(),
-      canGoBack: jest.fn().mockReturnValue(false),
-      goBack: jest.fn(),
-      getState: jest.fn().mockReturnValue({ routes: [{ name: 'SomeScreen' }], index: 0 }),
-    }
-
-    beforeEach(() => {
-      jest.clearAllMocks()
-    })
-
     describe('runCheck', () => {
       it('should return true when server status ok', () => {
-        const mockUtils = { dispatch: jest.fn(), translation: jest.fn() as any, logger: {} as any }
-        const check = new ServerStatusSystemCheck({ status: 'ok' } as any, mockUtils, mockNavigation)
+        const check = new ServerStatusSystemCheck({ status: 'ok' } as any, makeUtils(), makeNavigation())
 
         expect(check.runCheck()).toBe(true)
       })
 
       it('should return false when server status not ok', () => {
-        const mockUtils = { dispatch: jest.fn(), translation: jest.fn() as any, logger: {} as any }
-        const check = new ServerStatusSystemCheck({ status: 'unavailable' } as any, mockUtils, mockNavigation)
+        const check = new ServerStatusSystemCheck({ status: 'unavailable' } as any, makeUtils(), makeNavigation())
 
         expect(check.runCheck()).toBe(false)
       })
@@ -331,11 +307,8 @@ describe('System Checks', () => {
 
     describe('onFail', () => {
       it('should navigate to ServiceOutage modal and dispatch a non-dismissible info banner', () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn().mockReturnValue('Server unavailable') as any,
-          logger: {} as any,
-        }
+        const mockUtils = makeUtils(jest.fn().mockReturnValue('Server unavailable'))
+        const mockNavigation = makeNavigation()
         const check = new ServerStatusSystemCheck(
           { status: 'unavailable', contactLink: 'https://status.com' } as any,
           mockUtils,
@@ -365,11 +338,7 @@ describe('System Checks', () => {
       })
 
       it('should use statusMessage as description when available', () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn().mockReturnValue('Server unavailable') as any,
-          logger: {} as any,
-        }
+        const mockUtils = makeUtils(jest.fn().mockReturnValue('Server unavailable'))
         const check = new ServerStatusSystemCheck(
           {
             status: 'unavailable',
@@ -377,7 +346,7 @@ describe('System Checks', () => {
             statusMessage: 'Custom server down message',
           } as any,
           mockUtils,
-          mockNavigation
+          makeNavigation()
         )
 
         check.onFail()
@@ -397,15 +366,8 @@ describe('System Checks', () => {
       })
 
       it('should not navigate if modal is already visible', () => {
-        const navWithModal = {
-          ...mockNavigation,
-          getState: jest.fn().mockReturnValue({ routes: [{ name: BCSCModals.ServiceOutage }], index: 0 }),
-        }
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn().mockReturnValue('Server unavailable') as any,
-          logger: {} as any,
-        }
+        const navWithModal = makeNavigation(BCSCModals.ServiceOutage)
+        const mockUtils = makeUtils(jest.fn().mockReturnValue('Server unavailable'))
         const check = new ServerStatusSystemCheck(
           { status: 'unavailable', contactLink: 'https://status.com' } as any,
           mockUtils,
@@ -421,8 +383,8 @@ describe('System Checks', () => {
 
     describe('onSuccess', () => {
       it('should remove both banner messages when no statusMessage', () => {
-        const mockUtils = { dispatch: jest.fn(), translation: jest.fn() as any, logger: {} as any }
-        const check = new ServerStatusSystemCheck({ status: 'ok' } as any, mockUtils, mockNavigation)
+        const mockUtils = makeUtils()
+        const check = new ServerStatusSystemCheck({ status: 'ok' } as any, mockUtils, makeNavigation())
 
         check.onSuccess()
 
@@ -438,12 +400,8 @@ describe('System Checks', () => {
       })
 
       it('should dismiss modal if visible and go back', () => {
-        const navWithModal = {
-          ...mockNavigation,
-          getState: jest.fn().mockReturnValue({ routes: [{ name: BCSCModals.ServiceOutage }], index: 0 }),
-          canGoBack: jest.fn().mockReturnValue(true),
-        }
-        const mockUtils = { dispatch: jest.fn(), translation: jest.fn() as any, logger: {} as any }
+        const navWithModal = makeNavigation(BCSCModals.ServiceOutage, { canGoBack: jest.fn().mockReturnValue(true) })
+        const mockUtils = makeUtils()
         const check = new ServerStatusSystemCheck({ status: 'ok' } as any, mockUtils, navWithModal)
 
         check.onSuccess()
@@ -452,11 +410,11 @@ describe('System Checks', () => {
       })
 
       it('should dispatch non-dismissible info banner if statusMessage exists', () => {
-        const mockUtils = { dispatch: jest.fn(), translation: jest.fn() as any, logger: {} as any }
+        const mockUtils = makeUtils()
         const check = new ServerStatusSystemCheck(
           { status: 'ok', contactLink: 'https://status.com', statusMessage: 'Server maintenance scheduled' } as any,
           mockUtils,
-          mockNavigation
+          makeNavigation()
         )
 
         check.onSuccess()

--- a/app/src/utils/analytics/analytics-tracker.test.ts
+++ b/app/src/utils/analytics/analytics-tracker.test.ts
@@ -1,35 +1,44 @@
 import { AlertInteractionEvent, AppEventCode } from '@/events/appEventCode'
 import { AnalyticsTracker } from '@/utils/analytics/analytics-tracker'
+import { removeTracker } from '@snowplow/react-native-tracker'
+
+jest.mock('@snowplow/react-native-tracker', () => ({
+  ...jest.requireActual('@snowplow/react-native-tracker'),
+  removeTracker: jest.fn(),
+}))
+
+/**
+ * The spies are wired into the client's `newTracker` result, so a test that never calls
+ * `initializeTracker` still fails loudly if a `!this.tracker` guard is removed — the
+ * production call would throw rather than silently no-op.
+ */
+const createSubject = () => {
+  const tracker = {
+    setAppId: jest.fn(),
+    trackScreenViewEvent: jest.fn(),
+    trackSelfDescribingEvent: jest.fn(),
+  }
+  const newTracker = jest.fn().mockResolvedValue(tracker)
+  const analytics = new AnalyticsTracker('namespace', 'endpoint', { newTracker } as never)
+
+  return { analytics, tracker, newTracker }
+}
 
 describe('Analytics Tracker', () => {
-  it('should construct properly', () => {
-    const analytics = new AnalyticsTracker('namespace', 'endpoint')
-
-    expect(analytics).toBeInstanceOf(AnalyticsTracker)
-  })
-
   describe('initializeTracker', () => {
     it('should initialize tracker', async () => {
-      const mockNewTracker = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: mockNewTracker,
-      }
+      const { analytics, newTracker } = createSubject()
 
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
-
-      // First initialization
       await analytics.initializeTracker('testAppId')
-      expect(mockNewTracker).toHaveBeenCalledTimes(1)
+
+      expect(newTracker).toHaveBeenCalledTimes(1)
+      expect(newTracker).toHaveBeenCalledWith(expect.objectContaining({ namespace: 'namespace', appId: 'testAppId' }))
     })
   })
 
   describe('hasTracker', () => {
     it('should return true if tracker exists', async () => {
-      const mockAnalyticsClient = {
-        newTracker: jest.fn().mockReturnValue({}),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      const { analytics } = createSubject()
 
       await analytics.initializeTracker('testAppId')
 
@@ -37,96 +46,72 @@ describe('Analytics Tracker', () => {
     })
 
     it('should return false if tracker is not initialized', () => {
-      const analytics = new AnalyticsTracker('namespace', 'endpoint')
+      const { analytics } = createSubject()
 
       expect(analytics.hasTracker()).toBe(false)
     })
+  })
 
-    it('should return false if tracking not enabled', async () => {
-      const mockAnalyticsClient = {
-        newTracker: jest.fn(),
-      }
+  describe('stopTracking', () => {
+    it('should remove the tracker', async () => {
+      const { analytics } = createSubject()
 
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      await analytics.initializeTracker('testAppId')
 
+      analytics.stopTracking()
+
+      expect(removeTracker).toHaveBeenCalledWith('namespace')
       expect(analytics.hasTracker()).toBe(false)
     })
   })
 
   describe('setAppId', () => {
     it('should set app ID when tracker exists', async () => {
-      const mockSetAppId = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn().mockResolvedValue({
-          setAppId: mockSetAppId,
-        }),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      const { analytics, tracker } = createSubject()
 
       await analytics.initializeTracker('testAppId')
 
       analytics.setAppId('newAppId')
 
-      expect(mockSetAppId).toHaveBeenCalledWith('newAppId')
+      expect(tracker.setAppId).toHaveBeenCalledWith('newAppId')
     })
 
     it('should not set app ID when tracker does not exist', () => {
-      const mockSetAppId = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn(),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      const { analytics, tracker } = createSubject()
 
       analytics.setAppId('newAppId')
 
-      expect(mockSetAppId).not.toHaveBeenCalled()
+      expect(tracker.setAppId).not.toHaveBeenCalled()
     })
   })
 
   describe('trackScreenEvent', () => {
-    it('should not track when missing tracker', async () => {
-      const mockTrackScreenView = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn(),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+    it('should not track when missing tracker', () => {
+      const { analytics, tracker } = createSubject()
 
       analytics.trackScreenEvent('HomeScreen')
 
-      expect(mockTrackScreenView).not.toHaveBeenCalled()
+      expect(tracker.trackScreenViewEvent).not.toHaveBeenCalled()
     })
 
     it('should not track when screen name === previous screen name', async () => {
-      const mockTrackScreenView = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn(),
-      }
+      const { analytics, tracker } = createSubject()
 
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      await analytics.initializeTracker('testAppId')
 
       analytics.trackScreenEvent('HomeScreen', 'HomeScreen')
 
-      expect(mockTrackScreenView).not.toHaveBeenCalled()
+      expect(tracker.trackScreenViewEvent).not.toHaveBeenCalled()
     })
 
     it('should track when tracking enabled and valid screen names', async () => {
-      const mockTrackScreenView = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn().mockResolvedValue({
-          trackScreenViewEvent: mockTrackScreenView,
-        }),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      const { analytics, tracker } = createSubject()
 
       await analytics.initializeTracker('testAppId')
 
       analytics.trackScreenEvent('HomeScreen', 'NewScreen')
 
-      expect(mockTrackScreenView).toHaveBeenCalledWith({
+      expect(tracker.trackScreenViewEvent).toHaveBeenCalledWith({
         name: 'HomeScreen',
         previousName: 'NewScreen',
       })
@@ -134,34 +119,22 @@ describe('Analytics Tracker', () => {
   })
 
   describe('trackErrorEvent', () => {
-    it('should not track when missing tracker', async () => {
-      const mockTrackError = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn(),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+    it('should not track when missing tracker', () => {
+      const { analytics, tracker } = createSubject()
 
       analytics.trackErrorEvent({ code: 'test', message: 'Test error' })
 
-      expect(mockTrackError).not.toHaveBeenCalled()
+      expect(tracker.trackSelfDescribingEvent).not.toHaveBeenCalled()
     })
 
     it('should track when tracking enabled and valid error', async () => {
-      const mockTrackError = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn().mockResolvedValue({
-          trackSelfDescribingEvent: mockTrackError,
-        }),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      const { analytics, tracker } = createSubject()
 
       await analytics.initializeTracker('testAppId')
 
       analytics.trackErrorEvent({ code: 'test', message: 'Test error' })
 
-      expect(mockTrackError).toHaveBeenCalledWith({
+      expect(tracker.trackSelfDescribingEvent).toHaveBeenCalledWith({
         schema: 'iglu:ca.bc.gov.idim/mobile_error/jsonschema/1-0-0',
         data: {
           errorCode: 'test',
@@ -169,75 +142,51 @@ describe('Analytics Tracker', () => {
         },
       })
     })
+  })
 
-    describe('trackAlertDisplayEvent', () => {
-      it('should not track when missing tracker', async () => {
-        const mockTrackAlert = jest.fn()
-        const mockAnalyticsClient = {
-          newTracker: jest.fn(),
-        }
+  describe('trackAlertDisplayEvent', () => {
+    it('should not track when missing tracker', () => {
+      const { analytics, tracker } = createSubject()
 
-        const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      analytics.trackAlertDisplayEvent(AppEventCode.ADD_CARD_CAMERA_BROKEN)
 
-        analytics.trackAlertDisplayEvent(AppEventCode.ADD_CARD_CAMERA_BROKEN)
+      expect(tracker.trackSelfDescribingEvent).not.toHaveBeenCalled()
+    })
 
-        expect(mockTrackAlert).not.toHaveBeenCalled()
-      })
+    it('should track when tracking enabled and valid app event', async () => {
+      const { analytics, tracker } = createSubject()
 
-      it('should track when tracking enabled and valid app event', async () => {
-        const mockTrackAlert = jest.fn()
-        const mockAnalyticsClient = {
-          newTracker: jest.fn().mockResolvedValue({
-            trackSelfDescribingEvent: mockTrackAlert,
-          }),
-        }
+      await analytics.initializeTracker('testAppId')
 
-        const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      analytics.trackAlertDisplayEvent(AppEventCode.ADD_CARD_CAMERA_BROKEN)
 
-        await analytics.initializeTracker('testAppId')
-
-        analytics.trackAlertDisplayEvent(AppEventCode.ADD_CARD_CAMERA_BROKEN)
-
-        expect(mockTrackAlert).toHaveBeenCalledWith({
-          schema: 'iglu:ca.bc.gov.idim/action/jsonschema/1-0-0',
-          data: {
-            action: AlertInteractionEvent.ALERT_DISPLAY,
-            text: AppEventCode.ADD_CARD_CAMERA_BROKEN,
-          },
-        })
+      expect(tracker.trackSelfDescribingEvent).toHaveBeenCalledWith({
+        schema: 'iglu:ca.bc.gov.idim/action/jsonschema/1-0-0',
+        data: {
+          action: AlertInteractionEvent.ALERT_DISPLAY,
+          text: AppEventCode.ADD_CARD_CAMERA_BROKEN,
+        },
       })
     })
   })
 
   describe('trackAlertActionEvent', () => {
-    it('should not track when missing tracker', async () => {
-      const mockTrackAlert = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn(),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+    it('should not track when missing tracker', () => {
+      const { analytics, tracker } = createSubject()
 
       analytics.trackAlertActionEvent(AppEventCode.ADD_CARD_CAMERA_BROKEN, 'ok')
 
-      expect(mockTrackAlert).not.toHaveBeenCalled()
+      expect(tracker.trackSelfDescribingEvent).not.toHaveBeenCalled()
     })
 
     it('should track when tracking enabled and valid app event', async () => {
-      const mockTrackAlert = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn().mockResolvedValue({
-          trackSelfDescribingEvent: mockTrackAlert,
-        }),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      const { analytics, tracker } = createSubject()
 
       await analytics.initializeTracker('testAppId')
 
       analytics.trackAlertActionEvent(AppEventCode.ADD_CARD_CAMERA_BROKEN, 'ok')
 
-      expect(mockTrackAlert).toHaveBeenCalledWith({
+      expect(tracker.trackSelfDescribingEvent).toHaveBeenCalledWith({
         schema: 'iglu:ca.bc.gov.idim/action/jsonschema/1-0-0',
         data: {
           action: AlertInteractionEvent.ALERT_ACTION,

--- a/app/src/utils/expiration.test.ts
+++ b/app/src/utils/expiration.test.ts
@@ -1,8 +1,6 @@
 import { expirationOverrideInMinutes } from '@utils/expiration'
 import MockDate from 'mockdate'
 
-jest.useFakeTimers({ legacyFakeTimers: true })
-
 describe('Helpers', () => {
   beforeAll(() => {
     // Set the date to a fixed point in time

--- a/app/src/utils/version.test.ts
+++ b/app/src/utils/version.test.ts
@@ -2,126 +2,49 @@ import deviceInfo from 'react-native-device-info'
 
 import { AppVersion, isVersionAtLeast } from './version'
 
+const expectIsVersionAtLeast = (appVersion: string, minVersion: string, expected: boolean) => {
+  jest.spyOn(deviceInfo, 'getVersion').mockReturnValue(appVersion)
+
+  expect(isVersionAtLeast(minVersion)).toBe(expected)
+}
+
 describe('isVersionAtLeast', () => {
   describe('exact version comparisons', () => {
-    it('returns true when the app version equals the minimum version', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1.0')
-
-      expect(isVersionAtLeast('4.1.0')).toBe(true)
-    })
-
-    it('returns true when the major version is greater', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('5.0.0')
-
-      expect(isVersionAtLeast('4.9.9')).toBe(true)
-    })
-
-    it('returns false when the major version is lower', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('3.9.9')
-
-      expect(isVersionAtLeast('4.0.0')).toBe(false)
-    })
-
-    it('returns true when the minor version is greater within the same major', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.2.0')
-
-      expect(isVersionAtLeast('4.1.9')).toBe(true)
-    })
-
-    it('returns false when the minor version is lower within the same major', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.0.9')
-
-      expect(isVersionAtLeast('4.1.0')).toBe(false)
-    })
-
-    it('returns true when the patch version is greater', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1.2')
-
-      expect(isVersionAtLeast('4.1.1')).toBe(true)
-    })
-
-    it('returns false when the patch version is lower', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1.0')
-
-      expect(isVersionAtLeast('4.1.1')).toBe(false)
-    })
+    it.each([
+      ['4.1.0', '4.1.0', true, 'the app version equals the minimum version'],
+      ['5.0.0', '4.9.9', true, 'the major version is greater'],
+      ['3.9.9', '4.0.0', false, 'the major version is lower'],
+      ['4.2.0', '4.1.9', true, 'the minor version is greater within the same major'],
+      ['4.0.9', '4.1.0', false, 'the minor version is lower within the same major'],
+      ['4.1.2', '4.1.1', true, 'the patch version is greater'],
+      ['4.1.0', '4.1.1', false, 'the patch version is lower'],
+    ])('app %s vs minimum %s -> %s when %s', expectIsVersionAtLeast)
   })
 
   describe('wildcard segments', () => {
-    it('ignores the patch segment when the minimum version uses "x"', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1.0')
-
-      expect(isVersionAtLeast('4.1.x')).toBe(true)
-    })
-
-    it('returns true when the minor version exceeds a wildcard minimum', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.2.0')
-
-      expect(isVersionAtLeast('4.1.x')).toBe(true)
-    })
-
-    it('returns false when the version is below a wildcard minimum', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.0.9')
-
-      expect(isVersionAtLeast('4.1.x')).toBe(false)
-    })
-
-    it('supports "*" as a wildcard segment', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1.3')
-
-      expect(isVersionAtLeast('4.1.*')).toBe(true)
-    })
-
-    it('returns true for any version when the first segment is a wildcard', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('0.0.1')
-
-      expect(isVersionAtLeast('x')).toBe(true)
-    })
+    it.each([
+      ['4.1.0', '4.1.x', true, 'the patch segment is ignored for an "x" minimum'],
+      ['4.2.0', '4.1.x', true, 'the minor version exceeds a wildcard minimum'],
+      ['4.0.9', '4.1.x', false, 'the version is below a wildcard minimum'],
+      ['4.1.3', '4.1.*', true, '"*" is used as a wildcard segment'],
+      ['0.0.1', 'x', true, 'the first segment is a wildcard'],
+    ])('app %s vs minimum %s -> %s when %s', expectIsVersionAtLeast)
   })
 
   describe('versions with differing segment counts', () => {
-    it('treats missing app version segments as 0', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1')
-
-      expect(isVersionAtLeast('4.1.1')).toBe(false)
-    })
-
-    it('returns true when missing segments compare equal to 0', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1')
-
-      expect(isVersionAtLeast('4.1.0')).toBe(true)
-    })
-
-    it('returns true when the app version has more segments than the minimum', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1.2')
-
-      expect(isVersionAtLeast('4.1')).toBe(true)
-    })
+    it.each([
+      ['4.1', '4.1.1', false, 'missing app version segments are treated as 0'],
+      ['4.1', '4.1.0', true, 'missing segments compare equal to 0'],
+      ['4.1.2', '4.1', true, 'the app version has more segments than the minimum'],
+    ])('app %s vs minimum %s -> %s when %s', expectIsVersionAtLeast)
   })
 
   describe('AppVersion enum values', () => {
-    it('returns true when the app version is within V4_1_x', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1.0')
-
-      expect(isVersionAtLeast(AppVersion.V4_1_x)).toBe(true)
-    })
-
-    it('returns true when the app version is above V4_1_x', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.2.0')
-
-      expect(isVersionAtLeast(AppVersion.V4_1_x)).toBe(true)
-    })
-
-    it('returns false when the app version is below V4_2_x', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1.5')
-
-      expect(isVersionAtLeast(AppVersion.V4_2_x)).toBe(false)
-    })
-
-    it('returns true when the app version satisfies V4_0_x', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.0.3')
-
-      expect(isVersionAtLeast(AppVersion.V4_0_x)).toBe(true)
-    })
+    it.each([
+      ['4.1.0', AppVersion.V4_1_x, true, 'the app version is within V4_1_x'],
+      ['4.2.0', AppVersion.V4_1_x, true, 'the app version is above V4_1_x'],
+      ['4.1.5', AppVersion.V4_2_x, false, 'the app version is below V4_2_x'],
+      ['4.0.3', AppVersion.V4_0_x, true, 'the app version satisfies V4_0_x'],
+    ])('app %s vs minimum %s -> %s when %s', expectIsVersionAtLeast)
   })
 })


### PR DESCRIPTION
<!-- No issue — this came out of an audit of the Jest suites. Labelled `status/no-issue`. -->

Fifth in the jest cleanup series, after #4518, #4554, #4586 and #4598.

## What changed

Five analytics tests asserted on spies that were never connected to anything, so they could not fail. A system check test named for navigating to a modal never called the method that navigates, leaving that branch uncovered.

## What should the reviewer focus on

`analytics-tracker.test.ts` — the spies now run through `newTracker`, so check the rewired setup reads the way you'd expect. And `EventReasonAlertsSystemCheck.test.ts`, where the test now drives `onFail()` and asserts the dispatch and the navigate it always claimed to cover.

## How to test

Covered by the existing suites: **300 suites, 3212 passing**. `yarn lint`, `yarn format:check` and `yarn typecheck` clean.

No production code is touched. The remaining ~300 deleted lines are duplication in `appError`, `version` and `errorRegistry` collapsing into tables, plus fake timers that now get restored.
