### PR TITLE
fix(android): auto-focus postal code after province selection

### DIFF
--- a/app/src/bcsc-theme/components/DropdownWithValidation.tsx
+++ b/app/src/bcsc-theme/components/DropdownWithValidation.tsx
@@ -136,10 +136,12 @@ export const DropdownWithValidation = <T extends string | number>({
   const handleSelect = (selectedValue: T) => {
     onChange(selectedValue)
     setIsOpen(false)
+    onModalClose?.()
   }
 
   const handleClose = () => {
     setIsOpen(false)
+    onModalClose?.()
   }
 
   const renderOption = ({ item, index }: { item: DropdownOption<T>; index: number }) => {

--- a/app/src/bcsc-theme/components/DropdownWithValidation.tsx
+++ b/app/src/bcsc-theme/components/DropdownWithValidation.tsx
@@ -135,8 +135,7 @@ export const DropdownWithValidation = <T extends string | number>({
 
   const handleSelect = (selectedValue: T) => {
     onChange(selectedValue)
-    setIsOpen(false)
-    onModalClose?.()
+    handleClose()
   }
 
   const handleClose = () => {
@@ -211,7 +210,7 @@ export const DropdownWithValidation = <T extends string | number>({
         </ThemedText>
       ) : null}
 
-      <Modal visible={isOpen} transparent animationType="slide" onRequestClose={handleClose} onDismiss={onModalClose}>
+      <Modal visible={isOpen} transparent animationType="slide" onRequestClose={handleClose}>
         <View
           style={[styles.modalContent, { paddingTop: insets.top, paddingBottom: insets.bottom }]}
           testID={testIdWithKey(`${id}${TestIds.shared.field.modalContent}`)}


### PR DESCRIPTION
Closes #4313 

<!-- Add the number above, like "Closes #1234", or link it in the Development
     panel. A bare "#1234" lower down doesn't count.
     No issue? Delete the line and add the `status/no-issue` label. -->

## What changed
Android bug preventing the "Postal code" input from being autofocused after the "Province" dropdown selected or closed.

<!-- Enough context to read the diff. The backstory lives in the issue.
     Drop in a screenshot or a short video if it shows what changed or how
     it's meant to work — often quicker than describing it. -->

## What should the reviewer focus on
Postal code auto focus in the Non-BCSC flow
<!-- Point at the scary bit — or say there isn't one:
     "Copy change, quick skim is fine."
     "The cancel path in useEvidenceUpload — not sure it clears the timer."
     "iOS only, Android untouched." -->

## How to test
0. On Android
1. Non-BCSC flow
2. Residential address form select province
3. Postal code input auto focused
<!-- How someone else checks it. "Covered by unit tests" counts. -->
