### PR TITLE
chore: test-ids for main features

### DIFF
--- a/app/eslint.config.mjs
+++ b/app/eslint.config.mjs
@@ -101,16 +101,7 @@ export default [
   // so unmigrated areas stay green while migrated ones cannot regress. Tests are exempt on purpose:
   // asserting the literal id string is what proves the emitted ids never moved.
   {
-    files: [
-      'src/test-ids/**',
-      'src/bcsc-theme/features/onboarding/**',
-      'src/bcsc-theme/features/auth/**',
-      'src/bcsc-theme/features/verify/**',
-      'src/bcsc-theme/features/settings/**',
-      'src/bcsc-theme/features/account/**',
-      'src/bcsc-theme/features/account-transfer/**',
-      'src/bcsc-theme/features/contacts/**',
-    ],
+    files: ['src/test-ids/**', 'src/bcsc-theme/features/**', 'src/bcsc-theme/contexts/**'],
     ignores: ['**/*.test.{ts,tsx}'],
     rules: {
       'no-restricted-syntax': [

--- a/app/src/bcsc-theme/contexts/BCSCLoadingContext.tsx
+++ b/app/src/bcsc-theme/contexts/BCSCLoadingContext.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey } from '@bifold/core'
 import {
   createContext,
@@ -107,7 +108,7 @@ export const BCSCLoadingProvider = ({ children }: PropsWithChildren) => {
       {/** When loading make children invisible (still mounted) **/}
       <View
         style={childrenStyle}
-        testID={testIdWithKey('BCSCLoadingProviderChildren')}
+        testID={testIdWithKey(TestIds.common.loadingChildren)}
         importantForAccessibility={isLoading ? 'no-hide-descendants' : 'yes'} // Hide from screen readers when loading, show when not loading
       >
         {children}
@@ -116,7 +117,7 @@ export const BCSCLoadingProvider = ({ children }: PropsWithChildren) => {
       {/** When loading make loading overlay visible **/}
       <View
         style={loadingStyle}
-        testID={testIdWithKey('BCSCLoadingProviderOverlay')}
+        testID={testIdWithKey(TestIds.common.loadingOverlay)}
         accessible={isLoading} // Only make the loading screen accessible when it's visible
         importantForAccessibility={isLoading ? 'yes' : 'no-hide-descendants'} // Hide from screen readers when not visible, show when visible
       >

--- a/app/src/bcsc-theme/features/agent/AgentReadyGate.tsx
+++ b/app/src/bcsc-theme/features/agent/AgentReadyGate.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import React, { ComponentType, PropsWithChildren } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -37,7 +38,7 @@ const AgentReadyGate: React.FC<Props> = ({ children, testID }) => {
             buttonType={ButtonType.Primary}
             onPress={retry}
             accessibilityLabel={t('Init.Retry')}
-            testID={testIdWithKey('AgentRetry')}
+            testID={testIdWithKey(TestIds.common.agentRetry)}
           />
         </View>
       )

--- a/app/src/bcsc-theme/features/home/Home.tsx
+++ b/app/src/bcsc-theme/features/home/Home.tsx
@@ -8,6 +8,7 @@ import { useBCSCApiClient } from '@/bcsc-theme/hooks/useBCSCApiClient'
 import { useCardStatus } from '@/bcsc-theme/hooks/useCardStatus'
 import { BCSCQRCoreScreens, BCSCScreens, BCSCTabStackParams } from '@/bcsc-theme/types/navigators'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, useStore, useTheme } from '@bifold/core'
 import { StackScreenProps } from '@react-navigation/stack'
 import { a11yLabel } from '@utils/accessibility'
@@ -68,7 +69,7 @@ const Home: React.FC<HomeProps> = ({ navigation }) => {
             description={t('BCSC.Home.LogInFromComputerDescription')}
             onPress={handlePairingCodePress}
             accessibilityHint={a11yLabel(t('BCSC.Home.LogInFromComputerDescription'))}
-            testID={testIdWithKey('LogInFromComputer')}
+            testID={testIdWithKey(TestIds.main.pairing.logInFromComputer)}
           />
         ) : null}
         <NotificationsList />
@@ -117,14 +118,14 @@ export const HomeV4_0_x: React.FC<HomeProps> = ({ navigation }) => {
             description={t('BCSC.Home.WhereToUseDescription')}
             style={{ marginBottom: Spacing.md }}
             onPress={handleWhereToUsePress}
-            testID={testIdWithKey('WhereToUse')}
+            testID={testIdWithKey(TestIds.main.home.whereToUse)}
           />
           <SectionButton
             title={t('BCSC.Home.LogInFromComputerTitle')}
             accessibilityLabel={a11yLabel(t('BCSC.Home.LogInFromComputerAccessibilityLabel'))}
             description={t('BCSC.Home.LogInFromComputerDescription')}
             onPress={handlePairingCodePress}
-            testID={testIdWithKey('LogInFromComputer')}
+            testID={testIdWithKey(TestIds.main.pairing.logInFromComputer)}
           />
           {store.bcsc.bannerMessages.length > 0 && (
             <View style={{ marginTop: Spacing.lg }}>

--- a/app/src/bcsc-theme/features/home/components/PairingCodeCard.tsx
+++ b/app/src/bcsc-theme/features/home/components/PairingCodeCard.tsx
@@ -1,4 +1,5 @@
 import { PressableOpacity } from '@/components/PressableOpacity'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { a11yLabel } from '@utils/accessibility'
 import React from 'react'
@@ -69,7 +70,7 @@ const PairingCodeCard: React.FC<PairingCodeCardProps> = ({
       accessibilityRole="button"
       accessibilityLabel={a11yLabel(title)}
       accessibilityHint={accessibilityHint}
-      testID={testID ?? testIdWithKey('PairingCodeCard')}
+      testID={testID ?? testIdWithKey(TestIds.main.home.pairingCodeCard)}
     >
       <Icon name={'login'} size={ICON_SIZE} color={ColorPalette.brand.primary} accessible={false} />
       <View style={styles.content}>

--- a/app/src/bcsc-theme/features/home/components/SavedServiceCard.tsx
+++ b/app/src/bcsc-theme/features/home/components/SavedServiceCard.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { useTranslation } from 'react-i18next'
 import { Animated, StyleSheet, TouchableOpacity } from 'react-native'
@@ -54,7 +55,9 @@ export const SavedServiceCard: React.FC<SavedServiceCardProps> = (props: SavedSe
                 onPress={props.onRemove}
                 accessibilityLabel={`${t('BCSC.Services.Remove')} ${props.title}`}
                 accessibilityRole="button"
-                testID={testIdWithKey(`RemoveService-${props.title.replaceAll(/\s+/g, '')}`)}
+                testID={testIdWithKey(
+                  `${TestIds.main.home.savedServiceRemovePrefix}${props.title.replaceAll(/\s+/g, '')}`
+                )}
               >
                 <Icon name="delete" size={40} />
               </TouchableOpacity>
@@ -68,7 +71,7 @@ export const SavedServiceCard: React.FC<SavedServiceCardProps> = (props: SavedSe
           onPress={props.onPress}
           accessibilityLabel={`${t('BCSC.Services.Open')} ${props.title}`}
           accessibilityRole="button"
-          testID={testIdWithKey(`OpenService-${props.title.replaceAll(/\s+/g, '')}`)}
+          testID={testIdWithKey(`${TestIds.main.home.savedServiceOpenPrefix}${props.title.replaceAll(/\s+/g, '')}`)}
         >
           <ThemedText>{props.title}</ThemedText>
         </TouchableOpacity>

--- a/app/src/bcsc-theme/features/modal/ServiceOutage.tsx
+++ b/app/src/bcsc-theme/features/modal/ServiceOutage.tsx
@@ -1,5 +1,6 @@
 import { CardButton } from '@/bcsc-theme/components/CardButton'
 import usePreventGestureBack from '@/hooks/usePreventGestureBack'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { ScrollView, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -50,7 +51,7 @@ export const ServiceOutage = (): React.ReactElement => {
             title={learnMoreText}
             onPress={handleLearnMore}
             endIcon="open-in-new"
-            testID={testIdWithKey('ServiceOutageHelpCentre')}
+            testID={testIdWithKey(TestIds.systemModal.serviceOutage.helpCentre)}
           />
         </View>
       </ScrollView>
@@ -62,7 +63,7 @@ export const ServiceOutage = (): React.ReactElement => {
           onPress={handleCheckAgain}
           disabled={isCheckDisabled}
           accessibilityLabel={buttonText}
-          testID={testIdWithKey('ServiceOutageCheckAgain')}
+          testID={testIdWithKey(TestIds.systemModal.serviceOutage.checkAgain)}
         />
       </View>
     </SafeAreaView>

--- a/app/src/bcsc-theme/features/modal/VerificationSessionExpired.tsx
+++ b/app/src/bcsc-theme/features/modal/VerificationSessionExpired.tsx
@@ -1,6 +1,7 @@
 import { useFactoryReset } from '@/bcsc-theme/api/hooks/useFactoryReset'
 import { BCSCModals, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { useAlerts } from '@/hooks/useAlerts'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, TOKENS, useServices } from '@bifold/core'
 import { StackScreenProps } from '@react-navigation/stack'
 import { useCallback } from 'react'
@@ -48,7 +49,7 @@ export const VerificationSessionExpired = ({ navigation }: VerificationSessionEx
       ]}
       buttonText={t('BCSC.Modals.VerificationSessionExpired.Button')}
       onButtonPress={handleFactoryReset}
-      testID={testIdWithKey('VerificationSessionExpiredButton')}
+      testID={testIdWithKey(TestIds.systemModal.sessionExpired.button)}
     />
   )
 }

--- a/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
+++ b/app/src/bcsc-theme/features/modal/components/SystemModal.tsx
@@ -1,5 +1,6 @@
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import usePreventGestureBack from '@/hooks/usePreventGestureBack'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { StyleSheet } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
@@ -81,7 +82,7 @@ export const SystemModal = ({
         onPress={onButtonPress}
         disabled={buttonDisabled}
         accessibilityLabel={buttonText}
-        testID={testID ?? testIdWithKey('SystemModalButton')}
+        testID={testID ?? testIdWithKey(TestIds.systemModal.shared.button)}
       />
     </ControlContainer>
   )

--- a/app/src/bcsc-theme/features/notifications/NotificationActionCard.tsx
+++ b/app/src/bcsc-theme/features/notifications/NotificationActionCard.tsx
@@ -1,4 +1,5 @@
 import { ICON_CIRCLE_SIZE } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import React from 'react'
 import { StyleSheet, View } from 'react-native'
@@ -50,23 +51,27 @@ const NotificationActionCard: React.FC<NotificationActionCardProps> = (props) =>
   })
 
   return (
-    <View style={styles.container} testID={testIdWithKey('NotificationListItem')}>
+    <View style={styles.container} testID={testIdWithKey(TestIds.main.notification.item)}>
       <View style={styles.headerContainer}>
         <NotificationIcon iconName={iconName} iconColor={iconColor} hideIconCircle={props.hideIconCircle} />
-        <ThemedText variant="bold" style={styles.headerText} testID={testIdWithKey('HeaderText')}>
+        <ThemedText
+          variant="bold"
+          style={styles.headerText}
+          testID={testIdWithKey(TestIds.main.notification.headerText)}
+        >
           {props.title}
         </ThemedText>
         {props.onClose && <DismissButton onClose={props.onClose} />}
       </View>
       <View style={styles.bodyContainer}>
-        <ThemedText style={styles.bodyText} testID={testIdWithKey('BodyText')}>
+        <ThemedText style={styles.bodyText} testID={testIdWithKey(TestIds.main.notification.bodyText)}>
           {props.description}
         </ThemedText>
         <View style={styles.buttonContainer}>
           <Button
             title={props.buttonTitle}
             accessibilityLabel={props.buttonTitle}
-            testID={testIdWithKey('ViewNotification')}
+            testID={testIdWithKey(TestIds.main.notification.view)}
             buttonType={ButtonType.Primary}
             onPress={props.onPress}
           />

--- a/app/src/bcsc-theme/features/notifications/NotificationCard.tsx
+++ b/app/src/bcsc-theme/features/notifications/NotificationCard.tsx
@@ -1,4 +1,5 @@
 import { CLOSE_ICON_SIZE, hitSlop, ICON_CIRCLE_SIZE, ICON_INNER_SIZE, ICON_SIZE } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import { IColorPalette, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -45,7 +46,7 @@ export const NotificationIcon: React.FC<NotificationIconProps> = ({ logoUrl, ico
         accessible={false}
         source={{ uri: logoUrl }}
         style={styles.logoImage}
-        testID={testIdWithKey('NotificationLogo')}
+        testID={testIdWithKey(TestIds.main.notificationCard.logo)}
       />
     )
   }
@@ -79,7 +80,7 @@ export const DismissButton: React.FC<{ onClose: () => void }> = ({ onClose }) =>
     <TouchableOpacity
       accessibilityLabel={t('Global.Dismiss')}
       accessibilityRole="button"
-      testID={testIdWithKey('DismissNotification')}
+      testID={testIdWithKey(TestIds.main.notificationCard.dismiss)}
       onPress={onClose}
       hitSlop={hitSlop}
     >
@@ -163,8 +164,12 @@ const NotificationCard: React.FC<NotificationCardProps> = (props) => {
   const iconName = props.icon ?? cardStyle.defaultIcon
 
   return (
-    <Pressable onPress={props.onPress} accessibilityRole="button" testID={testIdWithKey('NotificationCardPressable')}>
-      <View style={styles.container} testID={testIdWithKey('NotificationListItem')}>
+    <Pressable
+      onPress={props.onPress}
+      accessibilityRole="button"
+      testID={testIdWithKey(TestIds.main.notificationCard.pressable)}
+    >
+      <View style={styles.container} testID={testIdWithKey(TestIds.main.notificationCard.item)}>
         <View style={styles.headerContainer}>
           <NotificationIcon
             logoUrl={props.logoUrl}
@@ -172,7 +177,11 @@ const NotificationCard: React.FC<NotificationCardProps> = (props) => {
             iconColor={iconColor}
             hideIconCircle={props.hideIconCircle}
           />
-          <ThemedText variant="bold" style={styles.headerText} testID={testIdWithKey('HeaderText')}>
+          <ThemedText
+            variant="bold"
+            style={styles.headerText}
+            testID={testIdWithKey(TestIds.main.notificationCard.headerText)}
+          >
             {props.title}
           </ThemedText>
           {props.onClose && <DismissButton onClose={props.onClose} />}
@@ -183,11 +192,11 @@ const NotificationCard: React.FC<NotificationCardProps> = (props) => {
               <ThemedText style={styles.badgeText}>{props.badge}</ThemedText>
             </View>
           )}
-          <ThemedText style={styles.bodyText} testID={testIdWithKey('BodyText')}>
+          <ThemedText style={styles.bodyText} testID={testIdWithKey(TestIds.main.notificationCard.bodyText)}>
             {props.description}
           </ThemedText>
           {props.timestamp && (
-            <ThemedText style={styles.timestampText} testID={testIdWithKey('TimestampText')}>
+            <ThemedText style={styles.timestampText} testID={testIdWithKey(TestIds.main.notificationCard.timestamp)}>
               {props.timestamp}
             </ThemedText>
           )}

--- a/app/src/bcsc-theme/features/pairing/ManualPairing.tsx
+++ b/app/src/bcsc-theme/features/pairing/ManualPairing.tsx
@@ -2,6 +2,7 @@ import useApi from '@/bcsc-theme/api/hooks/useApi'
 import CodeInput from '@/bcsc-theme/components/CodeInput'
 import { useLoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
 import { PAIRING_CODE_LENGTH } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import { BCSCMainStackParams, BCSCQRCoreScreens, BCSCQRCoreTabParams, BCSCScreens } from '@bcsc-theme/types/navigators'
 import { ScreenWrapper, testIdWithKey, ThemedText, TOKENS, useServices, useTheme } from '@bifold/core'
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs'
@@ -115,7 +116,7 @@ const ManualPairing: React.FC = () => {
           autoCapitalize: 'characters',
           autoComplete: 'off',
           autoCorrect: false,
-          testID: testIdWithKey('ManualPairingCodeInput'),
+          testID: testIdWithKey(TestIds.main.pairing.manualCodeInput),
           accessibilityLabel: 'Pairing-Code-Input',
         }}
       />

--- a/app/src/bcsc-theme/features/pairing/PairingConfirmation.tsx
+++ b/app/src/bcsc-theme/features/pairing/PairingConfirmation.tsx
@@ -1,5 +1,6 @@
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import { BCSCMainStackParams, BCSCScreens, BCSCStacks } from '@/bcsc-theme/types/navigators'
+import { TestIds } from '@/test-ids/registry'
 import ArrowUp from '@assets/img/arrowup.svg'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { CommonActions } from '@react-navigation/native'
@@ -56,7 +57,7 @@ const PairingConfirmation: React.FC<PairingConfirmationProps> = ({ navigation, r
       <Button
         title={t('Global.Close')}
         buttonType={ButtonType.Primary}
-        testID={testIdWithKey('Close')}
+        testID={testIdWithKey(TestIds.main.pairing.confirmationClose)}
         accessibilityLabel={t('Global.Close')}
         onPress={onClose}
       />

--- a/app/src/bcsc-theme/features/pairing/components/ServiceBookmarkButton.tsx
+++ b/app/src/bcsc-theme/features/pairing/components/ServiceBookmarkButton.tsx
@@ -1,5 +1,6 @@
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, ThemedText, useStore, useTheme } from '@bifold/core'
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -46,7 +47,7 @@ const ServiceBookmarkButton = ({ serviceName, serviceId }: ServiceBookmarkButton
       accessibilityRole="button"
       accessibilityState={{ selected: bookmarked }}
       accessibilityLabel={t('BCSC.ManualPairing.BookmarkServiceButton')}
-      testID={testIdWithKey('BookmarkService')}
+      testID={testIdWithKey(TestIds.main.pairing.bookmark)}
     >
       <ThemedText variant={'bold'} style={{ color: TextTheme.headingFour.color }}>
         {t('BCSC.ManualPairing.BookmarkServiceButton')}

--- a/app/src/bcsc-theme/features/qr-core/QRDisplay.tsx
+++ b/app/src/bcsc-theme/features/qr-core/QRDisplay.tsx
@@ -1,5 +1,6 @@
 import { BCSCMainStackParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import {
   ButtonLocation,
   IconButton,
@@ -61,7 +62,7 @@ const QRDisplay: React.FC = () => {
         icon="share-variant"
         iconTintColor={ColorPalette.brand.primary}
         accessibilityLabel={t('Global.Share')}
-        testID={testIdWithKey('Share')}
+        testID={testIdWithKey(TestIds.main.qrDisplay.share)}
         onPress={vm.share}
       />
     )
@@ -96,7 +97,7 @@ const QRDisplay: React.FC = () => {
 
   if (vm.status === QRDisplayStatus.LOADING) {
     return (
-      <View style={styles.stateContainer} testID={testIdWithKey('QRDisplay.Loading')}>
+      <View style={styles.stateContainer} testID={testIdWithKey(TestIds.main.qrDisplay.loading)}>
         <ActivityIndicator size="large" color={ColorPalette.brand.primary} />
       </View>
     )
@@ -104,7 +105,7 @@ const QRDisplay: React.FC = () => {
 
   if (vm.status === QRDisplayStatus.ERROR) {
     return (
-      <View style={styles.stateContainer} testID={testIdWithKey('QRDisplay.Error')}>
+      <View style={styles.stateContainer} testID={testIdWithKey(TestIds.main.qrDisplay.error)}>
         <InfoBox
           notificationType={InfoBoxType.Error}
           title={t('BCSC.QRDisplay.ErrorTitle')}

--- a/app/src/bcsc-theme/features/qr-core/QRScanner.tsx
+++ b/app/src/bcsc-theme/features/qr-core/QRScanner.tsx
@@ -3,6 +3,7 @@ import { QRScannerFrame } from '@/bcsc-theme/components/QRScannerFrame'
 import { LoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
 import { BCSCMainStackParams, BCSCQRCoreScreens, BCSCQRCoreTabParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { hitSlop } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import { DismissiblePopupModal, ScanCamera, testIdWithKey, useTheme } from '@bifold/core'
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs'
 import { useFocusEffect, useNavigation } from '@react-navigation/native'
@@ -92,7 +93,7 @@ const QRScanner: React.FC = () => {
         accessibilityRole="button"
         accessibilityLabel={t(torchActive ? 'BCSC.Scan.TorchOff' : 'BCSC.Scan.TorchOn')}
         hitSlop={hitSlop}
-        testID={testIdWithKey('TorchToggle')}
+        testID={testIdWithKey(TestIds.main.qrCore.torchToggle)}
       >
         <Icon name={torchActive ? 'flash' : 'flash-off'} size={28} style={styles.torchIcon} />
       </TouchableOpacity>

--- a/app/src/bcsc-theme/features/qr-core/WalletNameDisplay.tsx
+++ b/app/src/bcsc-theme/features/qr-core/WalletNameDisplay.tsx
@@ -1,4 +1,5 @@
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { ButtonLocation, IconButton, testIdWithKey, ThemedText, useStore, useTheme } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -34,13 +35,13 @@ const WalletNameDisplay: React.FC = () => {
 
   return (
     <View style={styles.container}>
-      <ThemedText variant="headingTwo" testID={testIdWithKey('WalletName')} style={styles.name}>
+      <ThemedText variant="headingTwo" testID={testIdWithKey(TestIds.main.qrDisplay.walletName)} style={styles.name}>
         {store.bcsc.selectedNickname || 'My Wallet'}
       </ThemedText>
       <IconButton
         buttonLocation={ButtonLocation.Right}
         accessibilityLabel={t('Nickname.EditNickname')}
-        testID={testIdWithKey('EditNickname')}
+        testID={testIdWithKey(TestIds.main.qrDisplay.editNickname)}
         onPress={handleEdit}
         icon="pencil"
         iconTintColor={TextTheme.headingTwo.color}

--- a/app/src/bcsc-theme/features/scan/FloatingScanButton.tsx
+++ b/app/src/bcsc-theme/features/scan/FloatingScanButton.tsx
@@ -1,4 +1,5 @@
 import { hitSlop } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -64,7 +65,7 @@ const FloatingScanButton: React.FC<FloatingScanButtonProps> = ({ activeTabName, 
       accessibilityLabel={t('AddCredentialSlider.ScanQRCode')}
       accessibilityRole="button"
       hitSlop={{ ...hitSlop, bottom: 0 }}
-      testID={testIdWithKey('FloatingScanButton')}
+      testID={testIdWithKey(TestIds.main.scan.fab)}
       onPress={onPress}
       style={({ pressed }) => [styles.button, pressed && styles.pressed]}
     >

--- a/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
+++ b/app/src/bcsc-theme/features/services/ServiceLoginScreen.tsx
@@ -5,6 +5,7 @@ import { BCSCMainStackParams, BCSCScreens, BCSCStacks } from '@/bcsc-theme/types
 import { HelpCentreUrl, hitSlop, REPORT_SUSPICIOUS_URL } from '@/constants'
 import { isHandledAppError } from '@/errors/appError'
 import { useAlerts } from '@/hooks/useAlerts'
+import { TestIds } from '@/test-ids/registry'
 import {
   Button,
   ButtonType,
@@ -82,7 +83,7 @@ const DevicePreferenceURLView: React.FC<DevicePreferenceURLViewProps> = ({
         <ThemedText selectable={true}>
           <Link
             linkText={serviceClientUri}
-            testID={testIdWithKey('ServiceClientLink')}
+            testID={testIdWithKey(TestIds.main.serviceLogin.serviceClientLink)}
             onPress={() => Linking.openURL(serviceClientUri)}
           />
         </ThemedText>
@@ -114,7 +115,7 @@ const ServiceLoginUnavailableView = ({ state, styles, t, logger, onCancel }: Ser
         title={''}
         accessibilityLabel={a11yLabel(t('BCSC.Services.GotoService', { service: state.serviceTitle }))}
         accessibilityHint={t('Global.A11y.OpensInBrowser')}
-        testID={testIdWithKey('GoToServiceClient')}
+        testID={testIdWithKey(TestIds.main.serviceLogin.goToService)}
         buttonType={ButtonType.Primary}
         onPress={async () => {
           if (!state.serviceClientUri) {
@@ -140,7 +141,7 @@ const ServiceLoginUnavailableView = ({ state, styles, t, logger, onCancel }: Ser
       <Button
         buttonType={ButtonType.Secondary}
         title={t('Global.Cancel')}
-        testID={testIdWithKey('Cancel')}
+        testID={testIdWithKey(TestIds.main.serviceLogin.cancelUnavailable)}
         accessibilityLabel={t('Global.Cancel')}
         onPress={onCancel}
       />
@@ -185,7 +186,7 @@ const ServiceLoginDefaultView = ({
       <Button
         title={t('Global.Continue')}
         accessibilityLabel={a11yLabel(t('Global.Continue'))}
-        testID={testIdWithKey('ServiceLoginContinue')}
+        testID={testIdWithKey(TestIds.main.serviceLogin.continue)}
         buttonType={ButtonType.Primary}
         disabled={isContinueDisabled}
         onPress={() => {
@@ -196,12 +197,12 @@ const ServiceLoginDefaultView = ({
       <Button
         title={t('Global.Cancel')}
         accessibilityLabel={a11yLabel(t('Global.Cancel'))}
-        testID={testIdWithKey('ServiceLoginCancel')}
+        testID={testIdWithKey(TestIds.main.serviceLogin.cancel)}
         buttonType={ButtonType.Secondary}
         onPress={onCancel}
       />
 
-      <ReportSuspiciousLink t={t} testID={testIdWithKey('ReportSuspiciousLink')} />
+      <ReportSuspiciousLink t={t} testID={testIdWithKey(TestIds.main.serviceLogin.reportSuspicious)} />
     </ControlContainer>
   )
 
@@ -235,7 +236,7 @@ const ServiceLoginDefaultView = ({
           >
             <ThemedText style={styles.infoHeader}>{t('BCSC.Services.FromAccount')}</ThemedText>
             <TouchableOpacity
-              testID={testIdWithKey('HelpButton')}
+              testID={testIdWithKey(TestIds.main.serviceLogin.help)}
               accessibilityLabel={a11yLabel(t('BCSC.Screens.HelpCentre'))}
               accessibilityRole="button"
               hitSlop={hitSlop}
@@ -249,7 +250,7 @@ const ServiceLoginDefaultView = ({
 
         {state.privacyPolicyUri ? (
           <TouchableOpacity
-            testID={testIdWithKey('ReadPrivacyPolicy')}
+            testID={testIdWithKey(TestIds.main.serviceLogin.readPrivacyPolicy)}
             accessibilityLabel={a11yLabel(t('BCSC.Services.PrivacyNotice'))}
             accessibilityRole="link"
             accessibilityHint={t('Global.A11y.OpensInBrowser')}

--- a/app/src/bcsc-theme/features/services/Services.tsx
+++ b/app/src/bcsc-theme/features/services/Services.tsx
@@ -8,6 +8,7 @@ import { getCardProcessForCardType } from '@/bcsc-theme/utils/card-utils'
 import { Mode } from '@/constants'
 import { useDebounce } from '@/hooks/useDebounce'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, ThemedText, TOKENS, useServices, useStore, useTheme } from '@bifold/core'
 import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -156,7 +157,7 @@ const Services: React.FC = () => {
               }
             }}
             accessibilityLabel={a11yLabel(t('BCSC.Services.CatalogueSearch'))}
-            testID={testIdWithKey('search')}
+            testID={testIdWithKey(TestIds.main.services.search)}
             style={styles.searchText}
           />
           {search.length > 0 ? (
@@ -169,7 +170,7 @@ const Services: React.FC = () => {
                 setSearch('')
               }}
               accessibilityLabel={a11yLabel(t('Global.Close'))}
-              testID={testIdWithKey('clearSearch')}
+              testID={testIdWithKey(TestIds.main.services.clearSearch)}
             />
           ) : null}
         </View>
@@ -179,7 +180,7 @@ const Services: React.FC = () => {
         <ActivityIndicator
           size={'large'}
           style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}
-          testID={testIdWithKey('ServicesLoading')}
+          testID={testIdWithKey(TestIds.main.services.loading)}
         />
       ) : (
         <View>

--- a/app/src/bcsc-theme/features/services/components/ServiceButton.tsx
+++ b/app/src/bcsc-theme/features/services/components/ServiceButton.tsx
@@ -2,6 +2,7 @@ import { ListButton, ListButtonProps } from '@/bcsc-theme/components/ListButton'
 import useSecureActions from '@/bcsc-theme/hooks/useSecureActions'
 import { hitSlop } from '@/constants'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, ThemedText, useStore, useTheme } from '@bifold/core'
 import { a11yLabel } from '@utils/accessibility'
 import React from 'react'
@@ -59,7 +60,7 @@ const ServiceButton: React.FC<ServiceButtonProps> = ({
           <ThemedText
             variant={'bold'}
             style={styles.title}
-            testID={testID ?? testIdWithKey(`ServiceButton-${title.replaceAll(/\s+/g, '')}`)}
+            testID={testID ?? testIdWithKey(`${TestIds.main.services.serviceRowPrefix}${title.replaceAll(/\s+/g, '')}`)}
           >
             {title}
           </ThemedText>
@@ -68,7 +69,7 @@ const ServiceButton: React.FC<ServiceButtonProps> = ({
             hitSlop={hitSlop}
             accessibilityRole={'button'}
             accessibilityLabel={a11yLabel(`Toggle bookmark for ${title}`)}
-            testID={testIdWithKey(`ServiceButton-Bookmark-${title.replaceAll(/\s+/g, '')}`)}
+            testID={testIdWithKey(`${TestIds.main.services.serviceBookmarkPrefix}${title.replaceAll(/\s+/g, '')}`)}
           >
             <Icon name={isBookmarked ? 'bookmark' : 'bookmark-outline'} size={24} color={ColorPalette.brand.primary} />
           </Pressable>

--- a/app/src/bcsc-theme/features/splash-loading/LoadingScreenContent.tsx
+++ b/app/src/bcsc-theme/features/splash-loading/LoadingScreenContent.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, View } from 'react-native'
@@ -47,7 +48,7 @@ export const LoadingScreenContent = ({ message, iconOnTop = true }: LoadingScree
   })
 
   return (
-    <SafeAreaView style={styles.container} testID={testIdWithKey('LoadingScreenContent')}>
+    <SafeAreaView style={styles.container} testID={testIdWithKey(TestIds.common.loadingScreen)}>
       <View style={styles.contentContainer}>
         {iconOnTop && <BCAnimatedLoadingIcon size={iconSize} />}
         <View style={styles.textContainer}>

--- a/app/src/test-ids/registry.ts
+++ b/app/src/test-ids/registry.ts
@@ -35,6 +35,12 @@ export const TestIds = {
     back: 'Back',
     /** Floating help menu button (headerRight on the onboarding/verify stacks). */
     help: 'HelpMenu',
+    // App-level gates and overlays, not screen controls: the splash/loading body, the two halves of
+    // `BCSCLoadingContext`'s overlay, and the retry on the Credo agent gate. Any screen can be behind them.
+    loadingScreen: 'LoadingScreenContent',
+    loadingOverlay: 'BCSCLoadingProviderOverlay',
+    loadingChildren: 'BCSCLoadingProviderChildren',
+    agentRetry: 'AgentRetry',
   },
 
   /**
@@ -51,6 +57,25 @@ export const TestIds = {
     details: 'DetailsText', // "Error code N - message", rendered only once ShowDetails is pressed
     title: 'HeaderText',
     body: 'BodyText',
+  },
+
+  /**
+   * App-wide system modals (`features/modal/`) — like `errorModal`, overlays any screen can raise.
+   * `shared.button` is `SystemModal`'s generic CTA, used as-is by DeviceInvalidated, MandatoryUpdate
+   * and InternetDisconnected; screens that pass their own testID get their own key below.
+   */
+  systemModal: {
+    shared: {
+      button: 'SystemModalButton',
+    },
+    sessionExpired: {
+      button: 'VerificationSessionExpiredButton',
+    },
+    /** ServiceOutage does NOT use `SystemModal` — it is its own component with two buttons. */
+    serviceOutage: {
+      helpCentre: 'ServiceOutageHelpCentre',
+      checkAgain: 'ServiceOutageCheckAgain',
+    },
   },
 
   onboarding: {
@@ -442,6 +467,15 @@ export const TestIds = {
       services: 'Services',
       wallet: 'Wallet',
     },
+    /** Home tab. `logInFromComputer` renders TWICE (a card and a SectionButton, different branches)
+     *  and is the pairing entry point, so its key lives under `main.pairing`. Saved-service rows are
+     *  NAME-DERIVED from the service title minus whitespace, same shape as the services catalogue. */
+    home: {
+      whereToUse: 'WhereToUse',
+      pairingCodeCard: 'PairingCodeCard',
+      savedServiceOpenPrefix: 'OpenService-',
+      savedServiceRemovePrefix: 'RemoveService-',
+    },
     /** Services catalogue (verified-only; unverified taps redirect to MainVerifyPrompt). `search` is
      *  the always-present sticky-header catalogue search field — the "Services opened, not gated" marker. */
     services: {
@@ -482,6 +516,7 @@ export const TestIds = {
       bodyText: 'BodyText',
       timestamp: 'TimestampText',
       dismiss: 'DismissNotification',
+      logo: 'NotificationLogo',
     },
     /** Floating scan FAB (rendered on the Home + Wallet tabs, not verification-gated) → QRCore. */
     scan: {
@@ -504,6 +539,16 @@ export const TestIds = {
       displayTab: 'MyQRCode',
       pairingCodeTab: 'PairingCode',
       torchToggle: 'TorchToggle',
+    },
+    /** The `MyQRCode` tab's body (dev-mode only, per `qrCore.displayTab`). `loading` and `error` are
+     *  mutually exclusive state containers — neither renders once the code is up. `editNickname` opens
+     *  the same nickname form as `main.editNickname`. */
+    qrDisplay: {
+      walletName: 'WalletName',
+      editNickname: 'EditNickname',
+      share: 'Share',
+      loading: 'QRDisplay.Loading',
+      error: 'QRDisplay.Error',
     },
     /** The QR scanner's failed-scan popup (bifold `DismissiblePopupModal`). `okay` is its CTA
      *  (labelled "Dismiss"); `header`/`body` are bifold-generic ids shared with the Home notification


### PR DESCRIPTION
Closes #4593

## What changed

Migrates the remaining BCSC features — home, services, notifications, qr-core, pairing, scan, modal, splash-loading, agent and `contexts` — 48 call sites across 21 files. Refactor-only.

**Stacked on `chore/e2e_testID_account`.** Review only this branch's diff.

- The eslint glob **shrinks** rather than grows: every subdirectory of `features/` is now migrated, so the eight-entry list collapses to `['src/test-ids/**', 'src/bcsc-theme/features/**', 'src/bcsc-theme/contexts/**']`.
- Registry: new `main.home` and `main.qrDisplay` groups, plus a top-level `systemModal` area (`shared` / `sessionExpired` / `serviceOutage`) alongside `errorModal`, since these overlay any screen.
- `common` gains the four app-level gate/overlay ids (splash body, both `BCSCLoadingContext` halves, the Credo agent retry).
- `SystemModalButton` is registered on the component that actually emits it. The previous PR removed it from `verify.cancelledReview`, where it was recorded against a screen that never rendered it.

## What should the reviewer focus on

- The collapsed glob is the claim worth checking: eslint passing over all of `features/**` is what proves the previous four PRs missed nothing in that tree.
- Whether `systemModal` belongs at the top level rather than under `main`. It sits next to `errorModal` because both are overlays no single screen owns.
- Two prettier reflows in the notification card files. Same elements, same props.

## How to test

```
cd app && yarn typecheck && yarn lint && yarn test
cd e2e && yarn typecheck
```

160/160 snapshots pass with no `.snap` written.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>