### PR TITLE
feat: e2e device lock

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -8,8 +8,11 @@
 # migration lane, then the remaining upgrade lanes (previous release →
 # current, 4.0.3 → current) as chained advisory jobs — each boots an OLD
 # build via its own config, so they cannot live inside the regression wdio
-# suite itself. A final queue-hygiene job drains the SIT review queue so
-# the UAT team never starts the day behind e2e leftovers.
+# suite itself — then the device-auth lane (the device-authentication
+# journey on a device with a screen lock + biometric interception, a state
+# no other journey may start from, so it has its own Sauce capability lane).
+# A final queue-hygiene job drains the SIT review queue so the UAT team
+# never starts the day behind e2e leftovers.
 #
 # Default device matrix: 1 iOS + 1 Android device (one modern OS major each).
 # os_version stays PINNED: unpinned, Sauce hands out iOS 15-era devices, where
@@ -59,6 +62,7 @@ on:
           - verify
           - send-video
           - a11y
+          - device-auth
           - migration
           - upgrade
           - upgrade403
@@ -250,12 +254,33 @@ jobs:
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
+  # ─── Device-auth lane: a locked device with biometric interception ─
+  # The device-authentication journey needs a Sauce session whose device carries a screen lock
+  # (`setupDeviceLock`) and biometric interception (`biometricsInterception`) — the app offers device
+  # auth only when the OS calls the device secure, and the prompts are answered through Sauce. Every
+  # OTHER journey must never start from that state, so the suite has its own capability lane in the RDC
+  # configs (`--suite device-auth` schedules only that lane) and runs here, last in the chain, so its
+  # two sessions stay inside the account-wide cap. Blocking, like the regression: the coverage-map row
+  # for "Change security method (biometrics)" is proved by this lane alone.
+  e2e-device-auth:
+    needs: [check-for-merges, resolve-build, e2e-upgrade403]
+    if: ${{ !cancelled() && needs.check-for-merges.outputs.should_run == 'true' && needs.resolve-build.result == 'success' && (inputs.suite || 'regression') == 'regression' }}
+    uses: ./.github/workflows/e2e.yml
+    permissions:
+      contents: read
+    with:
+      suite: device-auth
+      build_number: ${{ needs.resolve-build.outputs.build_number }}
+      device_matrix: ${{ inputs.device_matrix || '[{"platform":"iOS","device":"iPhone.*","os_version":"18"},{"platform":"Android","device":"Google.*","os_version":"15"}]' }}
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
   # ─── Queue hygiene: the last word on the SIT review queue ───────
   # The send-video journeys drain the queue before each upload and again in their teardown; this is
   # the end-of-night double check, whatever the lanes did (always()) — so a run that died mid-journey
   # never leaves a submission for the UAT team to clear in the morning.
   queue-hygiene:
-    needs: [check-for-merges, resolve-build, e2e, e2e-send-video, e2e-migration, e2e-upgrade, e2e-upgrade403]
+    needs: [check-for-merges, resolve-build, e2e, e2e-send-video, e2e-migration, e2e-upgrade, e2e-upgrade403, e2e-device-auth]
     if: ${{ always() && needs.check-for-merges.outputs.should_run == 'true' && needs.resolve-build.result == 'success' }}
     uses: ./.github/workflows/e2e-send-video-queue.yml
     permissions:
@@ -271,7 +296,7 @@ jobs:
   # reads the e2e-reports-* artifacts they uploaded, and writes the run summary + e2e-nightly-brief.
   brief:
     name: Nightly brief
-    needs: [check-for-merges, resolve-build, e2e, e2e-send-video, e2e-migration, e2e-upgrade, e2e-upgrade403, queue-hygiene]
+    needs: [check-for-merges, resolve-build, e2e, e2e-send-video, e2e-migration, e2e-upgrade, e2e-upgrade403, e2e-device-auth, queue-hygiene]
     if: ${{ always() && needs.check-for-merges.outputs.should_run == 'true' && needs.resolve-build.result == 'success' }}
     runs-on: ubuntu-22.04
     permissions:
@@ -306,12 +331,14 @@ jobs:
           LANE_MIGRATION: ${{ needs.e2e-migration.result }}
           LANE_UPGRADE: ${{ needs.e2e-upgrade.result }}
           LANE_UPGRADE403: ${{ needs.e2e-upgrade403.result }}
+          LANE_DEVICE_AUTH: ${{ needs.e2e-device-auth.result }}
         run: |
           ./node_modules/.bin/tsx scripts/brief.ts --reports artifacts \
             --title "E2E nightly — build ${BUILD_NUMBER}" --run-url "$RUN_URL" \
             --lane "regression=${LANE_REGRESSION}" --lane "send-video=${LANE_SEND_VIDEO}" \
             --lane "migration=${LANE_MIGRATION}" \
             --lane "upgrade=${LANE_UPGRADE}" --lane "upgrade403=${LANE_UPGRADE403}" \
+            --lane "device-auth=${LANE_DEVICE_AUTH}" \
             --out brief.md --json brief.json
           cat brief.md >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,9 @@
 #                  blind-FIFO SIT queue, so CI runs them one platform at a time (max-parallel 1) and
 #                  keeps them out of every concurrent multi-device run (exclude_send_video)
 #   a11y         — automated accessibility audits over the core screens (iOS: Apple's audit engine; Android: heuristics)
+#   device-auth  — the device-authentication journey on a device with a screen lock + biometric
+#                  interception: its own Sauce capability lane (a locked device changes the state every
+#                  other journey starts from), never inside regression
 #   regression   — every per-area journey (nightly default)
 #   migration    — v3 → v4 app upgrade flow (Sauce RDC only; separate v3 build)
 #   upgrade      — previous released build → current in-place upgrade (Sauce RDC, both platforms)
@@ -51,7 +54,7 @@ on:
   workflow_call:
     inputs:
       suite:
-        description: 'Test suite (smoke, onboarding, auth, main, verify, send-video, a11y, regression, migration, upgrade, upgrade403)'
+        description: 'Test suite (smoke, onboarding, auth, main, verify, send-video, a11y, device-auth, regression, migration, upgrade, upgrade403)'
         type: string
         required: true
       build_number:
@@ -114,6 +117,7 @@ on:
           - verify
           - send-video
           - a11y
+          - device-auth
           - regression
           - migration
           - upgrade
@@ -152,7 +156,7 @@ jobs:
   #   migration                → configs/sauce/wdio.{ios,android}.sauce.migration.conf.ts
   #   upgrade / upgrade403     → configs/sauce/wdio.{ios,android}.sauce.upgrade.conf.ts
   #   everything else (smoke,  → configs/sauce/wdio.{ios,android}.sauce.rdc.conf.ts
-  #    onboarding, auth, main,
+  #    onboarding, auth, main,    (device-auth selects that config's locked-device capability lane)
   #    verify, regression)
   #
   # Non-blocking suites (migration, upgrade, upgrade403): failures are reported but

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -48,6 +48,7 @@ _Tests are organized into named suites. Use the_ `--suite` _flag to select which
 | `upgrade403` | _Upgrade from the shipped **4.0.3** release specifically — its pre-rework onboarding runs via a frozen walk (`flows/onboarding-v403.ts`). Runs on Sauce on **both platforms**; retire once 4.1.0 is the previous release_ |
 | `scan`       | _Card-barcode scanning — non-BCSC→BCSC reroutes + the serial scanner (`scan/*.journey.ts`). **Android + Sauce only**, and also part of `regression`; the iOS configs `exclude` it_ |
 | `a11y`       | _Automated accessibility audits over the core unverified screens (`a11y/*.journey.ts`): iOS runs Apple's XCTest audit engine, Android the page-source/screenshot heuristics — see **[Accessibility audits](#accessibility-audits)**. Also part of `regression`_ |
+| `device-auth` | _Device authentication on a **locked** device (`device-auth/*.journey.ts`): onboarding on device auth, the "Confirm it's your device" interstitial, a failed match + retry, and the PIN ↔ device-auth switch in Settings with an unlock on each method. **Sauce RDC only**, on its own capability lane (`setupDeviceLock` + `biometricsInterception`, see **[Device authentication](#device-authentication-sauce-device-lock-lane)**) and never inside `regression` — a locked device changes the state every other journey starts from_ |
 
 ```bash
 # Run by suite name (per-area journey suites)
@@ -544,7 +545,7 @@ path CI already uses)._
 | Android | Non-BCSC reroute at the serial screen | ✅ WORKS (deterministic) | same jobs | _An unrecognised/undecodable code at `ScanSerial` routes to DualIdentificationRequired within seconds, every run — an edge case previously untestable_ |
 | Android | QR (FAB scanner) | ✅ WORKS | `a6f63e6f9f674fab95eea0f560918234` | _junk QR → "not recognized" popup AND pairing QR → full strategy pipeline, both first try; transfer-in scanning shares the same camera component_ |
 | iOS | QR (FAB scanner) | ✅ WORKS | `d7ea2c3c39c548a8a7ddc422d2c32714` | _Sauce's synthesized QR metadata reaches the vision-camera delegate: junk QR → "not recognized" popup AND pairing QR → full strategy pipeline_ |
-| iOS | Code-39 / PDF-417 (any surface) | ❌ DEAD (structural) | `d7ea2c3c39c548a8a7ddc422d2c32714`, `e7214db3895d4d67bb05d053e38e6350` | _Proven, not just documented: the injected card is plainly VISIBLE and sharp in the iOS preview, and code-39/PDF-417 still never fire, while QR fires reliably from the same image. iOS decodes in the OS (`AVCaptureMetadataOutput`) and Sauce only synthesizes QR metadata, so no rotation/clarity/size change can ever help. Mitigation: manual serial entry_ |
+| iOS | Code-39 / PDF-417 (any surface) | ❌ DEAD (structural) | `d7ea2c3c39c548a8a7ddc422d2c32714`, `e7214db3895d4d67bb05d053e38e6350`, `3b6691b413534c2299051991a0dc85e5` (serial: bare code-39, bare PDF-417, card back), `56f3c3775264490c8d92bf98465fd066` (evidence capture) | _Proven, not just documented: the injected card is plainly VISIBLE and sharp in the iOS preview, and code-39/PDF-417 still never fire, while QR fires reliably from the same image. iOS decodes in the OS (`AVCaptureMetadataOutput`) and Sauce only synthesizes QR metadata, so no rotation/clarity/size change can ever help. Mitigation: manual serial entry_ |
 
 _What that buys CI today, split by what each platform can actually do:_
 
@@ -610,6 +611,23 @@ nonexistent card._
 > `decodeBarcodes` — the same guard it already applies to `type === 'unknown'` — would fix the
 > user-facing behaviour and make this screen testable by injection._
 
+### Device authentication (Sauce device-lock lane)
+
+_The app offers "use device authentication" only when the OS calls the device secure —_ `KeyguardManager.isDeviceSecure` _on Android,_ `LAContext.canEvaluatePolicy(.deviceOwnerAuthentication)` _on iOS — and public pool devices carry no screen lock, so on a plain session the secure-app step renders the PIN option alone. Two per-session Sauce capabilities change that, and the_ `device-auth` _suite runs on a capability lane that requests both:_
+
+- `setupDeviceLock: true` _— Sauce sets a real screen lock for the session (000000 on Android, 089675 on iOS). The option renders and the OS credential prompt is real; typing the passcode answers it. On iOS that sheet is invisible to the driver, so it would be typed blind._
+- `biometricsInterception: true` _— Sauce swaps the biometric APIs for its own, and_ `sauce:biometrics-authenticate=true|false` _answers the app's prompt (`helpers/biometrics.ts`). Measured 2026-09-10: this alone also makes the option render on both platforms — on Android the instrumentation flips the keyguard check, which the docs do not list — but the lane keeps the lock too, so each option covers the other's failure mode._
+
+_A mocked answer drives the same path a real match does: the app binds no key to the sensor, so success means "read the stored hash and rotate the wallet key" either way. What it cannot drive: the same-prompt retry after an intermediate biometric failure (Sauce's_ `=false` _settles the prompt as an error, and the app drops back to the "Confirm it's your device" interstitial), and "App reset for security" (the OS lock removed after enrolment)._
+
+_Both options change the state every other journey starts from, so they are never a global switch: the RDC configs give_ `device-auth/*.journey.ts` _its own lane (`DEVICE_AUTH_SPECS`) and exclude those files from every other lane, the suite is not part of_ `regression`_, and the nightly runs it last in its chain. The App Storage "Device Passcode" setting stays OFF on every app group — Sauce applies it to all uploaded versions of the app, which would lock the device under every journey of every build._
+
+```sh
+# the journey, on its lane (Sauce RDC only; it skips itself anywhere else)
+yarn test:android:sauce --suite device-auth
+yarn test:ios:sauce --suite device-auth
+```
+
 ## _CI/CD_
 
 _Tests run automatically in GitHub Actions via a device matrix that controls which OS versions are tested:_
@@ -623,7 +641,9 @@ _Tests run automatically in GitHub Actions via a device matrix that controls whi
 
 _The four send-video journeys are excluded from that concurrent regression matrix and run right after it as their own_ `send-video` _lane — both platforms, one at a time (`max_parallel: 1`), alongside the Android-only migration lane — because they review a shared, blind-FIFO SIT agent queue with shared personas (see **Send-video review queue**). The journeys drain that queue around their own uploads, and the nightly ends with a_ `queue-hygiene` _job that drains it once more._
 
-_The device matrix is passed as a JSON array of_ `{platform, device, os_version}` _objects to_ `e2e.yml`_. Each entry spawns a separate SauceLabs session with its own logs and pass/fail status. (Biometric CI wiring — its Sauce configs, dev scripts, and workflow job — has been removed pending re-implementation as a journey; the_ `biometrics` _helper is retained for that future work.)_
+_The device matrix is passed as a JSON array of_ `{platform, device, os_version}` _objects to_ `e2e.yml`_. Each entry spawns a separate SauceLabs session with its own logs and pass/fail status._
+
+_The nightly ends with the_ `device-auth` _lane (both platforms, last in the chain so its two sessions stay inside the cap): the device-authentication journey on a Sauce session whose device carries a screen lock and biometric interception — see **[Device authentication](#device-authentication-sauce-device-lock-lane)**._
 
 _**Note:** There is no E2E job on_ `main` _merge by design — regression is deferred to the nightly workflow so SauceLabs devices stay free during the day when multiple PRs merge. The in-person verification step needs the runner's egress IP allowlisted with the BC Gov ID Check portal; see the notes in_ `e2e-nightly.yml` _and use the "Verify Allowlist Connectivity" workflow to confirm reachability._
 

--- a/e2e/configs/sauce/wdio.android.sauce.rdc.conf.ts
+++ b/e2e/configs/sauce/wdio.android.sauce.rdc.conf.ts
@@ -1,6 +1,16 @@
 // sauce/wdio.android.sauce.rdc.conf.ts
-import { NON_SEND_VIDEO_SPECS, SEND_VIDEO_SPECS } from '../wdio.shared.conf.js'
-import { config as sauceConfig, sauceRdcOptions, sauceRdcOptionsNoCameraInjection } from './wdio.shared.sauce.conf.js'
+import {
+  DEVICE_AUTH_SPECS,
+  NON_DEVICE_AUTH_SPECS,
+  NON_SEND_VIDEO_SPECS,
+  SEND_VIDEO_SPECS,
+} from '../wdio.shared.conf.js'
+import {
+  DEVICE_SECURITY_LANE,
+  config as sauceConfig,
+  sauceRdcOptions,
+  sauceRdcOptionsNoCameraInjection,
+} from './wdio.shared.sauce.conf.js'
 
 const appFilename = process.env.ANDROID_APP_FILENAME || 'BCSC-Dev-latest.apk'
 
@@ -21,10 +31,23 @@ const androidCaps = {
 }
 
 /**
- * Two capability lanes: everything with camera injection EXCEPT the send-video journeys, which get a
+ * The device-authentication lane: the same session plus a real screen lock and biometric
+ * interception, for the device-auth journeys ALONE — a locked device changes the state every other
+ * journey starts from. Excludes everything else, so `--suite device-auth` schedules only this lane and
+ * a regular suite never inherits the lock.
+ */
+const deviceAuthLane = {
+  ...androidCaps,
+  'wdio:exclude': NON_DEVICE_AUTH_SPECS,
+  'sauce:options': { ...sauceRdcOptions, ...DEVICE_SECURITY_LANE },
+}
+
+/**
+ * Three capability lanes: everything with camera injection EXCEPT the send-video journeys, which get a
  * session withOUT the injection instrumentation (it hooks the whole camera pipeline and wrecks the
  * recorder's stop/finalize — the app's "Recording error" modal on every Sauce Android recording) and
- * capture from the rack feed instead; the scripted reviewer never looks at the content.
+ * capture from the rack feed instead; the scripted reviewer never looks at the content — and the
+ * device-auth lane above.
  *
  * The exclude lists are complementary by construction (wdio.shared.conf.ts), and capability-level
  * `wdio:exclude` composes with --suite AND --spec — unlike `wdio:specs`, which --suite discards — so
@@ -34,13 +57,18 @@ const androidCaps = {
  * GLOBALLY: at the default 1 the injection lane drains fully, then send-video runs as a strictly
  * serial tail block (the blind-FIFO review queue requires that), retries included.
  *
- * SAUCE_CAMERA_INJECTION=1 collapses to the single injection-on capability (the A/B baseline arm).
+ * SAUCE_CAMERA_INJECTION=1 collapses the first two to the single injection-on capability (the A/B
+ * baseline arm); the device-auth lane stays its own.
  */
 config.capabilities =
   process.env.SAUCE_CAMERA_INJECTION === '1' || SEND_VIDEO_SPECS.length === 0
-    ? [{ ...androidCaps, 'sauce:options': sauceRdcOptions }]
+    ? [{ ...androidCaps, 'wdio:exclude': DEVICE_AUTH_SPECS, 'sauce:options': sauceRdcOptions }, deviceAuthLane]
     : [
-        { ...androidCaps, 'wdio:exclude': SEND_VIDEO_SPECS, 'sauce:options': sauceRdcOptions },
+        {
+          ...androidCaps,
+          'wdio:exclude': [...SEND_VIDEO_SPECS, ...DEVICE_AUTH_SPECS],
+          'sauce:options': sauceRdcOptions,
+        },
         {
           ...androidCaps,
           // Never more than one send-video session even if SAUCE_MAX_INSTANCES is raised — the
@@ -49,6 +77,7 @@ config.capabilities =
           'wdio:exclude': NON_SEND_VIDEO_SPECS,
           'sauce:options': sauceRdcOptionsNoCameraInjection,
         },
+        deviceAuthLane,
       ]
 
 export { config }

--- a/e2e/configs/sauce/wdio.ios.sauce.rdc.conf.ts
+++ b/e2e/configs/sauce/wdio.ios.sauce.rdc.conf.ts
@@ -1,6 +1,6 @@
 // sauce/wdio.ios.sauce.rdc.conf.ts
-import { ANDROID_ONLY_SPECS } from '../wdio.shared.conf.js'
-import { config as sauceConfig, sauceRdcOptions } from './wdio.shared.sauce.conf.js'
+import { ANDROID_ONLY_SPECS, DEVICE_AUTH_SPECS, NON_DEVICE_AUTH_SPECS } from '../wdio.shared.conf.js'
+import { DEVICE_SECURITY_LANE, config as sauceConfig, sauceRdcOptions } from './wdio.shared.sauce.conf.js'
 
 const appFilename = process.env.IOS_APP_FILENAME || 'BCSC-Dev-latest.ipa'
 
@@ -10,27 +10,41 @@ const config = { ...sauceConfig }
 // shared conf may already exclude the send-video journeys (E2E_EXCLUDE_SEND_VIDEO).
 config.exclude = [...(config.exclude ?? []), ...ANDROID_ONLY_SPECS]
 
+const iosCaps = {
+  platformName: 'iOS',
+  'appium:deviceName': process.env.IOS_DEVICE_NAME || 'iPhone.*',
+  'appium:automationName': 'XCUITest',
+  'appium:app': `storage:filename=${appFilename}`,
+  'appium:noReset': false,
+  'appium:fullReset': true,
+  'appium:newCommandTimeout': 180,
+  'appium:autoAcceptAlerts': false,
+  ...(process.env.IOS_PLATFORM_VERSION && {
+    'appium:platformVersion': process.env.IOS_PLATFORM_VERSION,
+  }),
+}
+
+// Pin the OFFICIAL Appium WebDriverAgent (appium3-2026-01+). The shared default `latest` uses Sauce's
+// CUSTOM WDA, whose iOS deep-link open is broken: `mobile: deepLink` with a bundleId throws "The
+// current Xcode SDK does not support opening of URLs with given application", and without a bundleId
+// it falls back to Siri. The official WDA implements the real open. Override via env if it ages out.
+const iosSauceOptions = {
+  ...sauceRdcOptions,
+  appiumVersion: process.env.SAUCE_APPIUM_VERSION || 'appium3-2026-07',
+}
+
+/**
+ * Two capability lanes: the default session, and the device-authentication lane — the same session
+ * plus a real screen lock and biometric interception, for the device-auth journeys ALONE (a locked
+ * device changes the state every other journey starts from). The exclude lists are complementary, so
+ * `--suite device-auth` schedules only the second lane and a regular suite never inherits the lock.
+ */
 config.capabilities = [
+  { ...iosCaps, 'wdio:exclude': DEVICE_AUTH_SPECS, 'sauce:options': iosSauceOptions },
   {
-    platformName: 'iOS',
-    'appium:deviceName': process.env.IOS_DEVICE_NAME || 'iPhone.*',
-    'appium:automationName': 'XCUITest',
-    'appium:app': `storage:filename=${appFilename}`,
-    'appium:noReset': false,
-    'appium:fullReset': true,
-    'appium:newCommandTimeout': 180,
-    'appium:autoAcceptAlerts': false,
-    ...(process.env.IOS_PLATFORM_VERSION && {
-      'appium:platformVersion': process.env.IOS_PLATFORM_VERSION,
-    }),
-    // Pin the OFFICIAL Appium WebDriverAgent (appium3-2026-01+). The shared default `latest` uses Sauce's
-    // CUSTOM WDA, whose iOS deep-link open is broken: `mobile: deepLink` with a bundleId throws "The
-    // current Xcode SDK does not support opening of URLs with given application", and without a bundleId
-    // it falls back to Siri. The official WDA implements the real open. Override via env if it ages out.
-    'sauce:options': {
-      ...sauceRdcOptions,
-      appiumVersion: process.env.SAUCE_APPIUM_VERSION || 'appium3-2026-07',
-    },
+    ...iosCaps,
+    'wdio:exclude': NON_DEVICE_AUTH_SPECS,
+    'sauce:options': { ...iosSauceOptions, ...DEVICE_SECURITY_LANE },
   },
 ]
 

--- a/e2e/configs/sauce/wdio.shared.sauce.conf.ts
+++ b/e2e/configs/sauce/wdio.shared.sauce.conf.ts
@@ -77,6 +77,16 @@ config.services = [
 ]
 
 /**
+ * The device-auth lane's Sauce options: `setupDeviceLock` sets a real screen lock for the session
+ * (000000 on Android, 089675 on iOS) — the gate behind the app's device-authentication option
+ * (`KeyguardManager.isDeviceSecure` / `LAContext.canEvaluatePolicy(.deviceOwnerAuthentication)`) —
+ * and `biometricsInterception` lets `sauce:biometrics-authenticate` answer the app's prompts. Requested
+ * by the RDC configs' device-auth lane ALONE. The persistent App Storage "Device Passcode" setting stays
+ * OFF on every app group: it would lock the device under every journey of every uploaded build.
+ */
+const DEVICE_SECURITY_LANE = { setupDeviceLock: true, biometricsInterception: true } as const
+
+/**
  * Shared Sauce RDC session options WITHOUT camera injection — the Android send-video lane
  * (see wdio.android.sauce.rdc.conf.ts): injection instruments the whole camera pipeline, which
  * kills the recorder's stop/finalize, and those journeys record from the rack feed instead.
@@ -117,4 +127,4 @@ config.afterTest = async function (test, _context, result) {
   await browser.execute(`sauce:job-result=${result.passed ? 'passed' : 'failed'}`)
 }
 
-export { config, sauceRdcOptions, sauceRdcOptionsNoCameraInjection }
+export { config, DEVICE_SECURITY_LANE, sauceRdcOptions, sauceRdcOptionsNoCameraInjection }

--- a/e2e/configs/wdio.shared.conf.ts
+++ b/e2e/configs/wdio.shared.conf.ts
@@ -43,6 +43,17 @@ export const SEND_VIDEO_SPECS = ALL_SPEC_FILES.filter(isSendVideoSpec)
 export const NON_SEND_VIDEO_SPECS = ALL_SPEC_FILES.filter((path) => !isSendVideoSpec(path))
 
 /**
+ * The device-authentication journeys, partitioned the same way. They need a session whose device
+ * carries a screen lock plus biometric interception (`setupDeviceLock` + `biometricsInterception`), and
+ * a locked device changes the state every OTHER journey starts from — the secure-app step renders two
+ * options, the device can lock mid-session — so the Sauce configs give them a capability lane of their
+ * own and exclude them from every other lane. Never a global switch.
+ */
+const isDeviceAuthSpec = (path: string) => /\/device-auth\/[^/]+\.journey\.ts$/.test(path)
+export const DEVICE_AUTH_SPECS = ALL_SPEC_FILES.filter(isDeviceAuthSpec)
+export const NON_DEVICE_AUTH_SPECS = ALL_SPEC_FILES.filter((path) => !isDeviceAuthSpec(path))
+
+/**
  * `E2E_EXCLUDE_SEND_VIDEO=1` drops the send-video journeys from whatever suite runs. They review a
  * shared, blind-FIFO agent queue and must never run on two platforms at once, so CI keeps them out
  * of the concurrent device matrix and runs them one platform at a time via `--suite send-video`.
@@ -101,6 +112,9 @@ export const config: WebdriverIO.Config = {
     scan: ANDROID_ONLY_SPECS,
     // Automated accessibility audits over the core unverified screens (src/helpers/a11y-audit.ts).
     a11y: [resolve(__dirname, `../test/${variant}/a11y/*.journey.ts`)],
+    // Device authentication on a LOCKED device (Sauce RDC only): its own capability lane, and not in
+    // `regression` — see DEVICE_AUTH_SPECS.
+    'device-auth': DEVICE_AUTH_SPECS,
     // Nightly full run: every per-area journey.
     // Excludes `migration` and `upgrade` — those suites boot an OLD build via their own configs, so
     // they cannot share this run's v4 RDC build (each stays its own suite + workflow path).

--- a/e2e/src/brief/coverage-map.ts
+++ b/e2e/src/brief/coverage-map.ts
@@ -275,9 +275,9 @@ export const UAT_CHECKLIST: CoverageSection[] = [
       {
         id: 'feat-change-security',
         label: 'Change security method (biometrics)',
-        platforms: { ios: 'skipped', android: 'skipped' },
-        proof: [],
-        note: 'skipped for e2e 2026-08-28 — device biometrics owned by the UAT team',
+        platforms: both,
+        proof: [{ file: spec('device-auth/device-auth.journey.ts') }],
+        note: 'the device-auth lane: a Sauce session with a screen lock + biometric interception (setupDeviceLock, biometricsInterception); switches to a PIN, unlocks with it, switches back. The prompt is answered by sauce:biometrics-authenticate, which drives the same code path a real match does — the app binds no key to the sensor',
       },
       {
         id: 'feat-change-pin',
@@ -495,6 +495,13 @@ export const OTHER_COVERAGE: CoverageSection[] = [
       { id: 'j-settings', label: 'Main: settings', platforms: both, proof: [{ file: spec('main/settings.journey.ts') }] },
       { id: 'j-wallet', label: 'Wallet: DIDComm credential lifecycle', platforms: both, proof: [{ file: spec('main/wallet.journey.ts') }] },
       { id: 'j-a11y', label: 'Accessibility: automated audits', platforms: both, proof: [{ file: spec('a11y/accessibility.journey.ts') }] },
+    ],
+  },
+  {
+    id: 'device-auth',
+    title: 'Device authentication (Sauce device-lock lane)',
+    rows: [
+      { id: 'j-device-auth', label: 'Device auth: onboarding, unlock and the security switch', platforms: both, proof: [{ file: spec('device-auth/device-auth.journey.ts') }] },
     ],
   },
   {

--- a/e2e/src/flows/auth.ts
+++ b/e2e/src/flows/auth.ts
@@ -1,7 +1,8 @@
 import { TEST_PIN, Timeouts } from '../constants.js'
+import { isBiometricPromptShowing, matchBiometric } from '../helpers/biometrics.js'
 import { getCurrentAppId } from '../helpers/deep-link.js'
 import { describeCurrentScreen } from '../helpers/screens.js'
-import { AccountLandingScreen, EnterPINScreen } from '../screens/auth.js'
+import { AccountLandingScreen, ConfirmDeviceAuthScreen, EnterPINScreen } from '../screens/auth.js'
 import type { ScreenPresence } from '../screens/core/defineScreen.js'
 import { HomeScreen } from '../screens/main.js'
 import { OnboardingIntroScreen } from '../screens/onboarding.js'
@@ -118,4 +119,65 @@ export async function unlockWithPin(
   } else if (landing !== 'any') {
     await landing.expectVisible(Timeouts.APP_LAUNCH)
   }
+}
+
+/** Whether the "Confirm it's your device" interstitial is expected on the way to the prompt. */
+export type InterstitialExpectation = 'expect' | 'absent' | 'either'
+
+/**
+ * Unlock a DEVICE-AUTH account: AccountLanding → Unlock → the "Confirm it's your device" interstitial
+ * (shown before every device-auth unlock until its checkbox is ticked) → the OS prompt, matched
+ * through Sauce's interception → Home. Sauce RDC only, on a session with a device lock.
+ *
+ * `interstitial` asserts the app's own memory of the checkbox: 'expect' fails if it is not shown,
+ * 'absent' fails if it is; `hideInterstitial` ticks "do not show me this again" on the way through.
+ */
+export async function unlockWithDeviceAuth(
+  options: { relaunch?: boolean; interstitial?: InterstitialExpectation; hideInterstitial?: boolean } = {}
+): Promise<void> {
+  if (options.relaunch) {
+    await relaunchApp()
+  }
+
+  await selectAccountLandingIfPresent()
+  await AccountLandingScreen.tap('primary')
+
+  const interstitial = options.interstitial ?? 'either'
+  const shown = await ConfirmDeviceAuthScreen.isPresent(
+    interstitial === 'absent' ? Timeouts.ELEMENT_VISIBLE : Timeouts.SCREEN_TRANSITION
+  )
+  if (interstitial === 'expect' && !shown) {
+    throw new Error(`The device-auth interstitial did not appear. On screen: ${await describeCurrentScreen()}`)
+  }
+  if (interstitial === 'absent' && shown) {
+    throw new Error('The device-auth interstitial appeared although "do not show me this again" was ticked')
+  }
+  if (shown) {
+    if (options.hideInterstitial) {
+      await ConfirmDeviceAuthScreen.link('hideConfirmation')
+    }
+    await ConfirmDeviceAuthScreen.tap('primary')
+  }
+
+  await matchBiometric()
+  await HomeScreen.expectVisible(Timeouts.APP_LAUNCH)
+}
+
+/**
+ * Recover from a failed device-auth match the way a user does. Sauce's `=false` settles the prompt as
+ * a terminal failure on both platforms (measured: the prompt closes and the app is back on the screen
+ * that raised it — the interstitial, or AccountLanding once that is hidden), so the unlock is
+ * re-raised from there; a prompt that stayed open is simply answered again. Ends on Home.
+ */
+export async function recoverFromFailedDeviceAuth(): Promise<void> {
+  if (!(await isBiometricPromptShowing())) {
+    if (await AccountLandingScreen.isPresent(Timeouts.ELEMENT_VISIBLE)) {
+      await AccountLandingScreen.tap('primary')
+    }
+    if (await ConfirmDeviceAuthScreen.isPresent(Timeouts.ELEMENT_VISIBLE)) {
+      await ConfirmDeviceAuthScreen.tap('primary')
+    }
+  }
+  await matchBiometric()
+  await HomeScreen.expectVisible(Timeouts.APP_LAUNCH)
 }

--- a/e2e/src/flows/onboarding.ts
+++ b/e2e/src/flows/onboarding.ts
@@ -88,15 +88,11 @@ export async function answerNotificationPermission(decision: 'allow' | 'deny'): 
 }
 
 /**
- * Complete the full onboarding walk from a fresh cold start, ending on the VerifyPrompt.
- *
- * Declines analytics and skips push notifications (avoids the OS permission dialog) so the arrange
- * has minimal side effects; journeys that test those choices drive the screens directly instead.
- *
- * The VerifyPrompt exists only in this session — relaunching afterwards lands on
- * AccountLanding → EnterPIN → Home, never back here (its gate is in-memory in the app).
+ * Fresh cold start → the "Secure your app" selector, declining analytics and skipping push
+ * notifications on the way. The shared head of {@link completeOnboarding}; the device-auth journey
+ * takes the selector's other option from here.
  */
-export async function completeOnboarding(pin: string = TEST_PIN): Promise<void> {
+export async function reachSecureApp(): Promise<void> {
   await OnboardingIntroScreen.expectVisible(Timeouts.COLD_START)
   await OnboardingIntroScreen.tap('primary')
 
@@ -113,6 +109,19 @@ export async function completeOnboarding(pin: string = TEST_PIN): Promise<void> 
   await skipNotificationsIfShown()
 
   await OnboardingSecureAppScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+}
+
+/**
+ * Complete the full onboarding walk from a fresh cold start, ending on the VerifyPrompt.
+ *
+ * Declines analytics and skips push notifications (avoids the OS permission dialog) so the arrange
+ * has minimal side effects; journeys that test those choices drive the screens directly instead.
+ *
+ * The VerifyPrompt exists only in this session — relaunching afterwards lands on
+ * AccountLanding → EnterPIN → Home, never back here (its gate is in-memory in the app).
+ */
+export async function completeOnboarding(pin: string = TEST_PIN): Promise<void> {
+  await reachSecureApp()
   await OnboardingSecureAppScreen.tap('primary')
 
   await OnboardingCreatePINScreen.expectVisible(Timeouts.SCREEN_TRANSITION)

--- a/e2e/src/helpers/biometrics.ts
+++ b/e2e/src/helpers/biometrics.ts
@@ -6,11 +6,15 @@ function bioLog(message: string): void {
   console.log(`[biometrics] ${message}`)
 }
 
-/** Subtitle set in bcsc-core `DeviceAuthenticationService` / `BcscCoreModule.performDeviceAuthentication`. */
+/**
+ * The app's own `BiometricPrompt`: title = the reason the JS passes (onboarding, unlock, security
+ * switch), subtitle = the fixed "Please authenticate to …" from `BcscCoreModule`. Any of them proves
+ * the prompt is up.
+ */
 const ANDROID_BIOMETRIC_SUBTITLE_SEL =
-  '//android.widget.TextView[contains(@text,"Sign in with FingerPrint") or contains(@text,"Sign in with FaceID") or contains(@text,"Authenticate to secure your app")]'
+  '//android.widget.TextView[contains(@text,"Please authenticate to") or contains(@text,"Authenticate to secure your app") or contains(@text,"Unlock your app") or contains(@text,"Authenticate to change your security method")]'
 
-/** iOS system biometric sheet (en — adjust if running localized Sauce sessions). */
+/** Sauce's interception sheet on iOS — titled after whatever biometry the pool device carries. */
 const IOS_BIOMETRIC_LABEL_SEL =
   '-ios class chain:**/XCUIElementTypeStaticText[`label CONTAINS "Touch ID Verification" OR label CONTAINS "Face ID Verification"`]'
 
@@ -28,6 +32,13 @@ async function waitForNativeBiometricPromptOnSauceRdc(): Promise<void> {
   })
 
   bioLog('Sauce RDC: biometric prompt is visible')
+}
+
+/** True while the prompt is on screen; never throws. */
+export async function isBiometricPromptShowing(): Promise<boolean> {
+  return $(driver.isIOS ? IOS_BIOMETRIC_LABEL_SEL : ANDROID_BIOMETRIC_SUBTITLE_SEL)
+    .isDisplayed()
+    .catch(() => false)
 }
 
 export async function matchBiometric() {

--- a/e2e/src/helpers/sauce.ts
+++ b/e2e/src/helpers/sauce.ts
@@ -13,3 +13,16 @@ export async function annotate(message: string) {
     await browser.execute(`sauce:context=${message}`)
   }
 }
+
+/**
+ * Whether THIS session asked Sauce for a locked device WITH biometric interception — the device-auth
+ * lane. Read off the requested `sauce:options`, so a journey that needs the lane can skip instead of
+ * failing on a missing option when it is run anywhere else.
+ */
+export function isDeviceSecurityLane(): boolean {
+  if (!isSauceLabs()) return false
+  const options = (driver.requestedCapabilities as Record<string, unknown>)['sauce:options'] as
+    | { setupDeviceLock?: boolean; biometricsInterception?: boolean }
+    | undefined
+  return options?.setupDeviceLock === true && options?.biometricsInterception === true
+}

--- a/e2e/src/screens/auth.ts
+++ b/e2e/src/screens/auth.ts
@@ -52,6 +52,31 @@ export const EnterPINScreen = defineScreen({
 })
 
 /**
+ * "Confirm it's your device" (`DeviceAuthInfo`) — the interstitial before EVERY device-auth unlock
+ * until `hideConfirmation` is ticked. `primary` (Continue) raises the OS prompt. Keyed on the checkbox
+ * because `Continue` is shared by a dozen screens.
+ */
+export const ConfirmDeviceAuthScreen = defineScreen({
+  self: bcsc(auth.confirmDeviceAuthInfo.hideConfirmation),
+  primary: bcsc(auth.confirmDeviceAuthInfo.continue),
+  links: {
+    hideConfirmation: bcsc(auth.confirmDeviceAuthInfo.hideConfirmation),
+  },
+})
+
+/**
+ * "App reset for security" (`DeviceAuthAppReset`) — where a device-auth account lands when the OS
+ * lock was removed after enrolment. Assert only: `primary` (SetUpApp) factory-resets the app.
+ */
+export const DeviceAuthAppResetScreen = defineScreen({
+  self: bcsc(auth.deviceAuthAppReset.setUpApp),
+  primary: bcsc(auth.deviceAuthAppReset.setUpApp),
+  links: {
+    learnMore: bcsc(auth.deviceAuthAppReset.learnMore),
+  },
+})
+
+/**
  * Timed lockout screen (route "Too many PIN attempts") — shown after five consecutive wrong PINs.
  * The native attempt counter persists across relaunches and escalates (5 → 1 min, 10 → 10 min, …);
  * `AccountLanding`'s Unlock goes straight here while locked. `RemoveAccount` (factory reset) is the

--- a/e2e/src/screens/main.ts
+++ b/e2e/src/screens/main.ts
@@ -176,11 +176,37 @@ export const SettingsRowIds = {
   autoLock: bcsc(main.settings.autoLock),
 } as const
 
-/** App Security (`MainChangeSecurity` → SecurityMethodSelector). `self` is the always-present
- *  `ChoosePINButton`; return via header `back`. */
+/**
+ * App Security (`MainChangeSecurity` → SecurityMethodSelector). `self` is the always-present
+ * `ChoosePINButton`; return via header `back`. `deviceAuth` renders only when the OS calls the device
+ * secure (same id as the onboarding selector — it is the same component); in settings the current
+ * method's card is the selected one.
+ */
 export const AppSecurityScreen = defineScreen({
   self: bcsc(main.appSecurity.choosePin),
   back: bcsc(common.back),
+  links: {
+    pin: bcsc(main.appSecurity.choosePin),
+    deviceAuth: bcsc(TestIds.onboarding.secureApp.chooseDeviceAuth),
+  },
+})
+
+/**
+ * The device-auth → PIN form (`MainChangePIN` WITHOUT `isChangingExistingPIN`): `PINEntryForm` again, so
+ * the onboarding CreatePIN ids — except the button, which is the generic `Continue`. Success pops
+ * both it and App Security, landing back on Settings.
+ */
+export const SwitchToPinScreen = defineScreen({
+  self: bcsc(TestIds.onboarding.createPin.pin),
+  primary: bcsc(TestIds.onboarding.createPin.continue),
+  back: bcsc(common.back),
+  inputs: {
+    pin: bcsc(TestIds.onboarding.createPin.pin),
+    confirmPin: bcsc(TestIds.onboarding.createPin.confirmPin),
+  },
+  links: {
+    understand: bcsc(TestIds.onboarding.createPin.understand),
+  },
 })
 
 /**

--- a/e2e/test/bcsc/device-auth/device-auth.journey.ts
+++ b/e2e/test/bcsc/device-auth/device-auth.journey.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict'
+import { TEST_PIN, Timeouts } from '../../../src/constants.js'
+import { recoverFromFailedDeviceAuth, relaunchApp, selectAccountLandingIfPresent, unlockWithDeviceAuth } from '../../../src/flows/auth.js'
+import { reachSecureApp } from '../../../src/flows/onboarding.js'
+import { failBiometric, matchBiometric } from '../../../src/helpers/biometrics.js'
+import { isDeviceSecurityLane } from '../../../src/helpers/sauce.js'
+import { describeCurrentScreen } from '../../../src/helpers/screens.js'
+import { AccountLandingScreen, ConfirmDeviceAuthScreen } from '../../../src/screens/auth.js'
+import { AppSecurityScreen, HomeScreen, SettingsScreen, SwitchToPinScreen } from '../../../src/screens/main.js'
+import { OnboardingSecureAppScreen, VerifyPromptScreen } from '../../../src/screens/onboarding.js'
+
+/**
+ * Device-authentication journey — the app's other security method, end to end.
+ *
+ * Runs ONLY on the device-auth lane: a Sauce RDC session whose device carries a screen lock
+ * (`setupDeviceLock`) and biometric interception (`biometricsInterception`). The lock is what makes
+ * the app offer the option at all — `KeyguardManager.isDeviceSecure` / `canEvaluatePolicy` — and
+ * interception is what answers the app's own prompts (`sauce:biometrics-authenticate`). A mocked
+ * answer drives exactly the path a real match does: the app binds no key to the sensor, so success
+ * means "read the stored hash and rotate the wallet key" either way.
+ *
+ * Ordered, state-carrying checkpoints: onboard on device auth → relaunch/unlock through the
+ * interstitial → a failed match, then the retry → the interstitial's "do not show me this again" →
+ * Settings: switch to a PIN (the Change PIN row appears) → switch back (it disappears) → a final
+ * relaunch proves the switch persisted. Out of scope: "App reset for security", which the app shows
+ * when the OS lock is removed after enrolment — the cloud cannot remove a lock mid-session.
+ */
+
+/** The availability gate resolves asynchronously, so the option lands after the screen does. */
+const DEVICE_AUTH_OPTION_WAIT_MS = 15_000
+
+async function expectDeviceAuthOption(): Promise<void> {
+  const deadline = Date.now() + DEVICE_AUTH_OPTION_WAIT_MS
+  do {
+    if (await OnboardingSecureAppScreen.isVisible('deviceAuth')) return
+  } while (Date.now() < deadline)
+  throw new Error(
+    `The device-auth option never rendered on the secure-app step — the OS does not call this device secure. On screen: ${await describeCurrentScreen()}`
+  )
+}
+
+describe('Device-auth journey: onboarding, unlock and the security switch', () => {
+  before(function () {
+    if (!isDeviceSecurityLane()) {
+      return this.skip()
+    }
+  })
+
+  it('onboards on device authentication and skips to unverified Home', async () => {
+    await reachSecureApp()
+    await expectDeviceAuthOption()
+    await OnboardingSecureAppScreen.link('deviceAuth')
+    await matchBiometric() // "Authenticate to secure your app"
+    await VerifyPromptScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    await VerifyPromptScreen.tap('secondary')
+    await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('relaunches and unlocks through the device-auth interstitial', async () => {
+    await unlockWithDeviceAuth({ relaunch: true, interstitial: 'expect' }) // "Unlock your app"
+  })
+
+  it('stays locked on a failed match and unlocks on the retry', async () => {
+    await relaunchApp()
+    await selectAccountLandingIfPresent()
+    await AccountLandingScreen.tap('primary')
+    await ConfirmDeviceAuthScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    await ConfirmDeviceAuthScreen.tap('primary')
+
+    await failBiometric()
+    if (await HomeScreen.isPresent(Timeouts.ELEMENT_VISIBLE)) {
+      throw new Error('A failed device-auth match unlocked the app')
+    }
+    await recoverFromFailedDeviceAuth()
+  })
+
+  it('hides the interstitial once "do not show me this again" is ticked', async () => {
+    await unlockWithDeviceAuth({ relaunch: true, interstitial: 'expect', hideInterstitial: true })
+    await unlockWithDeviceAuth({ relaunch: true, interstitial: 'absent' })
+  })
+
+  it('switches to a PIN from App Security and the Change PIN row appears', async () => {
+    await HomeScreen.tap('menu')
+    await SettingsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    assert.equal(await SettingsScreen.isVisible('changePin'), false, 'Change PIN must be absent for a device-auth account')
+
+    await SettingsScreen.link('appSecurity')
+    await AppSecurityScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    assert.ok(await AppSecurityScreen.isVisible('deviceAuth'), 'the device-auth card must render on a locked device')
+    await AppSecurityScreen.link('pin')
+
+    await SwitchToPinScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    await SwitchToPinScreen.fill('pin', TEST_PIN)
+    await SwitchToPinScreen.fill('confirmPin', TEST_PIN)
+    await SwitchToPinScreen.link('understand')
+    await SwitchToPinScreen.tapWhenEnabled('primary')
+
+    // Success pops both the form and App Security.
+    await SettingsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    await SettingsScreen.waitFor('changePin', Timeouts.SCREEN_TRANSITION)
+  })
+
+  it('switches back to device authentication and unlocks with it after a relaunch (terminal)', async () => {
+    await SettingsScreen.link('appSecurity')
+    await AppSecurityScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    await AppSecurityScreen.link('deviceAuth')
+    await matchBiometric() // "Authenticate to change your security method"
+
+    await SettingsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    assert.equal(await SettingsScreen.isVisible('changePin'), false, 'Change PIN must disappear once the method is device auth again')
+    await SettingsScreen.back.tap()
+    await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+
+    // The checkbox was ticked earlier, so the interstitial must stay hidden.
+    await unlockWithDeviceAuth({ relaunch: true, interstitial: 'absent' })
+  })
+})

--- a/e2e/test/bcsc/device-auth/device-auth.journey.ts
+++ b/e2e/test/bcsc/device-auth/device-auth.journey.ts
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict'
 import { TEST_PIN, Timeouts } from '../../../src/constants.js'
-import { recoverFromFailedDeviceAuth, relaunchApp, selectAccountLandingIfPresent, unlockWithDeviceAuth } from '../../../src/flows/auth.js'
+import {
+  recoverFromFailedDeviceAuth,
+  relaunchApp,
+  selectAccountLandingIfPresent,
+  unlockWithDeviceAuth,
+  unlockWithPin,
+} from '../../../src/flows/auth.js'
 import { reachSecureApp } from '../../../src/flows/onboarding.js'
 import { failBiometric, matchBiometric } from '../../../src/helpers/biometrics.js'
 import { isDeviceSecurityLane } from '../../../src/helpers/sauce.js'
@@ -21,9 +27,10 @@ import { OnboardingSecureAppScreen, VerifyPromptScreen } from '../../../src/scre
  *
  * Ordered, state-carrying checkpoints: onboard on device auth → relaunch/unlock through the
  * interstitial → a failed match, then the retry → the interstitial's "do not show me this again" →
- * Settings: switch to a PIN (the Change PIN row appears) → switch back (it disappears) → a final
- * relaunch proves the switch persisted. Out of scope: "App reset for security", which the app shows
- * when the OS lock is removed after enrolment — the cloud cannot remove a lock mid-session.
+ * Settings: switch to a PIN (the Change PIN row appears) → relaunch and unlock with that PIN →
+ * switch back to device auth (the row disappears) → a final relaunch unlocks on device auth again.
+ * Out of scope: "App reset for security", which the app shows when the OS lock is removed after
+ * enrolment — the cloud cannot remove a lock mid-session.
  */
 
 /** The availability gate resolves asynchronously, so the option lands after the screen does. */
@@ -100,7 +107,14 @@ describe('Device-auth journey: onboarding, unlock and the security switch', () =
     await SettingsScreen.waitFor('changePin', Timeouts.SCREEN_TRANSITION)
   })
 
+  it('relaunches and unlocks with the PIN', async () => {
+    // AccountLanding → EnterPIN → Home, no interstitial and no prompt: the PIN is the live method.
+    await unlockWithPin(TEST_PIN, { relaunch: true })
+  })
+
   it('switches back to device authentication and unlocks with it after a relaunch (terminal)', async () => {
+    await HomeScreen.tap('menu')
+    await SettingsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
     await SettingsScreen.link('appSecurity')
     await AppSecurityScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
     await AppSecurityScreen.link('deviceAuth')


### PR DESCRIPTION
Closes #4637

## What changed

Adds device-authentication e2e coverage on Sauce Real Device Cloud. A new `device-auth` suite runs on its own capability lane (session screen lock + biometric interception) with a journey covering onboarding on device auth, unlock, a failed match, and the PIN ↔ device-auth switch. No other suite ever runs with a locked device.

- `test/bcsc/device-auth/device-auth.journey.ts`: onboard on device auth → relaunch unlock through the "Confirm it's your device" interstitial → failed match + retry → hide-interstitial checkbox → switch to PIN → unlock with the PIN → switch back → unlock with device auth. Skips itself off the lane.
- Configs: `DEVICE_AUTH_SPECS` partition in `wdio.shared.conf.ts`; both RDC configs add a lane requesting `setupDeviceLock` + `biometricsInterception` and exclude those specs from every other lane. Not part of `regression`.
- Flows/screens/helpers: `unlockWithDeviceAuth`, `recoverFromFailedDeviceAuth`, `reachSecureApp`; `ConfirmDeviceAuthScreen`, `DeviceAuthAppResetScreen`, `SwitchToPinScreen`; Android prompt matcher now covers the unlock and security-switch titles; `isDeviceSecurityLane()`.
- CI: `device-auth` suite choice in `e2e.yml`; `e2e-device-auth` nightly job last in the chain, reported to the brief as its own lane.
- Coverage map: "Change security method (biometrics)" flipped from skipped to automated; README suite row + section.

App code untouched — no new testIDs.

## What should the reviewer focus on

- `wdio.android.sauce.rdc.conf.ts` / `wdio.ios.sauce.rdc.conf.ts`: the `wdio:exclude` lists must stay complementary so a regular suite never inherits the lock. Android now has three lanes, and the `SAUCE_CAMERA_INJECTION=1` collapse keeps the device-auth lane separate.
- `e2e-nightly.yml`: the new job's `needs`/`if` chain and the brief's `--lane device-auth`. It is blocking, like the regression.

## How to test

```sh
cd e2e
SAUCE_SPEC_RETRIES=0 yarn test:android:sauce --suite device-auth
SAUCE_SPEC_RETRIES=0 yarn test:ios:sauce --suite device-auth
yarn typecheck && yarn brief:check
```

Ran green 7/7 on both platforms on 2026-09-11 (BCSC-Dev-8204): Sauce jobs `76d8b4bd57944391ba1df3ad82ffad53` (Pixel 9, Android 15) and `fdad5e05d2dd4d81835b7195ef0e8b7b` (iPhone 15 Pro, iOS 18.7.2). Any regular suite, e.g. `--suite smoke`, should still land on the default lane with the PIN-only secure-app step.
