### PR TITLE
ci: approve each publish ring on the way

### DIFF
--- a/.github/scripts/resolve_publishable_build.py
+++ b/.github/scripts/resolve_publishable_build.py
@@ -26,15 +26,6 @@ RINGS = ["ring-0", "ring-1", "ring-2", "ring-3", "ring-4"]
 RING_0_ONLY = {"bcwallet-prod"}
 
 
-def spaced(ring):
-    """The name TestFlight and Play know a ring by.
-
-    Firebase matches on a group alias, which cannot contain spaces, so it keeps
-    the hyphen. TestFlight matches on the group's display name and Play on the
-    track name, and both of those are written with a space. Same ring, three
-    services, two spellings.
-    """
-    return ring.replace("-", " ")
 KINDS = {
     "ipa": re.compile(r"^ios-(?P<variant>.+)\.ipa$"),
     "aab": re.compile(r"^android-(?P<variant>.+)\.aab$"),
@@ -133,29 +124,23 @@ for kind, variants in by_kind.items():
 # ring-0, ring-1 and ring-2. ring-0 is the upload; the rest only widen who
 # can see it, because Apple rejects a duplicate binary and Play rejects a
 # duplicate version code.
-widen_rings = RINGS[1 : RINGS.index(RING) + 1]
+reached = RINGS[: RINGS.index(RING) + 1]
+widen_rings = reached[1:]
 
 print(f"  ring:   {RING}")
-print(f"  reaches: {', '.join(RINGS[: RINGS.index(RING) + 1])}")
+print(f"  reaches: {', '.join(reached)}")
 print("  ring-0 publishes now, without approval")
 held_back = sorted(set(all_variants(by_kind)) & RING_0_ONLY)
 if held_back and widen_rings:
     print(f"  ring-0 only for: {', '.join(held_back)}")
 if widen_rings:
-    print(f"  after {RING} is approved: {', '.join(widen_rings)}")
+    print(f"  then, each behind its own approval, in order: {', '.join(widen_rings)}")
 
 with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
     for kind, variants in by_kind.items():
         widening = [v for v in variants if v not in RING_0_ONLY]
         output.write(f"widen_{kind}_variants={json.dumps(widening)}\n")
-    # Firebase group aliases keep the hyphen.
-    output.write(f"widen_rings_csv={','.join(widen_rings)}\n")
-    # Play track names use the spaced form.
-    output.write(f"widen_tracks_csv={','.join(spaced(r) for r in widen_rings)}\n")
-    # TestFlight takes one group per line, spaced, so it needs the heredoc form.
-    output.write("widen_groups_lines<<__RINGS_EOF__\n")
-    output.write("\n".join(spaced(r) for r in widen_rings) + "\n")
-    output.write("__RINGS_EOF__\n")
+    output.write(f"reached_rings={json.dumps(reached)}\n")
     output.write(f"run_id={run['id']}\n")
     output.write(f"run_number={run['run_number']}\n")
     output.write(f"head_sha={run['head_sha']}\n")

--- a/.github/scripts/resolve_publishable_build.py
+++ b/.github/scripts/resolve_publishable_build.py
@@ -24,6 +24,14 @@ RINGS = ["ring-0", "ring-1", "ring-2", "ring-3", "ring-4"]
 # never created past ring-0. It still publishes to the team; it is left out of
 # everything above that rather than failing the run on a missing group.
 RING_0_ONLY = {"bcwallet-prod"}
+# Which artifact kinds each `targets` choice widens with. Used to tell whether
+# a run has any widening to do, so the gates are not raised for nothing.
+TARGET_KINDS = {
+    "all": ("ipa", "aab", "apk"),
+    "apple-store": ("ipa",),
+    "google-store": ("aab",),
+    "firebase": ("ipa", "apk"),
+}
 
 
 KINDS = {
@@ -67,6 +75,7 @@ def fail(message):
 REPO = os.environ["REPO"]
 BRANCH = os.environ["BRANCH"]
 RING = os.environ["RING"]
+TARGETS = os.environ.get("TARGETS", "all")
 if RING not in RINGS:
     print(f"::error::Unknown ring '{RING}'. Expected one of: {', '.join(RINGS)}.")
     sys.exit(1)
@@ -127,20 +136,34 @@ for kind, variants in by_kind.items():
 reached = RINGS[: RINGS.index(RING) + 1]
 widen_rings = reached[1:]
 
+widen_by_kind = {
+    kind: [v for v in variants if v not in RING_0_ONLY]
+    for kind, variants in by_kind.items()
+}
+# An approval that can only be followed by skipped jobs is worse than no gate:
+# it holds the publish queue while distributing nothing.
+has_widening = bool(widen_rings) and any(
+    widen_by_kind[kind] for kind in TARGET_KINDS.get(TARGETS, TARGET_KINDS["all"])
+)
+
 print(f"  ring:   {RING}")
 print(f"  reaches: {', '.join(reached)}")
 print("  ring-0 publishes now, without approval")
 held_back = sorted(set(all_variants(by_kind)) & RING_0_ONLY)
 if held_back and widen_rings:
     print(f"  ring-0 only for: {', '.join(held_back)}")
-if widen_rings:
+if not widen_rings:
+    pass
+elif has_widening:
     print(f"  then, each behind its own approval, in order: {', '.join(widen_rings)}")
+else:
+    print(f"  nothing to widen for targets '{TARGETS}' — the approval gates are skipped")
 
 with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-    for kind, variants in by_kind.items():
-        widening = [v for v in variants if v not in RING_0_ONLY]
+    for kind, widening in widen_by_kind.items():
         output.write(f"widen_{kind}_variants={json.dumps(widening)}\n")
     output.write(f"reached_rings={json.dumps(reached)}\n")
+    output.write(f"has_widening={str(has_widening).lower()}\n")
     output.write(f"run_id={run['id']}\n")
     output.write(f"run_number={run['run_number']}\n")
     output.write(f"head_sha={run['head_sha']}\n")

--- a/.github/workflows/publish-ring.yml
+++ b/.github/workflows/publish-ring.yml
@@ -1,5 +1,6 @@
 # Widens an already-published build to ONE ring. Called once per ring by
-# publish.yml after that ring's gate; nothing here uploads.
+# publish.yml after that ring's gate. Nothing new reaches the stores here:
+# TestFlight and Play only change who can see the build, Firebase re-sends it.
 name: Publish ring
 
 on:

--- a/.github/workflows/publish-ring.yml
+++ b/.github/workflows/publish-ring.yml
@@ -1,0 +1,248 @@
+# Widens an already-published build to ONE ring. Called once per ring by
+# publish.yml after that ring's gate; nothing here uploads.
+name: Publish ring
+
+on:
+  workflow_call:
+    inputs:
+      ring:
+        type: string
+        required: true
+      run_id:
+        type: string
+        required: true
+      run_number:
+        type: string
+        required: true
+      head_sha:
+        type: string
+        required: true
+      widen_ipa_variants:
+        type: string
+        required: true
+      widen_aab_variants:
+        type: string
+        required: true
+      widen_apk_variants:
+        type: string
+        required: true
+      targets:
+        type: string
+        required: true
+
+permissions: {}
+
+jobs:
+  testflight-widen:
+    name: 'TestFlight widen - ${{ matrix.variant }}'
+    if: >-
+      inputs.widen_ipa_variants != '[]' &&
+      (inputs.targets == 'all' || inputs.targets == 'apple-store')
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJSON(inputs.widen_ipa_variants) }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Use the build's variant config
+        uses: ./.github/workflows/actions/use-build-variant-config
+        with:
+          head_sha: ${{ inputs.head_sha }}
+
+      - name: Load variant config
+        uses: ./.github/workflows/actions/load-variant-config
+        with:
+          variant: ${{ matrix.variant }}
+
+      # TestFlight and Play match the ring's display name, spaced; Firebase the alias, which cannot.
+      - name: Derive the ring's spaced name
+        id: ring
+        env:
+          RING: ${{ inputs.ring }}
+        run: echo "spaced=${RING//-/ }" >> "$GITHUB_OUTPUT"
+
+      - name: Add the higher rings to TestFlight
+        uses: ./.github/workflows/actions/distribute-testflight
+        with:
+          app_store_connect_issuer_id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          app_store_connect_key_identifier: ${{ secrets.APP_STORE_CONNECT_KEY_IDENTIFIER_95 }}
+          app_store_connect_private_key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY_95 }}
+          bundle_id: ${{ env.IOS_BUNDLE_ID }}
+          version_code: ${{ inputs.run_number }}
+          version_name: ${{ env.APP_VERSION }}
+          beta_groups: ${{ steps.ring.outputs.spaced }}
+
+  google-promote:
+    name: 'Google Play closed - ${{ matrix.variant }}'
+    if: >-
+      inputs.widen_aab_variants != '[]' &&
+      (inputs.targets == 'all' || inputs.targets == 'google-store')
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJSON(inputs.widen_aab_variants) }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Use the build's variant config
+        uses: ./.github/workflows/actions/use-build-variant-config
+        with:
+          head_sha: ${{ inputs.head_sha }}
+
+      - name: Load variant config
+        uses: ./.github/workflows/actions/load-variant-config
+        with:
+          variant: ${{ matrix.variant }}
+
+      # TestFlight and Play match the ring's display name, spaced; Firebase the alias, which cannot.
+      - name: Derive the ring's spaced name
+        id: ring
+        env:
+          RING: ${{ inputs.ring }}
+        run: echo "spaced=${RING//-/ }" >> "$GITHUB_OUTPUT"
+
+      - name: Install 1Password CLI
+        uses: 1password/install-cli-action@1a3160d5e9de1ae0803eaa08a88746f5ae3daa50 # v4.1.0
+
+      - name: Fetch Google Play publisher credentials
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          # `op read` to stdout appends a trailing newline, which would corrupt
+          # this JSON credentials file. --out-file writes the bytes as-is.
+          op read "op://bcsc-mobile-app-cd/google-play-publisher/service-account.json" --out-file "${RUNNER_TEMP}/play-service-account.json" --force
+
+      - name: Promote onto the ring's closed track
+        uses: ./.github/workflows/actions/promote-play-track
+        with:
+          service_account_file: ${{ runner.temp }}/play-service-account.json
+          package_name: ${{ env.ANDROID_PACKAGE_NAME }}
+          version_code: ${{ inputs.run_number }}
+          version_name: ${{ env.APP_VERSION }}
+          build_number: ${{ inputs.run_number }}
+          target_tracks: ${{ steps.ring.outputs.spaced }}
+
+  firebase-ios-widen:
+    name: 'Firebase iOS widen - ${{ matrix.variant }}'
+    if: >-
+      inputs.widen_ipa_variants != '[]' &&
+      (inputs.targets == 'all' || inputs.targets == 'firebase')
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJSON(inputs.widen_ipa_variants) }}
+    steps:
+      - name: Download IPA
+        uses: actions/download-artifact@v8
+        with:
+          name: ios-${{ matrix.variant }}.ipa
+          path: ${{ runner.temp }}/firebase-artifact
+          run-id: ${{ inputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - uses: actions/checkout@v7
+
+      - name: Use the build's variant config
+        uses: ./.github/workflows/actions/use-build-variant-config
+        with:
+          head_sha: ${{ inputs.head_sha }}
+
+      - name: Load variant config
+        uses: ./.github/workflows/actions/load-variant-config
+        with:
+          variant: ${{ matrix.variant }}
+
+      - name: Install 1Password CLI
+        uses: 1password/install-cli-action@1a3160d5e9de1ae0803eaa08a88746f5ae3daa50 # v4.1.0
+
+      - name: Fetch Firebase credentials
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          # `op read` to stdout appends a trailing newline; --out-file writes
+          # the document byte-for-byte instead.
+          op read "op://bcsc-mobile-app-cd/google-services-ios-${{ matrix.variant }}/GoogleService-Info.plist" --out-file "${RUNNER_TEMP}/google-services-source" --force
+          op read "${FIREBASE_IOS_SA_REF}" --out-file "${RUNNER_TEMP}/firebase-service-account.json" --force
+
+      - name: Add the higher rings to Firebase
+        uses: ./.github/workflows/actions/distribute-firebase
+        with:
+          platform: ios
+          app_identifier: ${{ env.IOS_BUNDLE_ID }}
+          google_services_file: ${{ runner.temp }}/google-services-source
+          service_account_file: ${{ runner.temp }}/firebase-service-account.json
+          artifact_path: ${{ runner.temp }}/firebase-artifact/BCWallet.ipa
+          groups: ${{ inputs.ring }}
+          version_name: ${{ env.APP_VERSION }}
+          version_code: ${{ inputs.run_number }}
+
+  firebase-android-widen:
+    name: 'Firebase Android widen - ${{ matrix.variant }}'
+    if: >-
+      inputs.widen_apk_variants != '[]' &&
+      (inputs.targets == 'all' || inputs.targets == 'firebase')
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJSON(inputs.widen_apk_variants) }}
+    steps:
+      - name: Download APK
+        uses: actions/download-artifact@v8
+        with:
+          name: android-${{ matrix.variant }}.apk
+          path: ${{ runner.temp }}/firebase-artifact
+          run-id: ${{ inputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - uses: actions/checkout@v7
+
+      - name: Use the build's variant config
+        uses: ./.github/workflows/actions/use-build-variant-config
+        with:
+          head_sha: ${{ inputs.head_sha }}
+
+      - name: Load variant config
+        uses: ./.github/workflows/actions/load-variant-config
+        with:
+          variant: ${{ matrix.variant }}
+
+      - name: Install 1Password CLI
+        uses: 1password/install-cli-action@1a3160d5e9de1ae0803eaa08a88746f5ae3daa50 # v4.1.0
+
+      - name: Fetch Firebase credentials
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          # `op read` to stdout appends a trailing newline; --out-file writes
+          # the document byte-for-byte instead.
+          op read "op://bcsc-mobile-app-cd/google-services-android-${{ matrix.variant }}/google-services.json" --out-file "${RUNNER_TEMP}/google-services-source" --force
+          op read "${FIREBASE_ANDROID_SA_REF}" --out-file "${RUNNER_TEMP}/firebase-service-account.json" --force
+
+      - name: Add the higher rings to Firebase
+        uses: ./.github/workflows/actions/distribute-firebase
+        with:
+          platform: android
+          app_identifier: ${{ env.ANDROID_PACKAGE_NAME }}
+          google_services_file: ${{ runner.temp }}/google-services-source
+          service_account_file: ${{ runner.temp }}/firebase-service-account.json
+          artifact_path: ${{ runner.temp }}/firebase-artifact/app-release.apk
+          groups: ${{ inputs.ring }}
+          version_name: ${{ env.APP_VERSION }}
+          version_code: ${{ inputs.run_number }}

--- a/.github/workflows/publish-ring.yml
+++ b/.github/workflows/publish-ring.yml
@@ -66,7 +66,7 @@ jobs:
           RING: ${{ inputs.ring }}
         run: echo "spaced=${RING//-/ }" >> "$GITHUB_OUTPUT"
 
-      - name: Add the higher rings to TestFlight
+      - name: Add the ring to TestFlight
         uses: ./.github/workflows/actions/distribute-testflight
         with:
           app_store_connect_issuer_id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
@@ -177,7 +177,7 @@ jobs:
           op read "op://bcsc-mobile-app-cd/google-services-ios-${{ matrix.variant }}/GoogleService-Info.plist" --out-file "${RUNNER_TEMP}/google-services-source" --force
           op read "${FIREBASE_IOS_SA_REF}" --out-file "${RUNNER_TEMP}/firebase-service-account.json" --force
 
-      - name: Add the higher rings to Firebase
+      - name: Add the ring to Firebase
         uses: ./.github/workflows/actions/distribute-firebase
         with:
           platform: ios
@@ -235,7 +235,7 @@ jobs:
           op read "op://bcsc-mobile-app-cd/google-services-android-${{ matrix.variant }}/google-services.json" --out-file "${RUNNER_TEMP}/google-services-source" --force
           op read "${FIREBASE_ANDROID_SA_REF}" --out-file "${RUNNER_TEMP}/firebase-service-account.json" --force
 
-      - name: Add the higher rings to Firebase
+      - name: Add the ring to Firebase
         uses: ./.github/workflows/actions/distribute-firebase
         with:
           platform: android

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,15 +7,15 @@
 # only from here.
 #
 # `ring` is the audience. ring-0 is the team and always publishes, without
-# approval. Picking a higher ring publishes every ring up to it, and those
-# wait on the chosen ring's environment approval. See docs/releases.md.
+# approval. Picking a higher ring publishes every ring up to it, each behind
+# its own environment approval, in order. See docs/releases.md.
 name: Publish
 
 on:
   workflow_dispatch:
     inputs:
       ring:
-        description: 'How far to publish. ring-0 (the team) always goes; this picks how much further, and needs approval.'
+        description: 'How far to publish. ring-0 (the team) always goes; this picks how much further, and each ring on the way needs its own approval.'
         required: false
         default: ring-2
         type: choice
@@ -77,9 +77,7 @@ jobs:
       widen_ipa_variants: ${{ steps.resolve.outputs.widen_ipa_variants }}
       widen_aab_variants: ${{ steps.resolve.outputs.widen_aab_variants }}
       widen_apk_variants: ${{ steps.resolve.outputs.widen_apk_variants }}
-      widen_rings_csv: ${{ steps.resolve.outputs.widen_rings_csv }}
-      widen_tracks_csv: ${{ steps.resolve.outputs.widen_tracks_csv }}
-      widen_groups_lines: ${{ steps.resolve.outputs.widen_groups_lines }}
+      reached_rings: ${{ steps.resolve.outputs.reached_rings }}
     steps:
       # A feature branch can produce a perfectly good build, but shipping one
       # to real testers is almost always a mistake. Releases come off main or
@@ -418,257 +416,164 @@ jobs:
           git push origin "refs/tags/${TAG}"
           echo "Tagged ${HEAD_SHA} as ${TAG}"
 
-  # ─── The approval gate ──────────────────────────────────────────────
-  # The environment is named after the chosen ring, so who may approve
-  # ring-4 is configured separately from who may approve ring-1. Everything
-  # below waits here; ring-0 above has already gone out, and still goes out
-  # if this is rejected.
-  #
-  # It waits on the ring-0 jobs so the prompt only appears once the team
-  # has the build — an approver deciding whether to go wider should be able
-  # to see that ring-0 landed. A failed ring-0 leg does not block approval —
-  # a broken iOS upload should not hold up widening on Android — and each
-  # widen job fails on its own if its variant's build never made it out:
-  # TestFlight bails NOT_FOUND after 180s, `tracks set-release` errors on a
-  # version code that was never uploaded, and Firebase widen re-distributes
-  # its own artifact.
-  #
-  # An environment with no protection rules approves instantly, so this gate
-  # is open until required reviewers are configured in Settings.
-  approval:
-    name: 'Approve ${{ inputs.ring }}'
+  # ─── The approval gates ──────────────────────────────────────────────
+  # Each gate is its own environment, so who approves ring-4 is configured
+  # separately from who approves ring-1. approve-ring-1 waits on the ring-0
+  # jobs so the prompt appears once the team has the build; a failed ring-0
+  # leg does not block it, because each widen job fails on its own if its
+  # variant's build never made it out: TestFlight bails NOT_FOUND after
+  # 180s, `tracks set-release` errors on a version code that was never
+  # uploaded, and Firebase widen re-distributes its own artifact. Later
+  # gates wait on the previous ring's widening the same way, and
+  # deliberately not on its result. An environment with no protection rules
+  # approves instantly, so a gate is open until required reviewers are
+  # configured in Settings.
+
+  approve-ring-1:
+    name: Approve ring-1
     needs: [resolve-build, apple-upload, google-upload, firebase-ios, firebase-android]
+    # resolve-build success is tested first: fromJSON must not see an empty output.
     if: >-
       always() && !cancelled() &&
-      needs.resolve-build.result == 'success'
+      needs.resolve-build.result == 'success' &&
+      contains(fromJSON(needs.resolve-build.outputs.reached_rings), 'ring-1')
     runs-on: ubuntu-22.04
     environment:
-      name: ${{ inputs.ring }}
+      name: ring-1
     permissions: {}
     steps:
       - name: Approved
         env:
-          RING: ${{ inputs.ring }}
-          RINGS: ${{ needs.resolve-build.outputs.widen_rings_csv }}
           BUILD: ${{ needs.resolve-build.outputs.run_number }}
-        run: echo "Build ${BUILD} approved for ${RING} — publishing ${RINGS}"
+        run: echo "Build ${BUILD} approved for ring-1"
 
-  # ─── Widening: every ring above ring-0 ──────────────────────────────
-  # Nothing here uploads. The build is already in the stores; these jobs
-  # only add rings to the audience that can see it.
-
-  testflight-widen:
-    name: 'TestFlight widen - ${{ matrix.variant }}'
-    needs: [resolve-build, approval, apple-upload]
+  ring-1:
+    needs: [resolve-build, approve-ring-1]
     if: >-
-      always() && !cancelled() &&
-      needs.resolve-build.result == 'success' &&
-      needs.approval.result == 'success' &&
-      needs.resolve-build.outputs.widen_ipa_variants != '[]' &&
-      (inputs.targets == 'all' || inputs.targets == 'apple-store')
-    runs-on: ubuntu-22.04
+      needs.approve-ring-1.result == 'success' &&
+      contains(fromJSON(needs.resolve-build.outputs.reached_rings), 'ring-1')
     permissions:
       contents: read
       actions: read
-    strategy:
-      fail-fast: false
-      matrix:
-        variant: ${{ fromJSON(needs.resolve-build.outputs.widen_ipa_variants) }}
-    steps:
-      - uses: actions/checkout@v7
+    uses: ./.github/workflows/publish-ring.yml
+    with:
+      ring: ring-1
+      run_id: ${{ needs.resolve-build.outputs.run_id }}
+      run_number: ${{ needs.resolve-build.outputs.run_number }}
+      head_sha: ${{ needs.resolve-build.outputs.head_sha }}
+      widen_ipa_variants: ${{ needs.resolve-build.outputs.widen_ipa_variants }}
+      widen_aab_variants: ${{ needs.resolve-build.outputs.widen_aab_variants }}
+      widen_apk_variants: ${{ needs.resolve-build.outputs.widen_apk_variants }}
+      targets: ${{ inputs.targets }}
+    secrets: inherit
 
-      - name: Use the build's variant config
-        uses: ./.github/workflows/actions/use-build-variant-config
-        with:
-          head_sha: ${{ needs.resolve-build.outputs.head_sha }}
-
-      - name: Load variant config
-        uses: ./.github/workflows/actions/load-variant-config
-        with:
-          variant: ${{ matrix.variant }}
-
-      - name: Add the higher rings to TestFlight
-        uses: ./.github/workflows/actions/distribute-testflight
-        with:
-          app_store_connect_issuer_id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-          app_store_connect_key_identifier: ${{ secrets.APP_STORE_CONNECT_KEY_IDENTIFIER_95 }}
-          app_store_connect_private_key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY_95 }}
-          bundle_id: ${{ env.IOS_BUNDLE_ID }}
-          version_code: ${{ needs.resolve-build.outputs.run_number }}
-          version_name: ${{ env.APP_VERSION }}
-          beta_groups: ${{ needs.resolve-build.outputs.widen_groups_lines }}
-
-  google-promote:
-    name: 'Google Play closed - ${{ matrix.variant }}'
-    needs: [resolve-build, approval, google-upload]
+  approve-ring-2:
+    name: Approve ring-2
+    needs: [resolve-build, approve-ring-1, ring-1]
     if: >-
       always() && !cancelled() &&
-      needs.resolve-build.result == 'success' &&
-      needs.approval.result == 'success' &&
-      needs.resolve-build.outputs.widen_aab_variants != '[]' &&
-      (inputs.targets == 'all' || inputs.targets == 'google-store')
+      needs.approve-ring-1.result == 'success' &&
+      contains(fromJSON(needs.resolve-build.outputs.reached_rings), 'ring-2')
     runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-      actions: read
-    strategy:
-      fail-fast: false
-      matrix:
-        variant: ${{ fromJSON(needs.resolve-build.outputs.widen_aab_variants) }}
+    environment:
+      name: ring-2
+    permissions: {}
     steps:
-      - uses: actions/checkout@v7
-
-      - name: Use the build's variant config
-        uses: ./.github/workflows/actions/use-build-variant-config
-        with:
-          head_sha: ${{ needs.resolve-build.outputs.head_sha }}
-
-      - name: Load variant config
-        uses: ./.github/workflows/actions/load-variant-config
-        with:
-          variant: ${{ matrix.variant }}
-
-      - name: Install 1Password CLI
-        uses: 1password/install-cli-action@1a3160d5e9de1ae0803eaa08a88746f5ae3daa50 # v4.1.0
-
-      - name: Fetch Google Play publisher credentials
+      - name: Approved
         env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        run: |
-          # `op read` to stdout appends a trailing newline, which would corrupt
-          # this JSON credentials file. --out-file writes the bytes as-is.
-          op read "op://bcsc-mobile-app-cd/google-play-publisher/service-account.json" --out-file "${RUNNER_TEMP}/play-service-account.json" --force
+          BUILD: ${{ needs.resolve-build.outputs.run_number }}
+        run: echo "Build ${BUILD} approved for ring-2"
 
-      - name: Promote onto the ring's closed track
-        uses: ./.github/workflows/actions/promote-play-track
-        with:
-          service_account_file: ${{ runner.temp }}/play-service-account.json
-          package_name: ${{ env.ANDROID_PACKAGE_NAME }}
-          version_code: ${{ needs.resolve-build.outputs.run_number }}
-          version_name: ${{ env.APP_VERSION }}
-          build_number: ${{ needs.resolve-build.outputs.run_number }}
-          target_tracks: ${{ needs.resolve-build.outputs.widen_tracks_csv }}
-
-  firebase-ios-widen:
-    name: 'Firebase iOS widen - ${{ matrix.variant }}'
-    needs: [resolve-build, approval, firebase-ios]
+  ring-2:
+    needs: [resolve-build, approve-ring-2]
     if: >-
-      always() && !cancelled() &&
-      needs.resolve-build.result == 'success' &&
-      needs.approval.result == 'success' &&
-      needs.resolve-build.outputs.widen_ipa_variants != '[]' &&
-      (inputs.targets == 'all' || inputs.targets == 'firebase')
-    runs-on: ubuntu-22.04
+      needs.approve-ring-2.result == 'success' &&
+      contains(fromJSON(needs.resolve-build.outputs.reached_rings), 'ring-2')
     permissions:
       contents: read
       actions: read
-    strategy:
-      fail-fast: false
-      matrix:
-        variant: ${{ fromJSON(needs.resolve-build.outputs.widen_ipa_variants) }}
-    steps:
-      - name: Download IPA
-        uses: actions/download-artifact@v8
-        with:
-          name: ios-${{ matrix.variant }}.ipa
-          path: ${{ runner.temp }}/firebase-artifact
-          run-id: ${{ needs.resolve-build.outputs.run_id }}
-          github-token: ${{ github.token }}
+    uses: ./.github/workflows/publish-ring.yml
+    with:
+      ring: ring-2
+      run_id: ${{ needs.resolve-build.outputs.run_id }}
+      run_number: ${{ needs.resolve-build.outputs.run_number }}
+      head_sha: ${{ needs.resolve-build.outputs.head_sha }}
+      widen_ipa_variants: ${{ needs.resolve-build.outputs.widen_ipa_variants }}
+      widen_aab_variants: ${{ needs.resolve-build.outputs.widen_aab_variants }}
+      widen_apk_variants: ${{ needs.resolve-build.outputs.widen_apk_variants }}
+      targets: ${{ inputs.targets }}
+    secrets: inherit
 
-      - uses: actions/checkout@v7
-
-      - name: Use the build's variant config
-        uses: ./.github/workflows/actions/use-build-variant-config
-        with:
-          head_sha: ${{ needs.resolve-build.outputs.head_sha }}
-
-      - name: Load variant config
-        uses: ./.github/workflows/actions/load-variant-config
-        with:
-          variant: ${{ matrix.variant }}
-
-      - name: Install 1Password CLI
-        uses: 1password/install-cli-action@1a3160d5e9de1ae0803eaa08a88746f5ae3daa50 # v4.1.0
-
-      - name: Fetch Firebase credentials
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        run: |
-          # `op read` to stdout appends a trailing newline; --out-file writes
-          # the document byte-for-byte instead.
-          op read "op://bcsc-mobile-app-cd/google-services-ios-${{ matrix.variant }}/GoogleService-Info.plist" --out-file "${RUNNER_TEMP}/google-services-source" --force
-          op read "${FIREBASE_IOS_SA_REF}" --out-file "${RUNNER_TEMP}/firebase-service-account.json" --force
-
-      - name: Add the higher rings to Firebase
-        uses: ./.github/workflows/actions/distribute-firebase
-        with:
-          platform: ios
-          app_identifier: ${{ env.IOS_BUNDLE_ID }}
-          google_services_file: ${{ runner.temp }}/google-services-source
-          service_account_file: ${{ runner.temp }}/firebase-service-account.json
-          artifact_path: ${{ runner.temp }}/firebase-artifact/BCWallet.ipa
-          groups: ${{ needs.resolve-build.outputs.widen_rings_csv }}
-          version_name: ${{ env.APP_VERSION }}
-          version_code: ${{ needs.resolve-build.outputs.run_number }}
-
-  firebase-android-widen:
-    name: 'Firebase Android widen - ${{ matrix.variant }}'
-    needs: [resolve-build, approval, firebase-android]
+  approve-ring-3:
+    name: Approve ring-3
+    needs: [resolve-build, approve-ring-2, ring-2]
     if: >-
       always() && !cancelled() &&
-      needs.resolve-build.result == 'success' &&
-      needs.approval.result == 'success' &&
-      needs.resolve-build.outputs.widen_apk_variants != '[]' &&
-      (inputs.targets == 'all' || inputs.targets == 'firebase')
+      needs.approve-ring-2.result == 'success' &&
+      contains(fromJSON(needs.resolve-build.outputs.reached_rings), 'ring-3')
     runs-on: ubuntu-22.04
+    environment:
+      name: ring-3
+    permissions: {}
+    steps:
+      - name: Approved
+        env:
+          BUILD: ${{ needs.resolve-build.outputs.run_number }}
+        run: echo "Build ${BUILD} approved for ring-3"
+
+  ring-3:
+    needs: [resolve-build, approve-ring-3]
+    if: >-
+      needs.approve-ring-3.result == 'success' &&
+      contains(fromJSON(needs.resolve-build.outputs.reached_rings), 'ring-3')
     permissions:
       contents: read
       actions: read
-    strategy:
-      fail-fast: false
-      matrix:
-        variant: ${{ fromJSON(needs.resolve-build.outputs.widen_apk_variants) }}
+    uses: ./.github/workflows/publish-ring.yml
+    with:
+      ring: ring-3
+      run_id: ${{ needs.resolve-build.outputs.run_id }}
+      run_number: ${{ needs.resolve-build.outputs.run_number }}
+      head_sha: ${{ needs.resolve-build.outputs.head_sha }}
+      widen_ipa_variants: ${{ needs.resolve-build.outputs.widen_ipa_variants }}
+      widen_aab_variants: ${{ needs.resolve-build.outputs.widen_aab_variants }}
+      widen_apk_variants: ${{ needs.resolve-build.outputs.widen_apk_variants }}
+      targets: ${{ inputs.targets }}
+    secrets: inherit
+
+  approve-ring-4:
+    name: Approve ring-4
+    needs: [resolve-build, approve-ring-3, ring-3]
+    if: >-
+      always() && !cancelled() &&
+      needs.approve-ring-3.result == 'success' &&
+      contains(fromJSON(needs.resolve-build.outputs.reached_rings), 'ring-4')
+    runs-on: ubuntu-22.04
+    environment:
+      name: ring-4
+    permissions: {}
     steps:
-      - name: Download APK
-        uses: actions/download-artifact@v8
-        with:
-          name: android-${{ matrix.variant }}.apk
-          path: ${{ runner.temp }}/firebase-artifact
-          run-id: ${{ needs.resolve-build.outputs.run_id }}
-          github-token: ${{ github.token }}
-
-      - uses: actions/checkout@v7
-
-      - name: Use the build's variant config
-        uses: ./.github/workflows/actions/use-build-variant-config
-        with:
-          head_sha: ${{ needs.resolve-build.outputs.head_sha }}
-
-      - name: Load variant config
-        uses: ./.github/workflows/actions/load-variant-config
-        with:
-          variant: ${{ matrix.variant }}
-
-      - name: Install 1Password CLI
-        uses: 1password/install-cli-action@1a3160d5e9de1ae0803eaa08a88746f5ae3daa50 # v4.1.0
-
-      - name: Fetch Firebase credentials
+      - name: Approved
         env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        run: |
-          # `op read` to stdout appends a trailing newline; --out-file writes
-          # the document byte-for-byte instead.
-          op read "op://bcsc-mobile-app-cd/google-services-android-${{ matrix.variant }}/google-services.json" --out-file "${RUNNER_TEMP}/google-services-source" --force
-          op read "${FIREBASE_ANDROID_SA_REF}" --out-file "${RUNNER_TEMP}/firebase-service-account.json" --force
+          BUILD: ${{ needs.resolve-build.outputs.run_number }}
+        run: echo "Build ${BUILD} approved for ring-4"
 
-      - name: Add the higher rings to Firebase
-        uses: ./.github/workflows/actions/distribute-firebase
-        with:
-          platform: android
-          app_identifier: ${{ env.ANDROID_PACKAGE_NAME }}
-          google_services_file: ${{ runner.temp }}/google-services-source
-          service_account_file: ${{ runner.temp }}/firebase-service-account.json
-          artifact_path: ${{ runner.temp }}/firebase-artifact/app-release.apk
-          groups: ${{ needs.resolve-build.outputs.widen_rings_csv }}
-          version_name: ${{ env.APP_VERSION }}
-          version_code: ${{ needs.resolve-build.outputs.run_number }}
+  ring-4:
+    needs: [resolve-build, approve-ring-4]
+    if: >-
+      needs.approve-ring-4.result == 'success' &&
+      contains(fromJSON(needs.resolve-build.outputs.reached_rings), 'ring-4')
+    permissions:
+      contents: read
+      actions: read
+    uses: ./.github/workflows/publish-ring.yml
+    with:
+      ring: ring-4
+      run_id: ${{ needs.resolve-build.outputs.run_id }}
+      run_number: ${{ needs.resolve-build.outputs.run_number }}
+      head_sha: ${{ needs.resolve-build.outputs.head_sha }}
+      widen_ipa_variants: ${{ needs.resolve-build.outputs.widen_ipa_variants }}
+      widen_aab_variants: ${{ needs.resolve-build.outputs.widen_aab_variants }}
+      widen_apk_variants: ${{ needs.resolve-build.outputs.widen_apk_variants }}
+      targets: ${{ inputs.targets }}
+    secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,6 +78,7 @@ jobs:
       widen_aab_variants: ${{ steps.resolve.outputs.widen_aab_variants }}
       widen_apk_variants: ${{ steps.resolve.outputs.widen_apk_variants }}
       reached_rings: ${{ steps.resolve.outputs.reached_rings }}
+      has_widening: ${{ steps.resolve.outputs.has_widening }}
     steps:
       # A feature branch can produce a perfectly good build, but shipping one
       # to real testers is almost always a mistake. Releases come off main or
@@ -105,6 +106,7 @@ jobs:
           REPO: ${{ github.repository }}
           BRANCH: ${{ github.ref_name }}
           RING: ${{ inputs.ring }}
+          TARGETS: ${{ inputs.targets }}
           REQUESTED_BUILD: ${{ inputs.build_number }}
         run: python3 .github/scripts/resolve_publishable_build.py
 
@@ -433,9 +435,11 @@ jobs:
     name: Approve ring-1
     needs: [resolve-build, apple-upload, google-upload, firebase-ios, firebase-android]
     # resolve-build success is tested first: fromJSON must not see an empty output.
+    # Skipping this gate skips the whole chain, since each one needs the last.
     if: >-
       always() && !cancelled() &&
       needs.resolve-build.result == 'success' &&
+      needs.resolve-build.outputs.has_widening == 'true' &&
       contains(fromJSON(needs.resolve-build.outputs.reached_rings), 'ring-1')
     runs-on: ubuntu-22.04
     environment:

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -16,9 +16,9 @@ flowchart TD
     H([Someone runs Publish]) --> R[Pick a build]
     A --> R
     R --> R0[ring-0 - the team, no approval]
-    R0 --> AP{Approve the chosen ring?}
-    AP -->|yes| W[Widen to rings 1 to 4]
-    AP -->|no| S[Stops at ring-0]
+    R0 --> G{Approve the next ring?}
+    G -->|yes| W[That ring's testers get it] --> G
+    G -->|no| S[Stops there]
 ```
 
 ## On a pull request
@@ -40,8 +40,8 @@ That's the end of it. No store, no testers, no notifications.
 ## Publishing
 
 Go to **Actions → Publish → Run workflow**, pick how far it should go, and run
-it. Anyone with write access can start one; only an approver can take it past
-ring-0. Publish runs from `main` or a `release/*` branch only.
+it. Anyone with write access can start one; each ring past ring-0 waits for
+that ring's approvers. Publish runs from `main` or a `release/*` branch only.
 
 Publish never builds. It uploads the artifacts an earlier run produced, so what
 a tester installs is exactly what CI made.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -44,7 +44,8 @@ is the one case where a build can knock another off a track.
 
 QA and UAT are separate rings with separate gates. ring-1 goes to QA testers,
 ring-2 to UAT testers, and each has its own approval even though the same
-people sit on both teams today. A ring-4 publish asks all four teams in turn.
+people sit on both teams today. A ring-4 publish stops at all four gates in
+turn, and the same team approves the last two.
 
 | Team | Approves | Who is on it |
 |---|---|---|

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -20,8 +20,8 @@ A ring is an audience. Each one is wider than the last.
 
 Publishing to a ring publishes every ring below it, so `ring-2` sends the build
 to ring-0, ring-1 and ring-2. The team gets it straight away, and each ring
-after that has its own gate — its testers get the build as soon as that gate
-passes. Rejecting at any gate stops the run there, and every ring below
+after that has its own gate, and its testers get the build as soon as that
+gate passes. Rejecting at any gate stops the run there, and every ring below
 already has it.
 
 BC Wallet is the exception. It is being retired after v4.1, so it publishes to
@@ -46,6 +46,10 @@ QA and UAT are separate rings with separate gates. ring-1 goes to QA testers,
 ring-2 to UAT testers, and each has its own approval even though the same
 people sit on both teams today. A ring-4 publish stops at all four gates in
 turn, and the same team approves the last two.
+
+A run with nothing to widen asks for no approvals at all. Picking `targets`
+that no artifact in the build can reach, such as `google-store` on an
+iOS-only build, publishes ring-0 and skips every gate.
 
 | Team | Approves | Who is on it |
 |---|---|---|

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -19,9 +19,10 @@ A ring is an audience. Each one is wider than the last.
 | `ring-4` | Everyone | `bcsc-approvers-ring-3-plus` |
 
 Publishing to a ring publishes every ring below it, so `ring-2` sends the build
-to ring-0, ring-1 and ring-2. The team gets it straight away; everything above
-ring-0 waits on one approval covering the whole run. Rejecting stops the
-widening, but the team already has it.
+to ring-0, ring-1 and ring-2. The team gets it straight away, and each ring
+after that has its own gate — its testers get the build as soon as that gate
+passes. Rejecting at any gate stops the run there, and every ring below
+already has it.
 
 BC Wallet is the exception. It is being retired after v4.1, so it publishes to
 the team and is left out of the wider rings rather than failing on groups that
@@ -43,7 +44,7 @@ is the one case where a build can knock another off a track.
 
 QA and UAT are separate rings with separate gates. ring-1 goes to QA testers,
 ring-2 to UAT testers, and each has its own approval even though the same
-people sit on both teams today.
+people sit on both teams today. A ring-4 publish asks all four teams in turn.
 
 | Team | Approves | Who is on it |
 |---|---|---|
@@ -61,7 +62,7 @@ run, so a publish always needs a second person.
 ## Publishing
 
 Go to **Actions → Publish → Run workflow**. Anyone with write access can start
-one; only an approver can take it past ring-0.
+one; each ring past ring-0 waits for that ring's approvers.
 
 | Input | Leave it alone to | Use it to |
 |---|---|---|
@@ -107,8 +108,8 @@ version comes from the variant files, not the branch name.
 ### One publish at a time
 
 Publishes queue in the order they started rather than running together, so more
-than one can be waiting. A run sitting at the approval gate holds the queue, so
-approve or reject promptly.
+than one can be waiting. A run waiting at any of its gates holds the queue, and
+a ring-4 publish has four, so approve or reject promptly.
 
 ## Version numbers
 
@@ -133,8 +134,8 @@ The tag lands on the commit that produced the published build, which is not
 always the branch tip — publishing an older `build_number` tags that older
 commit. It marks what was actually shipped, not just what merged.
 
-Tagging runs right after the ring-0 uploads and does not wait on approval or
-widening, since a build only reaches ring-0 once. It goes ahead as long as no
+Tagging runs right after the ring-0 uploads and does not wait on any approval
+or widening, since a build only reaches ring-0 once. It goes ahead as long as no
 ring-0 upload failed, so a run limited to one store via `targets` still gets
 tagged, and a retry after a partial failure re-runs it safely: the tag is left
 alone if it's already there.
@@ -189,7 +190,8 @@ away, or it publishes with nobody signing off.
 ## When something goes wrong
 
 Each store publishes separately, so one failing does not stop the others.
-Re-run with `targets` set to the store that failed.
+Re-run with `targets` set to the store that failed. A re-run walks back
+through every gate on the way, since a publish always starts from ring-0.
 
 A destination that is skipped rather than failed had no artifact to publish.
 The **Resolve build** step lists what it found. iOS and Android build


### PR DESCRIPTION
## What changed

Publishing to a wider audience now stops for approval at every ring along the way, not just the one you picked. Each ring is signed off by its own approver group, and that ring's testers get the build as soon as their gate passes.

## What should the reviewer focus on

The order the four gates run in, and that unused ones are skipped rather than failed. Picking ring-2 should ask for two approvals and leave ring-3 and ring-4 greyed out.

Worth knowing: a run now sits in the queue until its last gate is answered, so a ring-4 publish can hold up other publishes for longer than before.

## How to test

Only testable once it is on main, because Publish will not run from a feature branch. Suggested first run is ring-2 with an existing build number and targets set to firebase.
