### PR TITLE
chore: remaining test-ids and close the registry ratchet

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -15,3 +15,22 @@ Use banner messages (inline, persistent contextual alerts) instead of toast noti
 Where possible, users should be able to access screens or tools before async resources
 (e.g. wallet initialization) are ready. Rather than blocking navigation, show a banner
 message or text on the screen itself informing the user that the feature isn't available yet and to try again shortly.
+
+## Test IDs: Register the key, then reference it
+
+Never pass a string literal to `testIdWithKey`. Add the key to `app/src/test-ids/registry.ts` under
+the screen that renders it, then reference it: `testIdWithKey(TestIds.main.settings.help)`. The same
+applies to a `testIDKey` prop. eslint rejects literals in both positions.
+
+Dynamic ids compose from a registry stem rather than an inline prefix —
+``testIdWithKey(`${TestIds.main.services.serviceRowPrefix}${title}`)``.
+
+**Why:** the e2e suite imports the same file, so a rename is one edit and a key an e2e descriptor
+still uses cannot be deleted without failing `tsc` in PR CI — instead of surfacing minutes into a
+Sauce run behind an app build. A jest check also fails on a key added with no call site, or a call
+site removed while the key lingers.
+
+**Note:** a few ids are emitted from a translated label (`ActionScreenLayout`,
+`BulletedInstructionsScreen`) or from server data, so no key can be passed. Those are listed in the
+registry test's `KNOWN_UNREFERENCED` with the reason; don't add to that list to silence a failure
+without one.

--- a/app/eslint.config.mjs
+++ b/app/eslint.config.mjs
@@ -101,7 +101,7 @@ export default [
   // so unmigrated areas stay green while migrated ones cannot regress. Tests are exempt on purpose:
   // asserting the literal id string is what proves the emitted ids never moved.
   {
-    files: ['src/test-ids/**', 'src/bcsc-theme/**'],
+    files: ['src/**'],
     ignores: ['**/*.test.{ts,tsx}'],
     rules: {
       'no-restricted-syntax': [

--- a/app/src/bcwallet-theme/components/AddCredentialButton.tsx
+++ b/app/src/bcwallet-theme/components/AddCredentialButton.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import { ButtonLocation, IconButton, testIdWithKey } from '@bifold/core'
 import React, { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -15,7 +16,7 @@ const AddCredentialButton = () => {
     <IconButton
       buttonLocation={ButtonLocation.Right}
       accessibilityLabel={t('Credentials.AddCredential')}
-      testID={testIdWithKey('AddCredential')}
+      testID={testIdWithKey(TestIds.bcwallet.home.addCredential)}
       onPress={activateSlider}
       icon="plus-circle-outline"
     />

--- a/app/src/bcwallet-theme/components/AddCredentialSlider.tsx
+++ b/app/src/bcwallet-theme/components/AddCredentialSlider.tsx
@@ -1,5 +1,6 @@
 import { showPersonCredentialSelector } from '@/bcwallet-theme/features/person-flow/utils/BCIDHelper'
 import { hitSlop } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import { SafeAreaModal, Screens, Stacks, testIdForAccessabilityLabel, testIdWithKey, useTheme } from '@bifold/core'
 import { useCredentialByState } from '@bifold/react-hooks'
 import { AnonCredsCredentialMetadataKey } from '@credo-ts/anoncreds'
@@ -114,12 +115,12 @@ export default function AddCredentialSlider() {
         onPress={deactivateSlider}
         accessibilityLabel={t('BCID.DismissMenu')}
         accessibilityRole="button"
-        testID={testIdWithKey('DismissAddCredentialSlider')}
+        testID={testIdWithKey(TestIds.bcwallet.addCredentialSlider.dismiss)}
       />
       <View style={styles.centeredView}>
         <View style={styles.modalView}>
           <TouchableOpacity
-            testID={testIdWithKey('Close')}
+            testID={testIdWithKey(TestIds.bcwallet.addCredentialSlider.close)}
             accessibilityLabel={t('Global.Close')}
             accessibilityRole={'button'}
             onPress={deactivateSlider}

--- a/app/src/bcwallet-theme/components/EmptyList.tsx
+++ b/app/src/bcwallet-theme/components/EmptyList.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import EmptyWallet from '@assets/img/emptyWallet.svg'
 import { Button, ButtonType, testIdWithKey, useTheme } from '@bifold/core'
 import React, { useCallback, useEffect, useState } from 'react'
@@ -30,14 +31,17 @@ const EmptyList = ({ message }: EmptyListProps) => {
   return (
     <View style={{ marginTop: 100, height: '100%' }}>
       <EmptyWallet height={200} />
-      <Text style={[ListItems.emptyList, { textAlign: 'center' }]} testID={testIdWithKey('NoneYet')}>
+      <Text
+        style={[ListItems.emptyList, { textAlign: 'center' }]}
+        testID={testIdWithKey(TestIds.bcwallet.emptyList.noneYet)}
+      >
         {message || t('Global.NoneYet!')}
       </Text>
       <View style={{ margin: 25 }}>
         <Button
           title={t('Credentials.AddFirstCredential')}
           accessibilityLabel={t('Credentials.AddFirstCredential')}
-          testID={testIdWithKey('AddFirstCredential')}
+          testID={testIdWithKey(TestIds.bcwallet.emptyList.addFirstCredential)}
           buttonType={ButtonType.Primary}
           onPress={addCredentialPress}
           disabled={addCredentialPressed}

--- a/app/src/bcwallet-theme/components/HomeFooterView.tsx
+++ b/app/src/bcwallet-theme/components/HomeFooterView.tsx
@@ -1,4 +1,5 @@
 import { surveyMonkeyExitUrl, surveyMonkeyUrl } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, testIdWithKey, useTheme } from '@bifold/core'
 import WebDisplay from '@screens/WebDisplay'
 import React, { PropsWithChildren, useState } from 'react'
@@ -32,7 +33,7 @@ const HomeFooterView = ({ children }: HomeFooterViewProps) => {
       <Button
         title={t('Feedback.GiveFeedback')}
         accessibilityLabel={t('Feedback.GiveFeedback')}
-        testID={testIdWithKey('GiveFeedback')}
+        testID={testIdWithKey(TestIds.bcwallet.home.giveFeedback)}
         onPress={toggleSurveyVisibility}
         buttonType={ButtonType.Secondary}
       >

--- a/app/src/bcwallet-theme/components/HomeHeaderView.tsx
+++ b/app/src/bcwallet-theme/components/HomeHeaderView.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import { Screens, Stacks, testIdWithKey, useTheme } from '@bifold/core'
 import { useAgent } from '@bifold/react-hooks'
 import { RemoteLogger } from '@bifold/remote-logs'
@@ -35,7 +36,7 @@ const HomeHeaderView = () => {
   return logger?.remoteLoggingEnabled ? (
     <Pressable
       onPress={onPressBanner}
-      testID={testIdWithKey('SessionIdBanner')}
+      testID={testIdWithKey(TestIds.bcwallet.home.sessionIdBanner)}
       accessibilityLabel={a11yLabel(t('RemoteLogging.Banner', { sessionId: logger.sessionId.toString() }))}
       accessibilityRole="button"
     >

--- a/app/src/bcwallet-theme/features/person-flow/screens/PersonCredential.tsx
+++ b/app/src/bcwallet-theme/features/person-flow/screens/PersonCredential.tsx
@@ -1,4 +1,5 @@
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import PersonIssuance1 from '@assets/img/PersonIssuance1.svg'
 import PersonIssuance2 from '@assets/img/PersonIssuance2.svg'
 import {
@@ -140,7 +141,7 @@ const PersonCredential: React.FC<PersonProps> = ({ navigation }) => {
             {appInstalled && (
               <Icon
                 name="check-circle"
-                testID={testIdWithKey('AppInstalledIcon')}
+                testID={testIdWithKey(TestIds.bcwallet.personCredential.appInstalledIcon)}
                 size={35}
                 style={{ marginLeft: 10, color: ColorPalette.semantic.success }}
               />
@@ -152,13 +153,13 @@ const PersonCredential: React.FC<PersonProps> = ({ navigation }) => {
                 buttonType={ButtonType.Primary}
                 onPress={getBCServicesCardApp}
                 accessibilityLabel={t('PersonCredential.InstallApp')}
-                testID={testIdWithKey('InstallApp')}
+                testID={testIdWithKey(TestIds.bcwallet.personCredential.installApp)}
                 title={t('PersonCredential.InstallApp')}
               />
               <TouchableOpacity
                 onPress={() => setAppInstalled(true)}
                 accessibilityLabel={t('PersonCredential.AppOnOtherDevice')}
-                testID={testIdWithKey('AppOnOtherDevice')}
+                testID={testIdWithKey(TestIds.bcwallet.personCredential.appOnOtherDevice)}
                 style={styles.sectionSecondaryAction}
               >
                 <Text style={{ ...TextTheme.bold, color: ColorPalette.brand.primary }}>
@@ -186,7 +187,7 @@ const PersonCredential: React.FC<PersonProps> = ({ navigation }) => {
           {appInstalled ? (
             <Button
               buttonType={ButtonType.Primary}
-              testID={testIdWithKey('StartProcess')}
+              testID={testIdWithKey(TestIds.bcwallet.personCredential.startProcess)}
               accessibilityLabel={t('PersonCredential.StartProcess')}
               title={t('PersonCredential.StartProcess')}
               onPress={acceptPersonCredentialOffer}
@@ -198,21 +199,21 @@ const PersonCredential: React.FC<PersonProps> = ({ navigation }) => {
             style={styles.link}
             linkText={t('PersonCredential.WhatIsPersonCredentialLink')}
             onPress={() => openLink(links.WhatIsPersonCredential)}
-            testID={testIdWithKey('WhatIsPersonCredentialLink')}
+            testID={testIdWithKey(TestIds.bcwallet.personCredential.whatIsPersonCredential)}
           />
           <View style={styles.line} />
           <Link
             style={styles.link}
             linkText={t('PersonCredential.WhereToUseLink')}
             onPress={() => openLink(links.WhereToUse)}
-            testID={testIdWithKey('WhereToUse')}
+            testID={testIdWithKey(TestIds.bcwallet.personCredential.whereToUse)}
           />
           <View style={styles.line} />
           <Link
             style={styles.link}
             linkText={t('PersonCredential.HelpLink')}
             onPress={() => openLink(links.Help)}
-            testID={testIdWithKey('Help')}
+            testID={testIdWithKey(TestIds.bcwallet.personCredential.help)}
           />
         </View>
       </ScrollView>

--- a/app/src/bcwallet-theme/features/person-flow/screens/PersonCredentialLoading.tsx
+++ b/app/src/bcwallet-theme/features/person-flow/screens/PersonCredentialLoading.tsx
@@ -1,5 +1,6 @@
 import { useErrorAlert } from '@/contexts/ErrorAlertContext'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import {
   AttestationEventTypes,
   BifoldError,
@@ -253,7 +254,10 @@ const PersonCredentialLoading: React.FC<PersonProps> = ({ navigation }) => {
       </ThemedText>
       <ScrollView style={styles.container}>
         <View style={styles.messageContainer}>
-          <Text style={[TextTheme.modalHeadingThree, styles.messageText]} testID={testIdWithKey('RequestProcessing')}>
+          <Text
+            style={[TextTheme.modalHeadingThree, styles.messageText]}
+            testID={testIdWithKey(TestIds.bcwallet.personCredentialLoading.requestProcessing)}
+          >
             {t('ProofRequest.RequestProcessing')}
           </Text>
         </View>
@@ -266,7 +270,7 @@ const PersonCredentialLoading: React.FC<PersonProps> = ({ navigation }) => {
         <Button
           title={t('Global.GoBack')}
           accessibilityLabel={t('Global.GoBack')}
-          testID={testIdWithKey('BackToPersonScreen')}
+          testID={testIdWithKey(TestIds.bcwallet.personCredentialLoading.backToPersonScreen)}
           onPress={onDismissModalTouched}
           buttonType={ButtonType.ModalSecondary}
         />

--- a/app/src/components/OnboardingPages.tsx
+++ b/app/src/components/OnboardingPages.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import {
   Button,
   ButtonType,
@@ -42,7 +43,7 @@ const EndPage = (onTutorialCompleted: GenericFn, theme: ITheme['OnboardingTheme'
       <Button
         title={t('Onboarding.GetStarted')}
         accessibilityLabel={t('Onboarding.GetStarted')}
-        testID={testIdWithKey('GetStarted')}
+        testID={testIdWithKey(TestIds.bcwallet.onboarding.getStarted)}
         onPress={onTutorialCompleted}
         buttonType={ButtonType.Primary}
       />

--- a/app/src/errors/components/ErrorInfoCard.tsx
+++ b/app/src/errors/components/ErrorInfoCard.tsx
@@ -1,5 +1,6 @@
 import { PressableOpacity } from '@/components/PressableOpacity'
 import { CONTACT_US_HELP_URL, hitSlop } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import { testIdWithKey } from '@bifold/core'
 import Clipboard from '@react-native-clipboard/clipboard'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
@@ -109,14 +110,14 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
         <View style={styles.header}>
           <Icon name="error" size={30} color={colors.icon} style={styles.icon} />
           <View style={styles.headerTextContainer}>
-            <Text style={styles.titleText} testID={testIdWithKey('HeaderText')}>
+            <Text style={styles.titleText} testID={testIdWithKey(TestIds.errorModal.title)}>
               {title}
             </Text>
           </View>
           <PressableOpacity
             onPress={onDismiss}
             hitSlop={hitSlop}
-            testID={testIdWithKey('CloseButton')}
+            testID={testIdWithKey(TestIds.errorModal.close)}
             accessibilityLabel={t('Global.Close')}
             accessibilityRole="button"
           >
@@ -125,7 +126,7 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
         </View>
 
         <ScrollView style={styles.body} showsVerticalScrollIndicator={false}>
-          <Text style={styles.bodyText} testID={testIdWithKey('BodyText')}>
+          <Text style={styles.bodyText} testID={testIdWithKey(TestIds.errorModal.body)}>
             {description}
           </Text>
 
@@ -134,7 +135,7 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
               accessibilityLabel={showDetails ? t('Global.HideDetails') : t('Global.ShowDetails')}
               accessibilityRole="button"
               accessibilityState={{ expanded: showDetails }}
-              testID={testIdWithKey('ShowDetails')}
+              testID={testIdWithKey(TestIds.errorModal.showDetails)}
               style={styles.showDetailsTouchable}
               onPress={() => setShowDetails((prev) => !prev)}
               activeOpacity={0.7}
@@ -149,7 +150,7 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
           )}
 
           {message && showDetails && (
-            <Text style={styles.detailsText} testID={testIdWithKey('DetailsText')}>
+            <Text style={styles.detailsText} testID={testIdWithKey(TestIds.errorModal.details)}>
               {formattedDetails}
             </Text>
           )}
@@ -159,7 +160,7 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
               <TouchableOpacity
                 accessibilityLabel={reported ? t('Error.Reported') : t('Error.ReportThisProblem')}
                 accessibilityRole="button"
-                testID={testIdWithKey('ReportThisProblem')}
+                testID={testIdWithKey(TestIds.errorModal.reportThisProblem)}
                 style={[styles.primaryButton, reported && styles.primaryButtonDisabled]}
                 onPress={handleReport}
                 disabled={reported}
@@ -180,7 +181,7 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
               <TouchableOpacity
                 accessibilityLabel={action.text}
                 accessibilityRole="button"
-                testID={testIdWithKey('ActionButton')}
+                testID={testIdWithKey(TestIds.errorModal.action)}
                 style={action.style === 'destructive' ? styles.destructiveButton : styles.secondaryButton}
                 onPress={() => {
                   onDismiss()
@@ -198,13 +199,13 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
           </View>
 
           {enableReport && onReport && !reported && (
-            <Text style={styles.noteText} testID={testIdWithKey('ReportNote')}>
+            <Text style={styles.noteText} testID={testIdWithKey(TestIds.errorModal.reportNote)}>
               <Text style={styles.noteBold}>{t('Error.NotePrefix')}</Text>
               {t('Error.NoteBody')}
               <Text
                 style={styles.noteLink}
                 accessibilityRole="link"
-                testID={testIdWithKey('SupportLink')}
+                testID={testIdWithKey(TestIds.errorModal.supportLink)}
                 onPress={() => Linking.openURL(CONTACT_US_HELP_URL)}
               >
                 {t('Error.SupportLink')}
@@ -213,21 +214,21 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
           )}
 
           {reported && referenceCode && (
-            <View style={styles.referenceContainer} testID={testIdWithKey('ReportId')}>
+            <View style={styles.referenceContainer} testID={testIdWithKey(TestIds.errorModal.reportId)}>
               <Text style={styles.referenceLabel}>{t('Error.ReportId')}</Text>
               <View style={styles.referenceRow}>
                 <Text
                   style={styles.referenceCode}
                   selectable
                   accessibilityLabel={`${t('Error.ReportId')}: ${referenceCode}`}
-                  testID={testIdWithKey('ReportIdValue')}
+                  testID={testIdWithKey(TestIds.errorModal.reportIdValue)}
                 >
                   {referenceCode}
                 </Text>
                 <TouchableOpacity
                   accessibilityLabel={copied ? t('Error.CodeCopied') : t('Error.CopyCode')}
                   accessibilityRole="button"
-                  testID={testIdWithKey('CopyReportId')}
+                  testID={testIdWithKey(TestIds.errorModal.copyReportId)}
                   style={styles.copyButton}
                   onPress={handleCopy}
                   activeOpacity={0.7}
@@ -244,7 +245,7 @@ export const ErrorInfoCard: React.FC<ErrorInfoCardProps> = ({
             </View>
           )}
 
-          <Text style={styles.footer} testID={testIdWithKey('VersionNumber')}>
+          <Text style={styles.footer} testID={testIdWithKey(TestIds.errorModal.versionNumber)}>
             {t('Settings.Version')} {getVersion()} ({getBuildNumber()})
           </Text>
         </ScrollView>

--- a/app/src/screens/Developer.tsx
+++ b/app/src/screens/Developer.tsx
@@ -4,6 +4,7 @@ import { Switch } from '@/components/Switch'
 import { BCThemeNames, Mode } from '@/constants'
 import { AutoCredentialMonitor } from '@/services/auto-credential'
 import { BCDispatchAction, BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import {
   CredentialProvisioningEventTypes,
   DispatchAction,
@@ -436,7 +437,7 @@ const Developer: React.FC = () => {
             value={devMode}
             onToggle={toggleSwitch}
             accessibilityLabel={t('Developer.Toggle')}
-            testID={testIdWithKey('ToggleDeveloper')}
+            testID={testIdWithKey(TestIds.developer.toggleDeveloper)}
           />
         </ListButtonGroup>
       </View>
@@ -468,7 +469,7 @@ const Developer: React.FC = () => {
                 onToggle={toggleShareableLinkSwitch}
                 disabled={!store.authentication.didAuthenticate}
                 accessibilityLabel={t('PasteUrl.UseShareableLink')}
-                testID={testIdWithKey('ToggleUseShareableLink')}
+                testID={testIdWithKey(TestIds.developer.toggleUseShareableLink)}
               />
             ),
             BCSCMode ? null : (
@@ -478,7 +479,7 @@ const Developer: React.FC = () => {
                 value={useVerifierCapability}
                 onToggle={toggleVerifierCapabilitySwitch}
                 accessibilityLabel={t('Verifier.Toggle')}
-                testID={testIdWithKey('ToggleVerifierCapability')}
+                testID={testIdWithKey(TestIds.developer.toggleVerifierCapability)}
               />
             ),
             BCSCMode ? null : (
@@ -488,7 +489,7 @@ const Developer: React.FC = () => {
                 value={acceptDevCredentials}
                 onToggle={toggleAcceptDevCredentialsSwitch}
                 accessibilityLabel={t('Verifier.Toggle')}
-                testID={testIdWithKey('ToggleAcceptDevCredentials')}
+                testID={testIdWithKey(TestIds.developer.toggleAcceptDevCredentials)}
               />
             ),
             BCSCMode ? null : (
@@ -498,7 +499,7 @@ const Developer: React.FC = () => {
                 value={useConnectionInviterCapability}
                 onToggle={toggleConnectionInviterCapabilitySwitch}
                 accessibilityLabel={t('Connection.Toggle')}
-                testID={testIdWithKey('ToggleConnectionInviterCapabilitySwitch')}
+                testID={testIdWithKey(TestIds.developer.toggleConnectionInviterCapability)}
               />
             ),
             BCSCMode ? null : (
@@ -508,7 +509,7 @@ const Developer: React.FC = () => {
                 value={useDevVerifierTemplates}
                 onToggle={toggleDevVerifierTemplatesSwitch}
                 accessibilityLabel={t('Verifier.ToggleDevTemplates')}
-                testID={testIdWithKey('ToggleDevVerifierTemplatesSwitch')}
+                testID={testIdWithKey(TestIds.developer.toggleDevVerifierTemplates)}
               />
             ),
             !BCSCMode && !store.onboarding.didCreatePIN ? (
@@ -518,7 +519,7 @@ const Developer: React.FC = () => {
                 value={enableWalletNaming}
                 onToggle={toggleWalletNamingSwitch}
                 accessibilityLabel={t('NameWallet.ToggleWalletNaming')}
-                testID={testIdWithKey('ToggleWalletNamingSwitch')}
+                testID={testIdWithKey(TestIds.developer.toggleWalletNaming)}
               />
             ) : null,
             BCSCMode ? null : (
@@ -528,7 +529,7 @@ const Developer: React.FC = () => {
                 value={preventAutoLock}
                 onToggle={togglePreventAutoLockSwitch}
                 accessibilityLabel={t('Settings.TogglePreventAutoLock')}
-                testID={testIdWithKey('TogglePreventAutoLockSwitch')}
+                testID={testIdWithKey(TestIds.developer.togglePreventAutoLock)}
               />
             ),
             BCSCMode ? null : (
@@ -538,7 +539,7 @@ const Developer: React.FC = () => {
                 value={enableAppToAppPersonFlow}
                 onToggle={toggleEnableAppToAppPersonFlowSwitch}
                 accessibilityLabel={t('Developer.EnableAppToAppPersonFlow')}
-                testID={testIdWithKey('ToggleEnableAppToAppPersonFlow')}
+                testID={testIdWithKey(TestIds.developer.toggleEnableAppToAppPersonFlow)}
               />
             ),
           ]}
@@ -553,7 +554,7 @@ const Developer: React.FC = () => {
             value={!!remoteLoggingEnabled}
             onToggle={toggleRemoteLoggingSwitch}
             accessibilityLabel={t('RemoteLogging.ScreenTitle')}
-            testID={testIdWithKey('ToggleRemoteLoggingSwitch')}
+            testID={testIdWithKey(TestIds.developer.toggleRemoteLogging)}
             subContent={
               remoteLoggingEnabled ? (
                 <RowDetail label={t('RemoteLogging.SessionID')} value={logger.sessionId.toString()} />
@@ -565,14 +566,14 @@ const Developer: React.FC = () => {
             value={enableProxy}
             onToggle={toggleEnableProxySwitch}
             accessibilityLabel={t('Developer.EnableProxy')}
-            testID={testIdWithKey('ToggleEnableProxy')}
+            testID={testIdWithKey(TestIds.developer.toggleEnableProxy)}
           />
           <ToggleRow
             title={t('Developer.SwitchTheme')}
             value={themeName === BCThemeNames.Dark}
             onToggle={toggleTheme}
             accessibilityLabel={t('Developer.SwitchTheme')}
-            testID={testIdWithKey('ToggleTheme')}
+            testID={testIdWithKey(TestIds.developer.toggleTheme)}
           />
         </ListButtonGroup>
       </View>
@@ -585,14 +586,14 @@ const Developer: React.FC = () => {
               <ListButton
                 onPress={() => setErrorAlertTestModalVisible(true)}
                 accessibilityLabel={t('Developer.ErrorAlertTest')}
-                testID={testIdWithKey('ErrorAlertTest')}
+                testID={testIdWithKey(TestIds.developer.errorAlertTest)}
               >
                 <Row title={t('Developer.ErrorAlertTest')} />
               </ListButton>
               <ListButton
                 onPress={staleTermsOfUseAcceptance}
                 accessibilityLabel={t('Developer.StaleTermsOfUse')}
-                testID={testIdWithKey('StaleTermsOfUse')}
+                testID={testIdWithKey(TestIds.developer.staleTermsOfUse)}
               >
                 <Row
                   title={t('Developer.StaleTermsOfUse')}
@@ -608,7 +609,7 @@ const Developer: React.FC = () => {
               <ListButton
                 onPress={resetOnboardingIntro}
                 accessibilityLabel={t('Developer.ResetOnboardingIntro')}
-                testID={testIdWithKey('ResetOnboardingIntro')}
+                testID={testIdWithKey(TestIds.developer.resetOnboardingIntro)}
               >
                 <Row
                   title={t('Developer.ResetOnboardingIntro')}
@@ -624,7 +625,7 @@ const Developer: React.FC = () => {
               <ListButton
                 onPress={deleteTokens}
                 accessibilityLabel={t('Developer.DeleteTokens')}
-                testID={testIdWithKey('DeleteTokens')}
+                testID={testIdWithKey(TestIds.developer.deleteTokens)}
               >
                 <Row
                   title={t('Developer.DeleteTokens')}
@@ -634,7 +635,7 @@ const Developer: React.FC = () => {
               </ListButton>
               <ListButton
                 accessibilityLabel={t('Developer.FetchPersonCredentialTest')}
-                testID={testIdWithKey('FetchPersonCredentialTest')}
+                testID={testIdWithKey(TestIds.developer.fetchPersonCredentialTest)}
                 onPress={fetchPersonCredentialTest}
               >
                 <Row

--- a/app/src/screens/EnvironmentSelector.tsx
+++ b/app/src/screens/EnvironmentSelector.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, testIdWithKey, usePreventDoublePress, useStore, useTheme } from '@bifold/core'
 import { IASEnvironment } from '@utils/environment'
 import React from 'react'
@@ -85,7 +86,7 @@ const EnvironmentSelector: React.FC<EnvironmentSelectorProps> = ({ onEnvironment
         <Button
           title={t('Global.Cancel')}
           accessibilityLabel={t('Global.Cancel')}
-          testID={testIdWithKey('Cancel')}
+          testID={testIdWithKey(TestIds.developer.environmentSelectorCancel)}
           onPress={onCancel}
           buttonType={ButtonType.Secondary}
         />

--- a/app/src/screens/PINExplainer.tsx
+++ b/app/src/screens/PINExplainer.tsx
@@ -1,4 +1,5 @@
 import BulletPointWithText from '@/components/BulletPointWithText'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, ScreenWrapper, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -29,7 +30,7 @@ const PINExplainer: React.FC<PINExplainerProps> = ({ continueCreatePIN }) => {
     <Button
       title={t('Global.Continue')}
       accessibilityLabel={t('Global.Continue')}
-      testID={testIdWithKey('ContinueCreatePIN')}
+      testID={testIdWithKey(TestIds.bcwallet.pinExplainer.continue)}
       onPress={continueCreatePIN}
       buttonType={ButtonType.Primary}
     />

--- a/app/src/screens/Preface.tsx
+++ b/app/src/screens/Preface.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import {
   Button,
   ButtonType,
@@ -47,7 +48,7 @@ const Preface: React.FC = () => {
       <CheckBoxRow
         title={t('Preface.Confirmed')}
         accessibilityLabel={t('Terms.IAgree')}
-        testID={testIdWithKey('IAgree')}
+        testID={testIdWithKey(TestIds.bcwallet.preface.iAgree)}
         checked={checked}
         onPress={() => setChecked(!checked)}
         reverse
@@ -56,7 +57,7 @@ const Preface: React.FC = () => {
       <Button
         title={t('Global.Continue')}
         accessibilityLabel={t('Global.Continue')}
-        testID={testIdWithKey('Continue')}
+        testID={testIdWithKey(TestIds.bcwallet.preface.continue)}
         disabled={!checked}
         onPress={onSubmitPressed}
         buttonType={ButtonType.Primary}
@@ -69,7 +70,7 @@ const Preface: React.FC = () => {
       <Assets.svg.preface style={{ alignSelf: 'center', marginBottom: Spacing.lg }} height={200} />
       <Pressable
         onPress={incrementDeveloperMenuCounter}
-        testID={testIdWithKey('DeveloperCounter')}
+        testID={testIdWithKey(TestIds.developer.counter)}
         accessibilityLabel={t('Preface.PrimaryHeading')}
       >
         <Text style={TextTheme.headingTwo}>{t('Preface.PrimaryHeading')}</Text>

--- a/app/src/screens/RemoteLogWarning.tsx
+++ b/app/src/screens/RemoteLogWarning.tsx
@@ -1,5 +1,6 @@
 import { HeaderBackButton } from '@/bcsc-theme/components/HeaderBackButton'
 import { HEADER_SHADOW } from '@/constants'
+import { TestIds } from '@/test-ids/registry'
 import { Button, ButtonType, CheckBoxRow, Link, testIdWithKey, ThemedText, useTheme } from '@bifold/core'
 import ErrorTextBox from '@components/ErrorTextBox'
 import { Header } from '@react-navigation/elements'
@@ -60,7 +61,7 @@ const RemoteLogWarning: React.FC<RemoteLogWarningProps> = ({ onBackPressed, onEn
           <HeaderBackButton
             onPress={onBackPressed}
             accessibilityLabel={t('Global.Back')}
-            testID={testIdWithKey('BackButton')}
+            testID={testIdWithKey(TestIds.developer.remoteLogWarning.back)}
           />
         )}
       />
@@ -84,7 +85,7 @@ const RemoteLogWarning: React.FC<RemoteLogWarningProps> = ({ onBackPressed, onEn
             <CheckBoxRow
               title={t('RemoteLogging.CheckBoxTitle')}
               accessibilityLabel={t('RemoteLogging.IAgree')}
-              testID={testIdWithKey('IAgree')}
+              testID={testIdWithKey(TestIds.developer.remoteLogWarning.agree)}
               checked={checked}
               onPress={() => setChecked(!checked)}
               reverse
@@ -94,7 +95,7 @@ const RemoteLogWarning: React.FC<RemoteLogWarningProps> = ({ onBackPressed, onEn
               <Button
                 title={t('RemoteLogging.ButtonTitle')}
                 accessibilityLabel={t('RemoteLogging.ButtonTitle')}
-                testID={testIdWithKey('TurnOn')}
+                testID={testIdWithKey(TestIds.developer.remoteLogWarning.turnOn)}
                 disabled={!checked}
                 onPress={onSubmitPressed}
                 buttonType={ButtonType.Primary}

--- a/app/src/screens/Splash.tsx
+++ b/app/src/screens/Splash.tsx
@@ -2,6 +2,7 @@ import { ledgerResolver } from '@/configs/ledgers/indy/ledgerResolver'
 import { AppError, ErrorRegistry } from '@/errors'
 import { toBifoldError } from '@/errors/errorHandler'
 import { BCState } from '@/store'
+import { TestIds } from '@/test-ids/registry'
 import {
   InfoBox,
   InfoBoxType,
@@ -172,7 +173,7 @@ const Splash: React.FC<SplashProps> = ({ initializeAgent }) => {
   return (
     <SafeAreaView style={styles.screenContainer}>
       <ScrollView contentContainerStyle={styles.scrollContentContainer}>
-        <View style={styles.progressContainer} testID={testIdWithKey('LoadingActivityIndicator')}>
+        <View style={styles.progressContainer} testID={testIdWithKey(TestIds.common.splashProgress)}>
           <ProgressBar progressPercent={progressPercent} dark />
           <View style={styles.stepTextContainer}>
             <Text style={styles.stepText}>{stepText}</Text>
@@ -203,7 +204,7 @@ const Splash: React.FC<SplashProps> = ({ initializeAgent }) => {
           <Image
             source={Assets.img.logoPrimary.src}
             style={{ width: Assets.img.logoPrimary.width, height: Assets.img.logoPrimary.height }}
-            testID={testIdWithKey('LoadingActivityIndicatorImage')}
+            testID={testIdWithKey(TestIds.common.splashImage)}
           />
         </View>
       </ScrollView>

--- a/app/src/screens/Terms.tsx
+++ b/app/src/screens/Terms.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from '@/test-ids/registry'
 import {
   Button,
   ButtonType,
@@ -66,7 +67,7 @@ const Terms: React.FC = () => {
       <Button
         title={t('Global.Accept')}
         accessibilityLabel={t('Global.Accept')}
-        testID={testIdWithKey('Accept')}
+        testID={testIdWithKey(TestIds.bcwallet.terms.accept)}
         onPress={onSubmitPressed}
         buttonType={ButtonType.Primary}
       />

--- a/app/src/test-ids/registry.test.ts
+++ b/app/src/test-ids/registry.test.ts
@@ -1,11 +1,144 @@
+import fs from 'fs'
+import path from 'path'
+
 import { testIdWithKey } from '@bifold/core'
 
-import { TESTID_PREFIX } from './registry'
+import { TESTID_PREFIX, TestIds } from './registry'
 
 describe('test ID registry', () => {
   // The registry stores bare keys and bifold applies the prefix, so a bifold upgrade that changes
   // `testIdPrefix` would make every e2e selector miss at runtime. Fail here instead.
   it('pins TESTID_PREFIX to bifold testIdPrefix', () => {
     expect(testIdWithKey('AnyKey')).toBe(`${TESTID_PREFIX}AnyKey`)
+  })
+})
+
+/**
+ * Registry keys with no `TestIds.<path>` reference anywhere in app source. Every one is here for a
+ * reason, and the categories are the whole point of the list:
+ *
+ *   COMPOSED  the app emits the id through a shared component (a caller `id` plus `shared.field.*`),
+ *             so the spelled-out form exists for specs to select by, not for a call site.
+ *   ALIAS     the same id documented at a second mount; the shared component references one path.
+ *   BIFOLD    an upstream call site this app does not own and cannot refactor.
+ *   DERIVED   emitted from a translated label or server data, so no key can be passed at all.
+ *
+ * Anything else appearing here is drift: either a key was added with no consumer, or the app stopped
+ * emitting one the e2e suite still compiles against. The list is exact in both directions — start
+ * using a listed key and this fails too, which is the point.
+ */
+const KNOWN_UNREFERENCED = [
+  'TestIds.onboarding.intro.settings',
+  'TestIds.onboarding.createPin.pin1Visibility',
+  'TestIds.onboarding.createPin.pin2Visibility',
+  'TestIds.auth.accountLanding.settings',
+  'TestIds.auth.enterPin.pinVisibility',
+  'TestIds.verify.scanSerial.openSettings',
+  'TestIds.verify.manualSerial.serialPressable',
+  'TestIds.verify.manualSerial.serialInput',
+  'TestIds.verify.manualSerial.serialSubtext',
+  'TestIds.verify.enterBirthdate.birthdatePressable',
+  'TestIds.verify.enterBirthdate.birthdateInput',
+  'TestIds.verify.enterEmail.inputPressable',
+  'TestIds.verify.enterEmail.input',
+  'TestIds.verify.methodSelection.settingsMenu',
+  'TestIds.verify.selfieCapture.takePhoto',
+  'TestIds.verify.selfieCapture.cancel',
+  'TestIds.verify.emailConfirmation.codeError',
+  'TestIds.verify.additionalIdRequired.continue',
+  'TestIds.verify.dualIdRequired.continue',
+  'TestIds.verify.evidenceCapture.takePhoto',
+  'TestIds.verify.evidenceCapture.cancel',
+  'TestIds.verify.evidenceIdCollection.documentNumberPressable',
+  'TestIds.verify.evidenceIdCollection.documentNumberInput',
+  'TestIds.verify.evidenceIdCollection.lastName',
+  'TestIds.verify.evidenceIdCollection.firstName',
+  'TestIds.verify.evidenceIdCollection.middleNames',
+  'TestIds.verify.evidenceIdCollection.birthdate',
+  'TestIds.verify.evidenceIdCollection.birthdateSubtext',
+  'TestIds.verify.residentialAddress.streetAddress1Pressable',
+  'TestIds.verify.residentialAddress.streetAddress1Input',
+  'TestIds.verify.residentialAddress.cityPressable',
+  'TestIds.verify.residentialAddress.cityInput',
+  'TestIds.verify.residentialAddress.postalCodePressable',
+  'TestIds.verify.residentialAddress.postalCodeInput',
+  'TestIds.verify.residentialAddress.provinceInput',
+  'TestIds.verify.residentialAddress.provinceOptionBC',
+  'TestIds.main.header.settings',
+  'TestIds.main.verifyPrompt.continue',
+  'TestIds.main.scanError.header',
+  'TestIds.main.scanError.body',
+  'TestIds.main.scanError.okay',
+  'TestIds.main.appSecurity.choosePin',
+  'TestIds.main.autoLock.time5',
+  'TestIds.main.autoLock.time3',
+  'TestIds.main.autoLock.time1',
+  'TestIds.main.privacyPolicy.learnMore',
+  'TestIds.main.editNickname.input',
+  'TestIds.main.editNickname.pressable',
+  'TestIds.main.editNickname.error',
+  'TestIds.main.pairing.codeError',
+  'TestIds.main.contactEditName.save',
+  'TestIds.main.contactEditName.cancel',
+  'TestIds.main.accountDetails.nicknameFieldEdit',
+  'TestIds.main.accountDetails.addressFieldEdit',
+  'TestIds.credential.offer.accept',
+  'TestIds.credential.offer.decline',
+  'TestIds.credential.offer.header',
+  'TestIds.credential.offerAccept.onTheWay',
+  'TestIds.credential.offerAccept.added',
+  'TestIds.credential.offerAccept.done',
+  'TestIds.credential.offerAccept.backToHome',
+  'TestIds.credential.card.card',
+  'TestIds.credential.card.name',
+  'TestIds.credential.card.issuer',
+  'TestIds.credential.card.revoked',
+  'TestIds.credential.card.showDetails',
+  'TestIds.credential.details.issuerName',
+  'TestIds.credential.details.issuedDate',
+  'TestIds.credential.details.revokedDate',
+  'TestIds.credential.details.revocationMessage',
+  'TestIds.credential.details.remove',
+  'TestIds.credential.removeModal.confirm',
+  'TestIds.credential.removeModal.cancel',
+  'TestIds.credential.declineModal.confirm',
+  'TestIds.credential.declineModal.cancel',
+  'TestIds.proof.request.share',
+  'TestIds.proof.request.decline',
+  'TestIds.proof.request.cancel',
+  'TestIds.proof.request.loading',
+  'TestIds.proof.accept.sending',
+  'TestIds.proof.accept.sent',
+  'TestIds.proof.accept.backToHome',
+  'TestIds.developer.environment',
+  'TestIds.bcwallet.onboarding.next',
+  'TestIds.bcwallet.onboarding.back',
+]
+
+const SRC = path.join(__dirname, '..')
+
+const sourceFiles = (dir: string): string[] =>
+  fs.readdirSync(dir).flatMap((entry) => {
+    const full = path.join(dir, entry)
+    if (fs.statSync(full).isDirectory()) {
+      return ['__tests__', '__snapshots__', 'node_modules'].includes(entry) ? [] : sourceFiles(full)
+    }
+    return /\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry) ? [full] : []
+  })
+
+const leafPaths = (node: object, prefix: string[] = []): string[] =>
+  Object.entries(node).flatMap(([key, value]) =>
+    typeof value === 'string' ? [`TestIds.${[...prefix, key].join('.')}`] : leafPaths(value as object, [...prefix, key])
+  )
+
+describe('test ID registry coverage', () => {
+  it('every key is referenced by app code, or listed as deliberately unreferenced', () => {
+    const source = sourceFiles(SRC)
+      .filter((f) => !f.endsWith(path.join('test-ids', 'registry.ts')))
+      .map((f) => fs.readFileSync(f, 'utf8'))
+      .join('\n')
+    const referenced = new Set(source.match(/TestIds(?:\.[A-Za-z0-9_$]+)+/g) ?? [])
+
+    expect(leafPaths(TestIds).filter((p) => !referenced.has(p))).toEqual(KNOWN_UNREFERENCED)
   })
 })

--- a/app/src/test-ids/registry.test.ts
+++ b/app/src/test-ids/registry.test.ts
@@ -121,7 +121,10 @@ const sourceFiles = (dir: string): string[] =>
   fs.readdirSync(dir).flatMap((entry) => {
     const full = path.join(dir, entry)
     if (fs.statSync(full).isDirectory()) {
-      return ['__tests__', '__snapshots__', 'node_modules'].includes(entry) ? [] : sourceFiles(full)
+      // Skip node_modules and every Jest-convention `__x__` directory — tests, snapshots, mocks,
+      // fixtures. A reference from test-only code must not satisfy this ratchet, and matching the
+      // whole convention avoids extending a denylist each time one of them appears.
+      return entry === 'node_modules' || /^__.*__$/.test(entry) ? [] : sourceFiles(full)
     }
     return /\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry) ? [full] : []
   })

--- a/app/src/test-ids/registry.ts
+++ b/app/src/test-ids/registry.ts
@@ -41,6 +41,9 @@ export const TestIds = {
     loadingOverlay: 'BCSCLoadingProviderOverlay',
     loadingChildren: 'BCSCLoadingProviderChildren',
     agentRetry: 'AgentRetry',
+    // `screens/Splash.tsx` — the pre-container boot screen, before any stack mounts.
+    splashProgress: 'LoadingActivityIndicator',
+    splashImage: 'LoadingActivityIndicatorImage',
     // `SettingsHeaderButton`, the header-left menu on onboarding, auth and main. The per-mount
     // entries (`onboarding.intro.settings`, `auth.accountLanding.settings`, `main.header.settings`)
     // are the SAME id, kept where specs look for them; this is the one the component references.
@@ -61,6 +64,18 @@ export const TestIds = {
     details: 'DetailsText', // "Error code N - message", rendered only once ShowDetails is pressed
     title: 'HeaderText',
     body: 'BodyText',
+    /** Optional recovery CTA the raising screen supplies (retry, go back, …). */
+    action: 'ActionButton',
+    /** Report-a-problem controls ON THE CARD — distinct ids from the help-menu `reportProblem` modal.
+     *  `reportThisProblem` flips to a 'Reported' label in place; `reportId`/`reportIdValue` and
+     *  `copyReportId` appear only once a report has been filed. */
+    reportThisProblem: 'ReportThisProblem',
+    reportNote: 'ReportNote',
+    reportId: 'ReportId',
+    reportIdValue: 'ReportIdValue',
+    copyReportId: 'CopyReportId',
+    supportLink: 'SupportLink',
+    versionNumber: 'VersionNumber',
   },
 
   /**
@@ -944,6 +959,30 @@ export const TestIds = {
     resetOnboardingIntro: 'ResetOnboardingIntro',
     /** Deletes the refresh/registration/access tokens from the native keychain. */
     deleteTokens: 'DeleteTokens',
+    /** Feature-flag switches, in screen order. Each toggles a store flag immediately; none confirm. */
+    toggleUseShareableLink: 'ToggleUseShareableLink',
+    toggleVerifierCapability: 'ToggleVerifierCapability',
+    toggleAcceptDevCredentials: 'ToggleAcceptDevCredentials',
+    toggleConnectionInviterCapability: 'ToggleConnectionInviterCapabilitySwitch',
+    toggleDevVerifierTemplates: 'ToggleDevVerifierTemplatesSwitch',
+    toggleWalletNaming: 'ToggleWalletNamingSwitch',
+    togglePreventAutoLock: 'TogglePreventAutoLockSwitch',
+    toggleEnableAppToAppPersonFlow: 'ToggleEnableAppToAppPersonFlow',
+    toggleRemoteLogging: 'ToggleRemoteLoggingSwitch',
+    toggleEnableProxy: 'ToggleEnableProxy',
+    toggleTheme: 'ToggleTheme',
+    /** Raises a deliberate error so the ErrorInfoCard path can be exercised by hand. */
+    errorAlertTest: 'ErrorAlertTest',
+    fetchPersonCredentialTest: 'FetchPersonCredentialTest',
+    /** `EnvironmentSelector` — the rows are `testIdWithKey(name.toLowerCase())` over the configured
+     *  environments, so they are DATA-derived and have no fixed key; only the cancel control does. */
+    environmentSelectorCancel: 'Cancel',
+    /** `RemoteLogWarning` — the consent screen before remote logging is switched on. */
+    remoteLogWarning: {
+      back: 'BackButton',
+      agree: 'IAgree',
+      turnOn: 'TurnOn',
+    },
   },
 
   /** BC Wallet variant — the Preface + onboarding-carousel intro screens (bifold `com.ariesbifold:id/`
@@ -958,6 +997,46 @@ export const TestIds = {
       next: 'Next',
       back: 'Back',
       getStarted: 'GetStarted',
+    },
+    /** Container-wired intro screens (`container-imp.ts`), the bifold versions — BCSC has its own
+     *  `onboarding.termsOfUse` / `onboarding.createPin` equivalents. */
+    terms: {
+      accept: 'Accept',
+    },
+    pinExplainer: {
+      continue: 'ContinueCreatePIN',
+    },
+    /** Home chrome: the session-id debug banner, the add-credential entry, and the feedback footer. */
+    home: {
+      sessionIdBanner: 'SessionIdBanner',
+      addCredential: 'AddCredential',
+      giveFeedback: 'GiveFeedback',
+    },
+    /** Empty wallet list. */
+    emptyList: {
+      noneYet: 'NoneYet',
+      addFirstCredential: 'AddFirstCredential',
+    },
+    /** Add-credential sheet. Its two option rows are i18n-DERIVED
+     *  (`testIdForAccessabilityLabel(t(...))`), so they break under a locale change and have no key. */
+    addCredentialSlider: {
+      dismiss: 'DismissAddCredentialSlider',
+      close: 'Close',
+    },
+    /** Person-credential flow (`features/person-flow`). `installApp` / `appOnOtherDevice` render on the
+     *  branch where the BC Services Card app is absent; `appInstalledIcon` on the branch where it is. */
+    personCredential: {
+      appInstalledIcon: 'AppInstalledIcon',
+      installApp: 'InstallApp',
+      appOnOtherDevice: 'AppOnOtherDevice',
+      startProcess: 'StartProcess',
+      whatIsPersonCredential: 'WhatIsPersonCredentialLink',
+      whereToUse: 'WhereToUse',
+      help: 'Help',
+    },
+    personCredentialLoading: {
+      requestProcessing: 'RequestProcessing',
+      backToPersonScreen: 'BackToPersonScreen',
     },
   },
 } as const


### PR DESCRIPTION
Closes #4593

## What changed

Migrates the last of the app — `bcwallet-theme`, top-level `screens`, and the error card — then closes the ratchet. 58 call sites across 16 files.

**Top of the stack, on `chore/e2e_testID_components`.** Review only this branch's diff.

- eslint widens to `files: ['src/**']`. Verified directly: zero `testIdWithKey('literal')` and zero `testIDKey="literal"` remain anywhere in non-test source.
- Registry: ~43 new keys, the densest slice — `errorModal` gains the eight `ErrorInfoCard` controls it never listed, `developer` the eleven feature-flag toggles, `bcwallet` the person-credential flow, home chrome, empty list and add-credential sheet.
- New jest check catches **reverse** drift: a key added with no call site, or a call site removed while the key lingers.
- `CONVENTIONS.md`: a "Test IDs: Register the key, then reference it" entry.

## What should the reviewer focus on

- **`KNOWN_UNREFERENCED` in `registry.test.ts`.** 410 registry leaves, 325 used by app code, 85 legitimately not — so a strict "every key must be used" rule was never viable. The test pins the unreferenced set exactly, each entry falling into one of four categories (COMPOSED / ALIAS / BIFOLD / DERIVED). The risk is the list becoming a dumping ground: adding to it without a reason silences a real failure. Worth reading the categories and spot-checking a few.
- The eight remaining derived call sites are listed under DERIVED. Seven change id under a locale switch (`…/Continue` → `…/Continuer`). The registry documents the affected screens as en-only. A follow-up PR should thread a `testIDKey` prop through `ActionScreenLayout` and `BulletedInstructionsScreen` and their 11 callers.

## How to test

```
cd app && yarn typecheck && yarn lint && yarn test
cd e2e && yarn typecheck
```

160/160 snapshots pass with no `.snap` written. The new check runs in 65ms and fails both ways — add an unused key, or repoint a call site away from one, and it goes red.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>