### PR TITLE
chore: shared component and navigator test-ids

### DIFF
--- a/app/eslint.config.mjs
+++ b/app/eslint.config.mjs
@@ -101,7 +101,7 @@ export default [
   // so unmigrated areas stay green while migrated ones cannot regress. Tests are exempt on purpose:
   // asserting the literal id string is what proves the emitted ids never moved.
   {
-    files: ['src/test-ids/**', 'src/bcsc-theme/features/**', 'src/bcsc-theme/contexts/**'],
+    files: ['src/test-ids/**', 'src/bcsc-theme/**'],
     ignores: ['**/*.test.{ts,tsx}'],
     rules: {
       'no-restricted-syntax': [

--- a/app/src/bcsc-theme/components/AppBanner.tsx
+++ b/app/src/bcsc-theme/components/AppBanner.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import { ThemedText, testIdWithKey, useTheme } from '@bifold/core'
 import React, { useState } from 'react'
 import { StyleSheet, TouchableOpacity, View } from 'react-native'
@@ -120,7 +121,7 @@ export const AppBannerSection: React.FC<AppBannerSectionProps> = ({
   return (
     <TouchableOpacity
       style={[{ ...styles.container, backgroundColor: bannerColor(type) }]}
-      testID={testIdWithKey(`button-${type}`)}
+      testID={testIdWithKey(`${TestIds.shared.appBanner.buttonPrefix}${type}`)}
       accessibilityLabel={a11yLabel(title || description || '')}
       accessibilityRole="button"
       onPress={() => {
@@ -135,7 +136,7 @@ export const AppBannerSection: React.FC<AppBannerSectionProps> = ({
         size={24}
         color={type === 'warning' ? ColorPalette.brand.secondaryBackground : ColorPalette.grayscale.white}
         style={styles.icon}
-        testID={testIdWithKey(`icon-${type}`)}
+        testID={testIdWithKey(`${TestIds.shared.appBanner.iconPrefix}${type}`)}
       />
       <View style={styles.textContainer}>
         {title ? (
@@ -144,7 +145,7 @@ export const AppBannerSection: React.FC<AppBannerSectionProps> = ({
             style={{
               color: type === 'warning' ? ColorPalette.brand.secondaryBackground : ColorPalette.grayscale.white,
             }}
-            testID={testIdWithKey(`text-${type}`)}
+            testID={testIdWithKey(`${TestIds.shared.appBanner.textPrefix}${type}`)}
           >
             {title}
           </ThemedText>
@@ -155,7 +156,7 @@ export const AppBannerSection: React.FC<AppBannerSectionProps> = ({
               lineHeight: 24,
               color: type === 'warning' ? ColorPalette.brand.secondaryBackground : ColorPalette.grayscale.white,
             }}
-            testID={testIdWithKey(`description-${type}`)}
+            testID={testIdWithKey(`${TestIds.shared.appBanner.descriptionPrefix}${type}`)}
           >
             {description}
           </ThemedText>

--- a/app/src/bcsc-theme/components/CardButton.tsx
+++ b/app/src/bcsc-theme/components/CardButton.tsx
@@ -1,4 +1,5 @@
 import { PressableOpacity } from '@/components/PressableOpacity'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { a11yLabel } from '@utils/accessibility'
 import { StyleSheet, View } from 'react-native'
@@ -148,7 +149,7 @@ export const CardButton = (props: CardProps): React.ReactElement => {
         accessibilityLabel={a11yLabel(props.subtext ? `${props.title}. ${props.subtext}` : props.title)}
         accessibilityState={{ selected: true }}
         style={[styles.cardContainer, styles.cardContainerSelected]}
-        testID={props.testID ?? testIdWithKey(`CardButton-${props.title}`)}
+        testID={props.testID ?? testIdWithKey(`${TestIds.shared.cardButtonPrefix}${props.title}`)}
       >
         {cardContent}
       </View>
@@ -165,7 +166,7 @@ export const CardButton = (props: CardProps): React.ReactElement => {
       style={[styles.cardContainer, props.disabled && styles.cardContainerDisabled]}
       onPress={props.disabled ? undefined : props.onPress}
       disabled={props.disabled}
-      testID={props.testID ?? testIdWithKey(`CardButton-${props.title}`)}
+      testID={props.testID ?? testIdWithKey(`${TestIds.shared.cardButtonPrefix}${props.title}`)}
     >
       {cardContent}
     </PressableOpacity>

--- a/app/src/bcsc-theme/components/DestructiveConfirmationScreen.tsx
+++ b/app/src/bcsc-theme/components/DestructiveConfirmationScreen.tsx
@@ -1,5 +1,6 @@
 import { ControlContainer } from '@/bcsc-theme/components/ControlContainer'
 import { useLoadingScreen } from '@/bcsc-theme/contexts/BCSCLoadingContext'
+import { TestIds } from '@/test-ids/registry'
 import {
   Button,
   ButtonType,
@@ -76,7 +77,7 @@ const DestructiveConfirmationScreen: React.FC<DestructiveConfirmationScreenProps
         accessibilityLabel={confirmLabel}
         buttonType={ButtonType.Critical}
         title={confirmLabel}
-        testID={testIdWithKey('ConfirmDestructiveAction')}
+        testID={testIdWithKey(TestIds.main.removeAccount.confirm)}
         onPress={onConfirm}
         disabled={disabled}
       />

--- a/app/src/bcsc-theme/components/DeveloperModeTrigger.tsx
+++ b/app/src/bcsc-theme/components/DeveloperModeTrigger.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, useDeveloperMode } from '@bifold/core'
 import React from 'react'
 import { Pressable, StyleProp, Vibration, ViewStyle } from 'react-native'
@@ -28,7 +29,7 @@ export const DeveloperModeTrigger: React.FC<DeveloperModeTriggerProps> = ({ onAc
       accessible={false}
       accessibilityElementsHidden={true}
       importantForAccessibility="no-hide-descendants"
-      testID={testIdWithKey('DeveloperCounter')}
+      testID={testIdWithKey(TestIds.developer.counter)}
     >
       {children}
     </Pressable>

--- a/app/src/bcsc-theme/components/DropdownWithValidation.tsx
+++ b/app/src/bcsc-theme/components/DropdownWithValidation.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -152,7 +153,7 @@ export const DropdownWithValidation = <T extends string | number>({
           isLastItem && { borderBottomWidth: 0 },
         ]}
         onPress={() => handleSelect(item.value)}
-        testID={testIdWithKey(`${id}-option-${item.value}`)}
+        testID={testIdWithKey(`${id}${TestIds.shared.field.optionPrefix}${item.value}`)}
         accessibilityLabel={a11yLabel(item.label)}
         accessibilityRole="menuitem"
         accessibilityState={{ selected: isSelected }}
@@ -168,7 +169,7 @@ export const DropdownWithValidation = <T extends string | number>({
       <ThemedText
         variant={'labelTitle'}
         style={[{ marginBottom: 8 }, labelProps]}
-        testID={testIdWithKey(`${id}-label`)}
+        testID={testIdWithKey(`${id}${TestIds.shared.field.label}`)}
       >
         {label}
       </ThemedText>
@@ -176,7 +177,7 @@ export const DropdownWithValidation = <T extends string | number>({
       <Pressable
         style={styles.dropdownButton}
         onPress={() => setIsOpen(true)}
-        testID={testIdWithKey(`${id}-input`)}
+        testID={testIdWithKey(`${id}${TestIds.shared.field.input}`)}
         accessibilityRole="combobox"
         accessibilityState={{ expanded: isOpen }}
         accessibilityLabel={a11yLabel(`${label}, ${selectedOption?.label || placeholder}`)}
@@ -192,7 +193,7 @@ export const DropdownWithValidation = <T extends string | number>({
       {error ? (
         <ThemedText
           style={[{ marginTop: 4, color: ColorPalette.semantic.error, fontSize: 12 }, errorProps]}
-          testID={testIdWithKey(`${id}-error`)}
+          testID={testIdWithKey(`${id}${TestIds.shared.field.error}`)}
         >
           {error}
         </ThemedText>
@@ -202,7 +203,7 @@ export const DropdownWithValidation = <T extends string | number>({
         <ThemedText
           style={[{ marginTop: 8 }, subtextProps]}
           variant={'labelSubtitle'}
-          testID={testIdWithKey(`${id}-subtext`)}
+          testID={testIdWithKey(`${id}${TestIds.shared.field.subtext}`)}
         >
           {subtext}
         </ThemedText>
@@ -211,7 +212,7 @@ export const DropdownWithValidation = <T extends string | number>({
       <Modal visible={isOpen} transparent animationType="slide" onRequestClose={handleClose} onDismiss={onModalClose}>
         <View
           style={[styles.modalContent, { paddingTop: insets.top, paddingBottom: insets.bottom }]}
-          testID={testIdWithKey(`${id}-modal-content`)}
+          testID={testIdWithKey(`${id}${TestIds.shared.field.modalContent}`)}
         >
           <View style={styles.modalHeader}>
             <View style={{ width: 32 }} />
@@ -219,7 +220,7 @@ export const DropdownWithValidation = <T extends string | number>({
             <PressableOpacity
               style={styles.closeButton}
               onPress={handleClose}
-              testID={testIdWithKey(`${id}-close`)}
+              testID={testIdWithKey(`${id}${TestIds.shared.field.close}`)}
               accessibilityLabel={a11yLabel(t('Global.Close'))}
               accessibilityRole="button"
               hitSlop={hitSlop}

--- a/app/src/bcsc-theme/components/EmptyWalletList.tsx
+++ b/app/src/bcsc-theme/components/EmptyWalletList.tsx
@@ -1,5 +1,6 @@
 import { PressableOpacity } from '@/components/PressableOpacity'
 import { hitSlop, WALLET_LEARN_MORE_URL } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import { openLink } from '@/utils/links'
 import EmptyWalletIllustration from '@assets/img/bcsc-empty-wallet.svg'
 import { testIdWithKey, ThemedText, useTheme } from '@bifold/core'
@@ -47,12 +48,15 @@ const EmptyWalletList: React.FC = () => {
   }
 
   return (
-    <View style={[styles.container, { padding: Spacing.lg, minHeight }]} testID={testIdWithKey('Wallet.Empty')}>
+    <View
+      style={[styles.container, { padding: Spacing.lg, minHeight }]}
+      testID={testIdWithKey(TestIds.main.wallet.empty)}
+    >
       <EmptyWalletIllustration
         width={184}
         height={167}
         style={{ marginBottom: Spacing.lg }}
-        testID={testIdWithKey('Wallet.EmptyIllustration')}
+        testID={testIdWithKey(TestIds.main.wallet.emptyIllustration)}
       />
       <ThemedText variant="headingThree" style={[styles.message, { color: ColorPalette.brand.primary }]}>
         {t('BCSC.Wallet.EmptyMessage')}
@@ -63,7 +67,7 @@ const EmptyWalletList: React.FC = () => {
         accessibilityLabel={a11yLabel(t('BCSC.Wallet.EmptyLearnMore'))}
         hitSlop={hitSlop}
         onPress={handleLearnMore}
-        testID={testIdWithKey('Wallet.EmptyLearnMore')}
+        testID={testIdWithKey(TestIds.main.wallet.emptyLearnMore)}
         style={{
           alignSelf: 'stretch',
           marginTop: Spacing.lg,

--- a/app/src/bcsc-theme/components/FloatingHelpMenuHeaderButton.tsx
+++ b/app/src/bcsc-theme/components/FloatingHelpMenuHeaderButton.tsx
@@ -1,4 +1,5 @@
 import { FEEDBACK_URL, HelpCentreUrl } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import { a11yLabel } from '@/utils/accessibility'
 import { openLink } from '@/utils/links'
 import { ButtonLocation, IconButton, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
@@ -45,7 +46,7 @@ const FloatingHelpMenuButton = (props: FloatingHelpMenuButtonProps) => {
         icon={props.icon}
         iconTintColor={ColorPalette.brand.primary}
         accessibilityLabel={t('BCSC.HelpMenu.AccessibilityLabel')}
-        testID={testIdWithKey('HelpMenu')}
+        testID={testIdWithKey(TestIds.common.help)}
         onPress={() => setOpen(true)}
       />
       <FloatingHelpMenu ref={props.ref} open={open} onClose={() => setOpen(false)}>

--- a/app/src/bcsc-theme/components/InputWithValidation.tsx
+++ b/app/src/bcsc-theme/components/InputWithValidation.tsx
@@ -1,5 +1,6 @@
 import { useBCSCActivity } from '@/bcsc-theme/contexts/BCSCActivityContext'
 import { hitSlop } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import { a11yLabel } from '@/utils/accessibility'
 import { testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import type { ReactNode, RefObject } from 'react'
@@ -105,7 +106,7 @@ export const InputWithValidation: React.FC<InputWithValidationProps> = (props: I
         <ThemedText
           variant={'labelTitle'}
           style={[styles.label, props.labelProps]}
-          testID={testIdWithKey(`${props.id}-label`)}
+          testID={testIdWithKey(`${props.id}${TestIds.shared.field.label}`)}
         >
           {props.label}
         </ThemedText>
@@ -117,7 +118,7 @@ export const InputWithValidation: React.FC<InputWithValidationProps> = (props: I
           inputRef.current?.focus()
         }}
         hitSlop={hitSlop}
-        testID={testIdWithKey(`${props.id}-pressable`)}
+        testID={testIdWithKey(`${props.id}${TestIds.shared.field.pressable}`)}
         accessible={false}
       >
         <View style={{ flex: 1 }}>
@@ -143,7 +144,7 @@ export const InputWithValidation: React.FC<InputWithValidationProps> = (props: I
             }}
             onPressIn={props.onPressIn}
             accessibilityLabel={a11yLabel(props.label)}
-            testID={testIdWithKey(`${props.id}-input`)}
+            testID={testIdWithKey(`${props.id}${TestIds.shared.field.input}`)}
             {...props.textInputProps}
             keyboardType={props.textInputProps?.keyboardType ?? props.keyboardType ?? 'default'}
             onFocus={(event) => {
@@ -170,7 +171,7 @@ export const InputWithValidation: React.FC<InputWithValidationProps> = (props: I
         <ThemedText
           style={[styles.subtext, props.error && styles.errorText, props.subtextProps]}
           variant={'labelSubtitle'}
-          testID={testIdWithKey(`${props.id}-subtext`)}
+          testID={testIdWithKey(`${props.id}${TestIds.shared.field.subtext}`)}
         >
           {props.error ? props.error : props.subtext}
         </ThemedText>

--- a/app/src/bcsc-theme/components/MaskedCamera.tsx
+++ b/app/src/bcsc-theme/components/MaskedCamera.tsx
@@ -2,6 +2,7 @@ import { useErrorAlert } from '@/contexts/ErrorAlertContext'
 import { ensureAppError } from '@/errors/errorHandler'
 import { AppEventCode } from '@/events/appEventCode'
 import { useAlerts } from '@/hooks/useAlerts'
+import { TestIds } from '@/test-ids/registry'
 import {
   MaskType,
   SVGOverlay,
@@ -265,7 +266,7 @@ const MaskedCamera = ({
           onPress={handleCancel}
           accessibilityLabel={t('BCSC.CameraDisclosure.CancelCamera')}
           accessibilityRole="button"
-          testID={testIdWithKey('CancelCamera')}
+          testID={testIdWithKey(TestIds.shared.maskedCamera.cancel)}
         >
           <ThemedText style={{ color: ColorPalette.grayscale.white }}>{t('Global.Cancel')}</ThemedText>
         </TouchableOpacity>
@@ -274,7 +275,7 @@ const MaskedCamera = ({
           onPress={preventDoublePress(takePhoto)}
           accessibilityLabel={t('BCSC.CameraDisclosure.TakePhoto')}
           accessibilityRole="button"
-          testID={testIdWithKey('TakePhoto')}
+          testID={testIdWithKey(TestIds.shared.maskedCamera.takePhoto)}
         ></TouchableOpacity>
         {hasTorch ? (
           <TouchableOpacity
@@ -282,7 +283,7 @@ const MaskedCamera = ({
             onPress={toggleTorch}
             accessibilityLabel={t('BCSC.CameraDisclosure.ToggleFlash')}
             accessibilityRole="button"
-            testID={testIdWithKey('ToggleFlash')}
+            testID={testIdWithKey(TestIds.shared.maskedCamera.toggleFlash)}
           >
             <Icon size={24} name={torchOn ? 'flash' : 'flash-off'} color={ColorPalette.grayscale.white} />
           </TouchableOpacity>

--- a/app/src/bcsc-theme/components/PINInput.tsx
+++ b/app/src/bcsc-theme/components/PINInput.tsx
@@ -76,6 +76,8 @@ export const PINInput = ({
     setIsVisible(!isVisible)
   }
 
+  const visibilityTestIDKey = `${testIDKey ?? ''}${TestIds.shared.pinInput.visibilitySuffix}`
+
   return (
     <View style={styles.pinInputContainer}>
       <View style={styles.inputContainer}>
@@ -100,11 +102,7 @@ export const PINInput = ({
         <TouchableOpacity
           style={styles.visibilityButton}
           onPress={toggleVisibility}
-          testID={
-            testIDKey
-              ? testIdWithKey(`${testIDKey}${TestIds.shared.pinInput.visibilitySuffix}`)
-              : testIdWithKey(TestIds.shared.pinInput.visibilitySuffix)
-          }
+          testID={testIdWithKey(visibilityTestIDKey)}
           accessibilityLabel={a11yLabel(isVisible ? t('PINCreate.Hide') : t('PINCreate.Show'))}
           accessibilityRole="button"
         >

--- a/app/src/bcsc-theme/components/PINInput.tsx
+++ b/app/src/bcsc-theme/components/PINInput.tsx
@@ -1,4 +1,5 @@
 import { PIN_LENGTH } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -99,7 +100,11 @@ export const PINInput = ({
         <TouchableOpacity
           style={styles.visibilityButton}
           onPress={toggleVisibility}
-          testID={testIDKey ? testIdWithKey(`${testIDKey}VisibilityButton`) : testIdWithKey('VisibilityButton')}
+          testID={
+            testIDKey
+              ? testIdWithKey(`${testIDKey}${TestIds.shared.pinInput.visibilitySuffix}`)
+              : testIdWithKey(TestIds.shared.pinInput.visibilitySuffix)
+          }
           accessibilityLabel={a11yLabel(isVisible ? t('PINCreate.Hide') : t('PINCreate.Show'))}
           accessibilityRole="button"
         >

--- a/app/src/bcsc-theme/components/PermissionDisabled.tsx
+++ b/app/src/bcsc-theme/components/PermissionDisabled.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import { useTranslation } from 'react-i18next'
 import { Linking, Platform, StyleSheet, View } from 'react-native'
@@ -142,7 +143,7 @@ export const PermissionDisabled = ({
         title={t('BCSC.PermissionDisabled.OpenSettings')}
         buttonType={ButtonType.Primary}
         onPress={handleOpenSettings}
-        testID={testIdWithKey('OpenSettings')}
+        testID={testIdWithKey(TestIds.onboarding.notifications.openSettings)}
         accessibilityLabel={t('BCSC.PermissionDisabled.OpenSettings')}
       />
       {secondaryAction ? (
@@ -159,7 +160,7 @@ export const PermissionDisabled = ({
           title={t('BCSC.PermissionDisabled.ContinueWithoutNotifications')}
           buttonType={ButtonType.Secondary}
           onPress={navigateToNextScreen}
-          testID={testIdWithKey('ContinueWithoutNotifications')}
+          testID={testIdWithKey(TestIds.onboarding.notifications.continueWithout)}
           accessibilityLabel={t('BCSC.PermissionDisabled.ContinueWithoutNotifications')}
         />
       ) : null}

--- a/app/src/bcsc-theme/components/PhotoReview.tsx
+++ b/app/src/bcsc-theme/components/PhotoReview.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, testIdWithKey, useAnimatedComponents, useTheme } from '@bifold/core'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -43,7 +44,7 @@ const PhotoReview: React.FC<PhotoReviewProps> = ({ photoPath, onAccept, onRetake
         <Button
           buttonType={ButtonType.Primary}
           onPress={handleAccept}
-          testID={testIdWithKey(`UsePhoto`)}
+          testID={testIdWithKey(TestIds.verify.photoReview.usePhoto)}
           title={t('BCSC.PhotoReview.UsePhoto')}
           accessibilityLabel={t('BCSC.PhotoReview.UsePhoto')}
           disabled={loading}
@@ -53,7 +54,7 @@ const PhotoReview: React.FC<PhotoReviewProps> = ({ photoPath, onAccept, onRetake
         <Button
           buttonType={ButtonType.Secondary}
           onPress={onRetake}
-          testID={testIdWithKey(`RetakePhoto`)}
+          testID={testIdWithKey(TestIds.verify.photoReview.retake)}
           title={t('BCSC.PhotoReview.RetakePhoto')}
           accessibilityLabel={t('BCSC.PhotoReview.RetakePhoto')}
         />

--- a/app/src/bcsc-theme/components/ReportProblemModal.tsx
+++ b/app/src/bcsc-theme/components/ReportProblemModal.tsx
@@ -1,6 +1,7 @@
 import { PressableOpacity } from '@/components/PressableOpacity'
 import { CONTACT_US_HELP_URL, hitSlop, USER_REPORT_ERROR_CODE } from '@/constants'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { reportProblem } from '@/utils/logger'
 import { Button, ButtonType, Link, testIdWithKey, ThemedText, useStore, useTheme } from '@bifold/core'
 import Clipboard from '@react-native-clipboard/clipboard'
@@ -196,7 +197,7 @@ export const ReportProblemModal = ({ visible, onClose }: ReportProblemModalProps
           placeholder={t('BCSC.ReportProblem.DescriptionPlaceholder')}
           placeholderTextColor={ColorPalette.grayscale.mediumGrey}
           accessibilityLabel={t('BCSC.ReportProblem.DescriptionLabel')}
-          testID={testIdWithKey('ReportProblemDescription')}
+          testID={testIdWithKey(TestIds.reportProblem.description)}
         />
       </View>
 
@@ -220,7 +221,7 @@ export const ReportProblemModal = ({ visible, onClose }: ReportProblemModalProps
       <Button
         title={t('BCSC.ReportProblem.Submit')}
         accessibilityLabel={t('BCSC.ReportProblem.Submit')}
-        testID={testIdWithKey('ReportProblemSubmit')}
+        testID={testIdWithKey(TestIds.reportProblem.submit)}
         buttonType={ButtonType.Primary}
         onPress={handleSubmit}
         disabled={!canSubmit}
@@ -252,7 +253,7 @@ export const ReportProblemModal = ({ visible, onClose }: ReportProblemModalProps
             style={styles.reportIdValue}
             selectable
             accessibilityLabel={`${t('BCSC.ReportProblem.ReportIdLabel')}: ${reportId}`}
-            testID={testIdWithKey('ReportProblemReportId')}
+            testID={testIdWithKey(TestIds.reportProblem.reportId)}
           >
             {reportId}
           </ThemedText>
@@ -262,7 +263,7 @@ export const ReportProblemModal = ({ visible, onClose }: ReportProblemModalProps
           onPress={handleCopy}
           accessibilityRole="button"
           accessibilityLabel={copied ? t('Error.CodeCopied') : t('Error.CopyCode')}
-          testID={testIdWithKey('ReportProblemCopyReportId')}
+          testID={testIdWithKey(TestIds.reportProblem.copyReportId)}
         >
           <CommunityIcon name={copied ? 'check' : 'content-copy'} size={20} color={ColorPalette.brand.primary} />
           <ThemedText style={styles.copyButtonText}>{copied ? t('Error.CodeCopied') : t('Error.CopyCode')}</ThemedText>
@@ -274,7 +275,7 @@ export const ReportProblemModal = ({ visible, onClose }: ReportProblemModalProps
       <Button
         title={t('Global.Done')}
         accessibilityLabel={t('Global.Done')}
-        testID={testIdWithKey('ReportProblemDone')}
+        testID={testIdWithKey(TestIds.reportProblem.done)}
         buttonType={ButtonType.Primary}
         onPress={handleClose}
       />
@@ -287,7 +288,7 @@ export const ReportProblemModal = ({ visible, onClose }: ReportProblemModalProps
       transparent
       animationType="slide"
       onRequestClose={handleClose}
-      testID={testIdWithKey('ReportProblemModal')}
+      testID={testIdWithKey(TestIds.reportProblem.modal)}
     >
       <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
         <View style={styles.root}>
@@ -306,7 +307,7 @@ export const ReportProblemModal = ({ visible, onClose }: ReportProblemModalProps
                 hitSlop={hitSlop}
                 accessibilityRole="button"
                 accessibilityLabel={t('Global.Close')}
-                testID={testIdWithKey('ReportProblemClose')}
+                testID={testIdWithKey(TestIds.reportProblem.close)}
               >
                 <Icon name="close" size={24} color={ColorPalette.brand.headerText} />
               </PressableOpacity>

--- a/app/src/bcsc-theme/components/SectionButton.tsx
+++ b/app/src/bcsc-theme/components/SectionButton.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import React from 'react'
 import { StyleSheet, TouchableOpacity, ViewStyle } from 'react-native'
@@ -52,7 +53,7 @@ const SectionButton: React.FC<SectionButtonProps> = ({
       accessibilityLabel={a11yLabel(accessibilityLabel ?? title)}
       accessibilityRole="button"
       accessibilityHint={accessibilityHint}
-      testID={testID ?? testIdWithKey(`SectionButton-${title.replaceAll(/\s+/g, '')}`)}
+      testID={testID ?? testIdWithKey(`${TestIds.shared.sectionButtonPrefix}${title.replaceAll(/\s+/g, '')}`)}
     >
       <ThemedText variant={'headingFour'} style={styles.title}>
         {title}

--- a/app/src/bcsc-theme/components/SettingsHeaderButton.tsx
+++ b/app/src/bcsc-theme/components/SettingsHeaderButton.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import { ButtonLocation, IconButton, testIdWithKey, useTheme } from '@bifold/core'
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -43,7 +44,7 @@ const SettingsHeaderButton = ({
       icon={'menu'}
       iconTintColor={ColorPalette.brand.primary}
       accessibilityLabel={accessibilityLabel || a11yLabel(t('BCSC.Screens.Settings'))}
-      testID={testID || testIdWithKey('SettingsMenuButton')}
+      testID={testID || testIdWithKey(TestIds.common.settingsMenu)}
       onPress={onPress}
     />
   )

--- a/app/src/bcsc-theme/components/TorchButton.tsx
+++ b/app/src/bcsc-theme/components/TorchButton.tsx
@@ -1,4 +1,5 @@
 import { hitSlop } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, useTheme } from '@bifold/core'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -33,7 +34,7 @@ const TorchButton: React.FC<TorchButtonProps> = ({ active, onPress, size = 24 })
       accessible
       accessibilityLabel={active ? t('BCSC.Scan.TorchOn') : t('BCSC.Scan.TorchOff')}
       accessibilityRole={'button'}
-      testID={testIdWithKey('ScanTorch')}
+      testID={testIdWithKey(TestIds.verify.scanSerial.scanTorch)}
       style={styles.button}
       onPress={onPress}
       hitSlop={hitSlop}

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -87,21 +87,17 @@ const ScopedCredentialDetails = (props: CredentialDetailsProps) => {
 
 const VerifyPromptScreenNoSkip = () => <VerifyPromptScreen showSkip={false} />
 
+const mainIds = TestIds.main
+
 // Contact screens call Bifold connection hooks (useConnections / useConnectionById)
 // that require the providers BifoldScope only mounts once the agent is ready.
 // Gate them so an early mount — a cold-start quick-tap into Settings → Contacts,
 // or navigation state restoring onto a deep contact screen — shows the loading/
 // retry state instead of crashing on a missing ConnectionProvider.
-const ScopedContacts = withAgentReadyGate(ContactsScreen, testIdWithKey(TestIds.main.contacts.loading))
-const ScopedContactDetails = withAgentReadyGate(
-  ContactDetailsScreen,
-  testIdWithKey(TestIds.main.contactDetails.loading)
-)
-const ScopedEditContactName = withAgentReadyGate(
-  EditContactNameScreen,
-  testIdWithKey(TestIds.main.contactEditName.loading)
-)
-const ScopedRemoveContact = withAgentReadyGate(RemoveContactScreen, testIdWithKey(TestIds.main.contactRemove.loading))
+const ScopedContacts = withAgentReadyGate(ContactsScreen, testIdWithKey(mainIds.contacts.loading))
+const ScopedContactDetails = withAgentReadyGate(ContactDetailsScreen, testIdWithKey(mainIds.contactDetails.loading))
+const ScopedEditContactName = withAgentReadyGate(EditContactNameScreen, testIdWithKey(mainIds.contactEditName.loading))
+const ScopedRemoveContact = withAgentReadyGate(RemoveContactScreen, testIdWithKey(mainIds.contactRemove.loading))
 
 /**
  * Holds the startup loading screen until the system checks that decide the Home notification card

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -87,17 +87,21 @@ const ScopedCredentialDetails = (props: CredentialDetailsProps) => {
 
 const VerifyPromptScreenNoSkip = () => <VerifyPromptScreen showSkip={false} />
 
-const mainIds = TestIds.main
-
 // Contact screens call Bifold connection hooks (useConnections / useConnectionById)
 // that require the providers BifoldScope only mounts once the agent is ready.
 // Gate them so an early mount — a cold-start quick-tap into Settings → Contacts,
 // or navigation state restoring onto a deep contact screen — shows the loading/
 // retry state instead of crashing on a missing ConnectionProvider.
-const ScopedContacts = withAgentReadyGate(ContactsScreen, testIdWithKey(mainIds.contacts.loading))
-const ScopedContactDetails = withAgentReadyGate(ContactDetailsScreen, testIdWithKey(mainIds.contactDetails.loading))
-const ScopedEditContactName = withAgentReadyGate(EditContactNameScreen, testIdWithKey(mainIds.contactEditName.loading))
-const ScopedRemoveContact = withAgentReadyGate(RemoveContactScreen, testIdWithKey(mainIds.contactRemove.loading))
+const ScopedContacts = withAgentReadyGate(ContactsScreen, testIdWithKey(TestIds.main.contacts.loading))
+const ScopedContactDetails = withAgentReadyGate(
+  ContactDetailsScreen,
+  testIdWithKey(TestIds.main.contactDetails.loading)
+)
+const ScopedEditContactName = withAgentReadyGate(
+  EditContactNameScreen,
+  testIdWithKey(TestIds.main.contactEditName.loading)
+)
+const ScopedRemoveContact = withAgentReadyGate(RemoveContactScreen, testIdWithKey(TestIds.main.contactRemove.loading))
 
 /**
  * Holds the startup loading screen until the system checks that decide the Home notification card

--- a/app/src/bcsc-theme/navigators/MainStack.tsx
+++ b/app/src/bcsc-theme/navigators/MainStack.tsx
@@ -1,4 +1,5 @@
 import { DEFAULT_HEADER_TITLE_CONTAINER_STYLE, HelpCentreUrl, SYSTEM_CHECK_LOADING_GATE_MAX_WAIT_MS } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import {
   CredentialDetails,
   Screens,
@@ -78,7 +79,7 @@ const ScopedCredentialDetails = (props: CredentialDetailsProps) => {
   const { t } = useTranslation()
   const navigation = useMemo(() => createBifoldNavigationAdapter(props.navigation, { t }), [props.navigation, t])
   return (
-    <AgentReadyGate testID={testIdWithKey('CredentialDetails.Loading')}>
+    <AgentReadyGate testID={testIdWithKey(TestIds.credential.details.loading)}>
       <CredentialDetails {...props} navigation={navigation} />
     </AgentReadyGate>
   )
@@ -91,10 +92,16 @@ const VerifyPromptScreenNoSkip = () => <VerifyPromptScreen showSkip={false} />
 // Gate them so an early mount — a cold-start quick-tap into Settings → Contacts,
 // or navigation state restoring onto a deep contact screen — shows the loading/
 // retry state instead of crashing on a missing ConnectionProvider.
-const ScopedContacts = withAgentReadyGate(ContactsScreen, testIdWithKey('Contacts.Loading'))
-const ScopedContactDetails = withAgentReadyGate(ContactDetailsScreen, testIdWithKey('ContactDetails.Loading'))
-const ScopedEditContactName = withAgentReadyGate(EditContactNameScreen, testIdWithKey('EditContactName.Loading'))
-const ScopedRemoveContact = withAgentReadyGate(RemoveContactScreen, testIdWithKey('RemoveContact.Loading'))
+const ScopedContacts = withAgentReadyGate(ContactsScreen, testIdWithKey(TestIds.main.contacts.loading))
+const ScopedContactDetails = withAgentReadyGate(
+  ContactDetailsScreen,
+  testIdWithKey(TestIds.main.contactDetails.loading)
+)
+const ScopedEditContactName = withAgentReadyGate(
+  EditContactNameScreen,
+  testIdWithKey(TestIds.main.contactEditName.loading)
+)
+const ScopedRemoveContact = withAgentReadyGate(RemoveContactScreen, testIdWithKey(TestIds.main.contactRemove.loading))
 
 /**
  * Holds the startup loading screen until the system checks that decide the Home notification card
@@ -192,7 +199,7 @@ const MainStack: React.FC = () => {
             ...defaultStackOptions,
             headerShown: false,
             title: '',
-            headerBackTestID: testIdWithKey('Back'),
+            headerBackTestID: testIdWithKey(TestIds.common.back),
             headerShadowVisible: false,
             headerBackTitleVisible: false,
             headerTitleContainerStyle: DEFAULT_HEADER_TITLE_CONTAINER_STYLE,

--- a/app/src/bcsc-theme/navigators/OnboardingStack.tsx
+++ b/app/src/bcsc-theme/navigators/OnboardingStack.tsx
@@ -1,5 +1,6 @@
 import { DEFAULT_HEADER_TITLE_CONTAINER_STYLE } from '@/constants'
 import Developer from '@/screens/Developer'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, useDefaultStackOptions, useTheme } from '@bifold/core'
 import { createStackNavigator } from '@react-navigation/stack'
 import { useTranslation } from 'react-i18next'
@@ -48,7 +49,7 @@ const OnboardingStack = (): React.ReactElement => {
         title: '',
         headerShadowVisible: false,
         headerBackTitleVisible: false,
-        headerBackTestID: testIdWithKey('Back'),
+        headerBackTestID: testIdWithKey(TestIds.common.back),
         headerBackAccessibilityLabel: t('Global.Back'),
         headerTitleContainerStyle: DEFAULT_HEADER_TITLE_CONTAINER_STYLE,
         headerLeft: createHeaderBackButton,

--- a/app/src/bcsc-theme/navigators/QRCoreStack.tsx
+++ b/app/src/bcsc-theme/navigators/QRCoreStack.tsx
@@ -5,6 +5,7 @@ import { useCardStatus } from '@/bcsc-theme/hooks/useCardStatus'
 import { BCSCMainStackParams, BCSCQRCoreScreens, BCSCQRCoreTabParams, BCSCScreens } from '@/bcsc-theme/types/navigators'
 import { HelpCentreUrl } from '@/constants'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, TOKENS, useServices, useStore, useTheme } from '@bifold/core'
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
 import { useNavigation } from '@react-navigation/native'
@@ -38,7 +39,7 @@ const createQRBackButton = () => {
     return (
       <HeaderBackButton
         accessibilityLabel="Back"
-        testID={testIdWithKey('Back')}
+        testID={testIdWithKey(TestIds.common.back)}
         onPress={() => navigation.getParent()?.goBack()}
       />
     )
@@ -144,7 +145,7 @@ const QRCoreStack: React.FC = () => {
             tabBarIcon: createTabBarIcon(t('Scan.ScanQRCode'), 'qrcode-scan'),
             tabBarShowLabel: false,
             tabBarAccessibilityLabel: t('Scan.ScanQRCode'),
-            tabBarTestID: testIdWithKey('ScanQRCode'),
+            tabBarTestID: testIdWithKey(TestIds.main.qrCore.scannerTab),
             headerRight: createFloatingHelpMenuButton({
               webViewScreen: BCSCScreens.MainWebView,
               learnMoreUrl: HelpCentreUrl.COMPUTER_LOGIN,
@@ -161,7 +162,7 @@ const QRCoreStack: React.FC = () => {
               tabBarIcon: createTabBarIcon(t('Scan.MyQRCode'), 'qrcode'),
               tabBarShowLabel: false,
               tabBarAccessibilityLabel: t('Scan.MyQRCode'),
-              tabBarTestID: testIdWithKey('MyQRCode'),
+              tabBarTestID: testIdWithKey(TestIds.main.qrCore.displayTab),
             }}
           />
         ) : null}
@@ -174,7 +175,7 @@ const QRCoreStack: React.FC = () => {
             tabBarIcon: createTabBarIcon(t('BCSC.ManualPairing.TabTitle'), 'import'),
             tabBarShowLabel: false,
             tabBarAccessibilityLabel: t('BCSC.ManualPairing.TabTitle'),
-            tabBarTestID: testIdWithKey('PairingCode'),
+            tabBarTestID: testIdWithKey(TestIds.main.qrCore.pairingCodeTab),
             headerRight: createFloatingHelpMenuButton({
               webViewScreen: BCSCScreens.MainWebView,
               learnMoreUrl: HelpCentreUrl.COMPUTER_LOGIN,

--- a/app/src/bcsc-theme/navigators/TabStack.tsx
+++ b/app/src/bcsc-theme/navigators/TabStack.tsx
@@ -1,5 +1,6 @@
 import { useNotifications } from '@/hooks/notifications'
 import { useCustomNotifications } from '@/hooks/useCustomNotifications'
+import { TestIds } from '@/test-ids/registry'
 import {
   CredentialStack,
   OpenIDCredentialRecordProvider,
@@ -29,9 +30,9 @@ import { useCardStatus } from '../hooks/useCardStatus'
 import { BCSCMainStackParams, BCSCScreens, BCSCTabStackParams } from '../types/navigators'
 
 const ScopedCredentialStack: React.FC = () => (
-  <AgentReadyGate testID={testIdWithKey('Wallet.Loading')}>
+  <AgentReadyGate testID={testIdWithKey(TestIds.main.wallet.loading)}>
     <OpenIDCredentialRecordProvider>
-      <CredentialsReadyGate testID={testIdWithKey('Wallet.Loading')}>
+      <CredentialsReadyGate testID={testIdWithKey(TestIds.main.wallet.loading)}>
         <CredentialStack />
       </CredentialsReadyGate>
     </OpenIDCredentialRecordProvider>
@@ -246,7 +247,7 @@ const BCSCTabStack: React.FC = () => {
             tabBarIcon: createTabBarIcon('Home', 'home-outline'),
             tabBarShowLabel: false,
             tabBarAccessibilityLabel: t('BCSC.Home.Title'),
-            tabBarTestID: testIdWithKey('Home'),
+            tabBarTestID: testIdWithKey(TestIds.main.tabBar.home),
             tabBarBadge: homeNotificationsBadgeCount,
             headerLeft: createMainSettingsHeaderButton(),
           }}
@@ -259,7 +260,7 @@ const BCSCTabStack: React.FC = () => {
             tabBarIcon: createTabBarIcon('Services', 'list-alt'),
             tabBarShowLabel: false,
             tabBarAccessibilityLabel: 'Services',
-            tabBarTestID: testIdWithKey('Services'),
+            tabBarTestID: testIdWithKey(TestIds.main.tabBar.services),
             headerLeft: createMainSettingsHeaderButton(),
             title: t('BCSC.Services.Title'),
           }}
@@ -272,7 +273,7 @@ const BCSCTabStack: React.FC = () => {
             tabBarIcon: createTabBarIcon('Wallet', 'wallet'),
             tabBarShowLabel: false,
             tabBarAccessibilityLabel: 'Wallet',
-            tabBarTestID: testIdWithKey('Wallet'),
+            tabBarTestID: testIdWithKey(TestIds.main.tabBar.wallet),
             headerLeft: createMainSettingsHeaderButton(),
             headerShown: true,
           }}

--- a/app/src/bcsc-theme/navigators/VerifyStack.tsx
+++ b/app/src/bcsc-theme/navigators/VerifyStack.tsx
@@ -5,6 +5,7 @@ import { getDefaultModalOptions } from '@/bcsc-theme/navigators/stack-utils'
 import { BCSCModals, BCSCScreens, BCSCStacks, BCSCVerifyStackParams } from '@/bcsc-theme/types/navigators'
 import { DEFAULT_HEADER_TITLE_CONTAINER_STYLE, HelpCentreUrl } from '@/constants'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey, useDefaultStackOptions, useStore, useTheme } from '@bifold/core'
 import { HeaderBackButtonProps } from '@react-navigation/elements'
 import { useFocusEffect, useNavigation } from '@react-navigation/native'
@@ -161,7 +162,7 @@ const VerifyStack = ({ showVerifyPrompt = false, onVerifyPromptAnswered }: Verif
         headerShadowVisible: false,
         headerTitleContainerStyle: DEFAULT_HEADER_TITLE_CONTAINER_STYLE,
         headerLeft: createHeaderBackButton,
-        headerBackTestID: testIdWithKey('Back'),
+        headerBackTestID: testIdWithKey(TestIds.common.back),
         headerBackTitleVisible: false,
         header: createHeaderWithoutBanner,
         headerRight: createVerifyHelpMenuButton({ showRestartVerification: true }),

--- a/app/src/test-ids/registry.ts
+++ b/app/src/test-ids/registry.ts
@@ -41,6 +41,10 @@ export const TestIds = {
     loadingOverlay: 'BCSCLoadingProviderOverlay',
     loadingChildren: 'BCSCLoadingProviderChildren',
     agentRetry: 'AgentRetry',
+    // `SettingsHeaderButton`, the header-left menu on onboarding, auth and main. The per-mount
+    // entries (`onboarding.intro.settings`, `auth.accountLanding.settings`, `main.header.settings`)
+    // are the SAME id, kept where specs look for them; this is the one the component references.
+    settingsMenu: 'SettingsMenuButton',
   },
 
   /**
@@ -76,6 +80,65 @@ export const TestIds = {
       helpCentre: 'ServiceOutageHelpCentre',
       checkAgain: 'ServiceOutageCheckAgain',
     },
+  },
+
+  /**
+   * Ids that shared BCSC components COMPOSE, rather than ids a screen owns. A caller passes an `id`
+   * or a title and the component appends/prefixes these, so the emitted string is only knowable at
+   * the call site — which is exactly why the pieces belong here instead of being retyped per screen.
+   * Where a composed result is stable and specs use it, it ALSO appears spelled out under its screen
+   * (e.g. `verify.manualSerial.serialInput` is `'serial'` + `field.input`).
+   */
+  shared: {
+    /** bifold `MaskedCamera` — the selfie capture and the evidence capture mount the same component,
+     *  so `verify.selfieCapture` / `verify.evidenceCapture` document these same ids per mount. */
+    maskedCamera: {
+      takePhoto: 'TakePhoto',
+      cancel: 'CancelCamera',
+      toggleFlash: 'ToggleFlash',
+    },
+    /** `AppBanner` composes `<part>-<banner type>`; the type is the banner's variant, not a screen. */
+    appBanner: {
+      buttonPrefix: 'button-',
+      iconPrefix: 'icon-',
+      textPrefix: 'text-',
+      descriptionPrefix: 'description-',
+    },
+    /** `InputWithValidation` and `DropdownWithValidation` append these to the caller's `id`. iOS types
+     *  into `pressable`, not `input`. `subtext` doubles as the validation-error slot. */
+    field: {
+      label: '-label',
+      pressable: '-pressable',
+      input: '-input',
+      subtext: '-subtext',
+      error: '-error',
+      optionPrefix: '-option-',
+      modalContent: '-modal-content',
+      close: '-close',
+    },
+    /** `PINInput` appends this to its `testIDKey`, and uses it BARE when no key was passed. */
+    pinInput: {
+      visibilitySuffix: 'VisibilityButton',
+    },
+    /** Title-derived row ids. `SectionButton` strips whitespace from the title; `CardButton` does not. */
+    cardButtonPrefix: 'CardButton-',
+    sectionButtonPrefix: 'SectionButton-',
+  },
+
+  /**
+   * `ReportProblemModal`, raised from the floating help menu — an overlay, like `errorModal` and
+   * `systemModal`. Two phases: the description form (`description` + `submit`), then the receipt
+   * (`reportId` + `copyReportId` + `done`). `modal` is the container, `close` the header dismiss.
+   * Distinct from `ErrorInfoCard`'s own report controls, which are different ids on a different card.
+   */
+  reportProblem: {
+    modal: 'ReportProblemModal',
+    close: 'ReportProblemClose',
+    description: 'ReportProblemDescription',
+    submit: 'ReportProblemSubmit',
+    reportId: 'ReportProblemReportId',
+    copyReportId: 'ReportProblemCopyReportId',
+    done: 'ReportProblemDone',
   },
 
   onboarding: {
@@ -531,6 +594,7 @@ export const TestIds = {
     wallet: {
       loading: 'Wallet.Loading',
       empty: 'Wallet.Empty',
+      emptyIllustration: 'Wallet.EmptyIllustration',
       emptyLearnMore: 'Wallet.EmptyLearnMore',
     },
     /** QRCore bottom-tab navigator (opened by the scan FAB). Display tab only exists in dev mode. */
@@ -744,6 +808,7 @@ export const TestIds = {
     /** Edit-contact-name form. `save`/`cancel` are label-derived by `ActionScreenLayout`
      *  (`testIdWithKey(t('Global.Continue'))` etc.), so they break under a locale change — en-only. */
     contactEditName: {
+      loading: 'EditContactName.Loading',
       nameInput: 'NameInput',
       save: 'Continue',
       cancel: 'Cancel',
@@ -751,6 +816,7 @@ export const TestIds = {
     /** Remove-contact confirmation — a modal with NO header back (`headerLeft: null`); `cancel` is the
      *  only non-destructive exit. The failure branch is an untestID'd native alert. */
     contactRemove: {
+      loading: 'RemoveContact.Loading',
       confirm: 'ConfirmRemove',
       cancel: 'CancelRemove',
     },
@@ -867,6 +933,8 @@ export const TestIds = {
    * hidden from the accessibility tree and cannot be selected. `Testing` rows are BCSC-mode only.
    */
   developer: {
+    /** Tap counter on the settings version row (`DeveloperModeTrigger`) that unlocks developer mode. */
+    counter: 'DeveloperCounter',
     /** Always-rendered first row — the reliable "Developer screen mounted" marker. */
     toggleDeveloper: 'ToggleDeveloper',
     /** i18n-DERIVED: `testIdWithKey(t('Developer.Environment').toLowerCase())` — breaks under a locale change. */


### PR DESCRIPTION
Closes #4593

## What changed

Migrates the shared BCSC components and navigators — 58 call sites across 21 files, 25 of them dynamic. Refactor-only.

**Stacked on `chore/e2e_testID_main`.** Review only this branch's diff.

- New top-level `shared` registry area for ids that components **compose** rather than own: the `MaskedCamera` trio, `AppBanner`'s four `<part>-<type>` prefixes, the eight `InputWithValidation`/`DropdownWithValidation` field suffixes, `PINInput`'s visibility suffix, and the `CardButton-`/`SectionButton-` title prefixes.
- New top-level `reportProblem` area for the help-menu modal — distinct from `ErrorInfoCard`'s own report controls, which are different ids and land in the next PR.
- The eslint glob widens to `['src/test-ids/**', 'src/bcsc-theme/**']`, so the whole BCSC tree is enforced.
- Six sites intentionally unchanged: two passthroughs (`TileButton`, `PINInput`) and four label-derived ids.

## What should the reviewer focus on

- **Blast radius.** These components feed nearly every screen, so this is the PR most likely to move an emitted id. It doesn't: 160/160 snapshots pass with no `.snap` written.
- The `shared` area deliberately duplicates ids that also appear spelled out under their screen (`verify.manualSerial.serialInput` is `'serial'` + `field.input`). The doc comment says why — specs select the composed form, call sites need the pieces.
- `ActionScreenLayout` and `BulletedInstructionsScreen` still derive ids from translated labels (`testIdWithKey(primaryActionText)`), so the emitted id differs by locale. The rule can't see them — they're identifiers, not literals. Left alone here on purpose; fixing them means a `testIDKey` prop across 11 callers, which isn't refactor-only.

## How to test

```
cd app && yarn typecheck && yarn lint && yarn test
cd e2e && yarn typecheck
```

Snapshots are the contract here more than anywhere: 160/160 with no `.snap` written.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>