### PR TITLE
fix: log heap usage in CI coverage runs

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -27,7 +27,7 @@
     "start": "react-native start --reset-cache",
     "test": "TZ=GMT jest --config ./jest.config.js",
     "test:watch": "TZ=GMT jest --config ./jest.config.js --watch",
-    "test:coverage": "TZ=GMT jest --config ./jest.config.js --coverage",
+    "test:coverage": "TZ=GMT jest --config ./jest.config.js --coverage --logHeapUsage",
     "test:snapshot": "TZ=GMT jest --updateSnapshot",
     "lint": "eslint --color .",
     "lint:fix": "eslint --color . --fix",


### PR DESCRIPTION
Closes #4634

## What changed

CI test runs fail at random a few times a week when a worker process crashes — a different test file each time, always green on re-run. `main` is red for this right now.

This adds memory reporting to the CI test run so the next failure tells us why. One flag, no behaviour change.

## What should the reviewer focus on

That this is deliberately a diagnostic and not a fix. The likely cause is memory — the settings in `jest.config.js` were tuned when the suite was ~260 files and it is now 306 — but the crash signature does not definitively say so. Changing memory limits on a guess could mask the problem instead of fixing it.

Once a failure is captured with this in place, the numbers will point at the real fix.

## How to test

`yarn coverage` now prints a heap size beside each test file:

```
PASS src/utils/expiration.test.ts (62 MB heap size)
```

Nothing else changes — same tests, same results.
