### PR TITLE
fix: stop ledger lookup messages from flooding development logs

### DIFF
--- a/.yarn/patches/@bifold-remote-logs-npm-3.0.21-4ae200989a.patch
+++ b/.yarn/patches/@bifold-remote-logs-npm-3.0.21-4ae200989a.patch
@@ -1,0 +1,68 @@
+diff --git a/build/logger.js b/build/logger.js
+index 7e9c252ba4d35eba614d8ac5362dba79e514a510..0c58b0e8665bc20703fed6f57af545431b54da94 100644
+--- a/build/logger.js
++++ b/build/logger.js
+@@ -27,14 +27,14 @@ class RemoteLogger extends core_1.AbstractBifoldLogger {
+         // Standardized logging methods with consistent overloads
+         this.test = (message, dataOrError, error) => {
+             var _a, _b;
+-            if (!this.isEnabled(core_2.LogLevel.debug))
++            if (!this.isEnabled(core_2.LogLevel.test))
+                 return;
+             const { data, actualError } = this.parseLogArguments(dataOrError, error);
+             (_b = (_a = this._log) === null || _a === void 0 ? void 0 : _a.test) === null || _b === void 0 ? void 0 : _b.call(_a, { message, data, error: actualError });
+         };
+         this.trace = (message, dataOrError, error) => {
+             var _a, _b;
+-            if (!this.isEnabled(core_2.LogLevel.debug))
++            if (!this.isEnabled(core_2.LogLevel.trace))
+                 return;
+             const { data, actualError } = this.parseLogArguments(dataOrError, error);
+             (_b = (_a = this._log) === null || _a === void 0 ? void 0 : _a.trace) === null || _b === void 0 ? void 0 : _b.call(_a, { message, data, error: actualError });
+@@ -105,8 +105,8 @@ class RemoteLogger extends core_1.AbstractBifoldLogger {
+             if (!this._sessionId) {
+                 this._sessionId = Math.floor(SESSION_ID_RANGE.MIN + Math.random() * (SESSION_ID_RANGE.MAX - SESSION_ID_RANGE.MIN + 1));
+             }
+-            // Override to most verbose when remote logging active
+-            this.logLevel = core_2.LogLevel.debug;
++            // Force the lowest level (test) so remote sessions keep full detail
++            this.logLevel = core_2.LogLevel.test;
+         }
+         else {
+             this._sessionId = undefined;
+@@ -146,7 +146,7 @@ class RemoteLogger extends core_1.AbstractBifoldLogger {
+     setLogLevel(level) {
+         this._baseLogLevel = level;
+         // Only apply immediately if remote logging isn't forcing
+-        // debug
++        // the lowest level (test)
+         if (!this._remoteLoggingEnabled) {
+             this.logLevel = level;
+         }
+diff --git a/build/transports/console.js b/build/transports/console.js
+index bdc70c2dd8bc37cebe02d32fcb1b170238fa5d13..9a207a82f35a0ef664b2acece7a2803df8b4cce1 100644
+--- a/build/transports/console.js
++++ b/build/transports/console.js
+@@ -100,9 +100,9 @@ const consoleTransport = (props) => {
+         const formattedData = messageDataFormatter(...Object.values(rest)).join(' ');
+         logMessage = `${logMessage} ${formattedData}`;
+     }
+-    // Only prepend a tag for test logs.
++    // Only prepend a tag for test/trace logs, to distinguish them from debug in Metro.
+     const levelText = props.level.text.toLowerCase();
+-    if (levelText === 'test') {
++    if (levelText === 'test' || levelText === 'trace') {
+         const levelTag = `[${props.level.text.toUpperCase()}]`;
+         logMessage = `${levelTag} ${logMessage}`;
+     }
+@@ -113,10 +113,6 @@ const consoleTransport = (props) => {
+         // Use appropriate console method based on log level
+         switch (props.level.text.toLowerCase()) {
+             case 'trace':
+-                // console.trace prints a stack; we only want the message. Provide a wrapper.
+-                // Some environments always include stack; if so this remains acceptable.
+-                console.trace(logMessage);
+-                break;
+             case 'debug':
+                 // Prefer console.debug for debug level; fallback to console.log if unavailable
+                 if (typeof console.debug === 'function') {

--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -31,3 +31,9 @@ New architecture support and turbomodule fixes. We should swap this library out 
 #### react-native-fs-npm-2.20.0-a38fe24051.patch
 
 Turbomodule fixes. We should swap this library out soon, hasn't been updated in four years.
+
+#### @bifold-remote-logs-npm-3.0.21-4ae200989a.patch
+
+Gates `test`/`trace` log methods on their own levels instead of `debug` (so ledger lookups no longer flood the default dev log level), drops `console.trace` for the `trace` level (no more stack traces on routine logs), and forces `LogLevel.test` instead of `debug` when remote logging is enabled (support sessions keep full detail). #4599
+
+Upstream (Bifold `packages/remote-logs`): `src/logger.ts` L86 (remote-logging override), L187/L193 (`test`/`trace` gates); `src/transports/console.ts` L146-148 (`console.trace`). Tests to adjust when porting: `src/__tests__/console.transport.test.ts` L18 (mocks `console.trace`), `src/__tests__/logger.comprehensive.test.ts` L44 (hardcodes `logLevel = 2`). Drop this patch once the upstream fix lands.

--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -34,6 +34,6 @@ Turbomodule fixes. We should swap this library out soon, hasn't been updated in 
 
 #### @bifold-remote-logs-npm-3.0.21-4ae200989a.patch
 
-Gates `test`/`trace` log methods on their own levels instead of `debug` (so ledger lookups no longer flood the default dev log level), drops `console.trace` for the `trace` level (no more stack traces on routine logs), and forces `LogLevel.test` instead of `debug` when remote logging is enabled (support sessions keep full detail). #4599
+Gates `test`/`trace` log methods on their own levels instead of `debug` (so ledger lookups no longer flood the default dev log level), drops `console.trace` for the `trace` level (no more stack traces on routine logs), forces `LogLevel.test` instead of `debug` when remote logging is enabled (support sessions keep full detail), and tags `trace` lines with a `[TRACE]` console prefix so they stay distinguishable from `debug` in Metro. #4599
 
-Upstream (Bifold `packages/remote-logs`): `src/logger.ts` L86 (remote-logging override), L187/L193 (`test`/`trace` gates); `src/transports/console.ts` L146-148 (`console.trace`). Tests to adjust when porting: `src/__tests__/console.transport.test.ts` L18 (mocks `console.trace`), `src/__tests__/logger.comprehensive.test.ts` L44 (hardcodes `logLevel = 2`). Drop this patch once the upstream fix lands.
+Upstream (Bifold `packages/remote-logs`): `src/logger.ts` L86 (remote-logging override), L187/L193 (`test`/`trace` gates); `src/transports/console.ts` L133-136 (`[TEST]` prefix block) and L146-150 (`console.trace` case). Tests to adjust when porting: `src/__tests__/console.transport.test.ts` L18 (mocks `console.trace`), `src/__tests__/logger.comprehensive.test.ts` L44 (hardcodes `logLevel = 2`). Drop this patch once the upstream fix lands.

--- a/app/package.json
+++ b/app/package.json
@@ -45,7 +45,7 @@
     "@bifold/oca": "3.0.21",
     "@bifold/react-hooks": "3.0.21",
     "@bifold/react-native-attestation": "3.0.21",
-    "@bifold/remote-logs": "3.0.21",
+    "@bifold/remote-logs": "patch:@bifold/remote-logs@npm%3A3.0.21#~/.yarn/patches/@bifold-remote-logs-npm-3.0.21-4ae200989a.patch",
     "@bifold/verifier": "3.0.21",
     "@credo-ts/anoncreds": "0.6.3",
     "@credo-ts/askar": "0.6.3",

--- a/app/src/utils/logger.test.ts
+++ b/app/src/utils/logger.test.ts
@@ -103,8 +103,8 @@ describe('createAppLogger', () => {
     ['fatal', LogLevel.fatal],
     ['error', LogLevel.error],
     ['warning', LogLevel.warn],
-    ['trace', LogLevel.debug],
-    ['test', LogLevel.debug],
+    ['trace', LogLevel.trace],
+    ['test', LogLevel.test],
     ['unknown', LogLevel.debug],
   ])('maps env value %s to correct log level', (envValue, expectedLevel) => {
     mockedConfig.LOG_LEVEL = envValue

--- a/app/src/utils/logger.ts
+++ b/app/src/utils/logger.ts
@@ -77,7 +77,9 @@ const parseEnvLogLevel = (value?: string): LogLevel => {
     case 'info':
       return LogLevel.info
     case 'trace':
+      return LogLevel.trace
     case 'test':
+      return LogLevel.test
     case 'debug':
       return LogLevel.debug
     default:

--- a/app/src/utils/remote-logger-patch.test.ts
+++ b/app/src/utils/remote-logger-patch.test.ts
@@ -60,13 +60,19 @@ describe('RemoteLogger trace/test level patch', () => {
     expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('[TRACE]'))
   })
 
-  it('forces the lowest level (test) when remote logging is enabled, and restores the base level after', () => {
+  it('forces the lowest level (test) when remote logging is enabled, and trace reaches the console', () => {
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+
     const logger = new RemoteLogger({ logLevel: LogLevel.warn })
 
     expect(logger.logLevel).toBe(LogLevel.warn)
 
     logger.remoteLoggingEnabled = true
     expect(logger.logLevel).toBe(LogLevel.test)
+
+    logger.trace('ledger lookup')
+    jest.runOnlyPendingTimers()
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('[TRACE]'))
 
     logger.remoteLoggingEnabled = false
     expect(logger.logLevel).toBe(LogLevel.warn)

--- a/app/src/utils/remote-logger-patch.test.ts
+++ b/app/src/utils/remote-logger-patch.test.ts
@@ -29,6 +29,9 @@ describe('RemoteLogger trace/test level patch', () => {
   it('hides trace and test messages at the default development level (debug)', () => {
     const traceSpy = jest.spyOn(console, 'trace').mockImplementation(() => {})
     const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+    // 'test' level falls through to the transport's default console.log branch,
+    // so this is the assertion that actually proves it's gated out.
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
 
     const logger = new RemoteLogger({ logLevel: LogLevel.debug })
 
@@ -38,6 +41,7 @@ describe('RemoteLogger trace/test level patch', () => {
     jest.runOnlyPendingTimers()
 
     expect(traceSpy).not.toHaveBeenCalled()
+    expect(logSpy).not.toHaveBeenCalled()
     expect(debugSpy).toHaveBeenCalledTimes(1)
     expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('a real debug message'))
   })

--- a/app/src/utils/remote-logger-patch.test.ts
+++ b/app/src/utils/remote-logger-patch.test.ts
@@ -1,14 +1,7 @@
-/**
- * Confirms the behaviour patched into @bifold/remote-logs by
- * .yarn/patches/@bifold-remote-logs-npm-3.0.21-4ae200989a.patch (#4599).
- *
- * app/jestSetup.js mocks @bifold/remote-logs and react-native-logs globally
- * so nothing else exercises the patched build. Unmocking both here (hoisted
- * above the imports by babel-jest) lets the real RemoteLogger construct
- * under jest, wired directly to the patched files in node_modules. If a
- * future dependency bump moves past 3.0.21 and this patch is dropped, this
- * file should be deleted along with it.
- */
+// Exercises the real @bifold/remote-logs build patched by
+// .yarn/patches/@bifold-remote-logs-npm-3.0.21-4ae200989a.patch (#4599); jestSetup.js
+// mocks the package globally, so the unmocks below (hoisted by babel-jest) are required.
+// Delete this file when the patch is dropped.
 import { RemoteLogger } from '@bifold/remote-logs'
 import { LogLevel } from '@credo-ts/core'
 

--- a/app/src/utils/remote-logger-patch.test.ts
+++ b/app/src/utils/remote-logger-patch.test.ts
@@ -97,6 +97,8 @@ describe('RemoteLogger trace/test level patch', () => {
 
     const logger = new RemoteLogger({
       logLevel: LogLevel.warn,
+      // Basic-auth credentials are load-bearing: the transport parses them out of the
+      // URL, matching the shape of the real REMOTE_LOGGING_URL.
       lokiUrl: 'https://user:pass@loki.example.com/loki/api/v1/push',
       lokiLabels: { application: 'test-app' },
     })
@@ -108,7 +110,7 @@ describe('RemoteLogger trace/test level patch', () => {
 
     expect(axios.post).toHaveBeenCalledTimes(1)
     expect(axios.post).toHaveBeenCalledWith(
-      expect.any(String),
+      'https://loki.example.com/loki/api/v1/push',
       expect.objectContaining({
         streams: [expect.objectContaining({ stream: expect.objectContaining({ level: 'trace' }) })],
       }),

--- a/app/src/utils/remote-logger-patch.test.ts
+++ b/app/src/utils/remote-logger-patch.test.ts
@@ -106,7 +106,14 @@ describe('RemoteLogger trace/test level patch', () => {
     logger.trace('ledger lookup')
     jest.runOnlyPendingTimers()
 
-    expect(axios.post).toHaveBeenCalled()
+    expect(axios.post).toHaveBeenCalledTimes(1)
+    expect(axios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        streams: [expect.objectContaining({ stream: expect.objectContaining({ level: 'trace' }) })],
+      }),
+      expect.anything()
+    )
 
     logger.remoteLoggingEnabled = false
     logger.dispose()

--- a/app/src/utils/remote-logger-patch.test.ts
+++ b/app/src/utils/remote-logger-patch.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Confirms the behaviour patched into @bifold/remote-logs by
+ * .yarn/patches/@bifold-remote-logs-npm-3.0.21-4ae200989a.patch (#4599).
+ *
+ * app/jestSetup.js mocks @bifold/remote-logs and react-native-logs globally
+ * so nothing else exercises the patched build. Unmocking both here (hoisted
+ * above the imports by babel-jest) lets the real RemoteLogger construct
+ * under jest, wired directly to the patched files in node_modules. If a
+ * future dependency bump moves past 3.0.21 and this patch is dropped, this
+ * file should be deleted along with it.
+ */
+import { RemoteLogger } from '@bifold/remote-logs'
+import { LogLevel } from '@credo-ts/core'
+
+jest.unmock('@bifold/remote-logs')
+jest.unmock('react-native-logs')
+
+// AbstractBifoldLogger._config.async is true: transports run via setTimeout(0).
+beforeEach(() => {
+  jest.useFakeTimers()
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+  jest.restoreAllMocks()
+})
+
+describe('RemoteLogger trace/test level patch', () => {
+  it('hides trace and test messages at the default development level (debug)', () => {
+    const traceSpy = jest.spyOn(console, 'trace').mockImplementation(() => {})
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+
+    const logger = new RemoteLogger({ logLevel: LogLevel.debug })
+
+    logger.trace('ledger lookup')
+    logger.test('some test message')
+    logger.debug('a real debug message')
+    jest.runOnlyPendingTimers()
+
+    expect(traceSpy).not.toHaveBeenCalled()
+    expect(debugSpy).toHaveBeenCalledTimes(1)
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('a real debug message'))
+  })
+
+  it('prints trace via console.debug (no stack) with a [TRACE] prefix once enabled', () => {
+    const traceSpy = jest.spyOn(console, 'trace').mockImplementation(() => {})
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+
+    const logger = new RemoteLogger({ logLevel: LogLevel.trace })
+
+    logger.trace('ledger lookup')
+    jest.runOnlyPendingTimers()
+
+    expect(traceSpy).not.toHaveBeenCalled()
+    expect(debugSpy).toHaveBeenCalledTimes(1)
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('[TRACE]'))
+  })
+
+  it('forces the lowest level (test) when remote logging is enabled, and restores the base level after', () => {
+    const logger = new RemoteLogger({ logLevel: LogLevel.warn })
+
+    expect(logger.logLevel).toBe(LogLevel.warn)
+
+    logger.remoteLoggingEnabled = true
+    expect(logger.logLevel).toBe(LogLevel.test)
+
+    logger.remoteLoggingEnabled = false
+    expect(logger.logLevel).toBe(LogLevel.warn)
+
+    logger.dispose()
+  })
+
+  it('leaves error reporting unchanged', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    const logger = new RemoteLogger({ logLevel: LogLevel.warn })
+
+    logger.error('something broke', new Error('boom'))
+    jest.runOnlyPendingTimers()
+
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/src/utils/remote-logger-patch.test.ts
+++ b/app/src/utils/remote-logger-patch.test.ts
@@ -4,6 +4,12 @@
 // Delete this file when the patch is dropped.
 import { RemoteLogger } from '@bifold/remote-logs'
 import { LogLevel } from '@credo-ts/core'
+import axios from 'axios'
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { post: jest.fn().mockResolvedValue({ status: 204 }) },
+}))
 
 jest.unmock('@bifold/remote-logs')
 jest.unmock('react-native-logs')
@@ -39,6 +45,19 @@ describe('RemoteLogger trace/test level patch', () => {
     expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('a real debug message'))
   })
 
+  it('prints test via console.log with a [TEST] prefix at the lowest level', () => {
+    // 'test' level falls through to the transport's default console.log branch, not console.debug.
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    const logger = new RemoteLogger({ logLevel: LogLevel.test })
+
+    logger.test('a test line')
+    jest.runOnlyPendingTimers()
+
+    expect(logSpy).toHaveBeenCalledTimes(1)
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[TEST]'))
+  })
+
   it('prints trace via console.debug (no stack) with a [TRACE] prefix once enabled', () => {
     const traceSpy = jest.spyOn(console, 'trace').mockImplementation(() => {})
     const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
@@ -70,6 +89,26 @@ describe('RemoteLogger trace/test level patch', () => {
     logger.remoteLoggingEnabled = false
     expect(logger.logLevel).toBe(LogLevel.warn)
 
+    logger.dispose()
+  })
+
+  it('actually reaches Loki (not just the console) once remote logging is enabled', () => {
+    jest.spyOn(console, 'debug').mockImplementation(() => {})
+
+    const logger = new RemoteLogger({
+      logLevel: LogLevel.warn,
+      lokiUrl: 'https://user:pass@loki.example.com/loki/api/v1/push',
+      lokiLabels: { application: 'test-app' },
+    })
+
+    logger.remoteLoggingEnabled = true
+
+    logger.trace('ledger lookup')
+    jest.runOnlyPendingTimers()
+
+    expect(axios.post).toHaveBeenCalled()
+
+    logger.remoteLoggingEnabled = false
     logger.dispose()
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1936,6 +1936,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bifold/remote-logs@patch:@bifold/remote-logs@npm%3A3.0.21#~/.yarn/patches/@bifold-remote-logs-npm-3.0.21-4ae200989a.patch":
+  version: 3.0.21
+  resolution: "@bifold/remote-logs@patch:@bifold/remote-logs@npm%3A3.0.21#~/.yarn/patches/@bifold-remote-logs-npm-3.0.21-4ae200989a.patch::version=3.0.21&hash=be24b1"
+  dependencies:
+    "@bifold/core": "npm:3.0.21"
+    "@credo-ts/core": "npm:0.6.3"
+    axios: "npm:~1.13.2"
+    buffer: "npm:~6.0.3"
+    react: "npm:~19.1.4"
+    react-native: "npm:0.81.5"
+    react-native-logs: "npm:~5.1.0"
+  peerDependencies:
+    "@credo-ts/core": 0.6.3
+    axios: ~1.13.2
+    buffer: ~6.0.3
+    react: ~19.1.4
+    react-native: 0.81.5
+    react-native-logs: ~5.1.0
+  checksum: 10c0/efe4c21fc9bf0620a4c153467c64ed3988e169b850fb7635fa43c3fc56bb4eaec6a157d1d478ddb08cf1dc8ec8388d4d2019f38eaa60b45287daab7098811542
+  languageName: node
+  linkType: hard
+
 "@bifold/verifier@npm:3.0.21":
   version: 3.0.21
   resolution: "@bifold/verifier@npm:3.0.21"
@@ -7715,7 +7737,7 @@ __metadata:
     "@bifold/oca": "npm:3.0.21"
     "@bifold/react-hooks": "npm:3.0.21"
     "@bifold/react-native-attestation": "npm:3.0.21"
-    "@bifold/remote-logs": "npm:3.0.21"
+    "@bifold/remote-logs": "patch:@bifold/remote-logs@npm%3A3.0.21#~/.yarn/patches/@bifold-remote-logs-npm-3.0.21-4ae200989a.patch"
     "@bifold/verifier": "npm:3.0.21"
     "@credo-ts/anoncreds": "npm:0.6.3"
     "@credo-ts/askar": "npm:0.6.3"


### PR DESCRIPTION
Closes #4599

## What changed

Ledger lookups printed three stack-trace-laden messages per ledger on every DID resolution. A temporary yarn patch on `@bifold/remote-logs` gates `trace`/`test` on their own log levels, drops `console.trace`, and keeps remote logging at full detail. Also fixes `LOG_LEVEL=trace|test`, which the README documents but which both behaved as `debug`.

## What should the reviewer focus on

The one to check is remote logging: enabling it must still capture the same detail it does today, since that is what support sessions rely on. There is a test that asserts the trace line actually reaches the log service, not just the console.

The patch belongs upstream in Bifold. It is a bridge until that lands, and it removes itself: bumping `@bifold/remote-logs` past 3.0.21 fails the install until someone deletes the patch. The upstream change and the two Bifold tests that will need updating are written up in the issue.

## How to test

Covered by unit tests, including a new spec that exercises the real patched build rather than the usual mock.

On device (BC Wallet), with a credential offer or connection invitation to scan:

1. Set `LOG_LEVEL=trace` in `app/.env`. Scanning produces the ledger lookup lines,
   now tagged `[TRACE]` and with no stack trace attached:

   console.js:661 [TRACE] Get public did 'Ttmj1pEotg8FbKZZD81S7i' from ledger 'candy'
   console.js:661 [TRACE] Submitting get did request for did 'Ttmj1pEotg8FbKZZD81S7i' to ledger 'candy'

2. Set `LOG_LEVEL=debug` (the default). The same scan produces none of those lines,
while other debug messages still appear.
