### PR TITLE
chore: verify test-ids

### DIFF
--- a/app/eslint.config.mjs
+++ b/app/eslint.config.mjs
@@ -101,7 +101,12 @@ export default [
   // so unmigrated areas stay green while migrated ones cannot regress. Tests are exempt on purpose:
   // asserting the literal id string is what proves the emitted ids never moved.
   {
-    files: ['src/test-ids/**', 'src/bcsc-theme/features/onboarding/**', 'src/bcsc-theme/features/auth/**'],
+    files: [
+      'src/test-ids/**',
+      'src/bcsc-theme/features/onboarding/**',
+      'src/bcsc-theme/features/auth/**',
+      'src/bcsc-theme/features/verify/**',
+    ],
     ignores: ['**/*.test.{ts,tsx}'],
     rules: {
       'no-restricted-syntax': [

--- a/app/src/bcsc-theme/features/verify/BirthdateLockoutScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/BirthdateLockoutScreen.tsx
@@ -1,4 +1,5 @@
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useTranslation } from 'react-i18next'
@@ -19,7 +20,7 @@ export const BirthdateLockoutScreen = ({ navigation }: BirthdateLockoutScreenPro
     <Button
       title={t('Global.Close')}
       accessibilityLabel={t('Global.Close')}
-      testID={testIdWithKey('Close')}
+      testID={testIdWithKey(TestIds.verify.birthdateLockout.close)}
       onPress={handleClose}
       buttonType={ButtonType.Secondary}
     />

--- a/app/src/bcsc-theme/features/verify/DeviceAuthorizationErrorScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/DeviceAuthorizationErrorScreen.tsx
@@ -1,4 +1,5 @@
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
+import { TestIds } from '@/test-ids/registry'
 import { openLink } from '@/utils/links'
 import { Button, ButtonType, ColorPalette, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { RouteProp, useRoute } from '@react-navigation/native'
@@ -23,7 +24,7 @@ const DeviceAuthorizationErrorScreen = () => {
         title=""
         accessibilityLabel={t(config.buttonTextKey)}
         accessibilityHint={t('Global.A11y.OpensInBrowser')}
-        testID={testIdWithKey('DeviceAuthorizationErrorLink')}
+        testID={testIdWithKey(TestIds.verify.deviceAuthorizationError.link)}
         buttonType={ButtonType.Primary}
         onPress={() => openLink(config.buttonUrl)}
       >

--- a/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/EnterBirthdate/EnterBirthdateScreen.tsx
@@ -3,6 +3,7 @@ import DateInput from '@/bcsc-theme/components/DateInput'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { parseBirthdateToLocalDate } from '@/bcsc-theme/utils/birthdate'
 import { isHandledAppError } from '@/errors/appError'
+import { TestIds } from '@/test-ids/registry'
 import {
   Button,
   ButtonType,
@@ -74,7 +75,7 @@ const EnterBirthdateScreen: React.FC<EnterBirthdateScreenProps> = ({ navigation 
       <Button
         title={t('Global.Continue')}
         accessibilityLabel={t('Global.Continue')}
-        testID={testIdWithKey('Continue')}
+        testID={testIdWithKey(TestIds.verify.enterBirthdate.continue)}
         onPress={handleSubmit}
         buttonType={ButtonType.Primary}
         disabled={loading}

--- a/app/src/bcsc-theme/features/verify/IdentitySelectionScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/IdentitySelectionScreen.tsx
@@ -3,6 +3,7 @@ import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { useVerificationReset } from '@/bcsc-theme/hooks/useVerificationReset'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import ScanExampleImage from '@assets/img/scan_example.png'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useStore, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -64,14 +65,14 @@ const IdentitySelectionScreen: React.FC<IdentitySelectionScreenProps> = ({
         buttonType={ButtonType.Primary}
         accessibilityLabel={t('BCSC.IdentitySelection.Scan')}
         title={t('BCSC.IdentitySelection.Scan')}
-        testID={testIdWithKey('Scan')}
+        testID={testIdWithKey(TestIds.verify.identitySelection.scan)}
         onPress={onPressScan}
       />
       <Button
         buttonType={ButtonType.Secondary}
         accessibilityLabel={t('BCSC.IdentitySelection.UseOtherID')}
         title={t('BCSC.IdentitySelection.UseOtherID')}
-        testID={testIdWithKey('OtherID')}
+        testID={testIdWithKey(TestIds.verify.identitySelection.otherId)}
         onPress={onPressOtherID}
       />
     </ControlContainer>

--- a/app/src/bcsc-theme/features/verify/ManualSerialScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/ManualSerialScreen.tsx
@@ -4,6 +4,7 @@ import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { firstErrorKey, serialSchema } from '@/bcsc-theme/utils/validation'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import SerialHighlightImage from '@assets/img/highlight_serial_barcode.png'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useStore, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -48,7 +49,7 @@ const ManualSerialScreen: React.FC<ManualSerialScreenProps> = ({ navigation }: M
       <Button
         title={t('Global.Continue')}
         buttonType={ButtonType.Primary}
-        testID={testIdWithKey('Continue')}
+        testID={testIdWithKey(TestIds.verify.manualSerial.continue)}
         accessibilityLabel={t('Global.Continue')}
         onPress={onContinuePressed}
       />

--- a/app/src/bcsc-theme/features/verify/PhotoInstructionsScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/PhotoInstructionsScreen.tsx
@@ -1,6 +1,7 @@
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import BulletPointList from '@/components/BulletPointList'
+import { TestIds } from '@/test-ids/registry'
 import WhiteHandHoldingPhone from '@assets/img/white-hand-holding-phone.svg'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { RouteProp } from '@react-navigation/native'
@@ -39,7 +40,7 @@ const PhotoInstructionsScreen = ({ navigation, route }: PhotoInstructionsScreenP
             forLiveCall,
           })
         }}
-        testID={testIdWithKey('TakePhoto')}
+        testID={testIdWithKey(TestIds.verify.photoInstructions.takePhoto)}
         accessibilityLabel={a11yLabel(t('BCSC.PhotoInstructions.TakePhotoAccessibilityLabel'))}
       />
     </ControlContainer>

--- a/app/src/bcsc-theme/features/verify/ResidentialAddressScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/ResidentialAddressScreen.tsx
@@ -3,6 +3,7 @@ import { DropdownWithValidation } from '@/bcsc-theme/components/DropdownWithVali
 import { InputWithValidation } from '@/bcsc-theme/components/InputWithValidation'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { PROVINCE_OPTIONS } from '@/bcsc-theme/utils/address-utils'
+import { TestIds } from '@/test-ids/registry'
 import {
   Button,
   ButtonType,
@@ -40,7 +41,7 @@ export const ResidentialAddressScreen = ({ navigation }: ResidentialAddressScree
       <Button
         title={t('Global.Continue')}
         accessibilityLabel={t('Global.Continue')}
-        testID={testIdWithKey('ResidentialAddressContinue')}
+        testID={testIdWithKey(TestIds.verify.residentialAddress.continue)}
         buttonType={ButtonType.Primary}
         onPress={handleSubmit}
         disabled={isSubmitting}

--- a/app/src/bcsc-theme/features/verify/ScanSerialScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/ScanSerialScreen.tsx
@@ -4,6 +4,7 @@ import { useCardScanner } from '@/bcsc-theme/hooks/useCardScanner'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { decodeBarcodes, DecodedCodeKind, ScanableCode } from '@/bcsc-theme/utils/decoder-strategy/DecoderStrategy'
 import { useAutoRequestPermission } from '@/hooks/useAutoRequestPermission'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, TOKENS, useServices, useTheme } from '@bifold/core'
 import { useFocusEffect } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -346,7 +347,7 @@ const ScanSerialScreen: React.FC<ScanSerialScreenProps> = ({ navigation }: ScanS
         secondaryAction={{
           title: t('BCSC.Instructions.EnterManually'),
           onPress: goToManualEntry,
-          testID: testIdWithKey('EnterManually'),
+          testID: testIdWithKey(TestIds.verify.scanSerial.enterManually),
         }}
       />
     )
@@ -406,7 +407,7 @@ const ScanSerialScreen: React.FC<ScanSerialScreenProps> = ({ navigation }: ScanS
             <Button
               title={t('BCSC.Instructions.EnterManually')}
               accessibilityLabel={t('BCSC.Instructions.EnterManually')}
-              testID={testIdWithKey('EnterManually')}
+              testID={testIdWithKey(TestIds.verify.scanSerial.enterManually)}
               onPress={goToManualEntry}
               buttonType={ButtonType.Primary}
             />
@@ -414,7 +415,7 @@ const ScanSerialScreen: React.FC<ScanSerialScreenProps> = ({ navigation }: ScanS
               <Button
                 title={t('BCSC.Scan.TryAgain')}
                 accessibilityLabel={t('BCSC.Scan.TryAgain')}
-                testID={testIdWithKey('RetryCamera')}
+                testID={testIdWithKey(TestIds.verify.scanSerial.retryCamera)}
                 onPress={retryCamera}
                 buttonType={ButtonType.Secondary}
               />

--- a/app/src/bcsc-theme/features/verify/SerialInstructionsScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/SerialInstructionsScreen.tsx
@@ -1,4 +1,5 @@
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
+import { TestIds } from '@/test-ids/registry'
 import SerialHighlightImage from '@assets/img/highlight_serial_barcode.png'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -42,14 +43,14 @@ const SerialInstructionsScreen: React.FC<SerialInstructionsScreenProps> = ({
         <Button
           title={t('BCSC.Instructions.ScanBarcode')}
           accessibilityLabel={t('BCSC.Instructions.ScanBarcode')}
-          testID={testIdWithKey('ScanBarcode')}
+          testID={testIdWithKey(TestIds.verify.serialInstructions.scanBarcode)}
           onPress={() => navigation.navigate(BCSCScreens.ScanSerial)}
           buttonType={ButtonType.Primary}
         />
         <Button
           title={t('BCSC.Instructions.EnterManually')}
           accessibilityLabel={t('BCSC.Instructions.EnterManually')}
-          testID={testIdWithKey('EnterManually')}
+          testID={testIdWithKey(TestIds.verify.serialInstructions.enterManually)}
           onPress={() => navigation.navigate(BCSCScreens.ManualSerial)}
           buttonType={ButtonType.Secondary}
         />

--- a/app/src/bcsc-theme/features/verify/VerificationCardErrorScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/VerificationCardErrorScreen.tsx
@@ -1,5 +1,6 @@
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useStore, useTheme } from '@bifold/core'
 import { RouteProp, useRoute } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -29,7 +30,7 @@ const VerificationCardErrorScreen = ({ navigation }: VerificationCardErrorScreen
           title={t('BCSC.VerificationCardError.CardExpired.ButtonText')}
           accessibilityLabel={t('BCSC.VerificationCardError.CardExpired.ButtonText')}
           accessibilityHint={t('Global.A11y.OpensInBrowser')}
-          testID={testIdWithKey('GetBCSC')}
+          testID={testIdWithKey(TestIds.verify.verificationCardError.getBcsc)}
           buttonType={ButtonType.Primary}
           onPress={() => Linking.openURL(GET_BCSC_URL)}
         />
@@ -53,7 +54,7 @@ const VerificationCardErrorScreen = ({ navigation }: VerificationCardErrorScreen
       <Button
         title={t('BCSC.MismatchedSerial.TryAnotherCard')}
         accessibilityLabel={t('BCSC.MismatchedSerial.TryAnotherCard')}
-        testID={testIdWithKey('TryAnother')}
+        testID={testIdWithKey(TestIds.verify.verificationCardError.tryAnother)}
         buttonType={ButtonType.Primary}
         onPress={() => {
           navigation.navigate(BCSCScreens.IdentitySelection)

--- a/app/src/bcsc-theme/features/verify/VerificationMethodSelectionScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/VerificationMethodSelectionScreen.tsx
@@ -1,5 +1,6 @@
 import { DeviceVerificationOption } from '@/bcsc-theme/api/hooks/useAuthorizationApi'
 import { Spacing } from '@/bcwallet-theme/theme'
+import { TestIds } from '@/test-ids/registry'
 import { BCSCScreens, BCSCVerifyStackParams } from '@bcsc-theme/types/navigators'
 import { ScreenWrapper, testIdWithKey, ThemedText, usePreventDoublePress } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -45,7 +46,7 @@ const VerificationMethodSelectionScreen = ({ navigation }: VerificationMethodSel
         <VerifyMethodActionButton
           key="send_video"
           title={t('BCSC.VerificationMethods.SendVideoTitle')}
-          testIDKey="SendVideo"
+          testIDKey={TestIds.verify.methodSelection.sendVideo}
           description={t('BCSC.VerificationMethods.SendVideoDescription')}
           icon={'video-outline'}
           onPress={preventDoublePress(handlePressSendVideo)}
@@ -59,7 +60,7 @@ const VerificationMethodSelectionScreen = ({ navigation }: VerificationMethodSel
         <VerifyMethodActionButton
           key="in_person"
           title={t('BCSC.VerificationMethods.InPersonTitle')}
-          testIDKey="InPerson"
+          testIDKey={TestIds.verify.methodSelection.inPerson}
           description={t('BCSC.VerificationMethods.InPersonDescription')}
           icon={'account-outline'}
           onPress={() => navigation.navigate(BCSCScreens.VerifyInPerson)}
@@ -73,7 +74,7 @@ const VerificationMethodSelectionScreen = ({ navigation }: VerificationMethodSel
         <VerifyMethodActionButton
           key="video_call"
           title={t('BCSC.VerificationMethods.VideoCallTitle')}
-          testIDKey="VideoCall"
+          testIDKey={TestIds.verify.methodSelection.videoCall}
           description={t('BCSC.VerificationMethods.VideoCallDescription')}
           icon={'face-agent'}
           onPress={preventDoublePress(handlePressLiveCall)}
@@ -98,7 +99,7 @@ const VerificationMethodSelectionScreen = ({ navigation }: VerificationMethodSel
       <ThemedText
         variant={'headingFour'}
         style={{ marginTop: Spacing.md, alignSelf: 'stretch' }}
-        testID={testIdWithKey('HoursOfServiceTitle')}
+        testID={testIdWithKey(TestIds.verify.methodSelection.hoursOfService)}
       >
         {t('BCSC.VideoCall.CallBusyOrClosed.HoursOfService')}
       </ThemedText>

--- a/app/src/bcsc-theme/features/verify/VerificationSuccessScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/VerificationSuccessScreen.tsx
@@ -1,5 +1,6 @@
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import StatusDetails from '@/bcsc-theme/components/StatusDetails'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, useAnimatedComponents, useTheme } from '@bifold/core'
 import { useFocusEffect } from '@react-navigation/native'
 import { useTranslation } from 'react-i18next'
@@ -33,7 +34,7 @@ const VerificationSuccessScreen = () => {
   const controls = (
     <ControlContainer>
       <Button
-        testID={testIdWithKey('Continue')}
+        testID={testIdWithKey(TestIds.verify.verificationSuccess.continue)}
         accessibilityLabel={t('BCSC.Verification.ButtonText')}
         title={t('BCSC.Verification.ButtonText')}
         buttonType={ButtonType.Primary}

--- a/app/src/bcsc-theme/features/verify/email/EmailConfirmationScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EmailConfirmationScreen.tsx
@@ -5,6 +5,7 @@ import { HighlightDivider } from '@/bcsc-theme/components/HighlightDivider'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import {
   Button,
   ButtonType,
@@ -136,7 +137,7 @@ const EmailConfirmationScreen = ({ navigation, route }: EmailConfirmationScreenP
         onPress={preventDoublePress(handleSubmit)}
         title={t('Global.Continue')}
         accessibilityLabel={t('Global.Continue')}
-        testID={testIdWithKey('Continue')}
+        testID={testIdWithKey(TestIds.verify.emailConfirmation.continue)}
       >
         {loading && <ButtonLoading />}
       </Button>
@@ -173,7 +174,7 @@ const EmailConfirmationScreen = ({ navigation, route }: EmailConfirmationScreenP
           keyboardType: 'number-pad',
           textContentType: 'oneTimeCode',
           autoComplete: 'sms-otp',
-          testID: testIdWithKey('EmailConfirmationCodeInput'),
+          testID: testIdWithKey(TestIds.verify.emailConfirmation.codeInput),
           accessibilityLabel: 'Confirmation-Code-Input',
         }}
       />
@@ -186,7 +187,7 @@ const EmailConfirmationScreen = ({ navigation, route }: EmailConfirmationScreenP
           onPress={loading ? undefined : preventDoublePress(handleResendCode)}
           accessibilityRole={'link'}
           accessibilityLabel={t('BCSC.EmailConfirmation.SendNewCode')}
-          testID={testIdWithKey('ResendCodeLink')}
+          testID={testIdWithKey(TestIds.verify.emailConfirmation.resendCode)}
         >
           {t('BCSC.EmailConfirmation.SendNewCode')}
         </ThemedText>
@@ -197,7 +198,7 @@ const EmailConfirmationScreen = ({ navigation, route }: EmailConfirmationScreenP
         onPress={handleGoToEmail}
         accessibilityRole={'link'}
         accessibilityLabel={t('BCSC.EmailConfirmation.GoToMyEmail')}
-        testID={testIdWithKey('GoToMyEmailLink')}
+        testID={testIdWithKey(TestIds.verify.emailConfirmation.goToMyEmail)}
       >
         {t('BCSC.EmailConfirmation.GoToMyEmail')}
       </ThemedText>

--- a/app/src/bcsc-theme/features/verify/email/EmailVerifiedScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EmailVerifiedScreen.tsx
@@ -2,6 +2,7 @@ import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import StatusDetails from '@/bcsc-theme/components/StatusDetails'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { Spacing } from '@/bcwallet-theme/theme'
+import { TestIds } from '@/test-ids/registry'
 import { BLUE_LIGHT } from '@/theme'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey } from '@bifold/core'
 import { CommonActions, useFocusEffect } from '@react-navigation/native'
@@ -34,7 +35,7 @@ const EmailVerifiedScreen = ({ navigation }: EmailVerifiedScreenProps) => {
   const controls = (
     <ControlContainer>
       <Button
-        testID={testIdWithKey('Continue')}
+        testID={testIdWithKey(TestIds.verify.emailVerified.continue)}
         accessibilityLabel={t('Global.Continue')}
         title={t('Global.Continue')}
         buttonType={ButtonType.Primary}

--- a/app/src/bcsc-theme/features/verify/email/EnterEmailScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/email/EnterEmailScreen.tsx
@@ -8,6 +8,7 @@ import { EMAIL_MAX_LENGTH, emailSchema, parseField } from '@/bcsc-theme/utils/va
 import BulletPointList from '@/components/BulletPointList'
 import { BCSC_EMAIL_NOT_PROVIDED } from '@/constants'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import {
   Button,
   ButtonType,
@@ -107,7 +108,7 @@ const EnterEmailScreen = ({ navigation, route }: EnterEmailScreenProps) => {
         onPress={handleSubmit}
         title={t('Global.Continue')}
         accessibilityLabel={t('Global.Continue')}
-        testID={testIdWithKey('Continue')}
+        testID={testIdWithKey(TestIds.verify.enterEmail.continue)}
       >
         {loading && <ButtonLoading />}
       </Button>
@@ -117,7 +118,7 @@ const EnterEmailScreen = ({ navigation, route }: EnterEmailScreenProps) => {
           onPress={handleSkip}
           title={t('BCSC.EnterEmail.EmailSkipButton2')}
           accessibilityLabel={t('BCSC.EnterEmail.EmailSkipButton2')}
-          testID={testIdWithKey('SkipEmail')}
+          testID={testIdWithKey(TestIds.verify.enterEmail.skip)}
         />
       ) : null}
     </ControlContainer>

--- a/app/src/bcsc-theme/features/verify/in-person/VerifyInPersonScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/in-person/VerifyInPersonScreen.tsx
@@ -2,6 +2,7 @@ import useApi from '@/bcsc-theme/api/hooks/useApi'
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import { BC_SERVICE_LOCATION_URL } from '@/constants'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { BCSCScreens, BCSCVerifyStackParams } from '@bcsc-theme/types/navigators'
 import {
   Button,
@@ -102,7 +103,7 @@ const VerifyInPersonScreen = ({ navigation }: VerifyInPersonScreenProps) => {
       <ControlContainer>
         <Button
           buttonType={ButtonType.Primary}
-          testID={testIdWithKey('Complete')}
+          testID={testIdWithKey(TestIds.verify.verifyInPerson.complete)}
           accessibilityLabel={t('BCSC.VerifyIdentity.Complete')}
           title={t('BCSC.VerifyIdentity.Complete')}
           onPress={onPressComplete}
@@ -130,7 +131,7 @@ const VerifyInPersonScreen = ({ navigation }: VerifyInPersonScreenProps) => {
           onPress={() => Linking.openURL(BC_SERVICE_LOCATION_URL)}
           accessibilityLabel={t('BCSC.VerifyIdentity.WhereToGoLink')}
           accessibilityHint={t('Global.A11y.OpensInBrowser')}
-          testID={testIdWithKey('ServiceBCLink')}
+          testID={testIdWithKey(TestIds.verify.verifyInPerson.serviceBcLink)}
         >
           <View style={styles.linkButtonContent}>
             <ThemedText style={Buttons.secondaryText}>{t('BCSC.VerifyIdentity.WhereToGoLink')}</ThemedText>
@@ -160,7 +161,7 @@ const VerifyInPersonScreen = ({ navigation }: VerifyInPersonScreenProps) => {
           {t('BCSC.VerifyIdentity.ShowThisConfirmationNumber')}
         </ThemedText>
         <ThemedText
-          testID={testIdWithKey('ConfirmationCode')}
+          testID={testIdWithKey(TestIds.verify.verifyInPerson.confirmationCode)}
           variant={'headingTwo'}
           style={[styles.dataValue, { marginBottom: Spacing.md, letterSpacing: 7 }]}
         >

--- a/app/src/bcsc-theme/features/verify/live-call/CallBusyOrClosedScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/CallBusyOrClosedScreen.tsx
@@ -1,6 +1,7 @@
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useStore, useTheme } from '@bifold/core'
 import { CommonActions, RouteProp } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -32,7 +33,7 @@ const CallBusyOrClosedScreen = ({ navigation, route }: CallBusyOrClosedScreenPro
     <ControlContainer>
       <Button
         buttonType={ButtonType.Primary}
-        testID={testIdWithKey('SendVideo')}
+        testID={testIdWithKey(TestIds.verify.callBusyOrClosed.sendVideo)}
         accessibilityLabel={t('BCSC.VideoCall.CallBusyOrClosed.SendVideoInstead')}
         title={t('BCSC.VideoCall.CallBusyOrClosed.SendVideoInstead')}
         onPress={onPressSendVideo}
@@ -45,7 +46,7 @@ const CallBusyOrClosedScreen = ({ navigation, route }: CallBusyOrClosedScreenPro
       <ThemedText
         variant={'headingThree'}
         style={{ marginBottom: Spacing.lg }}
-        testID={testIdWithKey('CallStatusTitle')}
+        testID={testIdWithKey(TestIds.verify.callBusyOrClosed.callStatusTitle)}
       >
         {busy ? t('BCSC.VideoCall.CallBusyOrClosed.AllAgentsBusy') : t('BCSC.VideoCall.CallBusyOrClosed.CallUsLater')}
       </ThemedText>
@@ -59,7 +60,7 @@ const CallBusyOrClosedScreen = ({ navigation, route }: CallBusyOrClosedScreenPro
       <ThemedText
         variant={'headingFour'}
         style={{ marginBottom: Spacing.sm }}
-        testID={testIdWithKey('HoursOfServiceTitle')}
+        testID={testIdWithKey(TestIds.verify.callBusyOrClosed.hoursOfServiceTitle)}
       >
         {t('BCSC.VideoCall.CallBusyOrClosed.HoursOfService')}
       </ThemedText>
@@ -67,7 +68,11 @@ const CallBusyOrClosedScreen = ({ navigation, route }: CallBusyOrClosedScreenPro
         <ServicePeriodList items={formattedHours} />
       </View>
 
-      <ThemedText variant={'headingFour'} style={{ marginTop: Spacing.md }} testID={testIdWithKey('ReminderTitle')}>
+      <ThemedText
+        variant={'headingFour'}
+        style={{ marginTop: Spacing.md }}
+        testID={testIdWithKey(TestIds.verify.callBusyOrClosed.reminderTitle)}
+      >
         {t('BCSC.VideoCall.CallBusyOrClosed.Reminder')}
       </ThemedText>
       <ThemedText>

--- a/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/LiveCallScreen.tsx
@@ -8,6 +8,7 @@ import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigator
 import { CROP_DELAY_MS } from '@/constants'
 import { useAlerts } from '@/hooks/useAlerts'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, ThemedText, TOKENS, usePreventDoublePress, useServices, useStore, useTheme } from '@bifold/core'
 import { CommonActions } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -410,7 +411,7 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
               style={styles.hasTroubleContainer}
               accessibilityLabel={a11yLabel(t('BCSC.VideoCall.VerifyNotComplete.HavingTrouble'))}
               accessibilityRole="button"
-              testID={testIdWithKey('HavingTrouble')}
+              testID={testIdWithKey(TestIds.verify.liveCall.havingTrouble)}
             >
               <ThemedText style={{ color: ColorPalette.grayscale.white, padding: Spacing.sm }}>
                 {t('BCSC.VideoCall.VerifyNotComplete.HavingTrouble')}
@@ -426,7 +427,7 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
               size={iconSize}
               iconName={onMute ? 'microphone-off' : 'microphone'}
               label={onMute ? 'Unmute' : 'Mute'}
-              testIDKey={'Mute'}
+              testIDKey={TestIds.verify.liveCall.mute}
             />
             <CallIconButton
               onPress={toggleVideo}
@@ -435,7 +436,7 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
               size={iconSize}
               iconName={videoHidden ? 'video-off' : 'video'}
               label={videoHidden ? 'Show Video' : 'Hide Video'}
-              testIDKey={'Video'}
+              testIDKey={TestIds.verify.liveCall.video}
             />
             <CallIconButton
               onPress={preventDoublePress(handleEndCall)}
@@ -444,7 +445,7 @@ const LiveCallScreen = ({ navigation }: LiveCallScreenProps) => {
               size={iconSize}
               iconName={'phone-cancel'}
               label={'End Call'}
-              testIDKey={'EndCall'}
+              testIDKey={TestIds.verify.liveCall.endCall}
             />
           </View>
         </View>

--- a/app/src/bcsc-theme/features/verify/live-call/StartCallScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/StartCallScreen.tsx
@@ -6,6 +6,7 @@ import { formatServiceAndUnavailableHours, FormattedServicePeriod } from '@/bcsc
 import BulletPointWithText from '@/components/BulletPointWithText'
 import { useAlerts } from '@/hooks/useAlerts'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import {
   Button,
   ButtonType,
@@ -145,7 +146,7 @@ const StartCallScreen = ({ navigation }: StartCallScreenProps) => {
         accessibilityLabel={t('BCSC.VideoCall.StartVideoCall')}
         onPress={onPressStart}
         disabled={isWaitingForPermissions}
-        testID={testIdWithKey('StartCall')}
+        testID={testIdWithKey(TestIds.verify.startCall.start)}
       >
         {isWaitingForPermissions && <ButtonLoading />}
       </Button>
@@ -178,7 +179,7 @@ const StartCallScreen = ({ navigation }: StartCallScreenProps) => {
       <ThemedText
         variant={'headingFour'}
         style={{ marginTop: Spacing.lg }}
-        testID={testIdWithKey('HoursOfServiceTitle')}
+        testID={testIdWithKey(TestIds.verify.startCall.hoursOfServiceTitle)}
       >
         {t('BCSC.VideoCall.CallBusyOrClosed.HoursOfService')}
       </ThemedText>

--- a/app/src/bcsc-theme/features/verify/live-call/VerifyNotComplete.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/VerifyNotComplete.tsx
@@ -1,6 +1,7 @@
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { HelpCentreUrl } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { CommonActions } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -40,14 +41,14 @@ const VerifyNotCompleteScreen = ({ navigation }: VerifyNotCompleteScreenProps) =
     <ControlContainer>
       <Button
         buttonType={ButtonType.Primary}
-        testID={testIdWithKey('SendVideo')}
+        testID={testIdWithKey(TestIds.verify.verifyNotComplete.sendVideo)}
         accessibilityLabel={t('BCSC.VideoCall.VerifyNotComplete.SendVideoInstead')}
         title={t('BCSC.VideoCall.VerifyNotComplete.SendVideoInstead')}
         onPress={onPressSendVideo}
       />
       <Button
         buttonType={ButtonType.Secondary}
-        testID={testIdWithKey('TryAgain')}
+        testID={testIdWithKey(TestIds.verify.verifyNotComplete.tryAgain)}
         accessibilityLabel={t('BCSC.VideoCall.VerifyNotComplete.TryAgain')}
         title={t('BCSC.VideoCall.VerifyNotComplete.TryAgain')}
         onPress={onPressSendVideo}
@@ -68,7 +69,7 @@ const VerifyNotCompleteScreen = ({ navigation }: VerifyNotCompleteScreenProps) =
         title={''}
         onPress={() => Linking.openURL(HelpCentreUrl.AUDIO_VIDEO_TROUBLESHOOTING)}
         accessibilityLabel={t('BCSC.VideoCall.VerifyNotComplete.HavingTrouble')}
-        testID={testIdWithKey('Trouble')}
+        testID={testIdWithKey(TestIds.verify.verifyNotComplete.trouble)}
       >
         <View style={styles.linkButtonContent}>
           <ThemedText style={Buttons.secondaryText}>{t('BCSC.VideoCall.VerifyNotComplete.HavingTrouble')}</ThemedText>

--- a/app/src/bcsc-theme/features/verify/live-call/components/CallErrorView.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/components/CallErrorView.tsx
@@ -1,4 +1,5 @@
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { useTranslation } from 'react-i18next'
 import { View } from 'react-native'
@@ -23,7 +24,7 @@ const CallErrorView = ({ title, message, onRetry, onGoBack }: CallErrorViewProps
           onPress={onRetry}
           title={t('BCSC.VideoCall.Errors.TryAgain')}
           accessibilityLabel={t('BCSC.VideoCall.Errors.TryAgain')}
-          testID={testIdWithKey('TryAgain')}
+          testID={testIdWithKey(TestIds.verify.liveCall.errorTryAgain)}
         />
       )}
       <Button
@@ -31,7 +32,7 @@ const CallErrorView = ({ title, message, onRetry, onGoBack }: CallErrorViewProps
         onPress={onGoBack}
         title={t('BCSC.VideoCall.Errors.GoBack')}
         accessibilityLabel={t('BCSC.VideoCall.Errors.GoBack')}
-        testID={testIdWithKey('GoBack')}
+        testID={testIdWithKey(TestIds.verify.liveCall.errorGoBack)}
       />
     </ControlContainer>
   )

--- a/app/src/bcsc-theme/features/verify/live-call/components/CallLoadingView.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/components/CallLoadingView.tsx
@@ -1,6 +1,7 @@
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import { BCAnimatedLoadingIcon } from '@/bcsc-theme/features/splash-loading/BCAnimatedLoadingIcon'
 import ProgressBar from '@/components/ProgressBar'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -47,7 +48,7 @@ const CallLoadingView = ({ onCancel, message }: CallLoadingViewProps) => {
         onPress={onCancel}
         title={t('Global.Cancel')}
         accessibilityLabel={t('Global.Cancel')}
-        testID={testIdWithKey('Cancel')}
+        testID={testIdWithKey(TestIds.verify.liveCall.cancel)}
       />
     </ControlContainer>
   )

--- a/app/src/bcsc-theme/features/verify/live-call/components/ServicePeriod.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/components/ServicePeriod.tsx
@@ -1,4 +1,5 @@
 import { FormattedServicePeriod } from '@/bcsc-theme/utils/service-hours-formatter'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { View } from 'react-native'
 
@@ -12,17 +13,17 @@ const ServicePeriod = ({ servicePeriod }: ServicePeriodProps) => {
     <View style={{ flex: 1, marginBottom: Spacing.md }}>
       <ThemedText
         style={{ fontWeight: servicePeriod.isUnavailable ? 'bold' : 'normal' }}
-        testID={testIdWithKey('ServicePeriodTitle_' + servicePeriod.title)}
+        testID={testIdWithKey(TestIds.verify.servicePeriods.titleStem + servicePeriod.title)}
       >
         {servicePeriod.title}
       </ThemedText>
       {servicePeriod.hours && (
-        <ThemedText testID={testIdWithKey('ServicePeriodHours_' + servicePeriod.hours)}>
+        <ThemedText testID={testIdWithKey(TestIds.verify.servicePeriods.hoursStem + servicePeriod.hours)}>
           {servicePeriod.hours}
         </ThemedText>
       )}
       {servicePeriod.dateLine && (
-        <ThemedText testID={testIdWithKey('ServicePeriodDate_' + servicePeriod.dateLine)}>
+        <ThemedText testID={testIdWithKey(TestIds.verify.servicePeriods.dateStem + servicePeriod.dateLine)}>
           {servicePeriod.dateLine}
         </ThemedText>
       )}

--- a/app/src/bcsc-theme/features/verify/live-call/components/ServicePeriodList.tsx
+++ b/app/src/bcsc-theme/features/verify/live-call/components/ServicePeriodList.tsx
@@ -1,4 +1,5 @@
 import { FormattedServicePeriod } from '@/bcsc-theme/utils/service-hours-formatter'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, ThemedText } from '@bifold/core'
 import { useTranslation } from 'react-i18next'
 import { View } from 'react-native'
@@ -10,10 +11,14 @@ type ServicePeriodListProps = {
 const ServicePeriodList = ({ items }: ServicePeriodListProps) => {
   const { t } = useTranslation()
   if (!items.length) {
-    return <ThemedText testID={testIdWithKey('ServiceHours')}>{t('BCSC.VideoCall.DefaultHours')}</ThemedText>
+    return (
+      <ThemedText testID={testIdWithKey(TestIds.verify.servicePeriods.hours)}>
+        {t('BCSC.VideoCall.DefaultHours')}
+      </ThemedText>
+    )
   }
   return (
-    <View testID={testIdWithKey('ServicePeriodList')} style={{ alignSelf: 'stretch' }}>
+    <View testID={testIdWithKey(TestIds.verify.servicePeriods.list)} style={{ alignSelf: 'stretch' }}>
       {items.map((item) => (
         <ServicePeriod servicePeriod={item} key={`${JSON.stringify(item)}`} />
       ))}

--- a/app/src/bcsc-theme/features/verify/non-photo/AdditionalIdentificationRequiredScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/AdditionalIdentificationRequiredScreen.tsx
@@ -2,6 +2,7 @@ import { BulletedInstructionsScreen } from '@/bcsc-theme/components/BulletedInst
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { ACCOUNT_SERVICES_URL } from '@/constants'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { openLink } from '@/utils/links'
 import { testIdWithKey, useStore } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -36,7 +37,7 @@ const AdditionalIdentificationRequiredScreen: React.FC<AdditionalIdentificationR
           paragraph: t('BCSC.AdditionalEvidence.LimitedAccessDescription'),
           footerLink: {
             label: t('BCSC.AdditionalEvidence.WhichServices'),
-            testID: testIdWithKey('WhichServices'),
+            testID: testIdWithKey(TestIds.verify.additionalIdRequired.whichServices),
             externalButton: true,
             onPress: () => openLink(ACCOUNT_SERVICES_URL),
           },

--- a/app/src/bcsc-theme/features/verify/non-photo/DualIdentificationRequiredScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/DualIdentificationRequiredScreen.tsx
@@ -1,6 +1,7 @@
 import { BulletedInstructionsScreen } from '@/bcsc-theme/components/BulletedInstructionsScreen'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { ACCOUNT_SERVICES_URL, HelpCentreUrl } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import { openLink } from '@/utils/links'
 import { testIdWithKey } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -35,7 +36,7 @@ const DualIdentificationRequiredScreen: React.FC<DualIdentificationRequiredScree
           ],
           link: {
             label: t('BCSC.DualNonBCSCEvidence.SeeAcceptedID'),
-            testID: testIdWithKey('SeeAcceptedID'),
+            testID: testIdWithKey(TestIds.verify.dualIdRequired.seeAcceptedId),
             onPress: () => {
               navigation.navigate(BCSCScreens.VerifyWebView, {
                 title: t('BCSC.Screens.HelpCentre'),
@@ -49,7 +50,7 @@ const DualIdentificationRequiredScreen: React.FC<DualIdentificationRequiredScree
           paragraph: t('BCSC.AdditionalEvidence.LimitedAccessDescription'),
           footerLink: {
             label: t('BCSC.AdditionalEvidence.WhichServices'),
-            testID: testIdWithKey('WhichServices'),
+            testID: testIdWithKey(TestIds.verify.dualIdRequired.whichServices),
             externalButton: true,
             onPress: () => openLink(ACCOUNT_SERVICES_URL),
           },

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceCaptureScreen.tsx
@@ -14,6 +14,7 @@ import { AppEventCode } from '@/events/appEventCode'
 import { useAlerts } from '@/hooks/useAlerts'
 import { useAutoRequestPermission } from '@/hooks/useAutoRequestPermission'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { withAlert } from '@/utils/alert'
 import { MaskType, testIdWithKey, TOKENS, useServices, useStore, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -243,7 +244,7 @@ const EvidenceCaptureScreen = ({ navigation, route }: EvidenceCaptureScreenProps
   return (
     <>
       {captureState === CaptureState.CAPTURING ? (
-        <View style={styles.container} testID={testIdWithKey('EvidenceCaptureScreenMaskedCamera')}>
+        <View style={styles.container} testID={testIdWithKey(TestIds.verify.evidenceCapture.maskedCamera)}>
           <MaskedCamera
             navigation={navigation}
             cameraFace={'back'}

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceIDCollectionScreen.tsx
@@ -8,6 +8,7 @@ import { getResumeStepRoute } from '@/bcsc-theme/utils/resume-step-route'
 import { normalizeForSubmission } from '@/bcsc-theme/utils/validation'
 import { MINIMUM_VERIFICATION_AGE } from '@/constants'
 import { BCState, NonBCSCUserMetadata } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import {
   Button,
   ButtonType,
@@ -213,7 +214,7 @@ const EvidenceIDCollectionScreen = ({ navigation, route }: EvidenceIDCollectionS
       <Button
         title={primaryActionLabel}
         accessibilityLabel={a11yLabel(primaryActionLabel)}
-        testID={testIdWithKey('EvidenceIDCollectionContinue')}
+        testID={testIdWithKey(TestIds.verify.evidenceIdCollection.continue)}
         buttonType={ButtonType.Primary}
         onPress={handleOnContinue}
         disabled={isSubmitting}

--- a/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/EvidenceTypeListScreen.tsx
@@ -7,6 +7,7 @@ import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigator
 import { isCardEvidenceComplete } from '@/bcsc-theme/utils/card-utils'
 import { ICON_SIZE } from '@/constants'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { ScreenWrapper, testIdWithKey, ThemedText, TOKENS, useServices, useStore, useTheme } from '@bifold/core'
 import { RouteProp, useFocusEffect } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -311,7 +312,7 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
               <ListButton
                 key={item.evidence_type_label}
                 onPress={() => handleSelectEvidenceType(item)}
-                testID={testIdWithKey(`EvidenceTypeListItem-${item.evidence_type}`)}
+                testID={testIdWithKey(`${TestIds.verify.evidenceTypeList.itemStem}${item.evidence_type}`)}
                 accessibilityLabel={a11yShortLabel(item.evidence_type_label)}
               >
                 <View style={styles.listButtonContainer}>
@@ -330,7 +331,7 @@ const EvidenceTypeListScreen = ({ navigation, route }: EvidenceTypeListScreenPro
           <ListButtonGroup>
             <ListButton
               onPress={handleShowOtherOptions}
-              testID={testIdWithKey('EvidenceTypeListOtherOptions')}
+              testID={testIdWithKey(TestIds.verify.evidenceTypeList.otherOptions)}
               accessibilityLabel={a11yLabel(t('BCSC.EvidenceTypeList.ShowMoreOptions'))}
             >
               <View style={styles.listButtonContainer}>

--- a/app/src/bcsc-theme/features/verify/non-photo/IDPhotoInformationScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/non-photo/IDPhotoInformationScreen.tsx
@@ -1,6 +1,7 @@
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import BulletPointList from '@/components/BulletPointList'
+import { TestIds } from '@/test-ids/registry'
 import ScanIdImage from '@assets/img/id-photo-info.svg'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -22,7 +23,7 @@ const IDPhotoInformationScreen = ({ navigation, route }: IDPhotoInformationScree
       <Button
         title={t('BCSC.IDPhotoInformation.TakePhoto')}
         accessibilityLabel={t('BCSC.IDPhotoInformation.TakePhoto')}
-        testID={testIdWithKey('IDPhotoInformationTakePhoto')}
+        testID={testIdWithKey(TestIds.verify.idPhotoInformation.takePhoto)}
         onPress={() => {
           // push (not navigate) so the second ID opens a fresh capture screen instead of popping back
           // to the first ID's EvidenceCapture already in the stack.

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -2,6 +2,7 @@ import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import { useLoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
 import { useVerificationReset } from '@/bcsc-theme/hooks/useVerificationReset'
 import usePreventGestureBack from '@/hooks/usePreventGestureBack'
+import { TestIds } from '@/test-ids/registry'
 import {
   Button,
   ButtonType,
@@ -73,7 +74,7 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
         onPress={preventDoublePress(retryWithNewVideo)}
         disabled={isPressing}
         accessibilityLabel={t('BCSC.CancelledVerification.RetryButton')}
-        testID={testIdWithKey('RetryWithNewVideo')}
+        testID={testIdWithKey(TestIds.verify.cancelledReview.retryWithNewVideo)}
       >
         <MaterialIcon name={'sensor-occupied'} size={24} color={ColorPalette.brand.primary} style={styles.buttonIcon} />
       </Button>
@@ -83,7 +84,7 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
         onPress={onPressRestart}
         disabled={isPressing}
         accessibilityLabel={t('BCSC.CancelledVerification.RestartButton')}
-        testID={testIdWithKey('RestartVerification')}
+        testID={testIdWithKey(TestIds.verify.cancelledReview.restartVerification)}
       >
         <CommunityIcon name={'restore'} size={24} color={ColorPalette.brand.primary} style={styles.buttonIcon} />
       </Button>

--- a/app/src/bcsc-theme/features/verify/send-video/PendingReviewScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/PendingReviewScreen.tsx
@@ -3,6 +3,7 @@ import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import { useVerificationPendingActions } from '@/bcsc-theme/hooks/useVerificationPendingActions'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { BCDispatchAction, BCState, VerificationStatus } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useStore, useTheme } from '@bifold/core'
 import { useFocusEffect } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -41,7 +42,7 @@ const PendingReviewScreen = ({ navigation }: PendingReviewScreenProps) => {
   const controls = (
     <ControlContainer>
       <Button
-        testID={testIdWithKey('ChooseAnotherWayToVerify')}
+        testID={testIdWithKey(TestIds.verify.pendingReview.chooseAnotherWay)}
         accessibilityLabel={t('BCSC.Steps.ChooseAnotherWayToVerify')}
         title={t('BCSC.Steps.ChooseAnotherWayToVerify')}
         buttonType={ButtonType.Secondary}

--- a/app/src/bcsc-theme/features/verify/send-video/SuccessfullySentScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/SuccessfullySentScreen.tsx
@@ -2,6 +2,7 @@ import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import StatusDetails from '@/bcsc-theme/components/StatusDetails'
 import { useLeaveVerification } from '@/bcsc-theme/hooks/useLeaveVerification'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
+import { TestIds } from '@/test-ids/registry'
 import { BLUE_LIGHT } from '@/theme/light'
 
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, useTheme } from '@bifold/core'
@@ -43,7 +44,7 @@ const SuccessfullySentScreen = ({ route }: SuccessfullySentScreenProps) => {
   const controls = (
     <ControlContainer>
       <Button
-        testID={testIdWithKey('GoToHome')}
+        testID={testIdWithKey(TestIds.verify.successfullySent.goToHome)}
         accessibilityLabel={t('BCSC.SendVideo.SuccessfullySent.ButtonText')}
         title={t('BCSC.SendVideo.SuccessfullySent.ButtonText')}
         buttonType={ButtonType.Primary}

--- a/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.tsx
@@ -489,7 +489,9 @@ const TakeVideoScreen = ({ navigation }: TakeVideoScreenProps) => {
                 title={isLastPrompt ? t('BCSC.SendVideo.TakeVideo.Done') : t('BCSC.SendVideo.TakeVideo.ShowNextPrompt')}
                 onPress={onPressNextPrompt}
                 testID={testIdWithKey(TestIds.verify.takeVideo.nextPrompt)}
-                accessibilityLabel={t('BCSC.SendVideo.TakeVideo.StartRecordingButton')}
+                accessibilityLabel={
+                  isLastPrompt ? t('BCSC.SendVideo.TakeVideo.Done') : t('BCSC.SendVideo.TakeVideo.ShowNextPrompt')
+                }
                 disabled={elapsedTime - promptTimestamp < MIN_PROMPT_DURATION_SECONDS}
               />
             </View>

--- a/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/TakeVideoScreen.tsx
@@ -19,6 +19,7 @@ import { AppEventCode } from '@/events/appEventCode'
 import { useAlerts } from '@/hooks/useAlerts'
 import { useAutoRequestPermission } from '@/hooks/useAutoRequestPermission'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import {
   Button,
   ButtonType,
@@ -458,7 +459,7 @@ const TakeVideoScreen = ({ navigation }: TakeVideoScreenProps) => {
               <TouchableOpacity
                 onPress={handleCancel}
                 hitSlop={hitSlop}
-                testID={testIdWithKey('CancelRecording')}
+                testID={testIdWithKey(TestIds.verify.takeVideo.cancel)}
                 accessibilityLabel={t('Global.Cancel')}
                 accessibilityRole="button"
                 style={{ flexDirection: 'row', alignItems: 'center' }}
@@ -487,7 +488,7 @@ const TakeVideoScreen = ({ navigation }: TakeVideoScreenProps) => {
                 buttonType={ButtonType.Primary}
                 title={isLastPrompt ? t('BCSC.SendVideo.TakeVideo.Done') : t('BCSC.SendVideo.TakeVideo.ShowNextPrompt')}
                 onPress={onPressNextPrompt}
-                testID={testIdWithKey('NextPrompt')}
+                testID={testIdWithKey(TestIds.verify.takeVideo.nextPrompt)}
                 accessibilityLabel={t('BCSC.SendVideo.TakeVideo.StartRecordingButton')}
                 disabled={elapsedTime - promptTimestamp < MIN_PROMPT_DURATION_SECONDS}
               />

--- a/app/src/bcsc-theme/features/verify/send-video/UploadingScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/UploadingScreen.tsx
@@ -2,6 +2,7 @@ import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import { LoadingScreenContent } from '@/bcsc-theme/features/splash-loading/LoadingScreenContent'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { Spacing } from '@/bcwallet-theme/theme'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey } from '@bifold/core'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { useEffect, useState } from 'react'
@@ -49,7 +50,7 @@ const UploadingScreen = ({ navigation }: UploadingScreenProps) => {
           buttonType={ButtonType.Secondary}
           onPress={handleCancel}
           disabled={isCancelling}
-          testID={testIdWithKey('CancelUpload')}
+          testID={testIdWithKey(TestIds.verify.evidenceUploading.cancelUpload)}
           title={t('Global.Cancel')}
           accessibilityLabel={t('Global.Cancel')}
         />

--- a/app/src/bcsc-theme/features/verify/send-video/VideoInstructionsScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/VideoInstructionsScreen.tsx
@@ -3,6 +3,7 @@ import useVideoPrompts from '@/bcsc-theme/hooks/useVideoPrompts'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { useAlerts } from '@/hooks/useAlerts'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import BrownHandHoldingPhone from '@assets/img/brown-hand-holding-phone.svg'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useStore, useTheme } from '@bifold/core'
 import { useFocusEffect } from '@react-navigation/native'
@@ -82,7 +83,7 @@ const VideoInstructionsScreen = ({ navigation }: VideoInstructionsScreenProps) =
         onPress={() => {
           navigation.navigate(BCSCScreens.TakeVideo)
         }}
-        testID={testIdWithKey('StartRecording')}
+        testID={testIdWithKey(TestIds.verify.videoInstructions.startRecording)}
         accessibilityLabel={t('BCSC.SendVideo.VideoInstructions.StartRecordingButton')}
         disabled={promptsStatus !== 'ready'}
       />
@@ -121,14 +122,17 @@ const VideoInstructionsScreen = ({ navigation }: VideoInstructionsScreenProps) =
           </Fragment>
         ))}
       {promptsStatus === 'loading' && (
-        <ActivityIndicator style={{ marginBottom: Spacing.xl }} testID={testIdWithKey('PromptsLoading')} />
+        <ActivityIndicator
+          style={{ marginBottom: Spacing.xl }}
+          testID={testIdWithKey(TestIds.verify.videoInstructions.promptsLoading)}
+        />
       )}
       {promptsStatus === 'failed' && (
         <Button
           buttonType={ButtonType.Secondary}
           title={t('Global.Retry')}
           onPress={loadPrompts}
-          testID={testIdWithKey('RetryLoadPrompts')}
+          testID={testIdWithKey(TestIds.verify.videoInstructions.retryLoadPrompts)}
           accessibilityLabel={t('Global.Retry')}
         />
       )}

--- a/app/src/bcsc-theme/features/verify/send-video/VideoReviewScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/VideoReviewScreen.tsx
@@ -5,6 +5,7 @@ import { MediaCache } from '@/bcsc-theme/utils/media-cache'
 import { useAlerts } from '@/hooks/useAlerts'
 import usePreventGestureBack from '@/hooks/usePreventGestureBack'
 import { BCDispatchAction, BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { withAlert } from '@/utils/alert'
 import readFileInChunks from '@/utils/read-file'
 import {
@@ -182,7 +183,7 @@ const VideoReviewScreen = ({ navigation, route }: VideoReviewScreenProps) => {
       <Button
         buttonType={ButtonType.Primary}
         onPress={onPressUse}
-        testID={testIdWithKey('UseVideo')}
+        testID={testIdWithKey(TestIds.verify.videoReview.useVideo)}
         title={t('BCSC.SendVideo.VideoReview.UseVideo')}
         accessibilityLabel={t('BCSC.SendVideo.VideoReview.UseVideo')}
         disabled={isRefreshingPrompts}
@@ -190,7 +191,7 @@ const VideoReviewScreen = ({ navigation, route }: VideoReviewScreenProps) => {
       <Button
         buttonType={ButtonType.Secondary}
         onPress={onPressRetake}
-        testID={testIdWithKey('RetakeVideo')}
+        testID={testIdWithKey(TestIds.verify.videoReview.retakeVideo)}
         title={t('BCSC.SendVideo.VideoReview.RetakeVideo')}
         accessibilityLabel={t('BCSC.SendVideo.VideoReview.RetakeVideo')}
         disabled={isRefreshingPrompts}
@@ -225,7 +226,7 @@ const VideoReviewScreen = ({ navigation, route }: VideoReviewScreenProps) => {
         onPress={onTogglePause}
         accessibilityLabel={t('BCSC.SendVideo.VideoReview.TogglePlayPause')}
         accessibilityRole="button"
-        testID={testIdWithKey('TogglePlayPause')}
+        testID={testIdWithKey(TestIds.verify.videoReview.togglePlayPause)}
       >
         <Icon name={paused ? 'play' : 'pause'} size={pauseButtonSize} color={ColorPalette.brand.primaryBackground} />
       </TouchableOpacity>

--- a/app/src/bcsc-theme/features/verify/send-video/VideoTooLongScreen.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/VideoTooLongScreen.tsx
@@ -3,6 +3,7 @@ import useVideoPrompts from '@/bcsc-theme/hooks/useVideoPrompts'
 import { BCSCScreens, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { useAlerts } from '@/hooks/useAlerts'
 import usePreventGestureBack from '@/hooks/usePreventGestureBack'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { CommonActions } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -51,7 +52,7 @@ const VideoTooLongScreen = ({ navigation, route }: VideoTooLongScreenProps) => {
         buttonType={ButtonType.Primary}
         title={t('BCSC.SendVideo.VideoTooLong.ButtonText')}
         onPress={onPressRetake}
-        testID={testIdWithKey('VideoTooLongRetake')}
+        testID={testIdWithKey(TestIds.verify.videoTooLong.retake)}
         accessibilityLabel={t('BCSC.SendVideo.VideoTooLong.ButtonText')}
         disabled={isRefreshingPrompts}
       />
@@ -66,7 +67,7 @@ const VideoTooLongScreen = ({ navigation, route }: VideoTooLongScreenProps) => {
             })
           )
         }}
-        testID={testIdWithKey('VideoTooLongCancel')}
+        testID={testIdWithKey(TestIds.verify.videoTooLong.cancel)}
         accessibilityLabel={t('BCSC.SendVideo.VideoTooLong.CancelButtonText')}
       />
     </ControlContainer>

--- a/app/src/test-ids/registry.ts
+++ b/app/src/test-ids/registry.ts
@@ -154,6 +154,12 @@ export const TestIds = {
       scan: 'Scan',
       otherId: 'OtherID',
     },
+    /** `SerialInstructions` — the primer before the camera; both CTAs lead into the serial flow
+     *  (`enterManually` shares its key with the ScanSerial control of the same name). */
+    serialInstructions: {
+      scanBarcode: 'ScanBarcode',
+      enterManually: 'EnterManually',
+    },
     /** Camera scan screen; `EnterManually` is the CI path around the live camera and renders in BOTH
      *  bodies. `openSettings` marks the refused-permission `PermissionDisabled` fallback — asserted,
      *  never tapped (it exits to the OS settings app). `scanTorch` is the shared `TorchButton`
@@ -162,6 +168,8 @@ export const TestIds = {
       enterManually: 'EnterManually',
       openSettings: 'OpenSettings',
       scanTorch: 'ScanTorch',
+      // Rendered only in the camera-failed body, alongside `enterManually`.
+      retryCamera: 'RetryCamera',
     },
     /** Manual serial form (`InputWithValidation id='serial'` → derived ids). `serialSubtext` is the
      *  shared error slot: no static subtext here, so it exists only while a validation error shows,
@@ -179,12 +187,20 @@ export const TestIds = {
       birthdateInput: 'birthDate-input',
       continue: 'Continue',
     },
+    /** `BirthdateLockout` — too many wrong birthdates. `close` just goes back; there is no header. */
+    birthdateLockout: {
+      close: 'Close',
+    },
     /** `VerificationCardError` — the authorize-failure screen at the EnterBirthdate submit. The
      *  `MismatchedSerial` variant (CSN/birthdate mismatch or card-not-found — the unhandled-error path)
      *  shows `tryAnother` → IdentitySelection; the `CardExpired` variant shows `getBcsc` (opens a browser). */
     verificationCardError: {
       tryAnother: 'TryAnother',
       getBcsc: 'GetBCSC',
+    },
+    /** `DeviceAuthorizationError` — device-authorization failure; its only control is the help link. */
+    deviceAuthorizationError: {
+      link: 'DeviceAuthorizationErrorLink',
     },
     /** `EnterEmail` — appears after birthdate only when the card provides no verified email (a photo
      *  card that already carries one resumes straight to method selection). `skip` (`SkipEmail`) is
@@ -205,6 +221,17 @@ export const TestIds = {
       sendVideo: 'SendVideo',
       videoCall: 'VideoCall',
       settingsMenu: 'SettingsMenuButton',
+    },
+    /** `ServicePeriodList` — the video-call hours block, mounted by THREE screens (method selection,
+     *  StartCall, CallBusyOrClosed), so these ids do not identify which screen you are on. It renders
+     *  `hours` (a single default line) when the period list is empty, otherwise `list` wrapping one
+     *  `ServicePeriod` per entry — those rows append server-provided text to the stems below. */
+    servicePeriods: {
+      hours: 'ServiceHours',
+      list: 'ServicePeriodList',
+      titleStem: 'ServicePeriodTitle_',
+      hoursStem: 'ServicePeriodHours_',
+      dateStem: 'ServicePeriodDate_',
     },
     /** In-person verification (`'Verify In Person Instruction'`) — shows the XXXX-XXXX confirmation
      *  code the SM approval reads; `complete` advances to VerificationSuccess. */
@@ -274,10 +301,12 @@ export const TestIds = {
     pendingReview: {
       chooseAnotherWay: 'ChooseAnotherWayToVerify',
     },
-    /** `CancelledReview` and its MainStack twin — both render the shared SystemModal, so the button is
-     *  that component's generic key. The agent's reason is body COPY (no testID): assert it by text. */
+    /** `CancelledReview` and its MainStack twin (same component on both stacks). The agent's reason is
+     *  body COPY (no testID): assert it by text. NB this screen does NOT render `SystemModal` — it has
+     *  its own two buttons; `retryWithNewVideo` is the stable arrival marker. */
     cancelledReview: {
-      button: 'SystemModalButton',
+      retryWithNewVideo: 'RetryWithNewVideo',
+      restartVerification: 'RestartVerification',
     },
     /** Live-call busy/closed (`'Video Verify Closed'`) — the live-call branch when no agent queue is
      *  free or outside service hours. `callStatusTitle` is the marker; `sendVideo` resets to method
@@ -339,12 +368,15 @@ export const TestIds = {
      *  the screen by heading copy when it matters. */
     additionalIdRequired: {
       continue: 'Continue',
+      // Opens the accepted-services webview; the same key renders on `dualIdRequired`.
+      whichServices: 'WhichServices',
     },
     /** `DualIdentificationRequired` — non-BCSC needs two IDs. CTA is label-derived `Continue`;
      *  `seeAcceptedId` opens the accepted-documents webview. */
     dualIdRequired: {
       continue: 'Continue',
       seeAcceptedId: 'SeeAcceptedID',
+      whichServices: 'WhichServices',
     },
     /** `EvidenceTypeList` — the document-type picker. Rows are `EvidenceTypeListItem-<evidence_type>`
      *  where evidence_type is SERVER-PROVIDED (unknown/variable, may contain spaces), so specs select a
@@ -352,6 +384,7 @@ export const TestIds = {
      *  document types. */
     evidenceTypeList: {
       otherOptions: 'EvidenceTypeListOtherOptions',
+      itemStem: 'EvidenceTypeListItem-',
     },
     /** `IDPhotoInformation` ('ID Photo Instructions') — the primer before the document camera. */
     idPhotoInformation: {

--- a/e2e/src/screens/verify.ts
+++ b/e2e/src/screens/verify.ts
@@ -290,16 +290,18 @@ export const PendingReviewScreen = defineScreen({
 })
 
 /**
- * `CancelledReview` — the rejected-request modal, reached from PendingReview's status check or (via
- * the Home card) as its MainStack twin; both render the same SystemModal, which is why `self` is that
- * component's generic button key rather than anything screen-specific.
+ * `CancelledReview` — the rejected-request screen, reached from PendingReview's status check or (via
+ * the Home card) as its MainStack twin (the same component on both stacks). It renders its own two
+ * buttons, NOT the shared SystemModal, so `self` anchors on the first of them.
  *
  * The agent's reason is body copy with no testID — assert it with `expectCancelledReviewReason`.
- * `primary` ('Retry verification') RESETS the device registration and re-enters verification.
+ * `primary` ('Try again') retries with a new video; `secondary` ('Restart from beginning') resets the
+ * device registration and re-enters verification from the top.
  */
 export const CancelledReviewScreen = defineScreen({
-  self: bcsc(v.cancelledReview.button),
-  primary: bcsc(v.cancelledReview.button),
+  self: bcsc(v.cancelledReview.retryWithNewVideo),
+  primary: bcsc(v.cancelledReview.retryWithNewVideo),
+  secondary: bcsc(v.cancelledReview.restartVerification),
 })
 
 /**


### PR DESCRIPTION
Closes #4593

## What changed

Migrates the verify feature onto the registry — 74 call sites across 38 files, the largest single area. Refactor-only apart from one e2e fix below.

**Stacked on `chore/e2e_testID_source`.** Review only this branch's diff.

- 64 string literals, 6 `testIDKey` props, and 4 dynamic ids repointed at registry stems (`ServicePeriodTitle_`, `EvidenceTypeListItem-`).
- Two passthrough call sites (`CallIconButton`, `VerifyMethodActionButton`) are intentionally unchanged — their callers carry the keys.
- Registry: 4 new screen groups (`serialInstructions`, `birthdateLockout`, `deviceAuthorizationError`, `servicePeriods`), 5 amended.
- **Fixes a broken e2e descriptor:** `verify.cancelledReview.button` was recorded as `SystemModalButton`, but `CancelledReview` renders its own two buttons, not the shared `SystemModal`. The registry now carries the real keys and `e2e/src/screens/verify.ts` anchors on them.

## What should the reviewer focus on

- The `CancelledReview` fix is the only change here that alters e2e runtime behaviour. `expectCancelledReviewReason` (used by `send-video-cancelled.journey.ts`) could never find the screen, and the `isPresent(1_000)` probe in `flows/verify.ts` always returned false and took the wrong branch. **Worth a Sauce run of that journey before merge** — it can only be confirmed on a device.
- Three prettier reflows (`ServicePeriodList`, `CallBusyOrClosedScreen`, `VideoInstructionsScreen`) where one-line JSX crossed 120 chars. Same elements, same props.

## How to test

```
cd app && yarn typecheck && yarn lint && yarn test
cd e2e && yarn typecheck
```

160/160 snapshots pass with no `.snap` written. Then the send-video cancelled journey on Sauce, which should go from failing at the reason checkpoint to passing.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>