### PR TITLE
fix: e2e nightly consistency + clean up brief

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -636,13 +636,13 @@ Every nightly run ends with a **brief** — one page on the run's Summary tab (a
 | Symbol | Meaning |
 | --- | --- |
 | ✅ / ❌ | every listed checkpoint passed / at least one failed |
-| ⛔ blocked | skipped because an earlier checkpoint in the same file failed (`mochaOpts.bail`) |
+| ⛔ blocked | never ran because an earlier checkpoint in the same file failed (`mochaOpts.bail`) — the reporter writes nothing for those, so the brief counts them from the spec's `it` titles |
 | ⏭️ skipped | a runtime `this.skip()` — an env or data gate (Sauce-only, iOS-only, missing SIT data) |
 | ⬜ not run | no result for it in these reports (lane not run, spec not scheduled, worker never got a session) |
 | ➖ n/a | not applicable on that platform (e.g. card-barcode scanning on iOS) |
 | 📝 manual | proved by the UAT team, not automation — the manual script is linked |
 
-Cells show `passed/listed` plus tallies when not everything listed passed (`✅ 4/5 ⏭1`). The rows come from `src/brief/coverage-map.ts` — each UAT row names the spec files and exact `it` titles that prove it, per platform — and `yarn brief:check` (the brief job runs it first) fails when a listed title no longer exists or a journey under `test/bcsc/` is not mapped, so renaming a checkpoint means updating the map.
+Cells show `passed/listed` plus tallies when not everything listed passed (`✅ 4/5 ⏭1`). The rows come from `src/brief/coverage-map.ts` — each UAT row names the spec files and exact `it` titles that prove it, per platform — and `yarn brief:check` (the brief job runs it first) fails when a listed title no longer exists or a journey under `test/bcsc/` is not mapped, so renaming a checkpoint means updating the map. `smoke.spec.ts` is the PR gate and has no row: the nightly never schedules it.
 
 ```bash
 yarn brief --reports reports                                   # the brief for a local run, to stdout

--- a/e2e/scripts/brief-check.ts
+++ b/e2e/scripts/brief-check.ts
@@ -164,6 +164,18 @@ function selfTest(): void {
   const migration = cellOf(model, 'ext-migration-v3', 'android')
   assert.deepEqual([migration.status, migration.passed, migration.listed], ['pass', 6, 6])
   assert.equal(cellOf(model, 'j-migration-upgrade', 'android').status, 'pass')
+  // …and when it bails mid-file (iOS fixture): the remainder comes from the sources, and a describe it never reached is blocked
+  const migrationSources = ['v3-onboarding', 'v3-to-v4-upgrade', 'v4-unlock'].map((name) => `test/bcsc/migration/${name}.spec.ts`)
+  const migrationTitles = migrationSources.flatMap((source) => specTitles(source)?.its ?? [])
+  const migrationIos = cellOf(model, 'ext-migration-v3', 'ios').auto
+  assert.deepEqual(
+    [migrationIos?.status, migrationIos?.passed, migrationIos?.failed, migrationIos?.blocked, migrationIos?.listed],
+    ['fail', 3, 1, migrationTitles.length - 4, migrationTitles.length]
+  )
+  const unlockIos = cellOf(model, 'j-migration-v4-unlock', 'ios').auto
+  assert.deepEqual([unlockIos?.status, unlockIos?.blocked, unlockIos?.listed], ['blocked', 2, 2])
+  assert.equal(cellOf(model, 'j-migration-v3-add-card', 'ios').auto?.status, 'pass')
+  assert.equal(model.failures.find((entry) => entry.platform === 'ios' && entry.file.endsWith('migration.spec.ts'))?.blockedAfter, migrationTitles.length - 4)
   // a worker that never got a session
   assert.equal(model.runnerErrors.length, 1)
   assert.equal(model.runnerErrors[0].platform, 'android')
@@ -185,7 +197,7 @@ function selfTest(): void {
   assert.deepEqual([birthdate?.newErrors, birthdate?.inBaseline, birthdate?.warnings], [1, false, 1])
 
   const markdown = renderMarkdown(model)
-  for (const heading of ['### UAT checklist', '### Failures (3)', '### Accessibility', '### Legend']) {
+  for (const heading of ['### UAT checklist', '### Failures (4)', '### Accessibility', '### Legend']) {
     assert.ok(markdown.includes(heading), `markdown has ${heading}`)
   }
 }

--- a/e2e/scripts/brief-check.ts
+++ b/e2e/scripts/brief-check.ts
@@ -4,11 +4,12 @@
  * Map checks: unique row ids; every proof file (and source) exists; every `suite` is a describe in its
  * sources; every listed `it` title is in its file verbatim (a renamed checkpoint fails here instead of
  * quietly rendering as "not run"); no two titles in a file collide once the JUnit reporter sanitizes
- * them; every journey/spec under test/bcsc is mapped in OTHER_COVERAGE.
+ * them; every journey/spec under test/bcsc is mapped in OTHER_COVERAGE (bar the PR-gate smoke spec).
  *
- * Self-test: `scripts/fixtures/brief/` holds hand-written reports covering the bail cascade, runtime
- * skips, a retried suite, a failed before() hook, a worker with no session, the migration
- * orchestrator's shared file and the a11y baseline — each asserted below.
+ * Self-test: `scripts/fixtures/brief/` holds hand-written reports covering the bail cascade (reported
+ * and unreported), runtime skips (and the reporter's doubled skip), a retried suite, a failed before()
+ * hook, a worker with no session, the migration orchestrator's shared file and the a11y baseline — each
+ * asserted below.
  *
  *   yarn brief:check        exit 1 on any problem, listed on stderr
  */
@@ -19,8 +20,9 @@ import { fileURLToPath } from 'node:url'
 import { buildBrief, resolveReportDirs } from '../src/brief/build.js'
 import { OTHER_COVERAGE, UAT_CHECKLIST, type CoverageRow } from '../src/brief/coverage-map.js'
 import type { CellResult } from '../src/brief/evaluate.js'
-import { sanitizeTitle } from '../src/brief/junit.js'
+import { parseJunitXml, sanitizeTitle } from '../src/brief/junit.js'
 import { renderMarkdown, type BriefModel } from '../src/brief/render.js'
+import { type SpecTitles, specTitles } from '../src/brief/spec-titles.js'
 import type { Platform } from '../src/brief/types.js'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
@@ -34,25 +36,11 @@ const fail = (message: string): void => {
 
 // --- the map ----------------------------------------------------------------------------------------
 
-/** `it('…')` / `describe("…")` titles in a spec, with the quote escapes undone. */
-function titlesIn(source: string): { its: Set<string>; describes: Set<string> } {
-  const its = new Set<string>()
-  const describes = new Set<string>()
-  const pattern = /\b(it|describe)(?:\.(?:skip|only))?\(\s*(['"`])((?:\\[\s\S]|(?!\2)[^\\])*)\2/g
-  for (const match of source.matchAll(pattern)) {
-    const title = match[3].replace(/\\(['"`\\])/g, '$1')
-    ;(match[1] === 'it' ? its : describes).add(title)
-  }
-  return { its, describes }
-}
+/** Specs the PR gate runs and the nightly never schedules — a row would only ever read "not run". */
+const NOT_IN_NIGHTLY = new Set(['test/bcsc/smoke.spec.ts'])
 
-const specCache = new Map<string, ReturnType<typeof titlesIn>>()
-function spec(file: string): ReturnType<typeof titlesIn> | undefined {
-  const path = join(E2E_ROOT, file)
-  if (!existsSync(path)) return undefined
-  if (!specCache.has(file)) specCache.set(file, titlesIn(readFileSync(path, 'utf8')))
-  return specCache.get(file)
-}
+/** Every spec the map names, for the collision check. */
+const mappedFiles = new Set<string>()
 
 function checkRow(row: CoverageRow, seenIds: Set<string>): void {
   if (seenIds.has(row.id)) fail(`duplicate row id "${row.id}"`)
@@ -61,21 +49,22 @@ function checkRow(row: CoverageRow, seenIds: Set<string>): void {
     const files = proof.sources ?? [proof.file]
     for (const file of [proof.file, ...(proof.sources ?? [])]) {
       if (!existsSync(join(E2E_ROOT, file))) fail(`${row.id}: ${file} does not exist`)
+      mappedFiles.add(file)
     }
-    const parsed = files.map(spec).filter((entry): entry is ReturnType<typeof titlesIn> => entry !== undefined)
-    if (proof.suite && !parsed.some((entry) => entry.describes.has(proof.suite as string))) {
+    const parsed = files.map(specTitles).filter((entry): entry is SpecTitles => entry !== undefined)
+    if (proof.suite && !parsed.some((entry) => entry.describes.includes(proof.suite as string))) {
       fail(`${row.id}: no describe('${proof.suite}') in ${files.join(', ')}`)
     }
     for (const title of proof.tests ?? []) {
-      if (!parsed.some((entry) => entry.its.has(title))) fail(`${row.id}: no it('${title}') in ${files.join(', ')}`)
+      if (!parsed.some((entry) => entry.its.includes(title))) fail(`${row.id}: no it('${title}') in ${files.join(', ')}`)
     }
   }
 }
 
 function checkCollisions(): void {
-  for (const [file, parsed] of specCache) {
+  for (const file of mappedFiles) {
     const seen = new Map<string, string>()
-    for (const title of parsed.its) {
+    for (const title of specTitles(file)?.its ?? []) {
       const key = sanitizeTitle(title)
       const other = seen.get(key)
       if (other && other !== title) fail(`${file}: "${title}" and "${other}" are the same title once sanitized`)
@@ -101,7 +90,7 @@ function checkUnmapped(): void {
     .map((entry) => `test/bcsc/${entry}`)
     .sort()
   for (const file of specs) {
-    if (!mapped.has(file)) fail(`${file} is not in OTHER_COVERAGE — add a row so the brief shows it`)
+    if (!mapped.has(file) && !NOT_IN_NIGHTLY.has(file)) fail(`${file} is not in OTHER_COVERAGE — add a row so the brief shows it`)
   }
 }
 
@@ -154,9 +143,23 @@ function selfTest(): void {
   assert.deepEqual([rerouteAndroid.status, rerouteAndroid.passed, rerouteAndroid.listed], ['pass', 2, 4])
   const videoCall = cellOf(model, 'photo-video-call', 'ios')
   assert.deepEqual([videoCall.status, videoCall.auto], ['manual', undefined])
-  // a failed before() hook fails the row
+  // a failed before() hook fails the row; nothing ran, so every checkpoint in the file is blocked
+  const walletTitles = specTitles('test/bcsc/main/wallet.journey.ts')?.its ?? []
   const wallet = cellOf(model, 'nav-wallet', 'android')
-  assert.deepEqual([wallet.status, wallet.failed, wallet.listed], ['fail', 1, 1])
+  assert.deepEqual([wallet.status, wallet.failed, wallet.blocked, wallet.listed], ['fail', 1, walletTitles.length, walletTitles.length + 1])
+  // a file that bailed: the reporter wrote nothing for the checkpoints behind the failure — blocked, not "not run"
+  const photoTitles = specTitles('test/bcsc/verify/verified-photo.journey.ts')?.its ?? []
+  const verifiedPhoto = cellOf(model, 'j-verified-photo', 'android')
+  assert.deepEqual(
+    [verifiedPhoto.status, verifiedPhoto.passed, verifiedPhoto.failed, verifiedPhoto.blocked, verifiedPhoto.listed],
+    ['fail', 2, 1, photoTitles.length - 3, photoTitles.length]
+  )
+  const photoInPerson = cellOf(model, 'photo-in-person', 'android')
+  assert.deepEqual([photoInPerson.status, photoInPerson.blocked, photoInPerson.notRun], ['blocked', 1, 0])
+  assert.equal(model.failures.find((entry) => entry.file.endsWith('verified-photo.journey.ts'))?.blockedAfter, photoTitles.length - 3)
+  // the reporter writes a runtime skip twice; the brief counts it once
+  const unverified = cellOf(model, 'j-unverified-main', 'ios')
+  assert.deepEqual([unverified.listed, unverified.skipped], [7, 3])
   // the migration orchestrator reports three suites under one file
   const migration = cellOf(model, 'ext-migration-v3', 'android')
   assert.deepEqual([migration.status, migration.passed, migration.listed], ['pass', 6, 6])
@@ -164,9 +167,12 @@ function selfTest(): void {
   // a worker that never got a session
   assert.equal(model.runnerErrors.length, 1)
   assert.equal(model.runnerErrors[0].platform, 'android')
-  // failures carry the blocked count and hook failures are named as such
+  // failures carry the blocked count (reported skips + the unreported remainder) and hook failures are named as such
+  const settingsReport = parseJunitXml(readFileSync(join(FIXTURES, 'e2e-reports-regression-iOS-18', 'junit', 'wdio-3-0.xml'), 'utf8'), 'fixture')
+  const settingsReported = new Set(settingsReport.suites.flatMap((suite) => suite.tests.map((test) => sanitizeTitle(test.name))))
+  const settingsUnreported = (specTitles('test/bcsc/main/settings.journey.ts')?.its ?? []).filter((title) => !settingsReported.has(sanitizeTitle(title)))
   const settingsFailure = model.failures.find((entry) => entry.file.endsWith('settings.journey.ts'))
-  assert.equal(settingsFailure?.blockedAfter, 6)
+  assert.equal(settingsFailure?.blockedAfter, 6 + settingsUnreported.length)
   assert.equal(model.failures.find((entry) => entry.kind === 'hook')?.suite, 'Wallet journey: DIDComm credential lifecycle')
   // lanes: upgrade produced no reports
   assert.deepEqual(model.lanes.map((lane) => lane.hasReports), [true, false])
@@ -179,7 +185,7 @@ function selfTest(): void {
   assert.deepEqual([birthdate?.newErrors, birthdate?.inBaseline, birthdate?.warnings], [1, false, 1])
 
   const markdown = renderMarkdown(model)
-  for (const heading of ['### UAT checklist', '### Failures (2)', '### Accessibility', '### Legend']) {
+  for (const heading of ['### UAT checklist', '### Failures (3)', '### Accessibility', '### Legend']) {
     assert.ok(markdown.includes(heading), `markdown has ${heading}`)
   }
 }

--- a/e2e/scripts/fixtures/brief/e2e-reports-regression-Android-15/junit/wdio-3-0.xml
+++ b/e2e/scripts/fixtures/brief/e2e-reports-regression-Android-15/junit/wdio-3-0.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="3" failures="1" errors="0" skipped="0">
+  <testsuite name="Verified journey photo card" timestamp="2026-08-28T05:40:10" time="182.553" tests="3" failures="1" errors="0" skipped="0">
+    <properties>
+      <property name="specId" value="0"/>
+      <property name="suiteName" value="Verified journey: photo card"/>
+      <property name="capabilities" value="android.2b291fdh2008n8"/>
+      <property name="file" value="file://./test/bcsc/verify/verified-photo.journey.ts"/>
+    </properties>
+    <testcase classname="android.2b291fdh2008n8.Verified_journey:_photo_card" name="onboards to the verify prompt" time="44.120"/>
+    <testcase classname="android.2b291fdh2008n8.Verified_journey:_photo_card" name="enters the photo serial and submits the birthdate" time="98.301"/>
+    <testcase classname="android.2b291fdh2008n8.Verified_journey:_photo_card" name="resumes to the verification method selection after authorizing" time="40.132">
+      <failure message="None of [methodSelection, home] appeared within 20000ms. On screen: SIT | Verify in person"/>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/e2e/scripts/fixtures/brief/e2e-reports-regression-iOS-18/junit/wdio-2-0.xml
+++ b/e2e/scripts/fixtures/brief/e2e-reports-regression-iOS-18/junit/wdio-2-0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="7" failures="0" errors="0" skipped="3">
-  <testsuite name="Main journey unverified gating" timestamp="2026-08-28T05:30:02" time="264.671" tests="7" failures="0" errors="0" skipped="3">
+<testsuites tests="8" failures="0" errors="0" skipped="4">
+  <testsuite name="Main journey unverified gating" timestamp="2026-08-28T05:30:02" time="264.671" tests="8" failures="0" errors="0" skipped="4">
     <properties>
       <property name="specId" value="0"/>
       <property name="suiteName" value="Main journey: unverified gating"/>
@@ -11,6 +11,9 @@
     <testcase classname="ios.5fc23a1b909c4d.Main_journey:_unverified_gating" name="Home shows exactly one custom card Start verification" time="6.114"/>
     <testcase classname="ios.5fc23a1b909c4d.Main_journey:_unverified_gating" name="the scan FAB opens the ungated QR scanner" time="14.228"/>
     <testcase classname="ios.5fc23a1b909c4d.Main_journey:_unverified_gating" name="an unrecognised QR raises the scan error popup" time="0">
+      <skipped/>
+    </testcase>
+    <testcase classname="ios.5fc23a1b909c4d.Main_journey:_unverified_gating" name="an OpenID credential offer QR is deliberately rejected" time="0">
       <skipped/>
     </testcase>
     <testcase classname="ios.5fc23a1b909c4d.Main_journey:_unverified_gating" name="an OpenID credential offer QR is deliberately rejected" time="0">

--- a/e2e/scripts/fixtures/brief/e2e-reports-regression-iOS-18/junit/wdio-5-0.xml
+++ b/e2e/scripts/fixtures/brief/e2e-reports-regression-iOS-18/junit/wdio-5-0.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="4" failures="1" errors="0" skipped="0">
+  <testsuite name="Upgrade from v3 setting up on the v3 release" timestamp="2026-08-28T06:20:05" time="120.311" tests="2" failures="0" errors="0" skipped="0">
+    <properties>
+      <property name="specId" value="0"/>
+      <property name="suiteName" value="Upgrade from v3: setting up on the v3 release"/>
+      <property name="capabilities" value="ios.5fc23a1b909c4d"/>
+      <property name="file" value="file://./test/bcsc/migration/migration.spec.ts"/>
+    </properties>
+    <testcase classname="ios.5fc23a1b909c4d.Upgrade_from_v3:_setting_up_on_the_v3_release" name="taps the Add Card Setup button" time="12.208"/>
+    <testcase classname="ios.5fc23a1b909c4d.Upgrade_from_v3:_setting_up_on_the_v3_release" name="completes the tutorial carousel" time="8.103"/>
+  </testsuite>
+  <testsuite name="Upgrade from v3 installing the current build" timestamp="2026-08-28T06:22:10" time="95.440" tests="2" failures="1" errors="0" skipped="0">
+    <properties>
+      <property name="specId" value="0"/>
+      <property name="suiteName" value="Upgrade from v3: installing the current build"/>
+      <property name="capabilities" value="ios.5fc23a1b909c4d"/>
+      <property name="file" value="file://./test/bcsc/migration/migration.spec.ts"/>
+    </properties>
+    <testcase classname="ios.5fc23a1b909c4d.Upgrade_from_v3:_installing_the_current_build" name="installs the current build over v3" time="60.102"/>
+    <testcase classname="ios.5fc23a1b909c4d.Upgrade_from_v3:_installing_the_current_build" name="relaunches as the current build" time="35.338">
+      <failure message="Element AccountLanding still not displayed after 30000ms"/>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/e2e/src/brief/build.ts
+++ b/e2e/src/brief/build.ts
@@ -5,6 +5,7 @@ import { OTHER_COVERAGE, UAT_CHECKLIST } from './coverage-map.js'
 import { collectFailures, evaluateSections, platformTotals } from './evaluate.js'
 import { loadJunitReports } from './junit.js'
 import type { BriefModel, LaneResult } from './render.js'
+import { specTitles } from './spec-titles.js'
 import { PLATFORM_LABEL, PLATFORMS, type Platform, type ReportDir } from './types.js'
 
 /** Report dirs in → a brief model out. Shared by the CLI and the fixture self-test. */
@@ -69,6 +70,7 @@ export function buildBrief(options: BuildOptions): BriefModel {
     hasReports: reportDirs.some((dir) => dir.name.includes(`-${lane.name}-`)),
   }))
 
+  const titlesOf = (file: string): string[] | undefined => specTitles(file)?.its
   const now = options.now ?? new Date()
   return {
     title: options.title,
@@ -77,9 +79,9 @@ export function buildBrief(options: BuildOptions): BriefModel {
     lanes,
     platforms,
     runnerErrors: junit.runnerErrors,
-    uat: evaluateSections(UAT_CHECKLIST, junit.results),
-    other: evaluateSections(OTHER_COVERAGE, junit.results),
-    failures: collectFailures(junit.results),
+    uat: evaluateSections(UAT_CHECKLIST, junit.results, titlesOf),
+    other: evaluateSections(OTHER_COVERAGE, junit.results, titlesOf),
+    failures: collectFailures(junit.results, titlesOf),
     a11y: summarizeA11y(a11y, baseline),
     baselineGeneratedAt: baseline?.generatedAt,
     warnings,

--- a/e2e/src/brief/build.ts
+++ b/e2e/src/brief/build.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync, statSync } from 'node:fs'
 import { basename, join, resolve } from 'node:path'
 import { loadA11yReports, loadBaseline, summarizeA11y } from './a11y-summary.js'
 import { OTHER_COVERAGE, UAT_CHECKLIST } from './coverage-map.js'
-import { collectFailures, evaluateSections, platformTotals } from './evaluate.js'
+import { collectFailures, evaluateSections, platformTotals, type SpecTitleLookup } from './evaluate.js'
 import { loadJunitReports } from './junit.js'
 import type { BriefModel, LaneResult } from './render.js'
 import { specTitles } from './spec-titles.js'
@@ -21,6 +21,26 @@ export interface BuildOptions {
 }
 
 const hasReports = (dir: string): boolean => existsSync(join(dir, 'junit')) || existsSync(join(dir, 'a11y'))
+
+/** The titles a reported file can carry: its own `it`s plus, for an orchestrator, those of the sources it imports. */
+function specTitleLookup(): SpecTitleLookup {
+  const sourcesOf = new Map<string, Set<string>>()
+  for (const section of [...UAT_CHECKLIST, ...OTHER_COVERAGE]) {
+    for (const row of section.rows) {
+      for (const proof of row.proof) {
+        if (!proof.sources) continue
+        const sources = sourcesOf.get(proof.file) ?? new Set<string>()
+        for (const source of proof.sources) sources.add(source)
+        sourcesOf.set(proof.file, sources)
+      }
+    }
+  }
+  return (file) => {
+    const own = specTitles(file)?.its
+    const imported = [...(sourcesOf.get(file) ?? [])].flatMap((source) => specTitles(source)?.its ?? [])
+    return own === undefined && imported.length === 0 ? undefined : [...(own ?? []), ...imported]
+  }
+}
 
 /** A path holding `junit/` or `a11y/` is one report dir; otherwise each child dir that does is one. */
 export function resolveReportDirs(paths: string[]): ReportDir[] {
@@ -70,7 +90,7 @@ export function buildBrief(options: BuildOptions): BriefModel {
     hasReports: reportDirs.some((dir) => dir.name.includes(`-${lane.name}-`)),
   }))
 
-  const titlesOf = (file: string): string[] | undefined => specTitles(file)?.its
+  const titlesOf = specTitleLookup()
   const now = options.now ?? new Date()
   return {
     title: options.title,

--- a/e2e/src/brief/coverage-map.ts
+++ b/e2e/src/brief/coverage-map.ts
@@ -343,22 +343,6 @@ export const UAT_CHECKLIST: CoverageSection[] = [
         ],
       },
       {
-        id: 'feat-sign-out-in',
-        label: 'Sign out / in',
-        platforms: { ios: 'na', android: 'na' },
-        proof: [
-          {
-            file: spec('main/settings.journey.ts'),
-            tests: ['auto-locks after the inactivity timeout and re-unlocks with the changed PIN'],
-          },
-          {
-            file: spec('auth/auth-unlock.journey.ts'),
-            tests: ['locks on return from a long background and re-unlocks with the PIN (terminal)'],
-          },
-        ],
-        note: 'no such feature in v4; lock is inactivity/background driven — nearest checkpoints shown',
-      },
-      {
         id: 'feat-login-tile',
         label: 'Log in using tile (deep link)',
         platforms: both,
@@ -466,13 +450,15 @@ export const UAT_CHECKLIST: CoverageSection[] = [
   },
 ]
 
-/** One row per journey/spec, so a file that stops running is visible even when no UAT row names it. */
+/**
+ * One row per journey/spec, so a file that stops running is visible even when no UAT row names it.
+ * `smoke.spec.ts` is the PR gate, never scheduled by the nightly, so it has no row (brief-check exempts it).
+ */
 export const OTHER_COVERAGE: CoverageSection[] = [
   {
     id: 'journeys',
     title: 'Journeys',
     rows: [
-      { id: 'j-smoke', label: 'Smoke: launch + onboarding entry', platforms: both, proof: [{ file: spec('smoke.spec.ts') }] },
       { id: 'j-onboarding-happy', label: 'Onboarding: happy path', platforms: both, proof: [{ file: spec('onboarding/onboarding.journey.ts') }] },
       { id: 'j-onboarding-detours', label: 'Onboarding: detours', platforms: both, proof: [{ file: spec('onboarding/onboarding-detours.journey.ts') }] },
       { id: 'j-onboarding-permissions', label: 'Onboarding: notification permission granted', platforms: both, proof: [{ file: spec('onboarding/onboarding-permissions.journey.ts') }] },
@@ -490,7 +476,13 @@ export const OTHER_COVERAGE: CoverageSection[] = [
       { id: 'j-send-video-cancelled', label: 'Send video: rejected', platforms: both, proof: [{ file: spec('verify/send-video-cancelled.journey.ts') }] },
       { id: 'j-send-video-non-photo', label: 'Send video: non-photo card', platforms: both, proof: [{ file: spec('verify/send-video-non-photo.journey.ts') }] },
       { id: 'j-send-video-non-bcsc', label: 'Send video: non-BCSC', platforms: both, proof: [{ file: spec('verify/send-video-non-bcsc.journey.ts') }] },
-      { id: 'j-video-call', label: 'Verify: video call to the approval boundary', platforms: both, proof: [{ file: spec('verify/video-call.journey.ts') }] },
+      {
+        id: 'j-video-call',
+        label: 'Verify: video call to the approval boundary',
+        platforms: both,
+        proof: [{ file: spec('verify/video-call.journey.ts') }],
+        note: 'the open-hours half skips in the nightly: SIT’s live-call service is closed at midnight PT',
+      },
       { id: 'j-unverified-main', label: 'Main: unverified gating', platforms: both, proof: [{ file: spec('main/unverified-main.journey.ts') }] },
       { id: 'j-settings', label: 'Main: settings', platforms: both, proof: [{ file: spec('main/settings.journey.ts') }] },
       { id: 'j-wallet', label: 'Wallet: DIDComm credential lifecycle', platforms: both, proof: [{ file: spec('main/wallet.journey.ts') }] },

--- a/e2e/src/brief/evaluate.ts
+++ b/e2e/src/brief/evaluate.ts
@@ -1,13 +1,22 @@
 import type { CoverageRow, CoverageSection, Proof } from './coverage-map.js'
 import { sanitizeTitle } from './junit.js'
-import type { CellStatus, CheckpointStatus, Platform, PlatformRun, RunResults, SuiteResult } from './types.js'
+import type { CellStatus, CheckpointStatus, Platform, PlatformRun, RunResults, SuiteResult, TestResult } from './types.js'
 
 /**
  * Coverage rows × platforms → cells. A row's automated status is the roll-up of its proving
  * checkpoints: any fail → fail, else any blocked → blocked, else any pass → pass, else any skipped →
  * skipped, else not run. Rows proved by hand (or not applicable) keep that verdict, but carry the
  * automated evidence alongside when there is some.
+ *
+ * mochaOpts.bail stops a file at its first failure and the reporter writes nothing for the checkpoints
+ * behind it, so a suite that failed counts its unreported `it` titles (read from the spec when it is on
+ * disk) as blocked instead of letting them read as "not run".
  */
+
+/** The `it` titles of a spec (relative to e2e/) in file order, or undefined when the spec is not on disk. */
+export type SpecTitleLookup = (file: string) => string[] | undefined
+
+const noSpecTitles: SpecTitleLookup = () => undefined
 
 export interface CellResult {
   status: CellStatus
@@ -80,12 +89,19 @@ function rollUp(cell: CellResult, hookFailed: boolean): CellStatus {
   return 'not-run'
 }
 
-/** Tally the listed titles by name; a title with no result counts as not run. */
-function tallyNamed(cell: CellResult, titles: string[], tests: SuiteResult['tests']): void {
+/** Titles in the spec with no result in the suite — what bail left unreported. */
+function unreportedTitles(file: string, tests: TestResult[], titlesOf: SpecTitleLookup): string[] {
+  const reported = new Set(tests.map((test) => sanitizeTitle(test.name)))
+  return (titlesOf(file) ?? []).filter((title) => !reported.has(sanitizeTitle(title)))
+}
+
+/** Tally the listed titles by name; a title with no result is blocked when the file bailed, else not run. */
+function tallyNamed(cell: CellResult, titles: string[], tests: TestResult[], bailed: boolean): void {
   for (const title of titles) {
     const wanted = sanitizeTitle(title)
     const test = tests.find((candidate) => sanitizeTitle(candidate.name) === wanted)
     if (test) tally(cell, test.status)
+    else if (bailed) tally(cell, 'blocked')
     else {
       cell.listed++
       cell.notRun++
@@ -94,7 +110,7 @@ function tallyNamed(cell: CellResult, titles: string[], tests: SuiteResult['test
 }
 
 /** One proof's contribution to the cell; true when a hook failure taints the roll-up. */
-function applyProof(cell: CellResult, proof: Proof, run: PlatformRun | undefined): boolean {
+function applyProof(cell: CellResult, proof: Proof, run: PlatformRun | undefined, titlesOf: SpecTitleLookup): boolean {
   const suites = matchSuites(proof, run)
   if (suites.length === 0) {
     const units = proof.tests?.length ?? 1
@@ -104,59 +120,80 @@ function applyProof(cell: CellResult, proof: Proof, run: PlatformRun | undefined
   }
   const tests = suites.flatMap((suite) => suite.tests)
   const hookFailed = suites.some((suite) => suite.hookFailures.length)
+  const bailed = hookFailed || tests.some((test) => test.status === 'fail')
   if (hookFailed && tests.length === 0) {
     // A hook that failed before any checkpoint ran is the failed unit.
     cell.listed++
     cell.failed++
   }
-  if (proof.tests) tallyNamed(cell, proof.tests, tests)
-  else for (const test of tests) tally(cell, test.status)
+  if (proof.tests) tallyNamed(cell, proof.tests, tests, bailed)
+  else {
+    for (const test of tests) tally(cell, test.status)
+    // Whole-file suites only: an orchestrator's describes share a file, so their remainder is unknowable.
+    if (bailed && !proof.suite) {
+      const blocked = unreportedTitles(proof.file, tests, titlesOf).length
+      cell.listed += blocked
+      cell.blocked += blocked
+    }
+  }
   return hookFailed
 }
 
-function evaluateAuto(row: CoverageRow, run: PlatformRun | undefined): CellResult {
+function evaluateAuto(row: CoverageRow, run: PlatformRun | undefined, titlesOf: SpecTitleLookup): CellResult {
   const cell = emptyCell('not-run')
   let hookFailed = false
-  for (const proof of row.proof) hookFailed = applyProof(cell, proof, run) || hookFailed
+  for (const proof of row.proof) hookFailed = applyProof(cell, proof, run, titlesOf) || hookFailed
   cell.status = rollUp(cell, hookFailed)
   return cell
 }
 
-export function evaluateRow(row: CoverageRow, platform: Platform, run: PlatformRun | undefined): CellResult {
+export function evaluateRow(
+  row: CoverageRow,
+  platform: Platform,
+  run: PlatformRun | undefined,
+  titlesOf: SpecTitleLookup = noSpecTitles
+): CellResult {
   const mode = row.platforms[platform]
-  if (mode === 'auto') return evaluateAuto(row, run)
+  if (mode === 'auto') return evaluateAuto(row, run, titlesOf)
   const cell = emptyCell(mode === 'na' ? 'na' : 'manual')
   if (row.proof.length) {
-    const auto = evaluateAuto(row, run)
+    const auto = evaluateAuto(row, run, titlesOf)
     if (auto.status !== 'not-run') cell.auto = auto
   }
   return cell
 }
 
-export function evaluateSections(sections: CoverageSection[], results: RunResults): EvaluatedSection[] {
+export function evaluateSections(
+  sections: CoverageSection[],
+  results: RunResults,
+  titlesOf: SpecTitleLookup = noSpecTitles
+): EvaluatedSection[] {
   return sections.map((section) => ({
     section,
     rows: section.rows.map((row) => ({
       row,
       cells: {
-        ios: evaluateRow(row, 'ios', results.ios),
-        android: evaluateRow(row, 'android', results.android),
+        ios: evaluateRow(row, 'ios', results.ios, titlesOf),
+        android: evaluateRow(row, 'android', results.android, titlesOf),
       },
     })),
   }))
 }
 
 /** Every failure in the run, mapped to a row or not — the brief lists them all. */
-export function collectFailures(results: RunResults): FailureDetail[] {
+export function collectFailures(results: RunResults, titlesOf: SpecTitleLookup = noSpecTitles): FailureDetail[] {
   const failures: FailureDetail[] = []
   for (const run of Object.values(results)) {
     for (const suite of run.suites) {
+      // Bail's unreported remainder lands on the failing checkpoint, or on the hook when nothing ran.
+      const unreported = unreportedTitles(suite.file, suite.tests, titlesOf).length
+      const failedTest = suite.tests.some((test) => test.status === 'fail')
       for (const hook of suite.hookFailures) {
-        failures.push({ platform: suite.platform, file: suite.file, suite: suite.title, checkpoint: hook.title, message: hook.message, blockedAfter: 0, kind: 'hook' })
+        failures.push({ platform: suite.platform, file: suite.file, suite: suite.title, checkpoint: hook.title, message: hook.message, blockedAfter: failedTest ? 0 : unreported, kind: 'hook' })
       }
       suite.tests.forEach((test, index) => {
         if (test.status !== 'fail') return
-        const blockedAfter = suite.tests.slice(index + 1).filter((later) => later.status === 'blocked').length
+        const blockedAfter = suite.tests.slice(index + 1).filter((later) => later.status === 'blocked').length + unreported
         failures.push({ platform: suite.platform, file: suite.file, suite: suite.title, checkpoint: test.name, message: test.message ?? 'failed', blockedAfter, kind: 'test' })
       })
     }

--- a/e2e/src/brief/evaluate.ts
+++ b/e2e/src/brief/evaluate.ts
@@ -89,10 +89,27 @@ function rollUp(cell: CellResult, hookFailed: boolean): CellStatus {
   return 'not-run'
 }
 
-/** Titles in the spec with no result in the suite — what bail left unreported. */
-function unreportedTitles(file: string, tests: TestResult[], titlesOf: SpecTitleLookup): string[] {
-  const reported = new Set(tests.map((test) => sanitizeTitle(test.name)))
-  return (titlesOf(file) ?? []).filter((title) => !reported.has(sanitizeTitle(title)))
+/** Titles with no result among `tests` — what bail left unreported. */
+function unreportedTitles(titles: string[], tests: TestResult[]): string[] {
+  const seen = new Set(tests.map((test) => sanitizeTitle(test.name)))
+  return titles.filter((title) => {
+    const key = sanitizeTitle(title)
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+/** The titles a proof's suites can report — from the sources when `file` is an orchestrator that imports them. */
+function proofTitles(proof: Proof, titlesOf: SpecTitleLookup): string[] {
+  return (proof.sources ?? [proof.file]).flatMap((file) => titlesOf(file) ?? [])
+}
+
+const suiteFailed = (suite: SuiteResult): boolean => suite.hookFailures.length > 0 || suite.tests.some((test) => test.status === 'fail')
+
+/** Did any describe in the file fail — so a describe with no result never got its turn. */
+function fileBailed(file: string, run: PlatformRun | undefined): boolean {
+  return (run?.suites ?? []).some((suite) => suite.file === file && suiteFailed(suite))
 }
 
 /** Tally the listed titles by name; a title with no result is blocked when the file bailed, else not run. */
@@ -112,10 +129,18 @@ function tallyNamed(cell: CellResult, titles: string[], tests: TestResult[], bai
 /** One proof's contribution to the cell; true when a hook failure taints the roll-up. */
 function applyProof(cell: CellResult, proof: Proof, run: PlatformRun | undefined, titlesOf: SpecTitleLookup): boolean {
   const suites = matchSuites(proof, run)
+  const titles = proofTitles(proof, titlesOf)
   if (suites.length === 0) {
-    const units = proof.tests?.length ?? 1
-    cell.listed += units
-    cell.notRun += units
+    if (fileBailed(proof.file, run)) {
+      // Another describe of the file failed first, so this one never got its turn.
+      const blocked = proof.tests?.length ?? (titles.length || 1)
+      cell.listed += blocked
+      cell.blocked += blocked
+    } else {
+      const units = proof.tests?.length ?? 1
+      cell.listed += units
+      cell.notRun += units
+    }
     return false
   }
   const tests = suites.flatMap((suite) => suite.tests)
@@ -129,9 +154,9 @@ function applyProof(cell: CellResult, proof: Proof, run: PlatformRun | undefined
   if (proof.tests) tallyNamed(cell, proof.tests, tests, bailed)
   else {
     for (const test of tests) tally(cell, test.status)
-    // Whole-file suites only: an orchestrator's describes share a file, so their remainder is unknowable.
-    if (bailed && !proof.suite) {
-      const blocked = unreportedTitles(proof.file, tests, titlesOf).length
+    // A suite-scoped proof knows its remainder only through `sources` — the file may hold other describes.
+    if (bailed && (!proof.suite || proof.sources)) {
+      const blocked = unreportedTitles(titles, tests).length
       cell.listed += blocked
       cell.blocked += blocked
     }
@@ -184,9 +209,12 @@ export function evaluateSections(
 export function collectFailures(results: RunResults, titlesOf: SpecTitleLookup = noSpecTitles): FailureDetail[] {
   const failures: FailureDetail[] = []
   for (const run of Object.values(results)) {
+    // Several describes can share a file (the migration orchestrator): the remainder is the FILE's.
+    const reportedByFile = new Map<string, TestResult[]>()
+    for (const suite of run.suites) reportedByFile.set(suite.file, [...(reportedByFile.get(suite.file) ?? []), ...suite.tests])
     for (const suite of run.suites) {
       // Bail's unreported remainder lands on the failing checkpoint, or on the hook when nothing ran.
-      const unreported = unreportedTitles(suite.file, suite.tests, titlesOf).length
+      const unreported = unreportedTitles(titlesOf(suite.file) ?? [], reportedByFile.get(suite.file) ?? []).length
       const failedTest = suite.tests.some((test) => test.status === 'fail')
       for (const hook of suite.hookFailures) {
         failures.push({ platform: suite.platform, file: suite.file, suite: suite.title, checkpoint: hook.title, message: hook.message, blockedAfter: failedTest ? 0 : unreported, kind: 'hook' })

--- a/e2e/src/brief/junit.ts
+++ b/e2e/src/brief/junit.ts
@@ -101,6 +101,7 @@ export function parseJunitXml(xml: string, source: string, hint?: Platform): Par
     const tests: TestResult[] = []
     const hookFailures: SuiteResult['hookFailures'] = []
     let failedBefore = false
+    let previous: TestResult | undefined
     $suite.children('testcase').each((_, tcEl) => {
       const $tc = $(tcEl)
       const name = $tc.attr('name') ?? ''
@@ -118,12 +119,12 @@ export function parseJunitXml(xml: string, source: string, hint?: Platform): Par
         failedBefore = true
       } else if ($tc.children('skipped').length) {
         status = failedBefore ? 'blocked' : 'skipped'
-        const previous = tests[tests.length - 1]
         if (previous?.name === name && previous.status === status) return
       } else {
         status = 'pass'
       }
-      tests.push({ name, status, message, timeSec: Number($tc.attr('time')) || 0 })
+      previous = { name, status, message, timeSec: Number($tc.attr('time')) || 0 }
+      tests.push(previous)
     })
 
     suites.push({

--- a/e2e/src/brief/junit.ts
+++ b/e2e/src/brief/junit.ts
@@ -10,7 +10,8 @@ import type { CheckpointStatus, Platform, ReportDir, RunResults, RunnerError, Su
  * (`file://./test/…`) plus the exact describe title in `suiteName`; `name` attributes carry titles with
  * every non-alphanumeric run collapsed to a space, so titles are compared after {@link sanitizeTitle}
  * on both sides. A `<skipped/>` after a `<failure>` in the same file is the mochaOpts.bail cascade,
- * reported as `blocked` so it cannot pass for "nothing to run".
+ * reported as `blocked` so it cannot pass for "nothing to run". A runtime `this.skip()` arrives as two
+ * `<testcase>`s of the same name (the reporter sees the test start, then go pending) and counts once.
  */
 
 /** The reporter's `_prepareName`: split on non-alphanumerics (keeping `@`), rejoin with single spaces. */
@@ -117,6 +118,8 @@ export function parseJunitXml(xml: string, source: string, hint?: Platform): Par
         failedBefore = true
       } else if ($tc.children('skipped').length) {
         status = failedBefore ? 'blocked' : 'skipped'
+        const previous = tests[tests.length - 1]
+        if (previous?.name === name && previous.status === status) return
       } else {
         status = 'pass'
       }

--- a/e2e/src/brief/spec-titles.ts
+++ b/e2e/src/brief/spec-titles.ts
@@ -1,0 +1,35 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/** Titles read straight from a spec's source — what the brief holds JUnit results against. */
+
+export interface SpecTitles {
+  /** `it` titles in file order. */
+  its: string[]
+  describes: string[]
+}
+
+const E2E_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const cache = new Map<string, SpecTitles | undefined>()
+
+/** `it('…')` / `describe("…")` titles in a spec source, in order, with the quote escapes undone. */
+export function titlesIn(source: string): SpecTitles {
+  const its: string[] = []
+  const describes: string[] = []
+  const pattern = /\b(it|describe)(?:\.(?:skip|only))?\(\s*(['"`])((?:\\[\s\S]|(?!\2)[^\\])*)\2/g
+  for (const match of source.matchAll(pattern)) {
+    const title = match[3].replace(/\\(['"`\\])/g, '$1')
+    ;(match[1] === 'it' ? its : describes).push(title)
+  }
+  return { its, describes }
+}
+
+/** The titles of a spec path relative to e2e/, or undefined when it is not on disk. Cached per process. */
+export function specTitles(file: string): SpecTitles | undefined {
+  if (!cache.has(file)) {
+    const path = join(E2E_ROOT, file)
+    cache.set(file, existsSync(path) ? titlesIn(readFileSync(path, 'utf8')) : undefined)
+  }
+  return cache.get(file)
+}

--- a/e2e/src/flows/verify.ts
+++ b/e2e/src/flows/verify.ts
@@ -20,6 +20,7 @@ import {
   tapHelpMenuRow,
 } from '../helpers/help-menu.js'
 import { describeCurrentScreen, reachCameraScreen, type ScreenProbe, waitForAnyScreen } from '../helpers/screens.js'
+import { backgroundAppFor } from './auth.js'
 import { BaseScreen } from '../screens/core/BaseScreen.js'
 import type { ScreenPresence } from '../screens/core/defineScreen.js'
 import { AppErrorModal } from '../screens/errors.js'
@@ -344,6 +345,9 @@ async function recordPromptedVideo(): Promise<void> {
 /** Attempts at arming the recorder before the journey gives up on the device's camera stack. */
 const RECORDING_START_ATTEMPTS = 3
 
+/** Background dwell between arm attempts — long enough for the OS to tear the capture session down. */
+const RECORDER_RESET_BACKGROUND_S = 3
+
 /** How long StartRecording gets to leave the screen after its tap before the tap is called swallowed. */
 const RECORDING_START_LEAVE_MS = 5_000
 
@@ -355,7 +359,9 @@ type RecorderArmOutcome = 'armed' | 'error' | 'bounced'
  * Arming fails transiently on rack devices — the recorder errors at 00:00 behind the app's
  * "Recording error" modal, or the thumbnail snapshot fails and the app bounces back to the
  * instructions — so it is retried from VideoInstructions, whose StartRecording issues a fresh prompt
- * set each time. The final failure carries the modal's details rather than a timeout.
+ * set each time. A camera that errored once has never come back on a plain re-tap (iOS, error 2002),
+ * so each retry first cycles the app through the background: the app drops the capture session on
+ * background and rebuilds it on focus. The final failure carries the modal's details rather than a timeout.
  */
 async function startVideoRecording(): Promise<void> {
   let lastFailure = ''
@@ -366,6 +372,9 @@ async function startVideoRecording(): Promise<void> {
     }
     lastFailure = outcome === 'error' ? await recoverFromRecordingError() : await recoverFromRecorderBounce()
     console.warn(`[verify] The recorder did not arm (attempt ${attempt}/${RECORDING_START_ATTEMPTS}): ${lastFailure}`)
+    if (attempt < RECORDING_START_ATTEMPTS) {
+      await backgroundAppFor(RECORDER_RESET_BACKGROUND_S)
+    }
   }
   throw new Error(`The recording failed to start after ${RECORDING_START_ATTEMPTS} attempts. Last: ${lastFailure}`)
 }

--- a/e2e/src/helpers/pairing-code.ts
+++ b/e2e/src/helpers/pairing-code.ts
@@ -57,6 +57,9 @@ const IOS_USER_AGENT =
 const ANDROID_USER_AGENT =
   'Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Mobile Safari/537.36'
 const DEFAULT_TIMEOUT_MS = 20_000
+/** Whole-mint attempts before a transport failure is the checkpoint's: SIT drops a connection now and then. */
+const MINT_ATTEMPTS = 3
+const MINT_RETRY_DELAY_MS = 5_000
 
 export type DeepLinkPlatform = 'ios' | 'android'
 
@@ -107,30 +110,32 @@ export function pairingQrUri(pairingCode: string): string {
 
 export async function fetchPairingCode(options: FetchPairingCodeOptions = {}): Promise<PairingSession> {
   const { timeoutMs = DEFAULT_TIMEOUT_MS } = options
-  const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  return withMintRetry('pairing code', async () => {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
 
-  try {
-    const tx = await mintCardtapTransaction({ userAgent: USER_AGENT, signal: controller.signal })
+    try {
+      const tx = await mintCardtapTransaction({ userAgent: USER_AGENT, signal: controller.signal })
 
-    // Select BC Services Card app as the pairing device. Response body
-    // carries the six-letter pairing code we type into the app.
-    const deviceBody = await putCardtapDevice<{ pairingCode?: string }>(tx, {
-      deviceType: 'REMOTE_PAIRING_CODE',
-      mobileSdkParams: null,
-    })
-    if (!deviceBody.parsed?.pairingCode) {
-      throw new Error(`pairingCode missing from cardtap device response: ${deviceBody.raw.slice(0, 200)}`)
+      // Select BC Services Card app as the pairing device. Response body
+      // carries the six-letter pairing code we type into the app.
+      const deviceBody = await putCardtapDevice<{ pairingCode?: string }>(tx, {
+        deviceType: 'REMOTE_PAIRING_CODE',
+        mobileSdkParams: null,
+      })
+      if (!deviceBody.parsed?.pairingCode) {
+        throw new Error(`pairingCode missing from cardtap device response: ${deviceBody.raw.slice(0, 200)}`)
+      }
+
+      return {
+        transactionId: tx.transactionId,
+        pairingCode: deviceBody.parsed.pairingCode,
+        clientName: tx.clientName,
+      }
+    } finally {
+      clearTimeout(timeoutId)
     }
-
-    return {
-      transactionId: tx.transactionId,
-      pairingCode: deviceBody.parsed.pairingCode,
-      clientName: tx.clientName,
-    }
-  } finally {
-    clearTimeout(timeoutId)
-  }
+  })
 }
 
 /**
@@ -148,47 +153,93 @@ export async function fetchPairingCode(options: FetchPairingCodeOptions = {}): P
 export async function fetchPairingDeepLink(options: FetchPairingDeepLinkOptions): Promise<PairingDeepLinkSession> {
   const { timeoutMs = DEFAULT_TIMEOUT_MS, platform } = options
   const userAgent = platform === 'ios' ? IOS_USER_AGENT : ANDROID_USER_AGENT
-  const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  return withMintRetry('pairing deep link', async () => {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
 
+    try {
+      const tx = await mintCardtapTransaction({
+        userAgent,
+        signal: controller.signal,
+        // The live mobile flow always sends maxTouchPoints — the cardtap UI
+        // uses it to decide whether to surface the LOCAL_APP_SWITCH tile.
+        cardtapQueryExtras: { maxTouchPoints: '1' },
+      })
+
+      const deviceBody = await putCardtapDevice<{
+        pairingCode?: string
+        selectedDevice?: { handlerURI?: string }
+      }>(tx, { deviceType: 'LOCAL_APP_SWITCH' })
+
+      const pairingCode = deviceBody.parsed?.pairingCode
+      const handlerUri = deviceBody.parsed?.selectedDevice?.handlerURI
+      if (!pairingCode || !handlerUri) {
+        throw new Error(
+          `pairingCode or selectedDevice.handlerURI missing from cardtap device response: ${deviceBody.raw.slice(0, 200)}`
+        )
+      }
+
+      // handlerURI ends in `/`, e.g. `ca.bc.gov.iddev.servicescard://pair/https%3A%2F%2F.../device/BC+Parks+Discover+Camping/`
+      const deepLink = `${handlerUri}${pairingCode}`
+      const schemeMatch = /^([^:]+):\/\//.exec(handlerUri)
+      if (!schemeMatch) {
+        throw new Error(`Unable to parse scheme from handlerURI: ${handlerUri}`)
+      }
+
+      return {
+        transactionId: tx.transactionId,
+        pairingCode,
+        clientName: tx.clientName,
+        deepLink,
+        scheme: schemeMatch[1],
+      }
+    } finally {
+      clearTimeout(timeoutId)
+    }
+  })
+}
+
+/** One step of the mint failed; `retryable` = a transport fault (dropped connection, timeout, 5xx) worth another go. */
+class MintStepError extends Error {
+  constructor(
+    step: string,
+    detail: string,
+    readonly retryable: boolean,
+    readonly cause?: unknown
+  ) {
+    super(`${step}: ${detail}`)
+    this.name = 'MintStepError'
+  }
+}
+
+/** Run the whole mint again on a retryable step failure — every attempt opens a fresh transaction. */
+async function withMintRetry<T>(what: string, mint: () => Promise<T>): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await mint()
+    } catch (err) {
+      if (!(err instanceof MintStepError && err.retryable && attempt < MINT_ATTEMPTS)) throw err
+      console.warn(`[pairing-code] ${what} attempt ${attempt}/${MINT_ATTEMPTS} failed (${err.message}); retrying in ${MINT_RETRY_DELAY_MS}ms`)
+      await new Promise((resolve) => setTimeout(resolve, MINT_RETRY_DELAY_MS))
+    }
+  }
+}
+
+/** Undici's bare "fetch failed" hides the socket error in `cause`; our abort is the mint timeout. */
+function describeTransportError(err: unknown): string {
+  if (err instanceof Error && err.name === 'AbortError') return 'aborted — the mint timeout ran out'
+  const message = err instanceof Error ? err.message : String(err)
+  const cause = (err as { cause?: { code?: string; message?: string } } | undefined)?.cause
+  return cause ? `${message} — ${cause.code ?? cause.message ?? String(cause)}` : message
+}
+
+/** One HTTP round trip of the mint: a transport failure is named after the step, with its cause, and is retryable. */
+async function transport<T>(step: string, run: () => Promise<T>): Promise<T> {
   try {
-    const tx = await mintCardtapTransaction({
-      userAgent,
-      signal: controller.signal,
-      // The live mobile flow always sends maxTouchPoints — the cardtap UI
-      // uses it to decide whether to surface the LOCAL_APP_SWITCH tile.
-      cardtapQueryExtras: { maxTouchPoints: '1' },
-    })
-
-    const deviceBody = await putCardtapDevice<{
-      pairingCode?: string
-      selectedDevice?: { handlerURI?: string }
-    }>(tx, { deviceType: 'LOCAL_APP_SWITCH' })
-
-    const pairingCode = deviceBody.parsed?.pairingCode
-    const handlerUri = deviceBody.parsed?.selectedDevice?.handlerURI
-    if (!pairingCode || !handlerUri) {
-      throw new Error(
-        `pairingCode or selectedDevice.handlerURI missing from cardtap device response: ${deviceBody.raw.slice(0, 200)}`
-      )
-    }
-
-    // handlerURI ends in `/`, e.g. `ca.bc.gov.iddev.servicescard://pair/https%3A%2F%2F.../device/BC+Parks+Discover+Camping/`
-    const deepLink = `${handlerUri}${pairingCode}`
-    const schemeMatch = /^([^:]+):\/\//.exec(handlerUri)
-    if (!schemeMatch) {
-      throw new Error(`Unable to parse scheme from handlerURI: ${handlerUri}`)
-    }
-
-    return {
-      transactionId: tx.transactionId,
-      pairingCode,
-      clientName: tx.clientName,
-      deepLink,
-      scheme: schemeMatch[1],
-    }
-  } finally {
-    clearTimeout(timeoutId)
+    return await run()
+  } catch (err) {
+    if (err instanceof MintStepError) throw err
+    throw new MintStepError(step, describeTransportError(err), true, err)
   }
 }
 
@@ -215,11 +266,13 @@ async function mintCardtapTransaction({
   const headers = baseHeaders(userAgent)
 
   // 1. Demo RP login page — server returns an auto-submit SAML form.
-  const rpLoginRes = await fetchWithCookies(DEMO_RP_LOGIN, {
-    redirect: 'manual',
-    headers,
-    signal,
-  })
+  const rpLoginRes = await transport('GET /demo/rp1/login', () =>
+    fetchWithCookies(DEMO_RP_LOGIN, {
+      redirect: 'manual',
+      headers,
+      signal,
+    })
+  )
   const rpLoginHtml = await readBodyOrThrow('GET /demo/rp1/login', rpLoginRes)
   const $rpLogin = load(rpLoginHtml)
   const samlRequest = inputValue($rpLogin, 'SAMLRequest')
@@ -231,18 +284,20 @@ async function mintCardtapTransaction({
   // 2. Post the SAML form. Expect 302 with Location pointing at the login entry page.
   const samlBody = new URLSearchParams({ SAMLRequest: samlRequest })
   if (relayState) samlBody.append('RelayState', relayState)
-  const samlRes = await fetchWithCookies(SAML2_POST, {
-    method: 'POST',
-    redirect: 'manual',
-    headers: {
-      ...headers,
-      'Content-Type': 'application/x-www-form-urlencoded',
-      Origin: SIT_BASE,
-      Referer: DEMO_RP_LOGIN,
-    },
-    body: samlBody.toString(),
-    signal,
-  })
+  const samlRes = await transport('POST /login/saml2', () =>
+    fetchWithCookies(SAML2_POST, {
+      method: 'POST',
+      redirect: 'manual',
+      headers: {
+        ...headers,
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Origin: SIT_BASE,
+        Referer: DEMO_RP_LOGIN,
+      },
+      body: samlBody.toString(),
+      signal,
+    })
+  )
   if (samlRes.status !== 302) {
     throw new Error(`POST /login/saml2 expected 302, got ${samlRes.status}`)
   }
@@ -254,14 +309,16 @@ async function mintCardtapTransaction({
 
   // 3. Follow the 302 to the login entry page. Server embeds the cardtap
   //    transaction UUID as a JS literal — scrape it.
-  const entryRes = await fetchWithCookies(entryUrl, {
-    redirect: 'manual',
-    headers: {
-      ...headers,
-      Referer: DEMO_RP_LOGIN,
-    },
-    signal,
-  })
+  const entryRes = await transport('GET login entry', () =>
+    fetchWithCookies(entryUrl, {
+      redirect: 'manual',
+      headers: {
+        ...headers,
+        Referer: DEMO_RP_LOGIN,
+      },
+      signal,
+    })
+  )
   const entryHtml = await readBodyOrThrow(`GET ${entryUrl}`, entryRes)
   const transactionId = extractTransactionId(entryHtml)
   if (!transactionId) {
@@ -278,17 +335,19 @@ async function mintCardtapTransaction({
   const txUrl = `${SIT_BASE}/cardtap/v3/transactions/${transactionId}?clientId=${encodeURIComponent(
     CLIENT_ID
   )}${extraQuery}`
-  const txRes = await fetchWithCookies(txUrl, {
-    method: 'POST',
-    headers: {
-      ...headers,
-      'Content-Type': 'application/json',
-      'X-Requested-With': 'XMLHttpRequest',
-      Origin: SIT_BASE,
-      Referer: entryUrl,
-    },
-    signal,
-  })
+  const txRes = await transport('POST cardtap transaction', () =>
+    fetchWithCookies(txUrl, {
+      method: 'POST',
+      headers: {
+        ...headers,
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+        Origin: SIT_BASE,
+        Referer: entryUrl,
+      },
+      signal,
+    })
+  )
   const txBodyRaw = await readBodyOrThrow('POST cardtap transaction', txRes)
   const txBody = safeJson<{ clientName?: string }>(txBodyRaw)
 
@@ -307,19 +366,21 @@ async function putCardtapDevice<T>(
   body: Record<string, unknown>
 ): Promise<{ raw: string; parsed: T | null }> {
   const deviceUrl = `${SIT_BASE}/cardtap/v3/transactions/${tx.transactionId}/device`
-  const deviceRes = await tx.fetchWithCookies(deviceUrl, {
-    method: 'PUT',
-    headers: {
-      ...baseHeaders(tx.userAgent),
-      'Content-Type': 'application/json',
-      Accept: 'application/json, text/javascript, */*; q=0.01',
-      'X-Requested-With': 'XMLHttpRequest',
-      Origin: SIT_BASE,
-      Referer: tx.entryUrl,
-    },
-    body: JSON.stringify(body),
-    signal: tx.signal,
-  })
+  const deviceRes = await transport('PUT cardtap device', () =>
+    tx.fetchWithCookies(deviceUrl, {
+      method: 'PUT',
+      headers: {
+        ...baseHeaders(tx.userAgent),
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/javascript, */*; q=0.01',
+        'X-Requested-With': 'XMLHttpRequest',
+        Origin: SIT_BASE,
+        Referer: tx.entryUrl,
+      },
+      body: JSON.stringify(body),
+      signal: tx.signal,
+    })
+  )
   const raw = await readBodyOrThrow('PUT cardtap device', deviceRes)
   return { raw, parsed: safeJson<T>(raw) }
 }
@@ -333,11 +394,11 @@ function baseHeaders(userAgent: string): Record<string, string> {
 }
 
 async function readBodyOrThrow(step: string, response: Response): Promise<string> {
-  const body = await response.text()
+  const body = await transport(step, () => response.text())
   if (!response.ok) {
     const snippet = body.slice(0, 200).replaceAll(/\s+/g, ' ').trim()
     const detail = snippet ? ` — ${snippet}` : ''
-    throw new Error(`${step} failed: HTTP ${response.status}${detail}`)
+    throw new MintStepError(step, `HTTP ${response.status}${detail}`, response.status >= 500)
   }
   return body
 }

--- a/e2e/src/helpers/pairing-code.ts
+++ b/e2e/src/helpers/pairing-code.ts
@@ -229,8 +229,9 @@ async function withMintRetry<T>(what: string, mint: () => Promise<T>): Promise<T
 function describeTransportError(err: unknown): string {
   if (err instanceof Error && err.name === 'AbortError') return 'aborted — the mint timeout ran out'
   const message = err instanceof Error ? err.message : String(err)
-  const cause = (err as { cause?: { code?: string; message?: string } } | undefined)?.cause
-  return cause ? `${message} — ${cause.code ?? cause.message ?? String(cause)}` : message
+  const cause = (err as { cause?: unknown } | undefined)?.cause
+  const detail = cause instanceof Error ? ((cause as { code?: string }).code ?? cause.message) : undefined
+  return detail ? `${message} — ${detail}` : message
 }
 
 /** One HTTP round trip of the mint: a transport failure is named after the step, with its cause, and is retryable. */
@@ -299,6 +300,7 @@ async function mintCardtapTransaction({
     })
   )
   if (samlRes.status !== 302) {
+    await readBodyOrThrow('POST /login/saml2', samlRes) // a 4xx/5xx is named (and a 5xx retried) like every other step
     throw new Error(`POST /login/saml2 expected 302, got ${samlRes.status}`)
   }
   const entryLocation = samlRes.headers.get('location')

--- a/e2e/src/helpers/screens.ts
+++ b/e2e/src/helpers/screens.ts
@@ -21,7 +21,26 @@ export async function describeCurrentScreen(limit = 8): Promise<string> {
       break
     }
   }
-  return texts.length ? texts.join(' | ') : '(no visible text found)'
+  return texts.length ? texts.join(' | ') : `(no visible text found; ${await describeSilentScreen()})`
+}
+
+/** The view classes on a text-less screen, so a blank camera or a bare surface is still identifiable. */
+async function describeSilentScreen(): Promise<string> {
+  try {
+    const source = await driver.getPageSource()
+    const counts = new Map<string, number>()
+    for (const [, name] of source.matchAll(driver.isIOS ? /\btype="([^"]+)"/g : /\bclass="([^"]+)"/g)) {
+      counts.set(name, (counts.get(name) ?? 0) + 1)
+    }
+    const top = [...counts]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([name, n]) => `${name.split('.').pop()}×${n}`)
+    const where = driver.isAndroid ? `${await driver.getCurrentPackage()}/${await driver.getCurrentActivity()}: ` : ''
+    return `${where}${top.join(', ') || 'empty page source'}`
+  } catch (err) {
+    return `page source unavailable: ${(err as Error).message}`
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #4299

## What changed

The nightly brief now tells the truth about a file that bailed and drops the rows the nightly never fills; the pairing-code mint survives a dropped SIT connection; a recorder that errors gets a real reset between arm attempts.

- Brief: checkpoints behind a bail read ⛔ blocked with a count (from the spec's `it` titles) instead of ⬜ not run, and each failure says how many it blocked.
- Brief: a runtime `this.skip()` counts once (the junit reporter writes it twice).
- Brief: "Sign out / in" and smoke rows removed; the video-call row explains its nightly skips.
- Pairing-code mint: names the failing step and socket error, retries transport failures up to 3×.
- Recorder arm: cycles the app through the background between attempts so iOS rebuilds the capture session.
- A screen with no visible text now reports its activity and view classes in failure messages.

## What should the reviewer focus on

`e2e/src/brief/evaluate.ts` (`applyProof`, `tallyNamed`): a listed title missing from a suite that failed is blocked, not "not run", and whole-file suites add the spec's unreported titles. `e2e/src/helpers/pairing-code.ts` (`withMintRetry`, `transport`): only a retryable `MintStepError` (transport fault, timeout, 5xx) retries. The background cycle in `startVideoRecording` is unverified on a device; it only runs after an arm already failed. No spec or config changes.

## How to test

```bash
cd e2e
yarn typecheck
yarn brief:check   # coverage map + fixture self-test; fixtures cover the unreported bail remainder and the doubled skip
gh run download 34572894192 -p 'e2e-reports-*' -D artifacts && yarn brief --reports artifacts
```

In the rendered brief: no "Sign out / in" or smoke rows; "Verified: combined card" on iOS reads `❌ 11/23 ⛔11`; video call reads `✅ 4/9 ⏭️5`.

The mint retry and recorder reset only show on Sauce: dispatch E2E Nightly with suite `send-video` and look for `[pairing-code] … retrying` / `[verify] The recorder did not arm` followed by a successful arm.
