### PR TITLE
fix: dissect 2404 errors for grafana dashboard

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,10 +1,15 @@
 # E2E Nightly Full Regression
 #
 # Runs the `regression` E2E suite (every per-area journey) against the
-# latest successful main build's SauceLabs artifacts, then the upgrade
-# lanes (migration v3→v4, previous release → current, 4.0.3 → current) as
-# chained advisory jobs — each boots an OLD build via its own config, so
-# they cannot live inside the regression wdio suite itself.
+# latest successful main build's SauceLabs artifacts, then the send-video
+# lane (the four send-video journeys, one platform at a time — they review
+# a shared, blind-FIFO SIT agent queue with shared personas, so they are
+# kept out of the concurrent regression matrix) alongside the Android-only
+# migration lane, then the remaining upgrade lanes (previous release →
+# current, 4.0.3 → current) as chained advisory jobs — each boots an OLD
+# build via its own config, so they cannot live inside the regression wdio
+# suite itself. A final queue-hygiene job drains the SIT review queue so
+# the UAT team never starts the day behind e2e leftovers.
 #
 # Default device matrix: 1 iOS + 1 Android device (one modern OS major each).
 # os_version stays PINNED: unpinned, Sauce hands out iOS 15-era devices, where
@@ -52,6 +57,7 @@ on:
           - auth
           - main
           - verify
+          - send-video
           - a11y
           - migration
           - upgrade
@@ -170,6 +176,29 @@ jobs:
       suite: ${{ inputs.suite || 'regression' }}
       build_number: ${{ needs.resolve-build.outputs.build_number }}
       device_matrix: ${{ inputs.device_matrix || '[{"platform":"iOS","device":"iPhone.*","os_version":"18"},{"platform":"Android","device":"Google.*","os_version":"15"}]' }}
+      # The send-video journeys get their own lane below; a `send-video` dispatch runs them here instead.
+      exclude_send_video: ${{ (inputs.suite || 'regression') != 'send-video' }}
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+  # ─── Send-video lane: one platform at a time ────────────────────
+  # The four send-video journeys review a shared, blind-FIFO SIT agent queue with shared personas:
+  # two platforms at once would review (or drain) each other's uploads. So they leave the concurrent
+  # regression matrix (exclude_send_video above) and run here iOS-then-Android at max_parallel 1 —
+  # alongside the Android-only migration lane, which keeps both Sauce sessions busy. Blocking, like
+  # the regression it belongs to; the journeys drain the review queue around their own uploads, and
+  # queue-hygiene below is the end-of-night double check.
+  e2e-send-video:
+    needs: [check-for-merges, resolve-build, e2e]
+    if: ${{ !cancelled() && needs.check-for-merges.outputs.should_run == 'true' && needs.resolve-build.result == 'success' && (inputs.suite || 'regression') == 'regression' }}
+    uses: ./.github/workflows/e2e.yml
+    permissions:
+      contents: read
+    with:
+      suite: send-video
+      build_number: ${{ needs.resolve-build.outputs.build_number }}
+      device_matrix: ${{ inputs.device_matrix || '[{"platform":"iOS","device":"iPhone.*","os_version":"18"},{"platform":"Android","device":"Google.*","os_version":"15"}]' }}
+      max_parallel: 1
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
@@ -196,7 +225,7 @@ jobs:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
   e2e-upgrade:
-    needs: [check-for-merges, resolve-build, e2e-migration]
+    needs: [check-for-merges, resolve-build, e2e-migration, e2e-send-video]
     if: ${{ !cancelled() && needs.check-for-merges.outputs.should_run == 'true' && needs.resolve-build.result == 'success' && (inputs.suite || 'regression') == 'regression' }}
     uses: ./.github/workflows/e2e.yml
     permissions:
@@ -221,13 +250,28 @@ jobs:
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
+  # ─── Queue hygiene: the last word on the SIT review queue ───────
+  # The send-video journeys drain the queue before each upload and again in their teardown; this is
+  # the end-of-night double check, whatever the lanes did (always()) — so a run that died mid-journey
+  # never leaves a submission for the UAT team to clear in the morning.
+  queue-hygiene:
+    needs: [check-for-merges, resolve-build, e2e, e2e-send-video, e2e-migration, e2e-upgrade, e2e-upgrade403]
+    if: ${{ always() && needs.check-for-merges.outputs.should_run == 'true' && needs.resolve-build.result == 'success' }}
+    uses: ./.github/workflows/e2e-send-video-queue.yml
+    permissions:
+      contents: read
+    with:
+      scope: all
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
   # ─── Nightly brief ──────────────────────────────────────────────
   # The page for the night: the UAT checklist per platform across every lane above, every failure,
   # and the accessibility findings vs e2e/a11y-baseline.json. Runs whatever the lanes did (always()),
   # reads the e2e-reports-* artifacts they uploaded, and writes the run summary + e2e-nightly-brief.
   brief:
     name: Nightly brief
-    needs: [check-for-merges, resolve-build, e2e, e2e-migration, e2e-upgrade, e2e-upgrade403]
+    needs: [check-for-merges, resolve-build, e2e, e2e-send-video, e2e-migration, e2e-upgrade, e2e-upgrade403, queue-hygiene]
     if: ${{ always() && needs.check-for-merges.outputs.should_run == 'true' && needs.resolve-build.result == 'success' }}
     runs-on: ubuntu-22.04
     permissions:
@@ -258,13 +302,15 @@ jobs:
           BUILD_NUMBER: ${{ needs.resolve-build.outputs.build_number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           LANE_REGRESSION: ${{ needs.e2e.result }}
+          LANE_SEND_VIDEO: ${{ needs.e2e-send-video.result }}
           LANE_MIGRATION: ${{ needs.e2e-migration.result }}
           LANE_UPGRADE: ${{ needs.e2e-upgrade.result }}
           LANE_UPGRADE403: ${{ needs.e2e-upgrade403.result }}
         run: |
           ./node_modules/.bin/tsx scripts/brief.ts --reports artifacts \
             --title "E2E nightly — build ${BUILD_NUMBER}" --run-url "$RUN_URL" \
-            --lane "regression=${LANE_REGRESSION}" --lane "migration=${LANE_MIGRATION}" \
+            --lane "regression=${LANE_REGRESSION}" --lane "send-video=${LANE_SEND_VIDEO}" \
+            --lane "migration=${LANE_MIGRATION}" \
             --lane "upgrade=${LANE_UPGRADE}" --lane "upgrade403=${LANE_UPGRADE403}" \
             --out brief.md --json brief.json
           cat brief.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e-send-video-queue.yml
+++ b/.github/workflows/e2e-send-video-queue.yml
@@ -1,0 +1,93 @@
+# Drain send-video queue
+#
+# The send-video e2e journeys upload real verification requests to the SIT IDcheck agent queue and
+# review them by script. The queue has no worklist — a review claims the NEXT request blindly — so
+# anything a failed journey leaves behind is what the next run claims, or what the UAT team cleans
+# by hand in the morning. This workflow rejects whatever is queued, with the reason
+# "Automated e2e queue cleanup", and lists what it rejected in the run summary.
+#
+#   workflow_call     — after every e2e.yml suite that ran the send-video journeys, and once more at
+#                       the end of the nightly (e2e-nightly.yml)
+#   workflow_dispatch — on demand from the Actions tab: scope `all` (everything queued) or `e2e`
+#                       (only the e2e personas; stops at the first foreign request)
+#
+# The drain talks to idsit.gov.bc.ca from the RUNNER (e2e/scripts/login.mjs), so it needs the
+# allowlisted `ubuntu-latest-m` runner and the SiteMinder test account from 1Password — the same
+# constraints as the in-person approval step in e2e.yml.
+name: Drain send-video queue
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      scope:
+        description: 'all (everything queued) or e2e (only the e2e personas)'
+        type: string
+        required: false
+        default: all
+      max_claims:
+        description: 'Stop after this many claims'
+        type: number
+        required: false
+        default: 25
+      runner_label:
+        description: 'Label of the large runner with whitelisted egress IPs'
+        type: string
+        required: false
+        default: 'ubuntu-latest-m'
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN:
+        required: true
+        description: '1Password service account token; SM_USER / SM_PASSWORD come from the bcsc-mobile-app-cd vault'
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: 'What to reject: everything queued, or only the e2e personas'
+        type: choice
+        options:
+          - all
+          - e2e
+        default: all
+      max_claims:
+        description: 'Stop after this many claims'
+        type: number
+        default: 25
+      runner_label:
+        description: 'Label of the large runner with whitelisted egress IPs'
+        type: string
+        default: 'ubuntu-latest-m'
+
+jobs:
+  drain:
+    name: 'drain send-video queue (${{ inputs.scope }})'
+    runs-on: ${{ inputs.runner_label }}
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup E2E
+        uses: ./.github/workflows/actions/setup-e2e
+
+      # Outputs (not export-env) keep the credentials scoped to the one step that uses them.
+      - name: Load SiteMinder secrets from 1Password
+        id: op_sm
+        uses: 1password/load-secrets-action@70062d7a876d3eb6334754fa26efd2fbd90c32f2 # v5.0.1
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SM_USER: op://bcsc-mobile-app-cd/bcsc-e2e-test-account/username
+          SM_PASSWORD: op://bcsc-mobile-app-cd/bcsc-e2e-test-account/password
+
+      - name: Drain the queue
+        working-directory: e2e
+        env:
+          SM_USER: ${{ steps.op_sm.outputs.SM_USER }}
+          SM_PASSWORD: ${{ steps.op_sm.outputs.SM_PASSWORD }}
+          SCOPE: ${{ inputs.scope }} # via env, never inline in run — inputs are attacker-controlled
+          MAX_CLAIMS: ${{ inputs.max_claims }}
+        run: |
+          # tsx binary directly — yarn's own stdout banners would garble the summary
+          ./node_modules/.bin/tsx scripts/send-video-queue.ts drain --scope "$SCOPE" --max "${MAX_CLAIMS:-25}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,9 @@
 #   auth         — auth/unlock journey
 #   main         — main navigation + settings + wallet credential journeys (issuer creds from 1Password)
 #   verify       — verify entry + verified card-type journeys (uses SM_* creds)
+#   send-video   — the four send-video journeys alone: scripted agent review against a shared,
+#                  blind-FIFO SIT queue, so CI runs them one platform at a time (max-parallel 1) and
+#                  keeps them out of every concurrent multi-device run (exclude_send_video)
 #   a11y         — automated accessibility audits over the core screens (iOS: Apple's audit engine; Android: heuristics)
 #   regression   — every per-area journey (nightly default)
 #   migration    — v3 → v4 app upgrade flow (Sauce RDC only; separate v3 build)
@@ -32,6 +35,13 @@
 # Constraint: the SauceLabs account allows 2 concurrent real-device sessions, shared across every
 # job AND every wdio worker inside them. max-parallel caps the jobs; SAUCE_MAX_INSTANCES (computed
 # in the run step) divides the session budget among the jobs running in parallel.
+#
+# This workflow only runs tests and uploads reports. The brief (UAT coverage per platform, failures,
+# accessibility findings) is rendered ONCE per run by the caller — e2e-nightly.yml, whose dispatch
+# takes the same suite choice and resolves the build itself. For a brief over the reports of any
+# other run: `gh run download <id> -p 'e2e-reports-*' -D e2e/artifacts && cd e2e && yarn brief
+# --reports artifacts`. The send-video review queue is drained by the journeys themselves and by
+# e2e-nightly.yml's queue-hygiene job (manual: the "Drain send-video queue" workflow).
 name: E2E Tests
 
 permissions:
@@ -41,7 +51,7 @@ on:
   workflow_call:
     inputs:
       suite:
-        description: 'Test suite (smoke, onboarding, auth, main, verify, a11y, regression, migration, upgrade, upgrade403)'
+        description: 'Test suite (smoke, onboarding, auth, main, verify, send-video, a11y, regression, migration, upgrade, upgrade403)'
         type: string
         required: true
       build_number:
@@ -65,13 +75,19 @@ on:
         type: string
         required: false
         default: 'ubuntu-latest-m'
-      brief:
+      exclude_send_video:
         description: >
-          Render the run brief (UAT coverage per platform, failures, accessibility findings) into the
-          run summary after the matrix. Off for callers — the nightly renders its own aggregate.
+          Drop the send-video journeys from the suite. They review a shared blind-FIFO agent queue with
+          shared personas and must never run on two platforms at once; the nightly runs them in their
+          own `send-video` lane. Auto-enabled for a verify/regression run with parallel platforms.
         type: boolean
         required: false
         default: false
+      max_parallel:
+        description: 'Matrix jobs allowed at once — 1 serialises the platforms (send-video is always 1)'
+        type: number
+        required: false
+        default: 2
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN:
         required: true
@@ -96,6 +112,7 @@ on:
           - auth
           - main
           - verify
+          - send-video
           - a11y
           - regression
           - migration
@@ -119,10 +136,14 @@ on:
         description: 'Label of the large runner with whitelisted egress IPs'
         type: string
         default: 'ubuntu-latest-m'
-      brief:
-        description: 'Render the run brief into the run summary'
+      exclude_send_video:
+        description: 'Drop the send-video journeys (auto for verify/regression with parallel platforms)'
         type: boolean
-        default: true
+        default: false
+      max_parallel:
+        description: 'Matrix jobs allowed at once — 1 serialises the platforms (send-video is always 1)'
+        type: number
+        default: 2
 
 jobs:
   # ─── E2E Tests ─────────────────────────────────────────────────────
@@ -141,11 +162,13 @@ jobs:
     runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: read
-    # regression runs every journey serially (~2h per platform with retries and growing); other suites (merge-queue smoke) stay tight
-    timeout-minutes: ${{ inputs.suite == 'regression' && 180 || 45 }}
+    # regression runs every journey serially (~2h per platform with retries and growing); send-video is four
+    # recording journeys with retries; other suites (merge-queue smoke) stay tight
+    timeout-minutes: ${{ (inputs.suite == 'regression' && 180) || (inputs.suite == 'send-video' && 90) || 45 }}
     continue-on-error: ${{ contains(fromJSON('["migration","upgrade","upgrade403"]'), inputs.suite) }}
     strategy:
-      max-parallel: 2
+      # send-video is pinned to 1: its journeys must never run on two platforms at once
+      max-parallel: ${{ (inputs.suite == 'send-video' && 1) || inputs.max_parallel || 2 }}
       fail-fast: false
       matrix:
         device: ${{ fromJSON(inputs.device_matrix) }}
@@ -225,6 +248,8 @@ jobs:
           BUILD_NUMBER: ${{ inputs.build_number }}
           PREV_BUILD_NUMBER: ${{ inputs.prev_build_number }}
           SUITE: ${{ inputs.suite }}
+          MAX_PARALLEL: ${{ inputs.max_parallel || 2 }}
+          EXCLUDE_SEND_VIDEO_INPUT: ${{ inputs.exclude_send_video }}
           BUILD_NAME: 'build-${{ inputs.build_number }}'
           TEST_NAME: 'E2E ${{ inputs.suite }} - ${{ matrix.device.platform }} ${{ matrix.device.os_version }}'
         run: |
@@ -234,9 +259,25 @@ jobs:
           # POST /session until the client aborts and reports "Failed to create a session".
           DEVICE_COUNT=$(printf '%s' "$DEVICE_MATRIX" | jq 'length')
           [ "$DEVICE_COUNT" -ge 1 ] 2>/dev/null || DEVICE_COUNT=1
-          PARALLEL_JOBS=$(( DEVICE_COUNT > 2 ? 2 : DEVICE_COUNT ))   # strategy.max-parallel is 2
+          [ "$MAX_PARALLEL" -ge 1 ] 2>/dev/null || MAX_PARALLEL=2
+          if [ "$SUITE" = "send-video" ]; then MAX_PARALLEL=1; fi   # mirrors strategy.max-parallel
+          PARALLEL_JOBS=$(( DEVICE_COUNT > MAX_PARALLEL ? MAX_PARALLEL : DEVICE_COUNT ))
           export SAUCE_MAX_INSTANCES=$(( SAUCE_RDS_CONCURRENCY / PARALLEL_JOBS ))
+          # The send-video journeys review a blind-FIFO queue: one session at a time whatever the budget
+          # (the Android lane caps itself, iOS has no per-lane cap).
+          if [ "$SUITE" = "send-video" ]; then export SAUCE_MAX_INSTANCES=1; fi
           echo "Devices: $DEVICE_COUNT | parallel jobs: $PARALLEL_JOBS | wdio maxInstances: $SAUCE_MAX_INSTANCES"
+
+          # Those journeys must never run on two platforms at once — each platform's queue drain would
+          # reject the other's live upload — so a multi-device parallel verify/regression run drops them;
+          # the nightly runs them in its own one-platform-at-a-time lane.
+          export E2E_EXCLUDE_SEND_VIDEO=0
+          if [ "$EXCLUDE_SEND_VIDEO_INPUT" = "true" ]; then
+            export E2E_EXCLUDE_SEND_VIDEO=1
+          elif [ "$PARALLEL_JOBS" -gt 1 ] && { [ "$SUITE" = "verify" ] || [ "$SUITE" = "regression" ]; }; then
+            export E2E_EXCLUDE_SEND_VIDEO=1
+            echo "::notice::Send-video journeys excluded from this ${SUITE} run: ${PARALLEL_JOBS} platforms run in parallel. Use the send-video suite (or max_parallel: 1) to include them."
+          fi
 
           case "$SUITE" in
             migration)
@@ -291,58 +332,5 @@ jobs:
         with:
           name: e2e-reports-${{ inputs.suite }}-${{ matrix.device.platform }}-${{ matrix.device.os_version }}
           path: e2e/reports/
-          if-no-files-found: warn
-          retention-days: 14
-
-  # ─── Brief ─────────────────────────────────────────────────────────
-  # One page for the run: the UAT checklist per platform, every failure, and the accessibility
-  # findings vs e2e/a11y-baseline.json — rendered from the e2e-reports-* artifacts above into the
-  # run summary, and saved as an artifact. Report-only: it never fails the run on findings.
-  brief:
-    name: 'brief - ${{ inputs.suite }}'
-    needs: [e2e-tests]
-    if: ${{ always() && inputs.brief }}
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Setup E2E
-        uses: ./.github/workflows/actions/setup-e2e
-
-      # A pattern that matches nothing must not kill the summary — the page says so instead.
-      - name: Download E2E reports
-        uses: actions/download-artifact@v8
-        continue-on-error: true
-        with:
-          pattern: e2e-reports-${{ inputs.suite }}-*
-          path: e2e/artifacts
-
-      - name: Check the coverage map
-        working-directory: e2e
-        run: ./node_modules/.bin/tsx scripts/brief-check.ts
-
-      - name: Render the brief
-        working-directory: e2e
-        env: # via env, never inline in run — inputs are attacker-controlled
-          SUITE: ${{ inputs.suite }}
-          BUILD_NUMBER: ${{ inputs.build_number }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          ./node_modules/.bin/tsx scripts/brief.ts --reports artifacts \
-            --title "E2E ${SUITE} — build ${BUILD_NUMBER}" --run-url "$RUN_URL" \
-            --out brief.md --json brief.json
-          cat brief.md >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload brief
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: e2e-brief-${{ inputs.suite }}
-          path: |
-            e2e/brief.md
-            e2e/brief.json
           if-no-files-found: warn
           retention-days: 14

--- a/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
+++ b/app/src/bcsc-theme/features/verify/send-video/CancelledReview.tsx
@@ -14,7 +14,8 @@ import {
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet } from 'react-native'
-import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
+import CommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons'
+import MaterialIcon from 'react-native-vector-icons/MaterialIcons'
 import useCancelledReviewViewModel from './CancelledReviewViewModel'
 
 interface CancelledReviewProps {
@@ -74,7 +75,7 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
         accessibilityLabel={t('BCSC.CancelledVerification.RetryButton')}
         testID={testIdWithKey('RetryWithNewVideo')}
       >
-        <Icon name={'video-outline'} size={24} color={ColorPalette.brand.primary} style={styles.buttonIcon} />
+        <MaterialIcon name={'sensor-occupied'} size={24} color={ColorPalette.brand.primary} style={styles.buttonIcon} />
       </Button>
       <Button
         title={t('BCSC.CancelledVerification.RestartButton')}
@@ -84,7 +85,7 @@ const CancelledReview = ({ route }: CancelledReviewProps) => {
         accessibilityLabel={t('BCSC.CancelledVerification.RestartButton')}
         testID={testIdWithKey('RestartVerification')}
       >
-        <Icon name={'restore'} size={24} color={ColorPalette.brand.primary} style={styles.buttonIcon} />
+        <CommunityIcon name={'restore'} size={24} color={ColorPalette.brand.primary} style={styles.buttonIcon} />
       </Button>
     </ControlContainer>
   )

--- a/app/src/bcsc-theme/features/verify/send-video/__snapshots__/CancelledReview.test.tsx.snap
+++ b/app/src/bcsc-theme/features/verify/send-video/__snapshots__/CancelledReview.test.tsx.snap
@@ -186,7 +186,7 @@ exports[`CancelledReview renders correctly with agent reason 1`] = `
                     "marginRight": 8,
                   },
                   {
-                    "fontFamily": "Material Design Icons",
+                    "fontFamily": "Material Icons",
                     "fontStyle": "normal",
                     "fontWeight": "normal",
                   },
@@ -194,7 +194,7 @@ exports[`CancelledReview renders correctly with agent reason 1`] = `
                 ]
               }
             >
-              󰯜
+              
             </Text>
             <Text
               maxFontSizeMultiplier={2}

--- a/app/src/bcsc-theme/utils/decoder-strategy/BCComboCardBarcodeDecoder.test.ts
+++ b/app/src/bcsc-theme/utils/decoder-strategy/BCComboCardBarcodeDecoder.test.ts
@@ -1,13 +1,10 @@
 import { BCComboCardBarcodeDecoder } from '@/bcsc-theme/utils/decoder-strategy/BCComboCardBarcodeDecoder'
 import { DriversLicenseBarcode, ScanableCode } from '@/bcsc-theme/utils/decoder-strategy/DecoderStrategy'
-import { DriversLicenseBarcodeDecoder } from '@/bcsc-theme/utils/decoder-strategy/DriversLicenseBarcodeDecoder'
-
-const BC_COMBO_CARD_DL_BARCODE_NO_BCSC_A =
-  "%BCVICTORIA^SPECIMEN,$TEST CARD^910 GOVERNMENT ST$VICTORIA BC  V8W 3Y8^?;6360282222222=240919700906=?_%0AV8W3Y8                     M185 95BRNBLU9123456789                E$''C(R2S6L?"
-const BC_COMBO_CARD_DL_BARCODE_NO_BCSC_B =
-  '%BCVICTORIA^SPECIMEN,$TEST CARD^910 GOVERNMENT ST$VICTORIA BC  V8W 3Y8^?;6360282222222=250419470429=?_%0AV8W3Y8                     X160 57WHIBLU9123456789                E$!(\\0CUPXD?'
-const BC_COMBO_CARD_DL_BARCODE_WITH_BCSC_C =
-  '%BCVICTORIA^SPECIMEN,$TEST CARD^910 GOVERNMENT ST$VICTORIA BC  V8W 3Y8^?;6360282222222=260119820104=?_%0AV8W3Y8                     M185 88BRNBLU                          00S00023254?'
+import {
+  BC_COMBO_CARD_DL_BARCODE_NO_BCSC_A,
+  BC_COMBO_CARD_DL_BARCODE_NO_BCSC_B,
+  BC_COMBO_CARD_DL_BARCODE_WITH_BCSC_C,
+} from '@/bcsc-theme/utils/decoder-strategy/__fixtures__/barcodes'
 
 describe('BCComboCardBarcodeDecoder', () => {
   describe('canDecode', () => {
@@ -33,7 +30,7 @@ describe('BCComboCardBarcodeDecoder', () => {
     })
 
     it('should return false for a malformed PDF-417 barcode', () => {
-      const decoder = new DriversLicenseBarcodeDecoder()
+      const decoder = new BCComboCardBarcodeDecoder()
       const barcode: DriversLicenseBarcode = {
         type: 'pdf-417',
         value: 'MALFORMED_BARCODE_DATA',

--- a/app/src/bcsc-theme/utils/decoder-strategy/BCServicesCardBarcodeDecoder.test.ts
+++ b/app/src/bcsc-theme/utils/decoder-strategy/BCServicesCardBarcodeDecoder.test.ts
@@ -10,48 +10,19 @@ import {
 
 describe('BCServicesCardBarcodeDecoder', () => {
   describe('isBCSCSerial', () => {
-    describe('returns true for valid BCSC serials', () => {
-      it('should validate serial with 1 letter followed by 8 digits', () => {
-        expect(isBCSCSerial('A12345678')).toBe(true)
-      })
-
-      it('should validate serial with multiple letters followed by digits', () => {
-        expect(isBCSCSerial('AB1234567')).toBe(true)
-      })
-
-      it('should validate serial with lowercase letter followed by digits', () => {
-        expect(isBCSCSerial('a12345678')).toBe(true)
-      })
-
-      it('should validate serial with multiple letters and digits', () => {
-        expect(isBCSCSerial('ABC1234')).toBe(true)
-      })
-    })
-
-    describe('returns false for invalid BCSC serials', () => {
-      it('should invalidate serial without leading letter', () => {
-        expect(isBCSCSerial('123456789')).toBe(false)
-      })
-
-      it('should invalidate serial with special characters', () => {
-        expect(isBCSCSerial('A1234@678')).toBe(false)
-      })
-
-      it('should invalidate serial that is too long', () => {
-        expect(isBCSCSerial('A1234567890')).toBe(false)
-      })
-
-      it('should invalidate empty serial', () => {
-        expect(isBCSCSerial('')).toBe(false)
-      })
-
-      it('should invalidate serial with only letters', () => {
-        expect(isBCSCSerial('ABCDEFGH')).toBe(false)
-      })
-
-      it('should invalidate serial with only digits', () => {
-        expect(isBCSCSerial('12345678')).toBe(false)
-      })
+    it.each([
+      ['A12345678', true, '1 letter followed by 8 digits'],
+      ['AB1234567', true, 'multiple letters followed by digits'],
+      ['a12345678', true, 'lowercase letter followed by digits'],
+      ['ABC1234', true, 'multiple letters and digits'],
+      ['123456789', false, 'no leading letter'],
+      ['A1234@678', false, 'special characters'],
+      ['A1234567890', false, 'too long'],
+      ['', false, 'empty serial'],
+      ['ABCDEFGH', false, 'only letters'],
+      ['12345678', false, 'only digits'],
+    ])('isBCSCSerial(%s) -> %s (%s)', (serial, expected) => {
+      expect(isBCSCSerial(serial)).toBe(expected)
     })
   })
   describe('canDecode', () => {

--- a/app/src/bcsc-theme/utils/decoder-strategy/DecoderStrategy.test.ts
+++ b/app/src/bcsc-theme/utils/decoder-strategy/DecoderStrategy.test.ts
@@ -1,11 +1,16 @@
 import { BCComboCardBarcodeDecoder } from '@/bcsc-theme/utils/decoder-strategy/BCComboCardBarcodeDecoder'
 import { BCServicesCardBarcodeDecoder } from '@/bcsc-theme/utils/decoder-strategy/BCServicesCardBarcodeDecoder'
 import {
+  decodeBarcodes,
+  DecodedCode,
+  DecodedCodeKind,
+  DecoderStrategy,
   decodeScannedCode,
   getDecoderStrategies,
   ScanableCode,
 } from '@/bcsc-theme/utils/decoder-strategy/DecoderStrategy'
 import { DriversLicenseBarcodeDecoder } from '@/bcsc-theme/utils/decoder-strategy/DriversLicenseBarcodeDecoder'
+import { MockLogger } from '@bifold/core'
 
 describe('getDecoderStrategies', () => {
   it('should return an array of decoder strategies', () => {
@@ -23,42 +28,98 @@ describe('getDecoderStrategies', () => {
   })
 })
 
+const makeStrategy = (canDecode: boolean, decode: () => DecodedCode): DecoderStrategy => ({
+  canDecode: jest.fn().mockReturnValue(canDecode),
+  decode: jest.fn(decode),
+})
+
 describe('decodeScannedCode', () => {
+  const mockCode: ScanableCode = {
+    type: 'unknown',
+    value: 'mock-value',
+  }
+
   it('should decode using the strategy', () => {
-    const mockStrategy = {
-      canDecode: jest.fn().mockReturnValue(true),
-      decode: jest.fn().mockReturnValue(true),
-    }
+    const decoded = { kind: DecodedCodeKind.BCServicesCardBarcode, bcscSerial: 'A12345678' } as DecodedCode
+    const mockStrategy = makeStrategy(true, () => decoded)
 
-    const mockCode: ScanableCode = {
-      type: 'unknown',
-      value: 'mock-value',
-    }
-
-    const mockLogger = { warn: jest.fn(), debug: jest.fn(), error: jest.fn(), info: jest.fn() } as any
-    const value = decodeScannedCode(mockCode, mockLogger, [mockStrategy])
+    const value = decodeScannedCode(mockCode, new MockLogger(), [mockStrategy])
 
     expect(mockStrategy.canDecode).toHaveBeenCalledWith(mockCode)
     expect(mockStrategy.decode).toHaveBeenCalledWith(mockCode)
-    expect(value).toBe(true)
+    expect(value).toBe(decoded)
   })
 
   it('should return null if no strategy can decode the code', () => {
-    const mockStrategy = {
-      canDecode: jest.fn().mockReturnValue(false),
-      decode: jest.fn(),
-    }
+    const mockStrategy = makeStrategy(false, () => {
+      throw new Error('should not be reached')
+    })
 
-    const mockCode: ScanableCode = {
-      type: 'unknown',
-      value: 'mock-value',
-    }
-
-    const mockLogger = { warn: jest.fn(), debug: jest.fn(), error: jest.fn(), info: jest.fn() } as any
-    const value = decodeScannedCode(mockCode, mockLogger, [mockStrategy])
+    const value = decodeScannedCode(mockCode, new MockLogger(), [mockStrategy])
 
     expect(mockStrategy.canDecode).toHaveBeenCalledWith(mockCode)
     expect(mockStrategy.decode).not.toHaveBeenCalled()
     expect(value).toBeNull()
+  })
+
+  it('should fall through to the next strategy when a matching strategy throws', () => {
+    const decoded = { kind: DecodedCodeKind.BCServicesCardBarcode, bcscSerial: 'A12345678' } as DecodedCode
+    const throwingStrategy = makeStrategy(true, () => {
+      throw new Error('bad parse')
+    })
+    const succeedingStrategy = makeStrategy(true, () => decoded)
+    const logger = new MockLogger()
+
+    const value = decodeScannedCode(mockCode, logger, [throwingStrategy, succeedingStrategy])
+
+    expect(value).toBe(decoded)
+    expect(logger.warn).toHaveBeenCalledWith('Error decoding unknown barcode', { error: expect.any(Error) })
+  })
+
+  it('should return null when every matching strategy throws', () => {
+    const throwingStrategy = makeStrategy(true, () => {
+      throw new Error('bad parse')
+    })
+    const logger = new MockLogger()
+
+    expect(decodeScannedCode(mockCode, logger, [throwingStrategy])).toBeNull()
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('decodeBarcodes', () => {
+  it('should skip codes of unknown type without adding an entry', () => {
+    const logger = new MockLogger()
+
+    const result = decodeBarcodes([{ type: 'unknown', value: 'A12345678' }], logger)
+
+    expect(result).toEqual([])
+    expect(logger.debug).toHaveBeenCalledWith('[DecodeBarcodes] Skipping unknown barcode')
+  })
+
+  it('should push null for a code no strategy can decode', () => {
+    const logger = new MockLogger()
+
+    const result = decodeBarcodes([{ type: 'code-39', value: 'not-a-serial' }], logger)
+
+    expect(result).toEqual([null])
+    expect(logger.debug).toHaveBeenCalledWith('[DecodeBarcodes] Failed to decode barcode', {
+      barcode: { type: 'code-39', value: 'not-a-serial' },
+    })
+  })
+
+  it('should decode each supported code and preserve order', () => {
+    const logger = new MockLogger()
+
+    const result = decodeBarcodes(
+      [
+        { type: 'code-39', value: 'A12345678' },
+        { type: 'unknown', value: 'ignored' },
+        { type: 'code-128', value: 'not-a-serial' },
+      ],
+      logger
+    )
+
+    expect(result).toEqual([{ kind: DecodedCodeKind.BCServicesCardBarcode, bcscSerial: 'A12345678' }, null])
   })
 })

--- a/app/src/bcsc-theme/utils/decoder-strategy/DriversLicenseBarcodeDecoder.test.ts
+++ b/app/src/bcsc-theme/utils/decoder-strategy/DriversLicenseBarcodeDecoder.test.ts
@@ -1,36 +1,24 @@
 import { DriversLicenseBarcode, ScanableCode } from '@/bcsc-theme/utils/decoder-strategy/DecoderStrategy'
 import { DriversLicenseBarcodeDecoder } from '@/bcsc-theme/utils/decoder-strategy/DriversLicenseBarcodeDecoder'
-
-const BC_COMBO_CARD_DL_BARCODE_NO_BCSC_A =
-  "%BCVICTORIA^SPECIMEN,$TEST CARD^910 GOVERNMENT ST$VICTORIA BC  V8W 3Y8^?;6360282222222=240919700906=?_%0AV8W3Y8                     M185 95BRNBLU9123456789                E$''C(R2S6L?"
-const BC_COMBO_CARD_DL_BARCODE_NO_BCSC_B =
-  '%BCVICTORIA^SPECIMEN,$TEST CARD^910 GOVERNMENT ST$VICTORIA BC  V8W 3Y8^?;6360282222222=250419470429=?_%0AV8W3Y8                     X160 57WHIBLU9123456789                E$!(\\0CUPXD?'
-const BC_COMBO_CARD_DL_BARCODE_WITH_BCSC_C =
-  '%BCVICTORIA^SPECIMEN,$TEST CARD^910 GOVERNMENT ST$VICTORIA BC  V8W 3Y8^?;6360282222222=260119820104=?_%0AV8W3Y8                     M185 88BRNBLU                          00S00023254?'
-
-// 3-caret format (no extra ^ before track separator) — some real-world cards use this variant
-const BC_DL_BARCODE_3_CARET =
-  '%BCVICTORIA^CPSIJSIT,$STANDALONE CITZ FOUR^910 GOVERNMENT ST$VICTORIA BC V8W 3Y5?;636028004023964=270419850410=?_%0AV8W3Y5                     F            9873904417                00C00015303?'
-
-const VALID_BC_DL_BARCODES = [
+import {
   BC_COMBO_CARD_DL_BARCODE_NO_BCSC_A,
   BC_COMBO_CARD_DL_BARCODE_NO_BCSC_B,
   BC_COMBO_CARD_DL_BARCODE_WITH_BCSC_C,
   BC_DL_BARCODE_3_CARET,
-]
+  VALID_BC_DL_BARCODES,
+} from '@/bcsc-theme/utils/decoder-strategy/__fixtures__/barcodes'
 
 describe('DriversLicenseBarcodeDecoder', () => {
   describe('canDecode', () => {
-    it('should return true for a PDF-417 barcode', () => {
+    it.each(VALID_BC_DL_BARCODES)('should return true for a PDF-417 barcode: %s', (validBarcode) => {
       const decoder = new DriversLicenseBarcodeDecoder()
 
-      for (const validBarcode of VALID_BC_DL_BARCODES) {
-        const barcode: DriversLicenseBarcode = {
-          type: 'pdf-417',
-          value: validBarcode,
-        }
-        expect(decoder.canDecode(barcode)).toBe(true)
+      const barcode: DriversLicenseBarcode = {
+        type: 'pdf-417',
+        value: validBarcode,
       }
+
+      expect(decoder.canDecode(barcode)).toBe(true)
     })
 
     it('should return false for a non PDF-417 barcode', () => {
@@ -167,37 +155,39 @@ describe('DriversLicenseBarcodeDecoder', () => {
       })
     })
 
-    it('should handle century rollover edge case for expiry dates', () => {
-      jest.useFakeTimers().setSystemTime(new Date('2100-01-01'))
+    describe('century rollover', () => {
+      beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2100-01-01'))
+      })
 
-      const decoder = new DriversLicenseBarcodeDecoder()
-      const barcode: DriversLicenseBarcode = {
-        type: 'pdf-417',
-        value:
-          '%BCVICTORIA^SPECIMEN,$TEST CARD^910 GOVERNMENT ST$VICTORIA BC  V8W 3Y8^?;6360282222222=250419470429=?_%0AV8W3Y8                     X160 57WHIBLU9123456789                E$!(\\0CUPXD?',
-      }
+      afterEach(() => {
+        jest.useRealTimers()
+      })
 
-      const decoded = decoder.decode(barcode)
+      it('should handle century rollover edge case for expiry dates', () => {
+        const decoder = new DriversLicenseBarcodeDecoder()
+        const barcode: DriversLicenseBarcode = {
+          type: 'pdf-417',
+          value: BC_COMBO_CARD_DL_BARCODE_NO_BCSC_B,
+        }
 
-      expect(decoded.expiryDate).toEqual(new Date('2125-04-29'))
+        const decoded = decoder.decode(barcode)
 
-      jest.useRealTimers()
-    })
+        expect(decoded.expiryDate).toEqual(new Date('2125-04-29'))
+      })
 
-    it('should handle century rollover edge case for birth dates', () => {
-      jest.useFakeTimers().setSystemTime(new Date('2100-01-01'))
-      const decoder = new DriversLicenseBarcodeDecoder()
-      const barcode: DriversLicenseBarcode = {
-        type: 'pdf-417',
-        value:
-          '%BCVICTORIA^SPECIMEN,$TEST CARD^910 GOVERNMENT ST$VICTORIA BC  V8W 3Y8^?;6360282222222=250420000429=?_%0AV8W3Y8                     X160 57WHIBLU9123456789                E$!(\\0CUPXD?',
-      }
+      it('should handle century rollover edge case for birth dates', () => {
+        const decoder = new DriversLicenseBarcodeDecoder()
+        const barcode: DriversLicenseBarcode = {
+          type: 'pdf-417',
+          value:
+            '%BCVICTORIA^SPECIMEN,$TEST CARD^910 GOVERNMENT ST$VICTORIA BC  V8W 3Y8^?;6360282222222=250420000429=?_%0AV8W3Y8                     X160 57WHIBLU9123456789                E$!(\\0CUPXD?',
+        }
 
-      const decoded = decoder.decode(barcode)
+        const decoded = decoder.decode(barcode)
 
-      expect(decoded.birthDate).toEqual(new Date('2000-04-29'))
-
-      jest.useRealTimers()
+        expect(decoded.birthDate).toEqual(new Date('2000-04-29'))
+      })
     })
   })
 })

--- a/app/src/bcsc-theme/utils/decoder-strategy/__fixtures__/barcodes.ts
+++ b/app/src/bcsc-theme/utils/decoder-strategy/__fixtures__/barcodes.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared PDF-417 fixtures for the decoder-strategy suites. All values are BC "SPECIMEN"
+ * test cards, not real credentials.
+ *
+ * Only the one value containing a backslash uses String.raw; the rest are plain
+ * strings so the tag is a signal rather than noise.
+ */
+
+export const BC_COMBO_CARD_DL_BARCODE_NO_BCSC_A =
+  "%BCVICTORIA^SPECIMEN,$TEST CARD^910 GOVERNMENT ST$VICTORIA BC  V8W 3Y8^?;6360282222222=240919700906=?_%0AV8W3Y8                     M185 95BRNBLU9123456789                E$''C(R2S6L?"
+
+export const BC_COMBO_CARD_DL_BARCODE_NO_BCSC_B = String.raw`%BCVICTORIA^SPECIMEN,$TEST CARD^910 GOVERNMENT ST$VICTORIA BC  V8W 3Y8^?;6360282222222=250419470429=?_%0AV8W3Y8                     X160 57WHIBLU9123456789                E$!(\0CUPXD?`
+
+export const BC_COMBO_CARD_DL_BARCODE_WITH_BCSC_C =
+  '%BCVICTORIA^SPECIMEN,$TEST CARD^910 GOVERNMENT ST$VICTORIA BC  V8W 3Y8^?;6360282222222=260119820104=?_%0AV8W3Y8                     M185 88BRNBLU                          00S00023254?'
+
+// 3-caret format (no extra ^ before track separator) — some real-world cards use this variant
+export const BC_DL_BARCODE_3_CARET =
+  '%BCVICTORIA^CPSIJSIT,$STANDALONE CITZ FOUR^910 GOVERNMENT ST$VICTORIA BC V8W 3Y5?;636028004023964=270419850410=?_%0AV8W3Y5                     F            9873904417                00C00015303?'
+
+export const VALID_BC_DL_BARCODES = [
+  BC_COMBO_CARD_DL_BARCODE_NO_BCSC_A,
+  BC_COMBO_CARD_DL_BARCODE_NO_BCSC_B,
+  BC_COMBO_CARD_DL_BARCODE_WITH_BCSC_C,
+  BC_DL_BARCODE_3_CARET,
+]

--- a/app/src/bcsc-theme/utils/file-info.test.ts
+++ b/app/src/bcsc-theme/utils/file-info.test.ts
@@ -18,27 +18,28 @@ jest.mock('@/utils/read-file', () => ({
 
 const mockReadFileInChunks = readFileInChunks as jest.MockedFunction<typeof readFileInChunks>
 
-describe('File Info Utils', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
+type FileStatOverrides = Partial<{ mtime: number; size: number; path: string; name: string }>
 
+const mockFileStat = (overrides: FileStatOverrides = {}) =>
+  jest.mocked(RNFS).stat.mockResolvedValue({
+    mtime: new Date('2025-01-15T12:00:00Z').getTime(),
+    size: 1024,
+    path: '/path/to/photo.png',
+    isFile: () => true,
+    isDirectory: () => false,
+    ctime: 0,
+    name: 'photo.png',
+    ...overrides,
+  } as any)
+
+describe('File Info Utils', () => {
   describe('getFileInfo', () => {
     it('should return filename, timestamp, and size from file stats', async () => {
-      const RNFSMock = jest.mocked(RNFS)
-      RNFSMock.stat.mockResolvedValue({
-        mtime: new Date('2025-01-15T12:00:00Z').getTime(),
-        size: 1024,
-        path: '/path/to/photo.png',
-        isFile: () => true,
-        isDirectory: () => false,
-        ctime: 0,
-        name: 'photo.png',
-      } as any)
+      mockFileStat()
 
       const result = await getFileInfo('/path/to/photo.png')
 
-      expect(RNFSMock.stat).toHaveBeenCalledWith('/path/to/photo.png')
+      expect(jest.mocked(RNFS).stat).toHaveBeenCalledWith('/path/to/photo.png')
       expect(result).toEqual({
         filename: 'photo.png',
         timestamp: new Date('2025-01-15T12:00:00Z').getTime() / 1000,
@@ -47,17 +48,8 @@ describe('File Info Utils', () => {
     })
 
     it('should default filename to selfie.png when path has no filename', async () => {
-      const RNFSMock = jest.mocked(RNFS)
       // Edge case: path ending with "/" so pop() returns ""
-      RNFSMock.stat.mockResolvedValue({
-        mtime: new Date('2025-01-15T12:00:00Z').getTime(),
-        size: 512,
-        path: '',
-        isFile: () => true,
-        isDirectory: () => false,
-        ctime: 0,
-        name: '',
-      } as any)
+      mockFileStat({ size: 512, path: '', name: '' })
 
       const result = await getFileInfo('')
 
@@ -68,18 +60,14 @@ describe('File Info Utils', () => {
   describe('getPhotoMetadata', () => {
     it('should return photo metadata with permanent path on successful save', async () => {
       const mockLogger = new MockLogger()
-      const RNFSMock = jest.mocked(RNFS)
       const mockBuffer = Buffer.from('fake-jpeg-data')
 
-      RNFSMock.stat.mockResolvedValue({
+      mockFileStat({
         mtime: new Date('2025-06-01T10:00:00Z').getTime(),
         size: mockBuffer.byteLength,
         path: '/tmp/photo.jpg',
-        isFile: () => true,
-        isDirectory: () => false,
-        ctime: 0,
         name: 'photo.jpg',
-      } as any)
+      })
 
       mockReadFileInChunks.mockResolvedValue(mockBuffer)
       ;(hashBase64 as jest.Mock).mockResolvedValue('sha256-hash-value')
@@ -106,18 +94,14 @@ describe('File Info Utils', () => {
 
     it('should fall back to original file path when saveEvidencePhoto fails', async () => {
       const mockLogger = new MockLogger()
-      const RNFSMock = jest.mocked(RNFS)
       const mockBuffer = Buffer.from('fake-jpeg-data')
 
-      RNFSMock.stat.mockResolvedValue({
+      mockFileStat({
         mtime: new Date('2025-06-01T10:00:00Z').getTime(),
         size: mockBuffer.byteLength,
         path: '/tmp/photo.jpg',
-        isFile: () => true,
-        isDirectory: () => false,
-        ctime: 0,
         name: 'photo.jpg',
-      } as any)
+      })
 
       mockReadFileInChunks.mockResolvedValue(mockBuffer)
       ;(hashBase64 as jest.Mock).mockResolvedValue('sha256-hash-value')
@@ -131,21 +115,12 @@ describe('File Info Utils', () => {
 
     it('should substitute the current time when the file mtime is implausible (e.g. 0)', async () => {
       const mockLogger = new MockLogger()
-      const RNFSMock = jest.mocked(RNFS)
       const mockBuffer = Buffer.from('fake-jpeg-data')
       const now = new Date('2026-07-28T00:00:00Z').getTime()
       const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(now)
 
       // Android's File.lastModified() can return 0 on failure.
-      RNFSMock.stat.mockResolvedValue({
-        mtime: 0,
-        size: mockBuffer.byteLength,
-        path: '/tmp/photo.jpg',
-        isFile: () => true,
-        isDirectory: () => false,
-        ctime: 0,
-        name: 'photo.jpg',
-      } as any)
+      mockFileStat({ mtime: 0, size: mockBuffer.byteLength, path: '/tmp/photo.jpg', name: 'photo.jpg' })
 
       mockReadFileInChunks.mockResolvedValue(mockBuffer)
       ;(hashBase64 as jest.Mock).mockResolvedValue('sha256-hash-value')
@@ -163,18 +138,14 @@ describe('File Info Utils', () => {
 
     it('should handle non-Error thrown by saveEvidencePhoto', async () => {
       const mockLogger = new MockLogger()
-      const RNFSMock = jest.mocked(RNFS)
       const mockBuffer = Buffer.from('fake-jpeg-data')
 
-      RNFSMock.stat.mockResolvedValue({
+      mockFileStat({
         mtime: new Date('2025-06-01T10:00:00Z').getTime(),
         size: mockBuffer.byteLength,
         path: '/tmp/photo.jpg',
-        isFile: () => true,
-        isDirectory: () => false,
-        ctime: 0,
         name: 'photo.jpg',
-      } as any)
+      })
 
       mockReadFileInChunks.mockResolvedValue(mockBuffer)
       ;(hashBase64 as jest.Mock).mockResolvedValue('sha256-hash-value')
@@ -262,19 +233,6 @@ describe('File Info Utils', () => {
 
       expect(RNFSMock.exists).toHaveBeenCalledWith(mockFilePath)
       expect(RNFSMock.unlink).toHaveBeenCalledWith(mockFilePath)
-    })
-
-    it('should not attempt to remove file when file does not exist', async () => {
-      const mockFilePath = '/path/to/selfie.png'
-      const mockLogger = new MockLogger()
-      const RNFSMock = jest.mocked(RNFS)
-
-      RNFSMock.exists.mockResolvedValue(false)
-
-      await removeFileSafely(mockFilePath, mockLogger)
-
-      expect(RNFSMock.exists).toHaveBeenCalledWith(mockFilePath)
-      expect(RNFSMock.unlink).not.toHaveBeenCalled()
     })
 
     it('should handle undefined file path gracefully', async () => {

--- a/app/src/bcsc-theme/utils/native-error-map.test.ts
+++ b/app/src/bcsc-theme/utils/native-error-map.test.ts
@@ -15,6 +15,18 @@ jest.mock('react-native-bcsc-core')
 /** Build a fake native module rejection: an Error carrying a string `code` (and optional userInfo). */
 const nativeError = (code: string, message = 'native failure'): Error => Object.assign(new Error(message), { code })
 
+/** Run `fn` once and return what it threw, failing the test if it returns normally. */
+const captureThrown = (fn: () => unknown): AppError => {
+  try {
+    fn()
+  } catch (thrown) {
+    expect(thrown).toBeInstanceOf(AppError)
+    return thrown as AppError
+  }
+
+  throw new Error('Expected the function to throw, but it returned')
+}
+
 jest.mock('@/contexts/NavigationContainerContext', () => ({
   navigationRef: { isReady: () => false, getCurrentRoute: () => undefined },
 }))
@@ -62,7 +74,8 @@ describe('native-error-map', () => {
       const error = new Error('test')
       const result = toAppError(error, ErrorRegistry.DEVICE_AUTHORIZATION_ERROR)
 
-      expect(result.code).toContain('device')
+      // AppError has no `category` field — the category is the first segment of `code`.
+      expect(result.code.split('.')[0]).toBe(ErrorRegistry.DEVICE_AUTHORIZATION_ERROR.category)
     })
   })
 
@@ -70,15 +83,10 @@ describe('native-error-map', () => {
     it('throws an AppError with the given definition', () => {
       const error = new Error('native failure')
 
-      expect(() => throwAppError(error, ErrorRegistry.DECRYPT_JWE_ERROR)).toThrow(AppError)
+      const thrown = captureThrown(() => throwAppError(error, ErrorRegistry.DECRYPT_JWE_ERROR))
 
-      try {
-        throwAppError(error, ErrorRegistry.DECRYPT_JWE_ERROR)
-      } catch (thrown) {
-        expect(thrown).toBeInstanceOf(AppError)
-        expect((thrown as AppError).appEvent).toBe(ErrorRegistry.DECRYPT_JWE_ERROR.appEvent)
-        expect((thrown as AppError).cause).toBe(error)
-      }
+      expect(thrown.appEvent).toBe(ErrorRegistry.DECRYPT_JWE_ERROR.appEvent)
+      expect(thrown.cause).toBe(error)
     })
 
     it('throws an AppError for a non-Error value', () => {
@@ -160,13 +168,10 @@ describe('native-error-map', () => {
     it('throws the mapped AppError', () => {
       const error = nativeError('E_KEY_NOT_FOUND')
 
-      expect(() => throwNativeBcscError(error)).toThrow(AppError)
-      try {
-        throwNativeBcscError(error)
-      } catch (thrown) {
-        expect((thrown as AppError).appEvent).toBe(ErrorRegistry.KEYCHAIN_KEY_NOT_FOUND.appEvent)
-        expect((thrown as AppError).cause).toBe(error)
-      }
+      const thrown = captureThrown(() => throwNativeBcscError(error))
+
+      expect(thrown.appEvent).toBe(ErrorRegistry.KEYCHAIN_KEY_NOT_FOUND.appEvent)
+      expect(thrown.cause).toBe(error)
     })
   })
 })

--- a/app/src/bcsc-theme/utils/push-notification-tokens.test.ts
+++ b/app/src/bcsc-theme/utils/push-notification-tokens.test.ts
@@ -1,81 +1,50 @@
 import { getNotificationTokens } from '@/bcsc-theme/utils/push-notification-tokens'
+import { MockLogger } from '@bifold/core'
+import {
+  getAPNSToken,
+  getToken,
+  isDeviceRegisteredForRemoteMessages,
+  registerDeviceForRemoteMessages,
+} from '@react-native-firebase/messaging'
 import { Platform } from 'react-native'
 
-// Mock the messaging module (modular API)
-const mockGetToken = jest.fn()
-const mockGetAPNSToken = jest.fn()
-const mockRegisterDeviceForRemoteMessages = jest.fn()
-const mockIsDeviceRegisteredForRemoteMessages = jest.fn()
+jest.mock('@react-native-firebase/app')
+jest.mock('@react-native-firebase/messaging')
 
-const mockMessagingInstance = {}
+const originalPlatformOS = Platform.OS
 
-jest.mock('@react-native-firebase/app', () => ({
-  getApp: jest.fn(() => ({})),
-}))
-
-jest.mock('@react-native-firebase/messaging', () => ({
-  getMessaging: jest.fn(() => mockMessagingInstance),
-  getToken: jest.fn(() => mockGetToken()),
-  getAPNSToken: jest.fn(() => mockGetAPNSToken()),
-  isDeviceRegisteredForRemoteMessages: jest.fn(() => mockIsDeviceRegisteredForRemoteMessages()),
-  registerDeviceForRemoteMessages: jest.fn(() => mockRegisterDeviceForRemoteMessages()),
-}))
-
-// Mock Platform
-jest.mock('react-native', () => ({
-  Platform: {
-    OS: 'ios', // Default to iOS, will override in specific tests
-  },
-}))
-
-// Create a mock logger that satisfies the BifoldLogger interface
-const mockLogger = {
-  // Methods used by the function under test
-  info: jest.fn(),
-  error: jest.fn(),
-  warn: jest.fn(),
-  debug: jest.fn(),
-
-  // Additional methods from BifoldLogger interface (not used but required for typing)
-  logLevel: 0,
-  isEnabled: jest.fn().mockReturnValue(true),
-  test: jest.fn(),
-  trace: jest.fn(),
-  fatal: jest.fn(),
-  report: jest.fn(),
-  log: jest.fn(),
-} as any // Use 'as any' to bypass private property type checking
-
-// Helper to set platform OS in a type-safe way
 const setPlatformOS = (os: 'ios' | 'android' | 'web') => {
-  Object.defineProperty(Platform, 'OS', {
-    writable: true,
-    value: os,
-  })
+  Object.defineProperty(Platform, 'OS', { writable: true, value: os })
 }
 
 describe('getNotificationTokens', () => {
+  let mockLogger: MockLogger
+
   beforeEach(() => {
-    jest.clearAllMocks()
-    // Reset Platform.OS to iOS for most tests
+    mockLogger = new MockLogger()
     setPlatformOS('ios')
-    // Default to device already registered (most common case)
-    mockIsDeviceRegisteredForRemoteMessages.mockReturnValue(true)
+    // The shared manual mock keeps its implementation across `clearMocks`, so re-state the
+    // happy-path defaults here rather than inheriting whatever the previous test set.
+    jest.mocked(isDeviceRegisteredForRemoteMessages).mockReturnValue(true)
+    jest.mocked(registerDeviceForRemoteMessages).mockResolvedValue(undefined)
+    jest.mocked(getToken).mockResolvedValue('mock_fcm_token')
+    jest.mocked(getAPNSToken).mockResolvedValue(null)
+  })
+
+  afterEach(() => {
+    setPlatformOS(originalPlatformOS as 'ios' | 'android' | 'web')
   })
 
   describe('when successful', () => {
     it('returns both FCM and APNS tokens on iOS', async () => {
-      const mockFCMToken = 'mock_fcm_token_123'
-      const mockAPNSToken = 'mock_apns_token_456'
-
-      mockGetToken.mockResolvedValue(mockFCMToken)
-      mockGetAPNSToken.mockResolvedValue(mockAPNSToken)
+      jest.mocked(getToken).mockResolvedValue('mock_fcm_token_123')
+      jest.mocked(getAPNSToken).mockResolvedValue('mock_apns_token_456')
 
       const result = await getNotificationTokens(mockLogger)
 
       expect(result).toEqual({
-        fcmDeviceToken: mockFCMToken,
-        deviceToken: mockAPNSToken,
+        fcmDeviceToken: 'mock_fcm_token_123',
+        deviceToken: 'mock_apns_token_456',
       })
       expect(mockLogger.info).toHaveBeenCalledWith(
         '[PushTokens] Successfully retrieved notification tokens for registration'
@@ -84,19 +53,15 @@ describe('getNotificationTokens', () => {
 
     it('returns only FCM token on Android (no APNS token needed)', async () => {
       setPlatformOS('android')
-      const mockFCMToken = 'mock_fcm_token_android'
-
-      mockGetToken.mockResolvedValue(mockFCMToken)
-      // APNS should not be called on Android
-      mockGetAPNSToken.mockResolvedValue(null)
+      jest.mocked(getToken).mockResolvedValue('mock_fcm_token_android')
 
       const result = await getNotificationTokens(mockLogger)
 
       expect(result).toEqual({
-        fcmDeviceToken: mockFCMToken,
+        fcmDeviceToken: 'mock_fcm_token_android',
         deviceToken: null,
       })
-      expect(mockGetAPNSToken).not.toHaveBeenCalled()
+      expect(getAPNSToken).not.toHaveBeenCalled()
       expect(mockLogger.info).toHaveBeenCalledWith(
         '[PushTokens] Successfully retrieved notification tokens for registration'
       )
@@ -105,9 +70,8 @@ describe('getNotificationTokens', () => {
 
   describe('when FCM token fails', () => {
     it('returns dummy token when FCM token is null', async () => {
-      setPlatformOS('ios')
-      mockGetToken.mockResolvedValue(null)
-      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+      jest.mocked(getToken).mockResolvedValue(null as unknown as string)
+      jest.mocked(getAPNSToken).mockResolvedValue('mock_apns_token')
 
       const result = await getNotificationTokens(mockLogger)
 
@@ -121,9 +85,8 @@ describe('getNotificationTokens', () => {
     })
 
     it('returns dummy token when FCM token is undefined', async () => {
-      setPlatformOS('ios')
-      mockGetToken.mockResolvedValue(undefined)
-      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+      jest.mocked(getToken).mockResolvedValue(undefined as unknown as string)
+      jest.mocked(getAPNSToken).mockResolvedValue('mock_apns_token')
 
       const result = await getNotificationTokens(mockLogger)
 
@@ -134,10 +97,8 @@ describe('getNotificationTokens', () => {
     })
 
     it('returns dummy token when FCM token fetch throws exception', async () => {
-      setPlatformOS('ios')
-      const mockError = new Error('FCM service unavailable')
-      mockGetToken.mockRejectedValue(mockError)
-      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+      jest.mocked(getToken).mockRejectedValue(new Error('FCM service unavailable'))
+      jest.mocked(getAPNSToken).mockResolvedValue('mock_apns_token')
 
       const result = await getNotificationTokens(mockLogger)
 
@@ -149,9 +110,7 @@ describe('getNotificationTokens', () => {
     })
 
     it('succeeds with null deviceToken when APNS token is null on iOS', async () => {
-      setPlatformOS('ios')
-      mockGetToken.mockResolvedValue('mock_fcm_token')
-      mockGetAPNSToken.mockResolvedValue(null)
+      jest.mocked(getAPNSToken).mockResolvedValue(null)
 
       const result = await getNotificationTokens(mockLogger)
 
@@ -162,10 +121,7 @@ describe('getNotificationTokens', () => {
     })
 
     it('succeeds with null deviceToken when APNS token fetch throws exception on iOS', async () => {
-      setPlatformOS('ios')
-      const mockError = new Error('APNS service unavailable')
-      mockGetToken.mockResolvedValue('mock_fcm_token')
-      mockGetAPNSToken.mockRejectedValue(mockError)
+      jest.mocked(getAPNSToken).mockRejectedValue(new Error('APNS service unavailable'))
 
       const result = await getNotificationTokens(mockLogger)
 
@@ -176,23 +132,9 @@ describe('getNotificationTokens', () => {
       expect(mockLogger.warn).toHaveBeenCalledWith('[PushTokens] APNS token fetch failed: APNS service unavailable')
     })
 
-    it('returns dummy FCM token when FCM fails even if APNS succeeds', async () => {
-      setPlatformOS('ios')
-      mockGetToken.mockResolvedValue(null)
-      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
-
-      const result = await getNotificationTokens(mockLogger)
-
-      expect(result).toEqual({
-        fcmDeviceToken: 'missing_token_due_to_fetch_failure',
-        deviceToken: 'mock_apns_token',
-      })
-    })
-
     it('handles non-Error exceptions (string messages)', async () => {
-      setPlatformOS('ios')
-      mockGetToken.mockRejectedValue('String error message')
-      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+      jest.mocked(getToken).mockRejectedValue('String error message')
+      jest.mocked(getAPNSToken).mockResolvedValue('mock_apns_token')
 
       const result = await getNotificationTokens(mockLogger)
 
@@ -205,41 +147,28 @@ describe('getNotificationTokens', () => {
   })
 
   describe('platform-specific behavior', () => {
-    it('does not call getAPNSToken on Android', async () => {
-      setPlatformOS('android')
-      mockGetToken.mockResolvedValue('mock_fcm_token')
-
-      await getNotificationTokens(mockLogger)
-
-      expect(mockGetAPNSToken).not.toHaveBeenCalled()
-    })
-
     it('calls getAPNSToken on iOS', async () => {
-      setPlatformOS('ios')
-      mockGetToken.mockResolvedValue('mock_fcm_token')
-      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+      jest.mocked(getAPNSToken).mockResolvedValue('mock_apns_token')
 
       await getNotificationTokens(mockLogger)
 
-      expect(mockGetAPNSToken).toHaveBeenCalled()
+      expect(getAPNSToken).toHaveBeenCalled()
     })
 
     it('treats unknown platforms as non-iOS (no APNS token)', async () => {
       setPlatformOS('web')
-      mockGetToken.mockResolvedValue('mock_fcm_token')
 
       const result = await getNotificationTokens(mockLogger)
 
       expect(result.deviceToken).toBe(null)
-      expect(mockGetAPNSToken).not.toHaveBeenCalled()
+      expect(getAPNSToken).not.toHaveBeenCalled()
     })
   })
 
   describe('edge cases with empty strings', () => {
     it('treats empty string FCM token as invalid and returns dummy token', async () => {
-      setPlatformOS('ios')
-      mockGetToken.mockResolvedValue('')
-      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+      jest.mocked(getToken).mockResolvedValue('')
+      jest.mocked(getAPNSToken).mockResolvedValue('mock_apns_token')
 
       const result = await getNotificationTokens(mockLogger)
 
@@ -250,9 +179,7 @@ describe('getNotificationTokens', () => {
     })
 
     it('succeeds with null deviceToken when APNS token is empty string on iOS', async () => {
-      setPlatformOS('ios')
-      mockGetToken.mockResolvedValue('mock_fcm_token')
-      mockGetAPNSToken.mockResolvedValue('')
+      jest.mocked(getAPNSToken).mockResolvedValue('')
 
       const result = await getNotificationTokens(mockLogger)
 
@@ -265,26 +192,20 @@ describe('getNotificationTokens', () => {
 
   describe('device registration for remote messages', () => {
     it('does not register when device is already registered', async () => {
-      setPlatformOS('ios')
-      mockIsDeviceRegisteredForRemoteMessages.mockReturnValue(true)
-      mockGetToken.mockResolvedValue('mock_fcm_token')
-      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+      jest.mocked(isDeviceRegisteredForRemoteMessages).mockReturnValue(true)
 
       await getNotificationTokens(mockLogger)
 
-      expect(mockRegisterDeviceForRemoteMessages).not.toHaveBeenCalled()
+      expect(registerDeviceForRemoteMessages).not.toHaveBeenCalled()
     })
 
     it('registers device when not registered and succeeds', async () => {
-      setPlatformOS('ios')
-      mockIsDeviceRegisteredForRemoteMessages.mockReturnValue(false)
-      mockRegisterDeviceForRemoteMessages.mockResolvedValue(undefined)
-      mockGetToken.mockResolvedValue('mock_fcm_token')
-      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+      jest.mocked(isDeviceRegisteredForRemoteMessages).mockReturnValue(false)
+      jest.mocked(getAPNSToken).mockResolvedValue('mock_apns_token')
 
       const result = await getNotificationTokens(mockLogger)
 
-      expect(mockRegisterDeviceForRemoteMessages).toHaveBeenCalledTimes(1)
+      expect(registerDeviceForRemoteMessages).toHaveBeenCalledTimes(1)
       expect(result).toEqual({
         fcmDeviceToken: 'mock_fcm_token',
         deviceToken: 'mock_apns_token',
@@ -292,15 +213,12 @@ describe('getNotificationTokens', () => {
     })
 
     it('continues with token fetch even if registration fails', async () => {
-      setPlatformOS('ios')
-      mockIsDeviceRegisteredForRemoteMessages.mockReturnValue(false)
-      mockRegisterDeviceForRemoteMessages.mockRejectedValue(new Error('Registration failed'))
-      mockGetToken.mockResolvedValue('mock_fcm_token')
-      mockGetAPNSToken.mockResolvedValue('mock_apns_token')
+      jest.mocked(isDeviceRegisteredForRemoteMessages).mockReturnValue(false)
+      jest.mocked(registerDeviceForRemoteMessages).mockRejectedValue(new Error('Registration failed'))
 
       const result = await getNotificationTokens(mockLogger)
 
-      expect(mockRegisterDeviceForRemoteMessages).toHaveBeenCalledTimes(1)
+      expect(registerDeviceForRemoteMessages).toHaveBeenCalledTimes(1)
       expect(mockLogger.error).toHaveBeenCalledWith(
         '[PushTokens] Failed to register device for remote messages: Registration failed'
       )
@@ -312,18 +230,17 @@ describe('getNotificationTokens', () => {
 
     it('works on Android when device is not registered', async () => {
       setPlatformOS('android')
-      mockIsDeviceRegisteredForRemoteMessages.mockReturnValue(false)
-      mockRegisterDeviceForRemoteMessages.mockResolvedValue(undefined)
-      mockGetToken.mockResolvedValue('mock_fcm_token_android')
+      jest.mocked(isDeviceRegisteredForRemoteMessages).mockReturnValue(false)
+      jest.mocked(getToken).mockResolvedValue('mock_fcm_token_android')
 
       const result = await getNotificationTokens(mockLogger)
 
-      expect(mockRegisterDeviceForRemoteMessages).toHaveBeenCalledTimes(1)
+      expect(registerDeviceForRemoteMessages).toHaveBeenCalledTimes(1)
       expect(result).toEqual({
         fcmDeviceToken: 'mock_fcm_token_android',
         deviceToken: null,
       })
-      expect(mockGetAPNSToken).not.toHaveBeenCalled()
+      expect(getAPNSToken).not.toHaveBeenCalled()
     })
   })
 })

--- a/app/src/bcsc-theme/utils/retry.test.ts
+++ b/app/src/bcsc-theme/utils/retry.test.ts
@@ -4,13 +4,8 @@ describe('retryAsync', () => {
   it('attempts the request the specified number of times', async () => {
     const fn = jest.fn().mockRejectedValue(new Error('Failed'))
 
-    try {
-      await retryAsync(fn, 3, 100)
-      expect(true).toBe(false) // This should not be reached
-    } catch (error) {
-      expect(error).toEqual(new Error('Failed'))
-      expect(fn).toHaveBeenCalledTimes(3)
-    }
+    await expect(retryAsync(fn, 3, 100)).rejects.toThrow('Failed')
+    expect(fn).toHaveBeenCalledTimes(3)
   })
 
   it('succeeds if the request eventually succeeds', async () => {
@@ -24,13 +19,8 @@ describe('retryAsync', () => {
   it('throws an error if the request fails after all retries', async () => {
     const fn = jest.fn().mockRejectedValue(new Error('Failed'))
 
-    try {
-      await retryAsync(fn, 2, 100)
-      expect(true).toBe(false) // This should not be reached
-    } catch (error) {
-      expect(error).toEqual(new Error('Failed'))
-      expect(fn).toHaveBeenCalledTimes(2)
-    }
+    await expect(retryAsync(fn, 2, 100)).rejects.toThrow('Failed')
+    expect(fn).toHaveBeenCalledTimes(2)
   })
 
   it('retries if retryIfNullish is true and the result is null', async () => {
@@ -42,26 +32,34 @@ describe('retryAsync', () => {
     expect(fn).toHaveBeenCalledTimes(2)
   })
 
-  it('waits the specified delay between retries', async () => {
-    jest.useFakeTimers()
-    const fn = jest.fn().mockRejectedValue(new Error('Failed'))
-    const delay = 100
+  describe('with a mocked clock', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+    })
 
-    const promise = retryAsync(fn, 3, delay).catch(() => {})
+    afterEach(() => {
+      jest.useRealTimers()
+    })
 
-    // First attempt is immediate
-    expect(fn).toHaveBeenCalledTimes(1)
+    it('waits the specified delay between retries', async () => {
+      const fn = jest.fn().mockRejectedValue(new Error('Failed'))
+      const delay = 100
 
-    // Advance past first delay
-    await jest.advanceTimersByTimeAsync(delay)
-    expect(fn).toHaveBeenCalledTimes(2)
+      const promise = retryAsync(fn, 3, delay).catch(() => {})
 
-    // Advance past second delay
-    await jest.advanceTimersByTimeAsync(delay)
-    expect(fn).toHaveBeenCalledTimes(3)
+      // First attempt is immediate
+      expect(fn).toHaveBeenCalledTimes(1)
 
-    await promise
-    jest.useRealTimers()
+      // Advance past first delay
+      await jest.advanceTimersByTimeAsync(delay)
+      expect(fn).toHaveBeenCalledTimes(2)
+
+      // Advance past second delay
+      await jest.advanceTimersByTimeAsync(delay)
+      expect(fn).toHaveBeenCalledTimes(3)
+
+      await promise
+    })
   })
 
   it('preserves retryIfNullish after an error recovery', async () => {
@@ -77,25 +75,10 @@ describe('retryAsync', () => {
     expect(fn).toHaveBeenCalledTimes(3)
   })
 
-  it('throws an error if maxRetries is set to 0', async () => {
+  it.each([0, -1])('throws an error if maxRetries is %s', async (maxRetries) => {
     const fn = jest.fn().mockRejectedValue(new Error('Failed'))
 
-    try {
-      await retryAsync(fn, 0, 100)
-      expect(true).toBe(false) // This should not be reached
-    } catch (error) {
-      expect(error).toEqual(new Error('[retryAsync]: attempts < 1'))
-    }
-  })
-
-  it('throws an error if maxRetries is negative', async () => {
-    const fn = jest.fn().mockRejectedValue(new Error('Failed'))
-
-    try {
-      await retryAsync(fn, -1, 100)
-      expect(true).toBe(false) // This should not be reached
-    } catch (error) {
-      expect(error).toEqual(new Error('[retryAsync]: attempts < 1'))
-    }
+    await expect(retryAsync(fn, maxRetries, 100)).rejects.toThrow('[retryAsync]: attempts < 1')
+    expect(fn).not.toHaveBeenCalled()
   })
 })

--- a/app/src/bcsc-theme/utils/setup-step-completion.test.ts
+++ b/app/src/bcsc-theme/utils/setup-step-completion.test.ts
@@ -1,12 +1,36 @@
 import { computeSetupStepCompletion } from '@/bcsc-theme/utils/setup-step-completion'
-import { AccountSetupType, initialState } from '@/store'
+import { AccountSetupType, BCSCSecureState, BCState, initialState } from '@/store'
 import { BCSCCardProcess } from 'react-native-bcsc-core'
+
+// structuredClone, not a spread: `{ ...initialState }` clones only the top level, so nested
+// bcsc/bcscSecure objects would stay shared references and leak between tests.
+const makeStore = (bcscSecure: Partial<BCSCSecureState> = {}): BCState => {
+  const store = structuredClone(initialState)
+  Object.assign(store.bcscSecure, bcscSecure)
+  return store
+}
+
+/** A nickname is the precondition for every step past the very beginning of setup. */
+const makeNamedStore = (bcscSecure: Partial<BCSCSecureState> = {}): BCState => {
+  const store = makeStore(bcscSecure)
+  store.bcsc.selectedNickname = 'test'
+  return store
+}
+
+const ID_COMPLETE: Partial<BCSCSecureState> = {
+  cardProcess: BCSCCardProcess.BCSCPhoto,
+  serial: '123456789',
+  emailAddress: 'steveBrule@email.com',
+}
+
+const ADDRESS_COMPLETE: Partial<BCSCSecureState> = { ...ID_COMPLETE, deviceCode: 'ABCDEFGH' }
+
+const EMAIL_COMPLETE: Partial<BCSCSecureState> = { ...ADDRESS_COMPLETE, isEmailVerified: true }
 
 describe('computeSetupStepCompletion', () => {
   describe('Init', () => {
     it('all steps should not be focused and completed', () => {
-      // note: const store = { ...initialState } clones only top level, nested objects remain references
-      const store = structuredClone(initialState)
+      const store = makeStore()
 
       const result = computeSetupStepCompletion(store)
 
@@ -23,8 +47,7 @@ describe('computeSetupStepCompletion', () => {
 
   describe('ID Step', () => {
     it('Combo Card: should be completed when serial and email provided', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
+      const store = makeNamedStore()
 
       expect(computeSetupStepCompletion(store).id.completed).toBe(false)
       expect(computeSetupStepCompletion(store).id.focused).toBe(true)
@@ -39,10 +62,8 @@ describe('computeSetupStepCompletion', () => {
     })
 
     it('NonPhoto Card: should not show needs additional card when only cardType is set (user backed out before serial)', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCNonPhoto
       // Note: serial is NOT set - simulates user selecting card type but backing out
+      const store = makeNamedStore({ cardProcess: BCSCCardProcess.BCSCNonPhoto })
 
       const result = computeSetupStepCompletion(store)
 
@@ -53,10 +74,8 @@ describe('computeSetupStepCompletion', () => {
     })
 
     it('Other Card: should not show needs additional card when only cardType is set (user backed out before evidence)', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.NonBCSC
       // Note: no evidence data - simulates user selecting card type but backing out
+      const store = makeNamedStore({ cardProcess: BCSCCardProcess.NonBCSC })
 
       const result = computeSetupStepCompletion(store)
 
@@ -67,8 +86,7 @@ describe('computeSetupStepCompletion', () => {
     })
 
     it('Non-Photo Card: should be completed when serial, email, and photo ID provided', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
+      const store = makeNamedStore()
 
       let result = computeSetupStepCompletion(store)
       expect(result.id.completed).toBe(false)
@@ -101,8 +119,7 @@ describe('computeSetupStepCompletion', () => {
     })
 
     it('Non-BCSC Card: should be completed when 2 IDs provided', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
+      const store = makeNamedStore()
 
       let result = computeSetupStepCompletion(store)
       expect(result.id.completed).toBe(false)
@@ -157,11 +174,7 @@ describe('computeSetupStepCompletion', () => {
 
   describe('Residential Address Step', () => {
     it('should be focused when ID step completed but address not yet completed', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.emailAddress = 'steveBrule@email.com'
+      const store = makeNamedStore(ID_COMPLETE)
 
       const result = computeSetupStepCompletion(store)
 
@@ -170,12 +183,7 @@ describe('computeSetupStepCompletion', () => {
     })
 
     it('should be completed when device code is provided', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.emailAddress = 'steveBrule@email.com'
-      store.bcscSecure.deviceCode = 'ABCDEFGH'
+      const store = makeNamedStore(ADDRESS_COMPLETE)
 
       const result = computeSetupStepCompletion(store)
 
@@ -186,12 +194,7 @@ describe('computeSetupStepCompletion', () => {
 
   describe('Email Step', () => {
     it('should be focused when ID step completed, address step completed, but email not yet completed', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.emailAddress = 'steveBrule@email.com'
-      store.bcscSecure.deviceCode = 'ABCDEFGH'
+      const store = makeNamedStore(ADDRESS_COMPLETE)
 
       const result = computeSetupStepCompletion(store)
 
@@ -200,12 +203,7 @@ describe('computeSetupStepCompletion', () => {
     })
 
     it('should be focused when BCSC card (Photo/NonPhoto) has serial but no email after completing ID and address steps', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.emailAddress = undefined
-      store.bcscSecure.deviceCode = 'ABCDEFGH'
+      const store = makeNamedStore({ ...ADDRESS_COMPLETE, emailAddress: undefined })
 
       const result = computeSetupStepCompletion(store)
 
@@ -223,21 +221,18 @@ describe('computeSetupStepCompletion', () => {
     })
 
     it('should be focused with NonPhoto card type when serial available but email is falsey', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCNonPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.emailAddress = ''
-      store.bcscSecure.deviceCode = 'ABCDEFGH'
-      store.bcscSecure.additionalEvidenceData = [
-        {
-          evidenceType: {
-            has_photo: true,
+      const store = makeNamedStore({
+        ...ADDRESS_COMPLETE,
+        cardProcess: BCSCCardProcess.BCSCNonPhoto,
+        emailAddress: '',
+        additionalEvidenceData: [
+          {
+            evidenceType: { has_photo: true },
+            metadata: [{ uri: 'photo1.jpg' }],
+            documentNumber: 'DL123456',
           },
-          metadata: [{ uri: 'photo1.jpg' }],
-          documentNumber: 'DL123456',
-        },
-      ] as any[]
+        ] as any[],
+      })
 
       const result = computeSetupStepCompletion(store)
 
@@ -252,13 +247,7 @@ describe('computeSetupStepCompletion', () => {
     })
 
     it('should not be completed when email is provided but emailConfirmed is false', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.emailAddress = 'steveBrule@email.com'
-      store.bcscSecure.deviceCode = 'ABCDEFGH'
-      store.bcscSecure.isEmailVerified = false
+      const store = makeNamedStore({ ...ADDRESS_COMPLETE, isEmailVerified: false })
 
       const result = computeSetupStepCompletion(store)
 
@@ -267,13 +256,7 @@ describe('computeSetupStepCompletion', () => {
     })
 
     it('should not be completed when emailConfirmed is true but email is missing', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.emailAddress = undefined
-      store.bcscSecure.deviceCode = 'ABCDEFGH'
-      store.bcscSecure.isEmailVerified = true
+      const store = makeNamedStore({ ...EMAIL_COMPLETE, emailAddress: undefined })
 
       const result = computeSetupStepCompletion(store)
 
@@ -282,13 +265,7 @@ describe('computeSetupStepCompletion', () => {
     })
 
     it('should be completed when both email and emailConfirmed are true (email may be set to BCSC_EMAIL_NOT_PROVIDED)', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.emailAddress = 'steveBrule@email.com'
-      store.bcscSecure.deviceCode = 'ABCDEFGH'
-      store.bcscSecure.isEmailVerified = true
+      const store = makeNamedStore(EMAIL_COMPLETE)
 
       const result = computeSetupStepCompletion(store)
 
@@ -297,14 +274,12 @@ describe('computeSetupStepCompletion', () => {
     })
 
     it('should be completed when user skipped email (userSkippedEmailVerification=true, no emailAddress — v3 migration case)', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.emailAddress = undefined
-      store.bcscSecure.deviceCode = 'ABCDEFGH'
-      store.bcscSecure.isEmailVerified = false
-      store.bcscSecure.userSkippedEmailVerification = true
+      const store = makeNamedStore({
+        ...ADDRESS_COMPLETE,
+        emailAddress: undefined,
+        isEmailVerified: false,
+        userSkippedEmailVerification: true,
+      })
 
       const result = computeSetupStepCompletion(store)
 
@@ -313,14 +288,7 @@ describe('computeSetupStepCompletion', () => {
     })
 
     it('should not be completed when email entered but not verified, even if userSkippedEmailVerification was previously set', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.emailAddress = 'steveBrule@email.com'
-      store.bcscSecure.deviceCode = 'ABCDEFGH'
-      store.bcscSecure.isEmailVerified = false
-      store.bcscSecure.userSkippedEmailVerification = false
+      const store = makeNamedStore({ ...ADDRESS_COMPLETE, isEmailVerified: false, userSkippedEmailVerification: false })
 
       const result = computeSetupStepCompletion(store)
 
@@ -331,14 +299,7 @@ describe('computeSetupStepCompletion', () => {
 
   describe('Verify Step', () => {
     it('should be focused when ID step completed, address step completed, email step completed, but verify not yet completed', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.emailAddress = 'steveBrule@email.com'
-      store.bcscSecure.deviceCode = 'ABCDEFGH'
-      store.bcscSecure.isEmailVerified = true
-      store.bcscSecure.verified = false
+      const store = makeNamedStore({ ...EMAIL_COMPLETE, verified: false })
 
       const result = computeSetupStepCompletion(store)
 
@@ -347,15 +308,7 @@ describe('computeSetupStepCompletion', () => {
     })
 
     it('should be completed when verified is true', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.emailAddress = 'steveBrule@email.com'
-      store.bcscSecure.deviceCode = 'ABCDEFGH'
-      store.bcscSecure.isEmailVerified = true
-      store.bcscSecure.verified = true
-      store.bcscSecure.userSubmittedVerificationVideo = false
+      const store = makeNamedStore({ ...EMAIL_COMPLETE, verified: true, userSubmittedVerificationVideo: false })
 
       const result = computeSetupStepCompletion(store)
 
@@ -364,15 +317,7 @@ describe('computeSetupStepCompletion', () => {
     })
 
     it('should be completed when userSubmittedVerificationVideo is true', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.emailAddress = 'steveBrule@email.com'
-      store.bcscSecure.deviceCode = 'ABCDEFGH'
-      store.bcscSecure.isEmailVerified = true
-      store.bcscSecure.verified = true
-      store.bcscSecure.userSubmittedVerificationVideo = true
+      const store = makeNamedStore({ ...EMAIL_COMPLETE, verified: false, userSubmittedVerificationVideo: true })
 
       const result = computeSetupStepCompletion(store)
 
@@ -383,7 +328,7 @@ describe('computeSetupStepCompletion', () => {
 
   describe('Full workflow', () => {
     it('should progress through all steps to completion', () => {
-      const store = structuredClone(initialState)
+      const store = makeStore()
 
       let result = computeSetupStepCompletion(store)
       expect(result.id.completed).toBe(false)
@@ -438,41 +383,37 @@ describe('computeSetupStepCompletion', () => {
 
   describe('currentStep property', () => {
     it('should return id when id step is focused', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
+      const store = makeNamedStore()
       expect(computeSetupStepCompletion(store).currentStep).toBe('id')
     })
 
     it('should return address when address step is focused', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
+      const store = makeNamedStore({ cardProcess: BCSCCardProcess.BCSCPhoto, serial: '123456789' })
       expect(computeSetupStepCompletion(store).currentStep).toBe('address')
     })
 
     it('should return email when email step is focused', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.deviceCode = 'ABCDEFGH'
+      const store = makeNamedStore({
+        cardProcess: BCSCCardProcess.BCSCPhoto,
+        serial: '123456789',
+        deviceCode: 'ABCDEFGH',
+      })
       expect(computeSetupStepCompletion(store).currentStep).toBe('email')
     })
 
     it('should return verify when verify step is focused', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.deviceCode = 'ABCDEFGH'
-      store.bcscSecure.emailAddress = 'test@email.com'
-      store.bcscSecure.isEmailVerified = true
+      const store = makeNamedStore({
+        cardProcess: BCSCCardProcess.BCSCPhoto,
+        serial: '123456789',
+        deviceCode: 'ABCDEFGH',
+        emailAddress: 'test@email.com',
+        isEmailVerified: true,
+      })
       expect(computeSetupStepCompletion(store).currentStep).toBe('verify')
     })
 
     it('should return transfer for a transfer account with no verification progress', () => {
-      const store = structuredClone(initialState)
+      const store = makeStore()
       store.bcsc.accountSetupType = AccountSetupType.TransferAccount
       // A fresh transfer device has none of the id/address/email/verify progress, so
       // transfer must take priority over the (otherwise-focused) id step.
@@ -482,28 +423,25 @@ describe('computeSetupStepCompletion', () => {
 
   describe('allCompleted property', () => {
     it('should be false when no steps are completed', () => {
-      const store = structuredClone(initialState)
+      const store = makeStore()
       expect(computeSetupStepCompletion(store).allCompleted).toBe(false)
     })
 
     it('should be false when some steps are completed', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
+      const store = makeNamedStore({ cardProcess: BCSCCardProcess.BCSCPhoto, serial: '123456789' })
       expect(computeSetupStepCompletion(store).allCompleted).toBe(false)
     })
 
     it('should be true when all steps are completed', () => {
-      const store = structuredClone(initialState)
-      store.bcsc.selectedNickname = 'test'
-      store.bcscSecure.cardProcess = BCSCCardProcess.BCSCPhoto
-      store.bcscSecure.serial = '123456789'
-      store.bcscSecure.deviceCode = 'ABCDEFGH'
-      store.bcscSecure.emailAddress = 'test@email.com'
-      store.bcscSecure.isEmailVerified = true
-      store.bcscSecure.verified = true
-      store.bcscSecure.userSubmittedVerificationVideo = false
+      const store = makeNamedStore({
+        cardProcess: BCSCCardProcess.BCSCPhoto,
+        serial: '123456789',
+        deviceCode: 'ABCDEFGH',
+        emailAddress: 'test@email.com',
+        isEmailVerified: true,
+        verified: true,
+        userSubmittedVerificationVideo: false,
+      })
       expect(computeSetupStepCompletion(store).allCompleted).toBe(true)
     })
   })

--- a/app/src/contexts/ErrorAlertContext.test.tsx
+++ b/app/src/contexts/ErrorAlertContext.test.tsx
@@ -32,11 +32,6 @@ jest.mock('react-native', () => ({
   },
 }))
 
-jest.mock('../errors/errorHandler', () => {
-  const actual = jest.requireActual('../errors/errorHandler')
-  return { ...actual }
-})
-
 jest.mock('@bifold/core', () => ({
   testIdWithKey: (key: string) => `com.aries.bifold:id/${key}`,
   useStore: jest.fn().mockReturnValue([
@@ -112,22 +107,11 @@ jest.mock('react-native-device-info', () => ({
 jest.mock('react-native-vector-icons/MaterialIcons', () => 'Icon')
 
 describe('ErrorAlertContext', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
-
   const wrapper = ({ children }: { children: React.ReactNode }) => <ErrorAlertProvider>{children}</ErrorAlertProvider>
 
   describe('useErrorAlert hook', () => {
     it('should throw error when used outside ErrorAlertProvider', () => {
       expect(() => renderHook(() => useErrorAlert())).toThrow('useErrorAlert must be used within an ErrorAlertProvider')
-    })
-
-    it('should return context with emitErrorModal, and emitAlert', () => {
-      const { result } = renderHook(() => useErrorAlert(), { wrapper })
-
-      expect(result.current).toHaveProperty('emitErrorModal')
-      expect(result.current).toHaveProperty('emitAlert')
     })
   })
 
@@ -246,12 +230,14 @@ describe('ErrorAlertContext', () => {
         result.current.emitErrorModal('Title 1', 'Desc 1', appError)
       })
 
+      expect(mockBCSCErrorModal).toHaveBeenLastCalledWith(expect.objectContaining({ errorKey: 1 }))
+
       act(() => {
         result.current.emitErrorModal('Title 2', 'Desc 2', appError)
       })
 
-      // Two calls should have triggered two trackAlertDisplayEvent calls
-      expect(Analytics.trackAlertDisplayEvent).toHaveBeenCalledTimes(2)
+      // A repeated error must bump the key, otherwise the modal never re-opens.
+      expect(mockBCSCErrorModal).toHaveBeenLastCalledWith(expect.objectContaining({ errorKey: 2 }))
     })
   })
 

--- a/app/src/errors/appError.test.ts
+++ b/app/src/errors/appError.test.ts
@@ -8,154 +8,112 @@ jest.mock('@/contexts/NavigationContainerContext', () => ({
   navigationRef: { isReady: () => false, getCurrentRoute: () => undefined },
 }))
 
-describe('AppError', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
+const GENERAL_IDENTITY = {
+  category: ErrorCategory.GENERAL,
+  appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
+  statusCode: 1234,
+}
 
+const BAD_REQUEST_IDENTITY = {
+  category: ErrorCategory.NETWORK,
+  appEvent: AppEventCode.ERR_209_BAD_REQUEST,
+  statusCode: 2107,
+}
+
+describe('AppError', () => {
   describe('constructor', () => {
     it('should create an AppError with correct properties', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
       const message = 'Detailed technical message'
-      const error = new AppError(message, identity, { cause: new Error(message) })
+      const error = new AppError(message, GENERAL_IDENTITY, { cause: new Error(message) })
 
       expect(error.message).toBe(message)
       expect(error.code).toBe('general.unknown_server_error.1234')
       expect(error.appEvent).toBe('unknown_server_error')
       expect(error.technicalMessage).toBe(message)
       expect(error.cause).toBeInstanceOf(Error)
-      expect(error.timestamp).toBeDefined()
+      expect(error.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
       expect(error.handled).toBe(false)
     })
   })
 
   describe('technicalMessage', () => {
     it('should return null if there is no cause', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Something went wrong', identity)
+      const error = new AppError('Something went wrong', GENERAL_IDENTITY)
 
       expect(error.technicalMessage).toBeNull()
     })
 
     it('should return null if cause is not an Error', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Something went wrong', identity, { cause: 'Not an error' as any })
+      const error = new AppError('Something went wrong', GENERAL_IDENTITY, { cause: 'Not an error' as any })
 
       expect(error.technicalMessage).toBeNull()
     })
 
     it('should prefix the native error code when present on the cause', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
       const cause = Object.assign(new Error("Key pair with alias 'abc' not found."), { code: 'E_KEY_NOT_FOUND' })
-      const error = new AppError('Something went wrong', identity, { cause })
+      const error = new AppError('Something went wrong', GENERAL_IDENTITY, { cause })
 
       expect(error.technicalMessage).toBe("E_KEY_NOT_FOUND: Key pair with alias 'abc' not found.")
     })
 
     it('should append the server response body for AxiosErrors when it is a short string', () => {
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { data: 'email_address is invalid' },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       expect(error.technicalMessage).toBe('Request failed with status code 400: email_address is invalid')
     })
 
     it('should not append the response body for objects without a string message', () => {
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { data: { error: 'bad_request' } },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       expect(error.technicalMessage).toBe('Request failed with status code 400')
     })
 
     it('should not append the response body when the JSON message field is not a string', () => {
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { data: { message: 42 } },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       expect(error.technicalMessage).toBe('Request failed with status code 400')
     })
 
     it('should append the JSON message field for AxiosErrors when the response body is an object (e.g. IAS 4xx evidence rejections)', () => {
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { data: { message: 'unexpected images count' } },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       expect(error.technicalMessage).toBe('Request failed with status code 400: unexpected images count')
     })
 
     it('should truncate a JSON message field longer than 500 chars', () => {
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const longMessage = 'x'.repeat(600)
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { data: { message: longMessage } },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       expect(error.technicalMessage).toBe(`Request failed with status code 400: ${'x'.repeat(500)}`)
     })
 
     it('should truncate a string response body longer than 500 chars', () => {
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const longBody = 'y'.repeat(600)
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { data: longBody },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       expect(error.technicalMessage).toBe(`Request failed with status code 400: ${'y'.repeat(500)}`)
     })
@@ -187,24 +145,14 @@ describe('AppError', () => {
 
   describe('fullMessage', () => {
     it('should return message without technicalMessage', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Something went wrong', identity)
+      const error = new AppError('Something went wrong', GENERAL_IDENTITY)
 
       expect(error.fullMessage).toBe('Something went wrong\nDebug: [general.unknown_server_error.1234]')
     })
 
     it('should return message with technicalMessage if cause is present', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
       const technicalMessage = 'Technical details about the error'
-      const error = new AppError('Something went wrong', identity, { cause: new Error(technicalMessage) })
+      const error = new AppError('Something went wrong', GENERAL_IDENTITY, { cause: new Error(technicalMessage) })
 
       expect(error.fullMessage).toBe(
         'Something went wrong\nDebug: [general.unknown_server_error.1234] Technical details about the error'
@@ -217,16 +165,11 @@ describe('AppError', () => {
       // fullMessage is what ErrorAlertContext.emitErrorModal forwards as `message` to
       // ErrorModal.handleReport -> logger.reportProblem, which is what reaches Loki when the
       // user taps "Report a problem". The server's real reason must survive that whole path.
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { data: { message: 'unexpected images count' } },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       expect(error.fullMessage).toBe(
         'Bad request\nDebug: [network.err_209_bad_request.2107] Request failed with status code 400: unexpected images count'
@@ -282,12 +225,7 @@ describe('AppError', () => {
       // Screen/Request are intentionally kept out of fullMessage (the "Show details" string)
       // so infra context never alarms the user. They ride along in toJSON() (screen + context)
       // when the full error is handed to reportProblem.
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Something went wrong', identity)
+      const error = new AppError('Something went wrong', GENERAL_IDENTITY)
       error.addContext({ url: 'https://example.com/device/token', method: 'POST' })
 
       expect(error.fullMessage).toBe('Something went wrong\nDebug: [general.unknown_server_error.1234]')
@@ -300,12 +238,7 @@ describe('AppError', () => {
     it('should track error event in analytics', () => {
       const trackErrorEventSpy = jest.spyOn(Analytics, 'trackErrorEvent')
 
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Something went wrong', identity)
+      const error = new AppError('Something went wrong', GENERAL_IDENTITY)
 
       error.track()
 
@@ -387,16 +320,17 @@ describe('AppError', () => {
   })
 
   describe('toJSON', () => {
-    it('should serialize AppError to JSON', () => {
+    beforeEach(() => {
       jest.useFakeTimers().setSystemTime(new Date('2024-01-01T00:00:00Z'))
+    })
 
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('should serialize AppError to JSON', () => {
       const cause = new Error('Technical message')
-      const error = new AppError('Something went wrong', identity, { cause })
+      const error = new AppError('Something went wrong', GENERAL_IDENTITY, { cause })
       const json = error.toJSON()
 
       expect(json).toEqual({
@@ -411,8 +345,6 @@ describe('AppError', () => {
         handled: false,
         context: {},
       })
-
-      jest.useRealTimers()
     })
 
     it('summarizes the cause so a large request body is never serialized', () => {
@@ -436,17 +368,12 @@ describe('AppError', () => {
     })
 
     it('includes the server response body in the summarized cause for AxiosErrors', () => {
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         code: 'ERR_BAD_REQUEST',
         response: { status: 400, data: 'email_address is invalid' },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       const json = error.toJSON()
 
@@ -462,16 +389,11 @@ describe('AppError', () => {
       // toJSON().technicalMessage is what client.ts and ErrorAlertContext auto-log to Loki for
       // every AppError (not just user-initiated "Report a problem"), so the lifted JSON `message`
       // must survive serialization too.
-      const identity = {
-        category: ErrorCategory.NETWORK,
-        appEvent: AppEventCode.ERR_209_BAD_REQUEST,
-        statusCode: 2107,
-      }
       const axiosLike = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { status: 400, data: { message: 'unexpected images count' } },
       })
-      const error = new AppError('Bad request', identity, { cause: axiosLike, track: false })
+      const error = new AppError('Bad request', BAD_REQUEST_IDENTITY, { cause: axiosLike, track: false })
 
       const json = error.toJSON()
 
@@ -504,24 +426,14 @@ describe('AppError', () => {
 
   describe('isHandledAppError', () => {
     it('should return true for handled AppError', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Error', identity)
+      const error = new AppError('Error', GENERAL_IDENTITY)
       error.handled = true
 
       expect(isHandledAppError(error)).toBe(true)
     })
 
     it('should return false for unhandled AppError', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Error', identity)
+      const error = new AppError('Error', GENERAL_IDENTITY)
 
       expect(isHandledAppError(error)).toBe(false)
     })
@@ -535,34 +447,19 @@ describe('AppError', () => {
 
   describe('isAppError', () => {
     it('should return true for AppError', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Error', identity)
+      const error = new AppError('Error', GENERAL_IDENTITY)
 
       expect(isAppError(error)).toBe(true)
     })
 
     it('should return true for AppError with matching appEvent code', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Error', identity)
+      const error = new AppError('Error', GENERAL_IDENTITY)
 
       expect(isAppError(error, AppEventCode.UNKNOWN_SERVER_ERROR)).toBe(true)
     })
 
     it('should return false for AppError with non-matching appEvent code', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-      const error = new AppError('Error', identity)
+      const error = new AppError('Error', GENERAL_IDENTITY)
 
       expect(isAppError(error, AppEventCode.ADD_CARD_CAMERA_BROKEN)).toBe(false)
     })
@@ -570,25 +467,13 @@ describe('AppError', () => {
 
   describe('isAxiosAppError', () => {
     it('should return true for AppError with AxiosError cause', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-
-      const axiosAppError = new AppError('Error', identity, { cause: new AxiosError() })
+      const axiosAppError = new AppError('Error', GENERAL_IDENTITY, { cause: new AxiosError() })
 
       expect(isAxiosAppError(axiosAppError)).toBe(true)
     })
 
     it('should return false for AppError without AxiosError cause', () => {
-      const identity = {
-        category: ErrorCategory.GENERAL,
-        appEvent: AppEventCode.UNKNOWN_SERVER_ERROR,
-        statusCode: 1234,
-      }
-
-      const appError = new AppError('Error', identity)
+      const appError = new AppError('Error', GENERAL_IDENTITY)
       expect(isAxiosAppError(appError)).toBe(false)
     })
   })

--- a/app/src/errors/errorRegistry.test.ts
+++ b/app/src/errors/errorRegistry.test.ts
@@ -1,29 +1,31 @@
 import { ErrorCategory, ErrorRegistry, ErrorRegistryKey, ErrorSeverity } from './errorRegistry'
 
 describe('errorRegistry', () => {
+  // These strings are serialized into AppError.code and shipped to analytics/Loki, so the
+  // exact set is a wire contract — asserting the whole set catches additions as well as renames.
   describe('ErrorSeverity', () => {
     it('should have all expected severity levels', () => {
-      expect(ErrorSeverity.INFO).toBe('info')
-      expect(ErrorSeverity.WARNING).toBe('warning')
-      expect(ErrorSeverity.ERROR).toBe('error')
-      expect(ErrorSeverity.CRITICAL).toBe('critical')
+      expect(Object.values(ErrorSeverity).sort()).toEqual(['critical', 'error', 'info', 'warning'])
     })
   })
 
   describe('ErrorCategory', () => {
     it('should have all expected categories', () => {
-      expect(ErrorCategory.CAMERA).toBe('camera')
-      expect(ErrorCategory.NETWORK).toBe('network')
-      expect(ErrorCategory.AUTHENTICATION).toBe('auth')
-      expect(ErrorCategory.CREDENTIAL).toBe('credential')
-      expect(ErrorCategory.PROOF).toBe('proof')
-      expect(ErrorCategory.CONNECTION).toBe('connection')
-      expect(ErrorCategory.WALLET).toBe('wallet')
-      expect(ErrorCategory.VERIFICATION).toBe('verification')
-      expect(ErrorCategory.DEVICE).toBe('device')
-      expect(ErrorCategory.STORAGE).toBe('storage')
-      expect(ErrorCategory.TOKEN).toBe('token')
-      expect(ErrorCategory.GENERAL).toBe('general')
+      expect(Object.values(ErrorCategory).sort()).toEqual([
+        'auth',
+        'camera',
+        'connection',
+        'credential',
+        'device',
+        'general',
+        'network',
+        'proof',
+        'storage',
+        'token',
+        'unknown',
+        'verification',
+        'wallet',
+      ])
     })
   })
 
@@ -40,55 +42,38 @@ describe('errorRegistry', () => {
       expect(uniqueAppEvents.size).toBe(appEvents.length)
     })
 
+    // Deliberately untyped strings: a typed `ErrorRegistryKey[]` would only fail the TS build,
+    // whereas plain strings make a rename or removal fail here with the offending key named.
     it('should contain all expected error keys', () => {
-      // Camera errors
-      expect(ErrorRegistry.CAMERA_BROKEN).toBeDefined()
-      expect(ErrorRegistry.INVALID_QR_CODE).toBeDefined()
+      const expectedKeys = [
+        'CAMERA_BROKEN',
+        'INVALID_QR_CODE',
+        'NO_INTERNET',
+        'SERVER_ERROR',
+        'SERVER_TIMEOUT',
+        'LOGIN_PARSE_URI',
+        'LOGIN_REJECTED_401',
+        'CARD_EXPIRED_WILL_REMOVE',
+        'VERIFY_NOT_COMPLETE',
+        'VIDEO_VERIFY_NOT_COMPLETE',
+        'INVALID_TOKEN',
+        'TOKEN_NULL',
+        'STORAGE_WRITE_ERROR',
+        'STORAGE_READ_ERROR',
+        'ANDROID_APP_UPDATE_REQUIRED',
+        'IOS_APP_UPDATE_REQUIRED',
+        'GENERAL_ERROR',
+        'DYNAMIC_REGISTRATION_ERROR',
+        'STATE_LOAD_ERROR',
+        'AGENT_INITIALIZATION_ERROR',
+        'WALLET_SECRET_NOT_FOUND',
+        'PARSE_INVITATION_ERROR',
+        'RECEIVE_INVITATION_ERROR',
+        'ATTESTATION_BAD_INVITATION',
+        'ATTESTATION_CONNECTION_ERROR',
+      ]
 
-      // Network errors
-      expect(ErrorRegistry.NO_INTERNET).toBeDefined()
-      expect(ErrorRegistry.SERVER_ERROR).toBeDefined()
-      expect(ErrorRegistry.SERVER_TIMEOUT).toBeDefined()
-
-      // Auth errors
-      expect(ErrorRegistry.LOGIN_PARSE_URI).toBeDefined()
-      expect(ErrorRegistry.LOGIN_REJECTED_401).toBeDefined()
-
-      // Credential errors
-      expect(ErrorRegistry.CARD_EXPIRED_WILL_REMOVE).toBeDefined()
-
-      // Verification errors
-      expect(ErrorRegistry.VERIFY_NOT_COMPLETE).toBeDefined()
-      expect(ErrorRegistry.VIDEO_VERIFY_NOT_COMPLETE).toBeDefined()
-
-      // Token errors
-      expect(ErrorRegistry.INVALID_TOKEN).toBeDefined()
-      expect(ErrorRegistry.TOKEN_NULL).toBeDefined()
-
-      // Storage errors
-      expect(ErrorRegistry.STORAGE_WRITE_ERROR).toBeDefined()
-      expect(ErrorRegistry.STORAGE_READ_ERROR).toBeDefined()
-
-      // Device errors
-      expect(ErrorRegistry.ANDROID_APP_UPDATE_REQUIRED).toBeDefined()
-      expect(ErrorRegistry.IOS_APP_UPDATE_REQUIRED).toBeDefined()
-
-      // General errors
-      expect(ErrorRegistry.GENERAL_ERROR).toBeDefined()
-      expect(ErrorRegistry.DYNAMIC_REGISTRATION_ERROR).toBeDefined()
-
-      // Wallet errors
-      expect(ErrorRegistry.STATE_LOAD_ERROR).toBeDefined()
-      expect(ErrorRegistry.AGENT_INITIALIZATION_ERROR).toBeDefined()
-      expect(ErrorRegistry.WALLET_SECRET_NOT_FOUND).toBeDefined()
-
-      // Connection errors
-      expect(ErrorRegistry.PARSE_INVITATION_ERROR).toBeDefined()
-      expect(ErrorRegistry.RECEIVE_INVITATION_ERROR).toBeDefined()
-
-      // Attestation errors
-      expect(ErrorRegistry.ATTESTATION_BAD_INVITATION).toBeDefined()
-      expect(ErrorRegistry.ATTESTATION_CONNECTION_ERROR).toBeDefined()
+      expect(Object.keys(ErrorRegistry)).toEqual(expect.arrayContaining(expectedKeys))
     })
 
     it('should have valid error definitions with all required fields', () => {

--- a/app/src/localization/en/index.ts
+++ b/app/src/localization/en/index.ts
@@ -1200,8 +1200,8 @@ const translation = {
     "CancelledVerification": {
       "Title": "Your identity couldn't be verified",
       "Label": "Details from Service BC agent: \n{{reason}}",
-      "RetryButton": "Retry with a new video",
-      "RestartButton": "Restart verification",
+      "RetryButton": "Try again",
+      "RestartButton": "Restart from beginning",
       "NoReason": "No reason provided"
     },
     "DualNonBCSCEvidence": {

--- a/app/src/services/system-checks/EventReasonAlertsSystemCheck.test.ts
+++ b/app/src/services/system-checks/EventReasonAlertsSystemCheck.test.ts
@@ -1,4 +1,5 @@
 import { tokenToCredentialMetadata } from '@/bcsc-theme/contexts/BCSCIdTokenContext'
+import { BCSCModals } from '@/bcsc-theme/types/navigators'
 import { BCSCEvent, BCSCReason, IdToken } from '@/bcsc-theme/utils/id-token'
 import { AppEventCode } from '@/events/appEventCode'
 import { EventReasonAlertsSystemCheck } from '@/services/system-checks/EventReasonAlertsSystemCheck'
@@ -176,9 +177,27 @@ describe('EventReasonAlertsSystemCheck', () => {
       const getIdToken = jest.fn().mockResolvedValue(mockIdToken)
       const check = new EventReasonAlertsSystemCheck(getIdToken, emitAlert, undefined, mockUtils, mockNavigation)
 
-      const result = await check.runCheck()
+      await check.runCheck()
+      check.onFail()
 
-      expect(result).toBe(false)
+      expect(mockUtils.dispatch).toHaveBeenCalledWith({
+        type: BCDispatchAction.UPDATE_CREDENTIAL_METADATA,
+        payload: [expect.objectContaining({ bcscReason: BCSCReason.Cancel })],
+      })
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(BCSCModals.DeviceInvalidated, {
+        invalidationReason: BCSCReason.Cancel,
+      })
+    })
+
+    it('should do nothing when onFail runs before runCheck', () => {
+      const getIdToken = jest.fn()
+      const check = new EventReasonAlertsSystemCheck(getIdToken, emitAlert, undefined, mockUtils, mockNavigation)
+
+      check.onFail()
+
+      expect(mockUtils.dispatch).not.toHaveBeenCalled()
+      expect(emitAlert).not.toHaveBeenCalled()
+      expect(mockNavigation.navigate).not.toHaveBeenCalled()
     })
     it('should render an alert with CARD_STATUS_UPDATED event when reason Renew', async () => {
       const mockIdToken = createMockIdToken({

--- a/app/src/services/system-checks/system-checks.test.ts
+++ b/app/src/services/system-checks/system-checks.test.ts
@@ -10,7 +10,24 @@ import { MockLogger } from '@bifold/core'
 
 const devGlobal = global as typeof global & { __DEV__: boolean }
 
-jest.mock('react-native-bcsc-core')
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const makeUtils = (translation: jest.Mock = jest.fn()) => ({
+  dispatch: jest.fn(),
+  translation: translation as any,
+  logger: {} as any,
+})
+
+// Built per test rather than shared: the outer `jest.resetAllMocks()` strips
+// `mockReturnValue` implementations, which would silently turn getState() into undefined.
+const makeNavigation = (currentRoute = 'SomeScreen', overrides: Record<string, unknown> = {}) => ({
+  navigate: jest.fn(),
+  canGoBack: jest.fn().mockReturnValue(false),
+  goBack: jest.fn(),
+  getState: jest.fn().mockReturnValue({ routes: [{ name: currentRoute }], index: 0 }),
+  ...overrides,
+})
+
 describe('System Checks', () => {
   beforeEach(() => {
     jest.resetAllMocks()
@@ -147,11 +164,7 @@ describe('System Checks', () => {
   describe('DeviceCountSystemCheck', () => {
     describe('runCheck', () => {
       it('should return true when device count is within limit', async () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn() as any,
-          logger: {} as any,
-        }
+        const mockUtils = makeUtils()
         const getIdToken = jest.fn().mockResolvedValue({
           bcsc_devices_count: 3,
           bcsc_max_devices: 5,
@@ -166,11 +179,7 @@ describe('System Checks', () => {
       })
 
       it('should return false when device count exceeds limit', async () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn() as any,
-          logger: {} as any,
-        }
+        const mockUtils = makeUtils()
         const getIdToken = jest.fn().mockResolvedValue({
           bcsc_devices_count: 6,
           bcsc_max_devices: 5,
@@ -185,11 +194,7 @@ describe('System Checks', () => {
       })
 
       it('should return false when device count is equal to limit', async () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn() as any,
-          logger: {} as any,
-        }
+        const mockUtils = makeUtils()
         const getIdToken = jest.fn().mockResolvedValue({
           bcsc_devices_count: 5,
           bcsc_max_devices: 5,
@@ -207,11 +212,7 @@ describe('System Checks', () => {
         const devReplacement = jest.replaceProperty(devGlobal, '__DEV__', true)
 
         try {
-          const mockUtils = {
-            dispatch: jest.fn(),
-            translation: jest.fn() as any,
-            logger: {} as any,
-          }
+          const mockUtils = makeUtils()
           const getIdToken = jest.fn()
           const dismissedAt = new Date(Date.now() - 29 * 60 * 1000).getTime() // 29 minute ago
 
@@ -228,11 +229,7 @@ describe('System Checks', () => {
       it('should run the check when dismissed for longer than cooldown time', async () => {
         const devReplacement = jest.replaceProperty(devGlobal, '__DEV__', true)
         try {
-          const mockUtils = {
-            dispatch: jest.fn(),
-            translation: jest.fn() as any,
-            logger: {} as any,
-          }
+          const mockUtils = makeUtils()
           const getIdToken = jest.fn().mockResolvedValue({
             bcsc_devices_count: 6,
             bcsc_max_devices: 5,
@@ -252,11 +249,7 @@ describe('System Checks', () => {
 
     describe('onFail', () => {
       it('should dispatch a warning banner message', async () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn().mockReturnValue('Device limit reached') as any,
-          logger: {} as any,
-        }
+        const mockUtils = makeUtils(jest.fn().mockReturnValue('Device limit reached'))
         const getIdToken = jest.fn()
 
         const deviceCountCheck = new DeviceCountSystemCheck(getIdToken, mockUtils)
@@ -281,11 +274,7 @@ describe('System Checks', () => {
 
     describe('onSuccess', () => {
       it('should dispatch action to remove the banner message', async () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn() as any,
-          logger: {} as any,
-        }
+        const mockUtils = makeUtils()
         const getIdToken = jest.fn()
 
         const deviceCountCheck = new DeviceCountSystemCheck(getIdToken, mockUtils)
@@ -302,28 +291,15 @@ describe('System Checks', () => {
   })
 
   describe('ServerStatusSystemCheck', () => {
-    const mockNavigation = {
-      navigate: jest.fn(),
-      canGoBack: jest.fn().mockReturnValue(false),
-      goBack: jest.fn(),
-      getState: jest.fn().mockReturnValue({ routes: [{ name: 'SomeScreen' }], index: 0 }),
-    }
-
-    beforeEach(() => {
-      jest.clearAllMocks()
-    })
-
     describe('runCheck', () => {
       it('should return true when server status ok', () => {
-        const mockUtils = { dispatch: jest.fn(), translation: jest.fn() as any, logger: {} as any }
-        const check = new ServerStatusSystemCheck({ status: 'ok' } as any, mockUtils, mockNavigation)
+        const check = new ServerStatusSystemCheck({ status: 'ok' } as any, makeUtils(), makeNavigation())
 
         expect(check.runCheck()).toBe(true)
       })
 
       it('should return false when server status not ok', () => {
-        const mockUtils = { dispatch: jest.fn(), translation: jest.fn() as any, logger: {} as any }
-        const check = new ServerStatusSystemCheck({ status: 'unavailable' } as any, mockUtils, mockNavigation)
+        const check = new ServerStatusSystemCheck({ status: 'unavailable' } as any, makeUtils(), makeNavigation())
 
         expect(check.runCheck()).toBe(false)
       })
@@ -331,11 +307,8 @@ describe('System Checks', () => {
 
     describe('onFail', () => {
       it('should navigate to ServiceOutage modal and dispatch a non-dismissible info banner', () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn().mockReturnValue('Server unavailable') as any,
-          logger: {} as any,
-        }
+        const mockUtils = makeUtils(jest.fn().mockReturnValue('Server unavailable'))
+        const mockNavigation = makeNavigation()
         const check = new ServerStatusSystemCheck(
           { status: 'unavailable', contactLink: 'https://status.com' } as any,
           mockUtils,
@@ -365,11 +338,7 @@ describe('System Checks', () => {
       })
 
       it('should use statusMessage as description when available', () => {
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn().mockReturnValue('Server unavailable') as any,
-          logger: {} as any,
-        }
+        const mockUtils = makeUtils(jest.fn().mockReturnValue('Server unavailable'))
         const check = new ServerStatusSystemCheck(
           {
             status: 'unavailable',
@@ -377,7 +346,7 @@ describe('System Checks', () => {
             statusMessage: 'Custom server down message',
           } as any,
           mockUtils,
-          mockNavigation
+          makeNavigation()
         )
 
         check.onFail()
@@ -397,15 +366,8 @@ describe('System Checks', () => {
       })
 
       it('should not navigate if modal is already visible', () => {
-        const navWithModal = {
-          ...mockNavigation,
-          getState: jest.fn().mockReturnValue({ routes: [{ name: BCSCModals.ServiceOutage }], index: 0 }),
-        }
-        const mockUtils = {
-          dispatch: jest.fn(),
-          translation: jest.fn().mockReturnValue('Server unavailable') as any,
-          logger: {} as any,
-        }
+        const navWithModal = makeNavigation(BCSCModals.ServiceOutage)
+        const mockUtils = makeUtils(jest.fn().mockReturnValue('Server unavailable'))
         const check = new ServerStatusSystemCheck(
           { status: 'unavailable', contactLink: 'https://status.com' } as any,
           mockUtils,
@@ -421,8 +383,8 @@ describe('System Checks', () => {
 
     describe('onSuccess', () => {
       it('should remove both banner messages when no statusMessage', () => {
-        const mockUtils = { dispatch: jest.fn(), translation: jest.fn() as any, logger: {} as any }
-        const check = new ServerStatusSystemCheck({ status: 'ok' } as any, mockUtils, mockNavigation)
+        const mockUtils = makeUtils()
+        const check = new ServerStatusSystemCheck({ status: 'ok' } as any, mockUtils, makeNavigation())
 
         check.onSuccess()
 
@@ -438,12 +400,8 @@ describe('System Checks', () => {
       })
 
       it('should dismiss modal if visible and go back', () => {
-        const navWithModal = {
-          ...mockNavigation,
-          getState: jest.fn().mockReturnValue({ routes: [{ name: BCSCModals.ServiceOutage }], index: 0 }),
-          canGoBack: jest.fn().mockReturnValue(true),
-        }
-        const mockUtils = { dispatch: jest.fn(), translation: jest.fn() as any, logger: {} as any }
+        const navWithModal = makeNavigation(BCSCModals.ServiceOutage, { canGoBack: jest.fn().mockReturnValue(true) })
+        const mockUtils = makeUtils()
         const check = new ServerStatusSystemCheck({ status: 'ok' } as any, mockUtils, navWithModal)
 
         check.onSuccess()
@@ -452,11 +410,11 @@ describe('System Checks', () => {
       })
 
       it('should dispatch non-dismissible info banner if statusMessage exists', () => {
-        const mockUtils = { dispatch: jest.fn(), translation: jest.fn() as any, logger: {} as any }
+        const mockUtils = makeUtils()
         const check = new ServerStatusSystemCheck(
           { status: 'ok', contactLink: 'https://status.com', statusMessage: 'Server maintenance scheduled' } as any,
           mockUtils,
-          mockNavigation
+          makeNavigation()
         )
 
         check.onSuccess()

--- a/app/src/store.test.ts
+++ b/app/src/store.test.ts
@@ -190,7 +190,7 @@ describe('migrateBCSCState', () => {
   it('stamps verificationSkipped:true on an onboarded blob that predates the field', () => {
     const result = migrateBCSCState({ hasAccount: true })
 
-    expect(result).toEqual({ bcsc: { hasAccount: true, verificationSkipped: false }, migrated: true })
+    expect(result).toEqual({ bcsc: { hasAccount: true, verificationSkipped: true }, migrated: true })
   })
 
   it.each([true, false])('leaves an existing verificationSkipped (%s) untouched', (verificationSkipped) => {
@@ -209,7 +209,7 @@ describe('migrateBCSCState', () => {
     const result = migrateBCSCState({ hasAccount: true, reportUUID: 'x' })
 
     expect(result).toEqual({
-      bcsc: { hasAccount: true, installId: 'x', verificationSkipped: false },
+      bcsc: { hasAccount: true, installId: 'x', verificationSkipped: true },
       migrated: true,
     })
     expect(result.bcsc).not.toHaveProperty('reportUUID')

--- a/app/src/store.tsx
+++ b/app/src/store.tsx
@@ -382,7 +382,7 @@ export const migrateBCSCState = <T extends Partial<BCSCState> & { reportUUID?: s
   }
 
   if (bcsc.hasAccount === true && bcsc.verificationSkipped === undefined) {
-    bcsc = { ...bcsc, verificationSkipped: false }
+    bcsc = { ...bcsc, verificationSkipped: true }
     migrated = true
   }
 

--- a/app/src/utils/analytics/analytics-tracker.test.ts
+++ b/app/src/utils/analytics/analytics-tracker.test.ts
@@ -1,35 +1,44 @@
 import { AlertInteractionEvent, AppEventCode } from '@/events/appEventCode'
 import { AnalyticsTracker } from '@/utils/analytics/analytics-tracker'
+import { removeTracker } from '@snowplow/react-native-tracker'
+
+jest.mock('@snowplow/react-native-tracker', () => ({
+  ...jest.requireActual('@snowplow/react-native-tracker'),
+  removeTracker: jest.fn(),
+}))
+
+/**
+ * The spies are wired into the client's `newTracker` result, so a test that never calls
+ * `initializeTracker` still fails loudly if a `!this.tracker` guard is removed — the
+ * production call would throw rather than silently no-op.
+ */
+const createSubject = () => {
+  const tracker = {
+    setAppId: jest.fn(),
+    trackScreenViewEvent: jest.fn(),
+    trackSelfDescribingEvent: jest.fn(),
+  }
+  const newTracker = jest.fn().mockResolvedValue(tracker)
+  const analytics = new AnalyticsTracker('namespace', 'endpoint', { newTracker } as never)
+
+  return { analytics, tracker, newTracker }
+}
 
 describe('Analytics Tracker', () => {
-  it('should construct properly', () => {
-    const analytics = new AnalyticsTracker('namespace', 'endpoint')
-
-    expect(analytics).toBeInstanceOf(AnalyticsTracker)
-  })
-
   describe('initializeTracker', () => {
     it('should initialize tracker', async () => {
-      const mockNewTracker = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: mockNewTracker,
-      }
+      const { analytics, newTracker } = createSubject()
 
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
-
-      // First initialization
       await analytics.initializeTracker('testAppId')
-      expect(mockNewTracker).toHaveBeenCalledTimes(1)
+
+      expect(newTracker).toHaveBeenCalledTimes(1)
+      expect(newTracker).toHaveBeenCalledWith(expect.objectContaining({ namespace: 'namespace', appId: 'testAppId' }))
     })
   })
 
   describe('hasTracker', () => {
     it('should return true if tracker exists', async () => {
-      const mockAnalyticsClient = {
-        newTracker: jest.fn().mockReturnValue({}),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      const { analytics } = createSubject()
 
       await analytics.initializeTracker('testAppId')
 
@@ -37,96 +46,72 @@ describe('Analytics Tracker', () => {
     })
 
     it('should return false if tracker is not initialized', () => {
-      const analytics = new AnalyticsTracker('namespace', 'endpoint')
+      const { analytics } = createSubject()
 
       expect(analytics.hasTracker()).toBe(false)
     })
+  })
 
-    it('should return false if tracking not enabled', async () => {
-      const mockAnalyticsClient = {
-        newTracker: jest.fn(),
-      }
+  describe('stopTracking', () => {
+    it('should remove the tracker', async () => {
+      const { analytics } = createSubject()
 
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      await analytics.initializeTracker('testAppId')
 
+      analytics.stopTracking()
+
+      expect(removeTracker).toHaveBeenCalledWith('namespace')
       expect(analytics.hasTracker()).toBe(false)
     })
   })
 
   describe('setAppId', () => {
     it('should set app ID when tracker exists', async () => {
-      const mockSetAppId = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn().mockResolvedValue({
-          setAppId: mockSetAppId,
-        }),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      const { analytics, tracker } = createSubject()
 
       await analytics.initializeTracker('testAppId')
 
       analytics.setAppId('newAppId')
 
-      expect(mockSetAppId).toHaveBeenCalledWith('newAppId')
+      expect(tracker.setAppId).toHaveBeenCalledWith('newAppId')
     })
 
     it('should not set app ID when tracker does not exist', () => {
-      const mockSetAppId = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn(),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      const { analytics, tracker } = createSubject()
 
       analytics.setAppId('newAppId')
 
-      expect(mockSetAppId).not.toHaveBeenCalled()
+      expect(tracker.setAppId).not.toHaveBeenCalled()
     })
   })
 
   describe('trackScreenEvent', () => {
-    it('should not track when missing tracker', async () => {
-      const mockTrackScreenView = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn(),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+    it('should not track when missing tracker', () => {
+      const { analytics, tracker } = createSubject()
 
       analytics.trackScreenEvent('HomeScreen')
 
-      expect(mockTrackScreenView).not.toHaveBeenCalled()
+      expect(tracker.trackScreenViewEvent).not.toHaveBeenCalled()
     })
 
     it('should not track when screen name === previous screen name', async () => {
-      const mockTrackScreenView = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn(),
-      }
+      const { analytics, tracker } = createSubject()
 
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      await analytics.initializeTracker('testAppId')
 
       analytics.trackScreenEvent('HomeScreen', 'HomeScreen')
 
-      expect(mockTrackScreenView).not.toHaveBeenCalled()
+      expect(tracker.trackScreenViewEvent).not.toHaveBeenCalled()
     })
 
     it('should track when tracking enabled and valid screen names', async () => {
-      const mockTrackScreenView = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn().mockResolvedValue({
-          trackScreenViewEvent: mockTrackScreenView,
-        }),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      const { analytics, tracker } = createSubject()
 
       await analytics.initializeTracker('testAppId')
 
       analytics.trackScreenEvent('HomeScreen', 'NewScreen')
 
-      expect(mockTrackScreenView).toHaveBeenCalledWith({
+      expect(tracker.trackScreenViewEvent).toHaveBeenCalledWith({
         name: 'HomeScreen',
         previousName: 'NewScreen',
       })
@@ -134,34 +119,22 @@ describe('Analytics Tracker', () => {
   })
 
   describe('trackErrorEvent', () => {
-    it('should not track when missing tracker', async () => {
-      const mockTrackError = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn(),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+    it('should not track when missing tracker', () => {
+      const { analytics, tracker } = createSubject()
 
       analytics.trackErrorEvent({ code: 'test', message: 'Test error' })
 
-      expect(mockTrackError).not.toHaveBeenCalled()
+      expect(tracker.trackSelfDescribingEvent).not.toHaveBeenCalled()
     })
 
     it('should track when tracking enabled and valid error', async () => {
-      const mockTrackError = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn().mockResolvedValue({
-          trackSelfDescribingEvent: mockTrackError,
-        }),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      const { analytics, tracker } = createSubject()
 
       await analytics.initializeTracker('testAppId')
 
       analytics.trackErrorEvent({ code: 'test', message: 'Test error' })
 
-      expect(mockTrackError).toHaveBeenCalledWith({
+      expect(tracker.trackSelfDescribingEvent).toHaveBeenCalledWith({
         schema: 'iglu:ca.bc.gov.idim/mobile_error/jsonschema/1-0-0',
         data: {
           errorCode: 'test',
@@ -169,75 +142,51 @@ describe('Analytics Tracker', () => {
         },
       })
     })
+  })
 
-    describe('trackAlertDisplayEvent', () => {
-      it('should not track when missing tracker', async () => {
-        const mockTrackAlert = jest.fn()
-        const mockAnalyticsClient = {
-          newTracker: jest.fn(),
-        }
+  describe('trackAlertDisplayEvent', () => {
+    it('should not track when missing tracker', () => {
+      const { analytics, tracker } = createSubject()
 
-        const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      analytics.trackAlertDisplayEvent(AppEventCode.ADD_CARD_CAMERA_BROKEN)
 
-        analytics.trackAlertDisplayEvent(AppEventCode.ADD_CARD_CAMERA_BROKEN)
+      expect(tracker.trackSelfDescribingEvent).not.toHaveBeenCalled()
+    })
 
-        expect(mockTrackAlert).not.toHaveBeenCalled()
-      })
+    it('should track when tracking enabled and valid app event', async () => {
+      const { analytics, tracker } = createSubject()
 
-      it('should track when tracking enabled and valid app event', async () => {
-        const mockTrackAlert = jest.fn()
-        const mockAnalyticsClient = {
-          newTracker: jest.fn().mockResolvedValue({
-            trackSelfDescribingEvent: mockTrackAlert,
-          }),
-        }
+      await analytics.initializeTracker('testAppId')
 
-        const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      analytics.trackAlertDisplayEvent(AppEventCode.ADD_CARD_CAMERA_BROKEN)
 
-        await analytics.initializeTracker('testAppId')
-
-        analytics.trackAlertDisplayEvent(AppEventCode.ADD_CARD_CAMERA_BROKEN)
-
-        expect(mockTrackAlert).toHaveBeenCalledWith({
-          schema: 'iglu:ca.bc.gov.idim/action/jsonschema/1-0-0',
-          data: {
-            action: AlertInteractionEvent.ALERT_DISPLAY,
-            text: AppEventCode.ADD_CARD_CAMERA_BROKEN,
-          },
-        })
+      expect(tracker.trackSelfDescribingEvent).toHaveBeenCalledWith({
+        schema: 'iglu:ca.bc.gov.idim/action/jsonschema/1-0-0',
+        data: {
+          action: AlertInteractionEvent.ALERT_DISPLAY,
+          text: AppEventCode.ADD_CARD_CAMERA_BROKEN,
+        },
       })
     })
   })
 
   describe('trackAlertActionEvent', () => {
-    it('should not track when missing tracker', async () => {
-      const mockTrackAlert = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn(),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+    it('should not track when missing tracker', () => {
+      const { analytics, tracker } = createSubject()
 
       analytics.trackAlertActionEvent(AppEventCode.ADD_CARD_CAMERA_BROKEN, 'ok')
 
-      expect(mockTrackAlert).not.toHaveBeenCalled()
+      expect(tracker.trackSelfDescribingEvent).not.toHaveBeenCalled()
     })
 
     it('should track when tracking enabled and valid app event', async () => {
-      const mockTrackAlert = jest.fn()
-      const mockAnalyticsClient = {
-        newTracker: jest.fn().mockResolvedValue({
-          trackSelfDescribingEvent: mockTrackAlert,
-        }),
-      }
-
-      const analytics = new AnalyticsTracker('namespace', 'endpoint', mockAnalyticsClient)
+      const { analytics, tracker } = createSubject()
 
       await analytics.initializeTracker('testAppId')
 
       analytics.trackAlertActionEvent(AppEventCode.ADD_CARD_CAMERA_BROKEN, 'ok')
 
-      expect(mockTrackAlert).toHaveBeenCalledWith({
+      expect(tracker.trackSelfDescribingEvent).toHaveBeenCalledWith({
         schema: 'iglu:ca.bc.gov.idim/action/jsonschema/1-0-0',
         data: {
           action: AlertInteractionEvent.ALERT_ACTION,

--- a/app/src/utils/expiration.test.ts
+++ b/app/src/utils/expiration.test.ts
@@ -1,8 +1,6 @@
 import { expirationOverrideInMinutes } from '@utils/expiration'
 import MockDate from 'mockdate'
 
-jest.useFakeTimers({ legacyFakeTimers: true })
-
 describe('Helpers', () => {
   beforeAll(() => {
     // Set the date to a fixed point in time

--- a/app/src/utils/version.test.ts
+++ b/app/src/utils/version.test.ts
@@ -2,126 +2,49 @@ import deviceInfo from 'react-native-device-info'
 
 import { AppVersion, isVersionAtLeast } from './version'
 
+const expectIsVersionAtLeast = (appVersion: string, minVersion: string, expected: boolean) => {
+  jest.spyOn(deviceInfo, 'getVersion').mockReturnValue(appVersion)
+
+  expect(isVersionAtLeast(minVersion)).toBe(expected)
+}
+
 describe('isVersionAtLeast', () => {
   describe('exact version comparisons', () => {
-    it('returns true when the app version equals the minimum version', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1.0')
-
-      expect(isVersionAtLeast('4.1.0')).toBe(true)
-    })
-
-    it('returns true when the major version is greater', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('5.0.0')
-
-      expect(isVersionAtLeast('4.9.9')).toBe(true)
-    })
-
-    it('returns false when the major version is lower', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('3.9.9')
-
-      expect(isVersionAtLeast('4.0.0')).toBe(false)
-    })
-
-    it('returns true when the minor version is greater within the same major', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.2.0')
-
-      expect(isVersionAtLeast('4.1.9')).toBe(true)
-    })
-
-    it('returns false when the minor version is lower within the same major', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.0.9')
-
-      expect(isVersionAtLeast('4.1.0')).toBe(false)
-    })
-
-    it('returns true when the patch version is greater', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1.2')
-
-      expect(isVersionAtLeast('4.1.1')).toBe(true)
-    })
-
-    it('returns false when the patch version is lower', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1.0')
-
-      expect(isVersionAtLeast('4.1.1')).toBe(false)
-    })
+    it.each([
+      ['4.1.0', '4.1.0', true, 'the app version equals the minimum version'],
+      ['5.0.0', '4.9.9', true, 'the major version is greater'],
+      ['3.9.9', '4.0.0', false, 'the major version is lower'],
+      ['4.2.0', '4.1.9', true, 'the minor version is greater within the same major'],
+      ['4.0.9', '4.1.0', false, 'the minor version is lower within the same major'],
+      ['4.1.2', '4.1.1', true, 'the patch version is greater'],
+      ['4.1.0', '4.1.1', false, 'the patch version is lower'],
+    ])('app %s vs minimum %s -> %s when %s', expectIsVersionAtLeast)
   })
 
   describe('wildcard segments', () => {
-    it('ignores the patch segment when the minimum version uses "x"', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1.0')
-
-      expect(isVersionAtLeast('4.1.x')).toBe(true)
-    })
-
-    it('returns true when the minor version exceeds a wildcard minimum', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.2.0')
-
-      expect(isVersionAtLeast('4.1.x')).toBe(true)
-    })
-
-    it('returns false when the version is below a wildcard minimum', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.0.9')
-
-      expect(isVersionAtLeast('4.1.x')).toBe(false)
-    })
-
-    it('supports "*" as a wildcard segment', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1.3')
-
-      expect(isVersionAtLeast('4.1.*')).toBe(true)
-    })
-
-    it('returns true for any version when the first segment is a wildcard', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('0.0.1')
-
-      expect(isVersionAtLeast('x')).toBe(true)
-    })
+    it.each([
+      ['4.1.0', '4.1.x', true, 'the patch segment is ignored for an "x" minimum'],
+      ['4.2.0', '4.1.x', true, 'the minor version exceeds a wildcard minimum'],
+      ['4.0.9', '4.1.x', false, 'the version is below a wildcard minimum'],
+      ['4.1.3', '4.1.*', true, '"*" is used as a wildcard segment'],
+      ['0.0.1', 'x', true, 'the first segment is a wildcard'],
+    ])('app %s vs minimum %s -> %s when %s', expectIsVersionAtLeast)
   })
 
   describe('versions with differing segment counts', () => {
-    it('treats missing app version segments as 0', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1')
-
-      expect(isVersionAtLeast('4.1.1')).toBe(false)
-    })
-
-    it('returns true when missing segments compare equal to 0', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1')
-
-      expect(isVersionAtLeast('4.1.0')).toBe(true)
-    })
-
-    it('returns true when the app version has more segments than the minimum', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1.2')
-
-      expect(isVersionAtLeast('4.1')).toBe(true)
-    })
+    it.each([
+      ['4.1', '4.1.1', false, 'missing app version segments are treated as 0'],
+      ['4.1', '4.1.0', true, 'missing segments compare equal to 0'],
+      ['4.1.2', '4.1', true, 'the app version has more segments than the minimum'],
+    ])('app %s vs minimum %s -> %s when %s', expectIsVersionAtLeast)
   })
 
   describe('AppVersion enum values', () => {
-    it('returns true when the app version is within V4_1_x', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1.0')
-
-      expect(isVersionAtLeast(AppVersion.V4_1_x)).toBe(true)
-    })
-
-    it('returns true when the app version is above V4_1_x', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.2.0')
-
-      expect(isVersionAtLeast(AppVersion.V4_1_x)).toBe(true)
-    })
-
-    it('returns false when the app version is below V4_2_x', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.1.5')
-
-      expect(isVersionAtLeast(AppVersion.V4_2_x)).toBe(false)
-    })
-
-    it('returns true when the app version satisfies V4_0_x', () => {
-      jest.spyOn(deviceInfo, 'getVersion').mockReturnValue('4.0.3')
-
-      expect(isVersionAtLeast(AppVersion.V4_0_x)).toBe(true)
-    })
+    it.each([
+      ['4.1.0', AppVersion.V4_1_x, true, 'the app version is within V4_1_x'],
+      ['4.2.0', AppVersion.V4_1_x, true, 'the app version is above V4_1_x'],
+      ['4.1.5', AppVersion.V4_2_x, false, 'the app version is below V4_2_x'],
+      ['4.0.3', AppVersion.V4_0_x, true, 'the app version satisfies V4_0_x'],
+    ])('app %s vs minimum %s -> %s when %s', expectIsVersionAtLeast)
   })
 })

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -41,8 +41,9 @@ _Tests are organized into named suites. Use the_ `--suite` _flag to select which
 | `onboarding` | _Onboarding journeys — happy path + detours (`onboarding/*.journey.ts`)_                    |
 | `auth`       | _Returning-user unlock journey — PIN unlock, wrong-PIN retry, lockout (`auth/*.journey.ts`)_ |
 | `verify`     | _Verification journeys — the four card types + entry spine/detours (`verify/*.journey.ts`)_ |
+| `send-video` | _The four send-video journeys alone (`verify/send-video-*.journey.ts`): a scripted agent review against the shared SIT queue. Also inside `verify` / `regression`, but CI runs them in their own one-platform-at-a-time lane and drops them from any parallel multi-device run (`E2E_EXCLUDE_SEND_VIDEO=1`) — see **[Send-video review queue](#send-video-review-queue)**_ |
 | `main`       | _Main-stack journeys — unverified gating + settings + wallet credential lifecycle (`main/*.journey.ts`)_ |
-| `migration`  | _V3→V4 upgrade: v3 onboarding + verification, upgrade to v4, unlock with the v3 PIN_                 |
+| `migration`  | _The upgrade **from v3**: v3 onboarding + verification, install the current build over it, unlock with the v3 PIN. Same shape as the two upgrade lanes below; its own suite because v3 is a different app lineage (own binaries + `src/v3TestIDs.ts`) and it runs Android-only in CI_ |
 | `upgrade`    | _Previous released build → current: onboard on the previous release, in-place upgrade, unlock with the old PIN + settings persistence. Runs on Sauce on **both platforms** (mid-session install passes Sauce resigning)_ |
 | `upgrade403` | _Upgrade from the shipped **4.0.3** release specifically — its pre-rework onboarding runs via a frozen walk (`flows/onboarding-v403.ts`). Runs on Sauce on **both platforms**; retire once 4.1.0 is the previous release_ |
 | `scan`       | _Card-barcode scanning — non-BCSC→BCSC reroutes + the serial scanner (`scan/*.journey.ts`). **Android + Sauce only**, and also part of `regression`; the iOS configs `exclude` it_ |
@@ -317,6 +318,23 @@ SM_PASSWORD='your-siteminder-password'
 ```
 
 _The same_ `scripts/login.mjs` _can also be invoked as a CLI; it loads_ `.env.e2e` _itself when run standalone. Without these credentials, any journey that completes in-person verification (the verified_ `verify` _/_ `main` _journeys, and_ `migration`_) will fail at the approval step._
+
+### _Send-video review queue_
+
+_The send-video journeys upload real verification requests to the SIT IDcheck agent queue and review them through the same SiteMinder session (`reviewSendVideoRequest`). That queue has **no worklist** — a review claims the_ next _request blindly and then checks it is the expected persona on the expected platform — and it is **shared** with the UAT team. Two things follow:_
+
+- _**Never run send-video journeys on two platforms at once.** The personas are shared, so one platform would review (or drain) the other's live upload. CI keeps them out of the concurrent device matrix and runs them in their own_ `send-video` _lane, one platform at a time; a parallel multi-device_ `verify` _/_ `regression` _run drops them automatically (`E2E_EXCLUDE_SEND_VIDEO=1`, with a notice)._
+- _**The queue is drained around every submission.** Each send-video journey rejects whatever is queued before it submits (so its own upload is the head the review claims), and its teardown drains again if the upload was never reviewed. The nightly ends with a_ `queue-hygiene` _job (`e2e-send-video-queue.yml`) that drains once more, so a run that died mid-journey leaves nothing for the morning. Rejections carry the reason "Automated e2e queue cleanup"._
+
+_On demand — locally with the SiteMinder credentials above (and an allowlisted egress IP, e.g. the VPN), or from the Actions tab as **Drain send-video queue**:_
+
+```bash
+yarn queue:drain                 # reject everything queued (scope all)
+yarn queue:drain --scope e2e     # only the e2e personas; stops at the first foreign request
+yarn queue:drain --dry-run       # log in and report which queues hold work; claims nothing
+```
+
+_The journeys drain with scope_ `all` _by default (the nightly runs at midnight PT, when anything still queued is stale);_ `E2E_QUEUE_DRAIN_SCOPE=e2e` _keeps a daytime run to the e2e personas so it never touches a UAT tester's pending request._
 
 ## _Config Hierarchy_
 
@@ -594,6 +612,8 @@ _Tests run automatically in GitHub Actions via a device matrix that controls whi
 
 > _The nightly `regression` suite (all per-area journeys) replaces the retired `happy-path` / `full-regression` suites. It is the default suite in_ `e2e-nightly.yml` _and selectable from_ `e2e.yml` _(alongside the per-area suites); `migration`, `upgrade`, and `upgrade403` are separate suites because each boots an OLD build via its own config, and the nightly runs them as chained advisory lanes after the regression (migration on Android 15; `upgrade` / `upgrade403` on iOS 18 + Android 15) — `upgrade` starts on the rolling previous-release build (`BCSC-prev.*`, or any stored build via the `prev_build_number` dispatch input; until the first full release publishes its e2e builds the lane skips with a notice) and installs the current build mid-session, while `upgrade403` pins the preserved `BCSC-v4.0.3.*`. `a11y` rides inside `regression` on both platforms as an advisory lane — its findings are reports, not failures. `scan` is inside `regression` but Android-only — the iOS configs list it in_ `exclude` _(`ANDROID_ONLY_SPECS`), so those specs are dropped before scheduling instead of costing an iOS session each to reach a skip._
 
+_The four send-video journeys are excluded from that concurrent regression matrix and run right after it as their own_ `send-video` _lane — both platforms, one at a time (`max_parallel: 1`), alongside the Android-only migration lane — because they review a shared, blind-FIFO SIT agent queue with shared personas (see **Send-video review queue**). The journeys drain that queue around their own uploads, and the nightly ends with a_ `queue-hygiene` _job that drains it once more._
+
 _The device matrix is passed as a JSON array of_ `{platform, device, os_version}` _objects to_ `e2e.yml`_. Each entry spawns a separate SauceLabs session with its own logs and pass/fail status. (Biometric CI wiring — its Sauce configs, dev scripts, and workflow job — has been removed pending re-implementation as a journey; the_ `biometrics` _helper is retained for that future work.)_
 
 _**Note:** There is no E2E job on_ `main` _merge by design — regression is deferred to the nightly workflow so SauceLabs devices stay free during the day when multiple PRs merge. The in-person verification step needs the runner's egress IP allowlisted with the BC Gov ID Check portal; see the notes in_ `e2e-nightly.yml` _and use the "Verify Allowlist Connectivity" workflow to confirm reachability._
@@ -602,7 +622,7 @@ _**Concurrency:** SauceLabs sessions are limited to_ `max-parallel: 2`_. For PRs
 
 ### Nightly brief
 
-Every nightly run ends with a **brief** — one page on the run's Summary tab (and the `e2e-nightly-brief` artifact: `brief.md` + `brief.json`) rendered from the `e2e-reports-*` artifacts of every lane: the UAT checklist with an iOS and an Android column, every other journey, every failure with its checkpoint, and the accessibility findings against `a11y-baseline.json`. A manual dispatch of `e2e.yml` gets the same page for its suite (input `brief`, on by default). Nothing in it fails a run — it is what to read instead of downloading artifacts.
+Every nightly run ends with a **brief** — one page on the run's Summary tab (and the `e2e-nightly-brief` artifact: `brief.md` + `brief.json`) rendered from the `e2e-reports-*` artifacts of every lane: the UAT checklist with an iOS and an Android column, every other journey, every failure with its checkpoint, and the accessibility findings against `a11y-baseline.json`. Dispatching **E2E Nightly** with a `suite` renders the same page for that suite (it resolves the build itself), and `yarn brief --reports <dir>` renders it locally from downloaded `e2e-reports-*` artifacts. Nothing in it fails a run — it is what to read instead of downloading artifacts.
 
 | Symbol | Meaning |
 | --- | --- |

--- a/e2e/configs/local/wdio.ios.local.device.conf.ts
+++ b/e2e/configs/local/wdio.ios.local.device.conf.ts
@@ -8,8 +8,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const config = { ...localConfig }
 
-// Dropped before scheduling, so `--suite regression` costs no iOS session on them.
-config.exclude = ANDROID_ONLY_SPECS
+// Dropped before scheduling, so `--suite regression` costs no iOS session on them. Appended: the
+// shared conf may already exclude the send-video journeys (E2E_EXCLUDE_SEND_VIDEO).
+config.exclude = [...(config.exclude ?? []), ...ANDROID_ONLY_SPECS]
 
 config.capabilities = [
   {

--- a/e2e/configs/local/wdio.ios.local.sim.conf.ts
+++ b/e2e/configs/local/wdio.ios.local.sim.conf.ts
@@ -8,8 +8,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const config = { ...localConfig }
 
-// Dropped before scheduling, so `--suite regression` costs no iOS session on them.
-config.exclude = ANDROID_ONLY_SPECS
+// Dropped before scheduling, so `--suite regression` costs no iOS session on them. Appended: the
+// shared conf may already exclude the send-video journeys (E2E_EXCLUDE_SEND_VIDEO).
+config.exclude = [...(config.exclude ?? []), ...ANDROID_ONLY_SPECS]
 
 config.capabilities = [
   {

--- a/e2e/configs/sauce/wdio.android.sauce.rdc.conf.ts
+++ b/e2e/configs/sauce/wdio.android.sauce.rdc.conf.ts
@@ -28,7 +28,9 @@ const androidCaps = {
  *
  * The exclude lists are complementary by construction (wdio.shared.conf.ts), and capability-level
  * `wdio:exclude` composes with --suite AND --spec — unlike `wdio:specs`, which --suite discards — so
- * every spec routes to exactly one lane under any invocation. `config.maxInstances` caps the lanes
+ * every spec routes to exactly one lane under any invocation, and a lane left with no specs is never
+ * scheduled — `--suite send-video` runs the injection-off lane alone, `E2E_EXCLUDE_SEND_VIDEO=1` the
+ * injection lane alone (that is how CI keeps send-video to one platform at a time). `config.maxInstances` caps the lanes
  * GLOBALLY: at the default 1 the injection lane drains fully, then send-video runs as a strictly
  * serial tail block (the blind-FIFO review queue requires that), retries included.
  *

--- a/e2e/configs/sauce/wdio.ios.sauce.rdc.conf.ts
+++ b/e2e/configs/sauce/wdio.ios.sauce.rdc.conf.ts
@@ -6,8 +6,9 @@ const appFilename = process.env.IOS_APP_FILENAME || 'BCSC-Dev-latest.ipa'
 
 const config = { ...sauceConfig }
 
-// Dropped before scheduling, so `--suite regression` costs no iOS session on them.
-config.exclude = ANDROID_ONLY_SPECS
+// Dropped before scheduling, so `--suite regression` costs no iOS session on them. Appended: the
+// shared conf may already exclude the send-video journeys (E2E_EXCLUDE_SEND_VIDEO).
+config.exclude = [...(config.exclude ?? []), ...ANDROID_ONLY_SPECS]
 
 config.capabilities = [
   {

--- a/e2e/configs/wdio.shared.conf.ts
+++ b/e2e/configs/wdio.shared.conf.ts
@@ -43,6 +43,13 @@ export const SEND_VIDEO_SPECS = ALL_SPEC_FILES.filter(isSendVideoSpec)
 export const NON_SEND_VIDEO_SPECS = ALL_SPEC_FILES.filter((path) => !isSendVideoSpec(path))
 
 /**
+ * `E2E_EXCLUDE_SEND_VIDEO=1` drops the send-video journeys from whatever suite runs. They review a
+ * shared, blind-FIFO agent queue and must never run on two platforms at once, so CI keeps them out
+ * of the concurrent device matrix and runs them one platform at a time via `--suite send-video`.
+ */
+export const EXCLUDE_SEND_VIDEO = process.env.E2E_EXCLUDE_SEND_VIDEO === '1'
+
+/**
  * Did the test end in a runtime `this.skip()`? WDIO reports a skip as `{ passed: false, skipped: true }`
  * — a shape that reads as a FAILURE to anything checking `passed` alone — and `@wdio/types` does not
  * declare `skipped` yet.
@@ -86,6 +93,8 @@ export const config: WebdriverIO.Config = {
     onboarding: [resolve(__dirname, `../test/${variant}/onboarding/*.journey.ts`)],
     auth: [resolve(__dirname, `../test/${variant}/auth/*.journey.ts`)],
     verify: [resolve(__dirname, `../test/${variant}/verify/*.journey.ts`)],
+    // The send-video journeys alone: CI's own sequential lane (see EXCLUDE_SEND_VIDEO).
+    'send-video': SEND_VIDEO_SPECS,
     main: [resolve(__dirname, `../test/${variant}/main/*.journey.ts`)],
     // Card-barcode scanning: Sauce + Android only (see ANDROID_ONLY_SPECS). Its own suite for targeted
     // runs, and part of `regression` — the iOS configs exclude it rather than schedule and skip it.
@@ -108,7 +117,8 @@ export const config: WebdriverIO.Config = {
     // Upgrade from the shipped 4.0.3 specifically — its pre-rework onboarding needs the frozen walk.
     upgrade403: [resolve(__dirname, `../test/${variant}/upgrade/upgrade-from-v403.spec.ts`)],
   },
-  exclude: [],
+  // iOS configs append ANDROID_ONLY_SPECS to this — append, never assign, or the env exclusion is lost.
+  exclude: EXCLUDE_SEND_VIDEO ? [...SEND_VIDEO_SPECS] : [],
   capabilities: [],
 
   logLevel: 'warn',

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,6 +12,7 @@
     "brief": "tsx scripts/brief.ts",
     "brief:check": "tsx scripts/brief-check.ts",
     "a11y:baseline": "tsx scripts/a11y-baseline.ts",
+    "queue:drain": "tsx scripts/send-video-queue.ts drain",
     "typecheck": "tsc --noEmit --skipLibCheck",
     "test:android:local": "wdio configs/local/wdio.android.local.emu.conf.ts",
     "test:android:device": "wdio configs/local/wdio.android.local.device.conf.ts",

--- a/e2e/scripts/fixtures/brief/e2e-reports-migration-Android-15/junit/wdio-0-0.xml
+++ b/e2e/scripts/fixtures/brief/e2e-reports-migration-Android-15/junit/wdio-0-0.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="6" failures="0" errors="0" skipped="0">
-  <testsuite name="V3 Add Card" timestamp="2026-08-28T06:02:11" time="512.907" tests="2" failures="0" errors="0" skipped="0">
+  <testsuite name="Upgrade from v3 setting up on the v3 release" timestamp="2026-08-28T06:02:11" time="512.907" tests="2" failures="0" errors="0" skipped="0">
     <properties>
       <property name="specId" value="0"/>
-      <property name="suiteName" value="V3 Add Card"/>
+      <property name="suiteName" value="Upgrade from v3: setting up on the v3 release"/>
       <property name="capabilities" value="android.2b291fdh2008n8"/>
       <property name="file" value="file://./test/bcsc/migration/migration.spec.ts"/>
     </properties>
-    <testcase classname="android.2b291fdh2008n8.V3_Add_Card" name="should tap the Add Card Setup button" time="11.480"/>
-    <testcase classname="android.2b291fdh2008n8.V3_Add_Card" name="should read the confirmation code and approve via SiteMinder" time="91.226"/>
+    <testcase classname="android.2b291fdh2008n8.Upgrade_from_v3:_setting_up_on_the_v3_release" name="taps the Add Card Setup button" time="11.480"/>
+    <testcase classname="android.2b291fdh2008n8.Upgrade_from_v3:_setting_up_on_the_v3_release" name="reads the confirmation code and approves it via SiteMinder" time="91.226"/>
   </testsuite>
-  <testsuite name="Upgrade v3 v4" timestamp="2026-08-28T06:11:40" time="88.520" tests="2" failures="0" errors="0" skipped="0">
+  <testsuite name="Upgrade from v3 installing the current build" timestamp="2026-08-28T06:11:40" time="88.520" tests="2" failures="0" errors="0" skipped="0">
     <properties>
       <property name="specId" value="0"/>
-      <property name="suiteName" value="Upgrade v3 → v4"/>
+      <property name="suiteName" value="Upgrade from v3: installing the current build"/>
       <property name="capabilities" value="android.2b291fdh2008n8"/>
       <property name="file" value="file://./test/bcsc/migration/migration.spec.ts"/>
     </properties>
-    <testcase classname="android.2b291fdh2008n8.Upgrade_v3_→_v4" name="should install the v4 app over v3" time="61.212"/>
-    <testcase classname="android.2b291fdh2008n8.Upgrade_v3_→_v4" name="should terminate and relaunch the app as v4" time="27.308"/>
+    <testcase classname="android.2b291fdh2008n8.Upgrade_from_v3:_installing_the_current_build" name="installs the current build over v3" time="61.212"/>
+    <testcase classname="android.2b291fdh2008n8.Upgrade_from_v3:_installing_the_current_build" name="relaunches as the current build" time="27.308"/>
   </testsuite>
-  <testsuite name="V4 Unlock After Migration" timestamp="2026-08-28T06:13:12" time="64.114" tests="2" failures="0" errors="0" skipped="0">
+  <testsuite name="Upgrade from v3 unlocking with the v3 PIN" timestamp="2026-08-28T06:13:12" time="64.114" tests="2" failures="0" errors="0" skipped="0">
     <properties>
       <property name="specId" value="0"/>
-      <property name="suiteName" value="V4 Unlock After Migration"/>
+      <property name="suiteName" value="Upgrade from v3: unlocking with the v3 PIN"/>
       <property name="capabilities" value="android.2b291fdh2008n8"/>
       <property name="file" value="file://./test/bcsc/migration/migration.spec.ts"/>
     </properties>
-    <testcase classname="android.2b291fdh2008n8.V4_Unlock_After_Migration" name="unlocks the migrated account and enters the v3 PIN" time="38.669"/>
-    <testcase classname="android.2b291fdh2008n8.V4_Unlock_After_Migration" name="lands on the Home screen" time="25.445"/>
+    <testcase classname="android.2b291fdh2008n8.Upgrade_from_v3:_unlocking_with_the_v3_PIN" name="unlocks the migrated account and enters the v3 PIN" time="38.669"/>
+    <testcase classname="android.2b291fdh2008n8.Upgrade_from_v3:_unlocking_with_the_v3_PIN" name="lands on the Home screen" time="25.445"/>
   </testsuite>
 </testsuites>

--- a/e2e/scripts/login.mjs
+++ b/e2e/scripts/login.mjs
@@ -25,6 +25,8 @@ const BACKCHECK_APPROVE_URL = `${BACKCHECK_BASE_URL}/approve`
 const BACKCHECK_NOTE_URL = `${BACKCHECK_BASE_URL}/note`
 /** Per-candidate identity data behind the match step; the page itself renders those names client-side. */
 const IDMATCH_RESULT_URL = `${IDCHECK_ORIGIN}/idcheck/protected/idmatch/result`
+/** A claim that took work lands on the request's own page; any other landing means the queue ran dry. */
+const CLAIMED_REQUEST_URL_PATTERN = /\/backCheckRequest\/(verify|review)Identity\/[^/?#]+$/
 
 /** The "all good" answer for every attestation radio group the review form renders. */
 const AFFIRMATIVE_ANSWER = '0'
@@ -634,26 +636,51 @@ function backcheckFormPostHeaders(referer) {
 }
 
 /**
- * Finds the dashboard's claim button. The portal renders a DIFFERENT form per queue — cardholder
+ * @typedef {'cardholder' | 'cardless'} ReviewQueue
+ * @typedef {{ action: string, csrfToken: string, queue: ReviewQueue }} ClaimForm
+ */
+
+/** Which queue a claim/detail URL belongs to: `verifyIdentity` is cardholder, `reviewIdentity` cardless. */
+function queueOfUrl(url) {
+  return /reviewIdentity/.test(url) ? 'cardless' : 'cardholder'
+}
+
+/**
+ * Every claim button on the dashboard. The portal renders a DIFFERENT form per queue — cardholder
  * requests post to `verifyIdentity`, cardless ones to `reviewIdentity` — and only for queues that
- * actually have work, so the endpoint is discovered rather than assumed.
+ * actually have work, so the endpoints are discovered rather than assumed.
  *
  * @param {string} dashboardHtml
- * @returns {{ action: string, csrfToken: string } | null}
+ * @returns {ClaimForm[]}
  */
-function findClaimForm(dashboardHtml) {
+function findClaimForms(dashboardHtml) {
   const $ = load(dashboardHtml)
-  const form = $('form[id^="open-next-request"]').first()
-  if (form.length === 0) {
-    return null
-  }
+  /** @type {ClaimForm[]} */
+  const forms = []
+  $('form[id^="open-next-request"]').each((_, element) => {
+    const form = $(element)
+    const action = form.attr('action')
+    const csrfToken = form.find('input[name="csrftoken"]').first().attr('value')
+    if (!action || !csrfToken) {
+      return
+    }
+    const href = new URL(action, IDCHECK_ORIGIN).href
+    forms.push({ action: href, csrfToken, queue: queueOfUrl(href) })
+  })
+  return forms
+}
 
-  const action = form.attr('action')
-  const csrfToken = form.find('input[name="csrftoken"]').first().attr('value')
-  if (!action || !csrfToken) {
-    return null
-  }
-  return { action: new URL(action, IDCHECK_ORIGIN).href, csrfToken }
+/**
+ * The claim button to press for `preferredQueue`, falling back to whichever queue has work (its head
+ * then reads as foreign and is released) — so a review never stalls on a claim it could have made.
+ *
+ * @param {string} dashboardHtml
+ * @param {ReviewQueue} preferredQueue
+ * @returns {ClaimForm | null}
+ */
+function findClaimForm(dashboardHtml, preferredQueue) {
+  const forms = findClaimForms(dashboardHtml)
+  return forms.find((form) => form.queue === preferredQueue) ?? forms[0] ?? null
 }
 
 /**
@@ -820,12 +847,14 @@ async function resolveIdentityMatch(fetchWithCookies, matchesHtml, matchesUrl, e
  * @property {string} cardSerialNumber - Expected serial; guards the blind FIFO claim ('N/A' when cardless)
  * @property {string} surname - Expected surname; the real guard for a cardless request
  * @property {string} firstName - Expected first name; also picks the identity match when one is asked for
+ * @property {'ios' | 'android'} [platform] - The submitting device's platform; a same-persona request from the other one is foreign
  *
  * @typedef {Object} SendVideoRejectInput
  * @property {'reject'} decision
  * @property {string} cardSerialNumber
  * @property {string} surname
  * @property {string} firstName
+ * @property {'ios' | 'android'} [platform]
  * @property {string} verificationComment - Reason text the app shows the user on the cancelled-review screen
  * @property {string} [comment] - Internal portal note; defaults to verificationComment
  * @property {string} [typeReasonId] - Portal reject-reason id; defaults to DEFAULT_REJECT_REASON_ID
@@ -860,13 +889,31 @@ function assertValidSendVideoReviewInput(input) {
  * @property {string} claimedName
  * @property {string} claimedSurname
  * @property {string} claimedFirstName
+ * @property {string} claimedOs - "iOS 18.6" / "Android 15" as the portal renders it ('' when absent)
+ * @property {'ios' | 'android' | 'unknown'} claimedPlatform
+ * @property {string} claimedAppVersion
+ * @property {string} videoDate
+ * @property {ReviewQueue} queue
  */
+
+/** @param {string} os */
+function platformOfOs(os) {
+  if (/^(ios|iphone|ipad)\b/i.test(os)) return 'ios'
+  if (/^android\b/i.test(os)) return 'android'
+  return 'unknown'
+}
+
+/** Text of one detail-page field, whitespace-collapsed (the portal pads them with newlines and tabs). */
+function detailText($detail, selector) {
+  return $detail(selector).first().text().replaceAll(/\s+/g, ' ').trim()
+}
 
 /**
  * @param {string} detailHtml
+ * @param {string} detailUrl
  * @returns {ClaimedRequest}
  */
-function parseClaimedRequest(detailHtml) {
+function parseClaimedRequest(detailHtml, detailUrl) {
   const detailAttributes = extractPageDataAttributes(detailHtml)
   const requestIdentifier = detailAttributes?.['request-identifier']
   if (!requestIdentifier) {
@@ -877,6 +924,7 @@ function parseClaimedRequest(detailHtml) {
     .map((_, element) => $detail(element).text().trim())
     .get()
     .filter(Boolean)
+  const claimedOs = detailText($detail, '#device-os')
   return {
     requestIdentifier,
     csrfToken: detailAttributes['csrf-token'],
@@ -885,23 +933,84 @@ function parseClaimedRequest(detailHtml) {
     claimedName: claimedNames.join(', '),
     claimedSurname: claimedNames[0] ?? '',
     claimedFirstName: claimedNames[1] ?? '',
+    claimedOs,
+    claimedPlatform: platformOfOs(claimedOs),
+    claimedAppVersion: detailText($detail, '#device-app-version'),
+    videoDate: detailText($detail, '#video-date').replace(/^video date:?\s*/i, ''),
+    queue: queueOfUrl(detailUrl),
   }
 }
 
 /**
  * Serial alone cannot identify a cardless request (they all read "N/A"), so the surname AND first
  * name are what actually distinguish those — all three are checked, since a shared surname alone
- * could otherwise match the wrong queued request.
+ * could otherwise match the wrong queued request. The personas are shared across platforms, so when
+ * the caller names its platform, the other platform's submission of the same person is foreign too.
  *
  * @param {ClaimedRequest} claimed
- * @param {SendVideoReviewInput} input
+ * @param {{ cardSerialNumber: string, surname: string, firstName: string, platform?: 'ios' | 'android' }} input
  */
 function matchesExpectedIdentity(claimed, input) {
   return (
     claimed.claimedSerial.toUpperCase() === input.cardSerialNumber.toUpperCase() &&
     claimed.claimedSurname.toUpperCase() === input.surname.toUpperCase() &&
-    claimed.claimedFirstName.toUpperCase() === input.firstName.toUpperCase()
+    claimed.claimedFirstName.toUpperCase() === input.firstName.toUpperCase() &&
+    matchesExpectedPlatform(claimed, input)
   )
+}
+
+/** Only blocks when the caller named a platform AND the page clearly names the other one. */
+function matchesExpectedPlatform(claimed, input) {
+  if (!input.platform || claimed.claimedPlatform === 'unknown') return true
+  return claimed.claimedPlatform === input.platform
+}
+
+/** One line naming a claimed request, for logs and summaries. */
+function describeClaimed(claimed) {
+  return `${claimed.queue} ${claimed.requestIdentifier}: ${claimed.claimedName} — serial ${claimed.claimedSerial}, ${claimed.claimedOs || 'os unknown'}, app ${claimed.claimedAppVersion || '?'}, video ${claimed.videoDate || '?'}`
+}
+
+/** Reads the dashboard — the only page that says which queues hold work. */
+async function fetchBackcheckDashboard(fetchWithCookies, signal) {
+  const response = await fetchWithCookies(BACKCHECK_DASHBOARD_URL, {
+    headers: backcheckDocumentHeaders(`${IDCHECK_ORIGIN}/idcheck/?`),
+    body: null,
+    method: 'GET',
+    signal,
+  })
+  return logStep('backcheck dashboard', response)
+}
+
+/**
+ * Presses a claim button and reports what it took. The queue can empty between the dashboard read and
+ * the claim, and the portal then lands the POST on a list page instead of a request — which is why
+ * `claimed` is optional. A non-OK response throws through logStep: a real error is never blind-retried.
+ *
+ * @param {typeof fetch} fetchWithCookies
+ * @param {ClaimForm} claimForm
+ * @param {string} step - log label, and the prefix on the error a non-OK response throws
+ * @param {AbortSignal} [signal]
+ * @returns {Promise<{ claimed?: ClaimedRequest, response: Response, html: string }>}
+ */
+async function claimQueueHead(fetchWithCookies, claimForm, step, signal) {
+  const response = await fetchWithCookies(claimForm.action, {
+    headers: backcheckFormPostHeaders(BACKCHECK_DASHBOARD_URL),
+    body: new URLSearchParams({ csrftoken: claimForm.csrfToken }).toString(),
+    method: 'POST',
+    signal,
+  })
+  const html = await response.text()
+  if (!response.ok) {
+    await logStep(step, response, html) // throws with the portal's message
+  }
+  // fetch-cookie follows the 302; landing on a per-request page means something was claimed.
+  const claimed = CLAIMED_REQUEST_URL_PATTERN.test(response.url) ? parseClaimedRequest(html, response.url) : undefined
+  return { claimed, response, html }
+}
+
+/** Where a claim that took nothing landed instead — the portal's way of saying the queue is empty. */
+function describeClaimLanding(response, html) {
+  return `${new URL(response.url).pathname} ("${extractPageTitle(html) || '(untitled)'}")`
 }
 
 /**
@@ -925,17 +1034,11 @@ async function claimMatchingSendVideoRequest(fetchWithCookies, input, claimTimeo
   const foreignClaims = new Map()
 
   for (let attempt = 1; ; attempt++) {
-    const dashboardResponse = await fetchWithCookies(BACKCHECK_DASHBOARD_URL, {
-      headers: backcheckDocumentHeaders(`${IDCHECK_ORIGIN}/idcheck/?`),
-      body: null,
-      method: 'GET',
-      signal,
-    })
-    const dashboardHtml = await logStep('backcheck dashboard', dashboardResponse)
+    const dashboardHtml = await fetchBackcheckDashboard(fetchWithCookies, signal)
 
     // Rendered only for a queue with work, so its absence is the empty-queue signal — and which one
     // it is decides the endpoint. A fresh-login role interstitial also lands here, hence the title.
-    const claimForm = findClaimForm(dashboardHtml)
+    const claimForm = findClaimForm(dashboardHtml, input.cardSerialNumber.toUpperCase() === 'N/A' ? 'cardless' : 'cardholder')
     if (!claimForm) {
       console.log(
         `[sm-login] [~] claim attempt ${attempt}: no claim button on the dashboard — page is "${extractPageTitle(dashboardHtml) || '(untitled)'}"`
@@ -944,56 +1047,49 @@ async function claimMatchingSendVideoRequest(fetchWithCookies, input, claimTimeo
       continue
     }
 
-    const claimResponse = await fetchWithCookies(claimForm.action, {
-      headers: backcheckFormPostHeaders(BACKCHECK_DASHBOARD_URL),
-      body: new URLSearchParams({ csrftoken: claimForm.csrfToken }).toString(),
-      method: 'POST',
-      signal,
-    })
-    const claimHtml = await claimResponse.text()
-    // fetch-cookie follows the 302; landing on a per-request page means something was claimed.
-    if (claimResponse.ok && /\/backCheckRequest\/(verify|review)Identity\/[^/?#]+$/.test(claimResponse.url)) {
-      const claimed = parseClaimedRequest(claimHtml)
-      if (matchesExpectedIdentity(claimed, input)) {
-        await logStep('claim send-video request', claimResponse, claimHtml)
-        console.log(`  claimed ${claimed.requestIdentifier}: ${claimed.claimedName} — serial ${claimed.claimedSerial}`)
-        return { detailUrl: claimResponse.url, claimed }
-      }
-
-      const timesClaimed = (foreignClaims.get(claimed.requestIdentifier) ?? 0) + 1
-      foreignClaims.set(claimed.requestIdentifier, timesClaimed)
-      if (timesClaimed >= 3) {
-        // One last release before failing: the previous ones evidently did not stick, but bailing
-        // while still holding the claim would leave the queue head ours and block the next run too.
-        await releaseClaimedRequest(fetchWithCookies, claimed.$detail, claimResponse.url, signal)
-        throw new Error(
-          `[claim send-video request] CloseRequest is not clearing ${claimed.requestIdentifier} ` +
-            `("${claimed.claimedName}", serial ${claimed.claimedSerial}) — claimed it ${timesClaimed} times while ` +
-            `waiting for "${input.surname}, ${input.firstName}" (serial ${input.cardSerialNumber}); ` +
-            `check the SIT backcheck dashboard`
-        )
-      }
-      console.log(
-        `[sm-login] [~] claim attempt ${attempt}: claimed foreign request ${claimed.requestIdentifier} ` +
-          `("${claimed.claimedName}", serial ${claimed.claimedSerial}) — closing it and retrying`
-      )
-      await releaseClaimedRequest(fetchWithCookies, claimed.$detail, claimResponse.url, signal)
-      await waitForNextClaimAttemptOrThrow(
-        claimDeadline,
-        claimTimeoutMs,
-        signal,
-        () => `closed foreign request ${claimed.requestIdentifier} ("${claimed.claimedName}")`
-      )
+    const {
+      claimed,
+      response: claimResponse,
+      html: claimHtml,
+    } = await claimQueueHead(fetchWithCookies, claimForm, 'claim send-video request', signal)
+    if (!claimed) {
+      const landing = describeClaimLanding(claimResponse, claimHtml)
+      console.log(`[sm-login] [~] claim attempt ${attempt}: nothing queued yet (landed on ${landing})`)
+      await waitForNextClaimAttemptOrThrow(claimDeadline, claimTimeoutMs, signal, () => landing)
       continue
     }
-    if (!claimResponse.ok) {
-      // Reuses logStep's throw path — a real error is never blind-retried.
+
+    if (matchesExpectedIdentity(claimed, input)) {
       await logStep('claim send-video request', claimResponse, claimHtml)
+      console.log(`  claimed ${describeClaimed(claimed)}`)
+      return { detailUrl: claimResponse.url, claimed }
     }
 
-    const landedPath = new URL(claimResponse.url).pathname
-    console.log(`[sm-login] [~] claim attempt ${attempt}: nothing queued yet (landed on ${landedPath})`)
-    await waitForNextClaimAttemptOrThrow(claimDeadline, claimTimeoutMs, signal, () => extractPageTitle(claimHtml) || landedPath)
+    const timesClaimed = (foreignClaims.get(claimed.requestIdentifier) ?? 0) + 1
+    foreignClaims.set(claimed.requestIdentifier, timesClaimed)
+    if (timesClaimed >= 3) {
+      // One last release before failing: the previous ones evidently did not stick, but bailing
+      // while still holding the claim would leave the queue head ours and block the next run too.
+      await releaseClaimedRequest(fetchWithCookies, claimed.$detail, claimResponse.url, signal)
+      throw new Error(
+        `[claim send-video request] CloseRequest is not clearing ${claimed.requestIdentifier} ` +
+          `("${claimed.claimedName}", serial ${claimed.claimedSerial}) — claimed it ${timesClaimed} times while ` +
+          `waiting for "${input.surname}, ${input.firstName}" (serial ${input.cardSerialNumber}); ` +
+          `check the SIT backcheck dashboard`
+      )
+    }
+
+    console.log(
+      `[sm-login] [~] claim attempt ${attempt}: claimed foreign request ${claimed.requestIdentifier} ` +
+        `("${claimed.claimedName}", serial ${claimed.claimedSerial}, ${claimed.claimedOs || 'os unknown'}) — closing it and retrying`
+    )
+    await releaseClaimedRequest(fetchWithCookies, claimed.$detail, claimResponse.url, signal)
+    await waitForNextClaimAttemptOrThrow(
+      claimDeadline,
+      claimTimeoutMs,
+      signal,
+      () => `closed foreign request ${claimed.requestIdentifier} ("${claimed.claimedName}")`
+    )
   }
 }
 
@@ -1010,7 +1106,7 @@ async function waitForNextClaimAttemptOrThrow(claimDeadline, claimTimeoutMs, sig
     await sleep(CLAIM_POLL_INTERVAL_MS, signal)
     return
   }
-  const suffix = describeLastPage ? ` — last: "${describeLastPage()}"` : ''
+  const suffix = describeLastPage ? ` — last: ${describeLastPage()}` : ''
   throw new Error(`[claim send-video request] no matching submission within ${claimTimeoutMs}ms${suffix}`)
 }
 
@@ -1117,7 +1213,7 @@ async function submitSendVideoDecision(fetchWithCookies, $detail, detailUrl, req
  *
  * @param {SendVideoReviewInput} input
  * @param {{ signal?: AbortSignal, claimTimeoutMs?: number }} [options]
- * @returns {Promise<{ requestIdentifier: string, claimedSerial: string, claimedName: string }>}
+ * @returns {Promise<ClaimedRequestSummary>}
  */
 export async function reviewSendVideoLogin(input, options = {}) {
   const { signal, claimTimeoutMs = DEFAULT_CLAIM_TIMEOUT_MS } = options
@@ -1126,11 +1222,153 @@ export async function reviewSendVideoLogin(input, options = {}) {
 
   const fetchWithCookies = await establishIdcheckSession(signal)
   const { detailUrl, claimed } = await claimMatchingSendVideoRequest(fetchWithCookies, input, claimTimeoutMs, signal)
-  const { requestIdentifier, csrfToken, $detail, claimedSerial, claimedName } = claimed
+  const { requestIdentifier, csrfToken, $detail } = claimed
 
   await submitSendVideoDecision(fetchWithCookies, $detail, detailUrl, requestIdentifier, csrfToken, input, signal)
 
-  return { requestIdentifier, claimedSerial, claimedName }
+  return summarizeClaimed(claimed)
+}
+
+/**
+ * @typedef {Object} ClaimedRequestSummary
+ * @property {string} requestIdentifier
+ * @property {ReviewQueue} queue
+ * @property {string} claimedName
+ * @property {string} claimedSerial
+ * @property {string} claimedOs
+ * @property {string} claimedAppVersion
+ * @property {string} videoDate
+ *
+ * @typedef {Object} DrainSendVideoQueueResult
+ * @property {ClaimedRequestSummary[]} rejected
+ * @property {ClaimedRequestSummary[]} released
+ * @property {ReviewQueue[]} queuesWithWork - Queues still showing a claim button when the drain ended
+ * @property {string} [stoppedReason] - Why the drain stopped before the dashboard ran dry
+ */
+
+/** @param {ClaimedRequest} claimed @returns {ClaimedRequestSummary} */
+function summarizeClaimed(claimed) {
+  const { requestIdentifier, queue, claimedName, claimedSerial, claimedOs, claimedAppVersion, videoDate } = claimed
+  return { requestIdentifier, queue, claimedName, claimedSerial, claimedOs, claimedAppVersion, videoDate }
+}
+
+/** The reason the portal records for a request the drain rejects — it lands in the card's activity log. */
+const DEFAULT_DRAIN_REASON = 'Automated e2e queue cleanup'
+/** Upper bound on claims per drain: a queue that deep is a person's problem, not a loop's. */
+const DEFAULT_DRAIN_MAX_CLAIMS = 25
+
+/**
+ * Guards JS/CLI callers the TS types cannot protect against.
+ * @param {string} scope
+ * @param {unknown[]} personas
+ */
+function assertValidDrainScope(scope, personas) {
+  if (scope !== 'all' && scope !== 'e2e') {
+    throw new Error(`[queue drain] unknown scope "${scope}" (all | e2e)`)
+  }
+  if (scope === 'e2e' && personas.length === 0) {
+    throw new Error("[queue drain] scope 'e2e' needs the personas to keep to")
+  }
+}
+
+/**
+ * Empty the review queues: claim the head, reject it, repeat until the dashboard renders no claim
+ * button. The journeys run it before they submit (so their own upload is the head the review claims)
+ * and after a failure (so an orphan never waits for the morning); CI runs it after every lane.
+ *
+ * `scope: 'e2e'` rejects only the listed personas and STOPS at the first foreign head, releasing it
+ * the way a review does — FIFO means nothing behind it is reachable without touching it. Rejecting,
+ * not closing: a rejection is a terminal, logged decision, while `CloseRequest` has only ever been
+ * observed to release the claim.
+ *
+ * `dryRun` only logs in and reads the dashboard — which queues hold work — claiming nothing.
+ *
+ * @param {{ scope?: 'all' | 'e2e', personas?: { cardSerialNumber: string, surname: string, firstName: string }[], reason?: string, maxClaims?: number, dryRun?: boolean, signal?: AbortSignal }} [options]
+ * @returns {Promise<DrainSendVideoQueueResult>}
+ */
+export async function drainSendVideoQueue(options = {}) {
+  const {
+    scope = 'all',
+    personas = [],
+    reason = DEFAULT_DRAIN_REASON,
+    maxClaims = DEFAULT_DRAIN_MAX_CLAIMS,
+    dryRun = false,
+    signal,
+  } = options
+  assertValidDrainScope(scope, personas)
+
+  const fetchWithCookies = await establishIdcheckSession(signal)
+  /** @type {DrainSendVideoQueueResult} */
+  const result = { rejected: [], released: [], queuesWithWork: [] }
+  /** @type {Map<string, 'rejected' | 'released'>} what this run already did to each request id */
+  const handled = new Map()
+
+  for (let claims = 0; ; claims++) {
+    const dashboardHtml = await fetchBackcheckDashboard(fetchWithCookies, signal)
+    const claimForms = findClaimForms(dashboardHtml)
+    result.queuesWithWork = claimForms.map((form) => form.queue)
+    const claimForm = claimForms[0]
+    if (!claimForm) {
+      console.log(`[queue drain] queues empty after ${claims} claim(s)`)
+      return result
+    }
+    if (dryRun) {
+      result.stoppedReason = `dry run — work queued in: ${result.queuesWithWork.join(', ')} (nothing claimed)`
+      return result
+    }
+    if (claims >= maxClaims) {
+      result.stoppedReason = `stopped after ${maxClaims} claims with the ${claimForm.queue} queue still holding work`
+      return result
+    }
+
+    const {
+      claimed,
+      response: claimResponse,
+      html: claimHtml,
+    } = await claimQueueHead(fetchWithCookies, claimForm, 'claim queued request', signal)
+    if (!claimed) {
+      result.stoppedReason = `the claim landed on ${describeClaimLanding(claimResponse, claimHtml)} instead of a request`
+      return result
+    }
+
+    const summary = summarizeClaimed(claimed)
+    const before = handled.get(claimed.requestIdentifier)
+    if (before) {
+      // A decision that did not stick, or a foreign head under 'e2e' — either way, stop churning.
+      await releaseClaimedRequest(fetchWithCookies, claimed.$detail, claimResponse.url, signal)
+      result.stoppedReason = `${claimed.requestIdentifier} ("${claimed.claimedName}") came back after being ${before}`
+      return result
+    }
+
+    if (scope === 'e2e' && !personas.some((persona) => matchesExpectedIdentity(claimed, persona))) {
+      await releaseClaimedRequest(fetchWithCookies, claimed.$detail, claimResponse.url, signal)
+      handled.set(claimed.requestIdentifier, 'released')
+      result.released.push(summary)
+      result.stoppedReason = `foreign request at the head — released ${claimed.requestIdentifier} ("${claimed.claimedName}") and stopped (scope e2e)`
+      console.log(`[queue drain] released ${describeClaimed(claimed)}`)
+      return result
+    }
+
+    await submitSendVideoDecision(
+      fetchWithCookies,
+      claimed.$detail,
+      claimResponse.url,
+      claimed.requestIdentifier,
+      claimed.csrfToken,
+      {
+        decision: 'reject',
+        cardSerialNumber: claimed.claimedSerial,
+        surname: claimed.claimedSurname,
+        firstName: claimed.claimedFirstName,
+        verificationComment: reason,
+        comment: reason,
+      },
+      signal
+    )
+    handled.set(claimed.requestIdentifier, 'rejected')
+    result.rejected.push(summary)
+    console.log(`[queue drain] rejected ${describeClaimed(claimed)}`)
+  }
 }
 
 function isRunAsCli() {
@@ -1164,6 +1402,7 @@ function printUsage() {
   console.error('  node login.mjs send-video approve <serial> <surname> <firstName>')
   console.error('  node login.mjs send-video reject  <serial> <surname> <firstName> [reasonId] [message]')
   console.error('     (serial is "N/A" for a cardless registration; the name is what identifies it)')
+  console.error('  Draining the review queue: yarn queue:drain [--scope all|e2e] (scripts/send-video-queue.ts)')
 }
 
 if (isRunAsCli()) {

--- a/e2e/scripts/send-video-queue.ts
+++ b/e2e/scripts/send-video-queue.ts
@@ -1,0 +1,100 @@
+/**
+ * Drain the SIT send-video review queue from the command line — locally and from CI:
+ *
+ *   yarn queue:drain [--scope all|e2e] [--max N] [--reason text] [--dry-run]
+ *
+ * `--dry-run` logs in and reports which queues hold work, claiming nothing. Needs SM_USER/SM_PASSWORD (e2e/.env.e2e locally, 1Password in CI) and an egress IP the IDcheck
+ * portal allowlists. Prints what it did as markdown, appends it to $GITHUB_STEP_SUMMARY when set,
+ * and exits non-zero only when the drain itself failed (login, network) — stopping with work still
+ * queued is a warning, not a failure.
+ */
+import { appendFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import dotenv from 'dotenv'
+import { type DrainScope, drainSendVideoQueue, renderDrainSummary, resolveDrainScope } from '../src/helpers/approval.js'
+
+dotenv.config({ path: resolve(dirname(fileURLToPath(import.meta.url)), '../.env.e2e') })
+
+/** A manual drain may face a week's worth of queue; the in-journey budget is far tighter. */
+const CLI_TIMEOUT_MS = 10 * 60_000
+
+interface Args {
+  scope?: DrainScope
+  maxClaims?: number
+  reason?: string
+  dryRun?: boolean
+}
+
+function usage(message: string): never {
+  console.error(`[queue] ${message}\nusage: yarn queue:drain [--scope all|e2e] [--max N] [--reason text] [--dry-run]`)
+  process.exit(2)
+}
+
+function parseArgs(argv: string[]): Args {
+  const [command, ...rest] = argv
+  if (command !== 'drain') usage(`unknown command "${command ?? ''}" — only "drain" exists`)
+  const args: Args = {}
+  for (let i = 0; i < rest.length; i++) {
+    const flag = rest[i]
+    const value = rest[i + 1]
+    switch (flag) {
+      case '--scope':
+        if (value !== 'all' && value !== 'e2e') usage(`--scope wants all|e2e, got "${value ?? ''}"`)
+        args.scope = value
+        i++
+        break
+      case '--max': {
+        const max = Number(value)
+        if (!Number.isInteger(max) || max < 1) usage(`--max wants a positive integer, got "${value ?? ''}"`)
+        args.maxClaims = max
+        i++
+        break
+      }
+      case '--reason':
+        if (!value) usage('--reason wants text')
+        args.reason = value
+        i++
+        break
+      case '--dry-run':
+        args.dryRun = true
+        break
+      default:
+        usage(`unknown flag "${flag}"`)
+    }
+  }
+  return args
+}
+
+function appendStepSummary(markdown: string): void {
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n\n`)
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+  const scope = resolveDrainScope(args.scope)
+  try {
+    const result = await drainSendVideoQueue({
+      scope,
+      maxClaims: args.maxClaims,
+      reason: args.reason,
+      dryRun: args.dryRun,
+      timeoutMs: CLI_TIMEOUT_MS,
+    })
+    const summary = renderDrainSummary(result, scope)
+    console.log(`\n${summary}\n`)
+    appendStepSummary(summary)
+    if (result.stoppedReason) {
+      console.log(`::warning::send-video queue drain stopped early: ${result.stoppedReason}`)
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`[queue] ${message}`)
+    appendStepSummary(`### Send-video review queue drain (scope: ${scope})\n\n❌ ${message}`)
+    process.exit(1)
+  }
+}
+
+await main()

--- a/e2e/src/brief/coverage-map.ts
+++ b/e2e/src/brief/coverage-map.ts
@@ -429,14 +429,14 @@ export const UAT_CHECKLIST: CoverageSection[] = [
       },
       {
         id: 'ext-migration-v3',
-        label: 'Migration v3 → v4',
+        label: 'Upgrade from v3 (migration)',
         platforms: androidOnly,
         proof: [
           {
             file: spec('migration/migration.spec.ts'),
             sources: [
               spec('migration/v3-onboarding.spec.ts'),
-              spec('migration/upgrade.spec.ts'),
+              spec('migration/v3-to-v4-upgrade.spec.ts'),
               spec('migration/v4-unlock.spec.ts'),
             ],
           },
@@ -516,21 +516,39 @@ export const OTHER_COVERAGE: CoverageSection[] = [
       { id: 'j-upgrade-403', label: 'Upgrade from 4.0.3', platforms: both, proof: [{ file: spec('upgrade/upgrade-from-v403.spec.ts') }] },
       {
         id: 'j-migration-v3-add-card',
-        label: 'Migration: v3 add card',
+        label: 'Upgrade from v3: set up on the v3 release',
         platforms: androidOnly,
-        proof: [{ file: spec('migration/migration.spec.ts'), suite: 'V3 Add Card', sources: [spec('migration/v3-onboarding.spec.ts')] }],
+        proof: [
+          {
+            file: spec('migration/migration.spec.ts'),
+            suite: 'Upgrade from v3: setting up on the v3 release',
+            sources: [spec('migration/v3-onboarding.spec.ts')],
+          },
+        ],
       },
       {
         id: 'j-migration-upgrade',
-        label: 'Migration: upgrade v3 → v4',
+        label: 'Upgrade from v3: install the current build',
         platforms: androidOnly,
-        proof: [{ file: spec('migration/migration.spec.ts'), suite: 'Upgrade v3 → v4', sources: [spec('migration/upgrade.spec.ts')] }],
+        proof: [
+          {
+            file: spec('migration/migration.spec.ts'),
+            suite: 'Upgrade from v3: installing the current build',
+            sources: [spec('migration/v3-to-v4-upgrade.spec.ts')],
+          },
+        ],
       },
       {
         id: 'j-migration-v4-unlock',
-        label: 'Migration: v4 unlock',
+        label: 'Upgrade from v3: unlock with the v3 PIN',
         platforms: androidOnly,
-        proof: [{ file: spec('migration/migration.spec.ts'), suite: 'V4 Unlock After Migration', sources: [spec('migration/v4-unlock.spec.ts')] }],
+        proof: [
+          {
+            file: spec('migration/migration.spec.ts'),
+            suite: 'Upgrade from v3: unlocking with the v3 PIN',
+            sources: [spec('migration/v4-unlock.spec.ts')],
+          },
+        ],
       },
     ],
   },

--- a/e2e/src/flows/auth.ts
+++ b/e2e/src/flows/auth.ts
@@ -1,12 +1,15 @@
 import { TEST_PIN, Timeouts } from '../constants.js'
 import { getCurrentAppId } from '../helpers/deep-link.js'
+import { describeCurrentScreen } from '../helpers/screens.js'
 import { AccountLandingScreen, EnterPINScreen } from '../screens/auth.js'
+import type { ScreenPresence } from '../screens/core/defineScreen.js'
 import { HomeScreen } from '../screens/main.js'
 import { OnboardingIntroScreen } from '../screens/onboarding.js'
 
 /**
  * UI-driven auth/unlock arranges. `didAuthenticate` is in-memory, so every launch of an
- * onboarded user passes through AccountLanding → EnterPIN before reaching Home.
+ * onboarded user passes through AccountLanding → EnterPIN before reaching Home — or, for a user
+ * who chose to verify and has not finished, the verification step the app resumes onto.
  */
 
 /** Terminate and reactivate the app under test — the standard way to reach the unlock flow mid-session. */
@@ -60,26 +63,59 @@ export async function selectAccountLandingIfPresent(): Promise<void> {
   }
 }
 
+/** Where an unlock may land: Home (skipped/verified users), a named screen, or anywhere off EnterPIN. */
+export type UnlockLanding = 'home' | 'any' | ScreenPresence
+
+/** Sampling interval while waiting for EnterPIN to leave once the PIN is in. */
+const PIN_LEAVE_PROBE_MS = 500
+
+async function waitForEnterPinToLeave(timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    if (!(await EnterPINScreen.isVisible('pin'))) return true
+    if (Date.now() > deadline) return false
+    await driver.pause(PIN_LEAVE_PROBE_MS)
+  }
+}
+
 /**
- * Unlock to Home: AccountLanding → EnterPIN → Home. With `relaunch: true`, terminates and
- * reactivates the app first — the standard way to reach the unlock flow mid-session.
- *
- * The PIN auto-submits on the 6th digit; when that doesn't navigate within the transition window,
- * the Continue button is tapped as a fallback.
+ * Type the PIN and wait for EnterPIN to leave. The PIN auto-submits on the 6th digit; Continue is the
+ * fallback, tapped only while the pin input is still up — its `Continue` id is shared by a dozen
+ * screens, so a blind tap after navigation lands on whatever the app resumed to.
  */
-export async function unlockWithPin(pin: string = TEST_PIN, options: { relaunch?: boolean } = {}): Promise<void> {
+export async function submitPin(pin: string = TEST_PIN): Promise<void> {
+  await EnterPINScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  await EnterPINScreen.fill('pin', pin)
+  if (await waitForEnterPinToLeave(Timeouts.SCREEN_TRANSITION)) return
+  await EnterPINScreen.tapWhenEnabled('primary')
+  if (await waitForEnterPinToLeave(Timeouts.SCREEN_TRANSITION)) return
+  throw new Error(`EnterPIN did not leave after the PIN was submitted. On screen: ${await describeCurrentScreen()}`)
+}
+
+/**
+ * Unlock: AccountLanding → EnterPIN → `landing`. With `relaunch: true`, terminates and reactivates
+ * the app first — the standard way to reach the unlock flow mid-session.
+ *
+ * Where the PIN lands is no longer always Home: an unverified user who chose "verify now" resumes
+ * onto their verification step on every launch. 'home' (default) asserts Home; a screen object
+ * asserts that screen; 'any' only proves EnterPIN left, for callers that branch on the landing.
+ */
+export async function unlockWithPin(
+  pin: string = TEST_PIN,
+  options: { relaunch?: boolean; landing?: UnlockLanding } = {}
+): Promise<void> {
   if (options.relaunch) {
     await relaunchApp()
   }
 
   await selectAccountLandingIfPresent()
   await AccountLandingScreen.tap('primary')
+  await submitPin(pin)
 
-  await EnterPINScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
-  await EnterPINScreen.fill('pin', pin)
-
-  if (!(await HomeScreen.isPresent(Timeouts.SCREEN_TRANSITION))) {
-    await EnterPINScreen.tapWhenEnabled('primary')
-    await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  const landing = options.landing ?? 'home'
+  if (landing === 'home') {
+    await HomeScreen.expectVisible(Timeouts.APP_LAUNCH)
+  } else if (landing !== 'any') {
+    await landing.expectVisible(Timeouts.APP_LAUNCH)
   }
 }

--- a/e2e/src/flows/verify.ts
+++ b/e2e/src/flows/verify.ts
@@ -1,8 +1,13 @@
 import type { TestUser } from '../constants.js'
 import { COMBO_CARD_BARCODE_MASKS, Timeouts } from '../constants.js'
-import { acceptSystemAlertsUntil, tapAlertButton } from '../helpers/alerts.js'
-import { isAppErrorShowing, throwIfAppErrorShowing } from '../helpers/app-error.js'
-import { ApproveInPersonInput, approveInPersonRequest } from '../helpers/approval.js'
+import { acceptAppAlert, acceptSystemAlert, acceptSystemAlertsUntil, tapAlertButton } from '../helpers/alerts.js'
+import { describeAppError, isAppErrorShowing, throwIfAppErrorShowing } from '../helpers/app-error.js'
+import {
+  ApproveInPersonInput,
+  approveInPersonRequest,
+  type ClaimedRequestSummary,
+  drainSendVideoQueue,
+} from '../helpers/approval.js'
 import type { ImageMaskRegion } from '../helpers/camera.js'
 import { canInjectImages, injectPhoto, injectScanTarget } from '../helpers/camera.js'
 import { getEmailConfirmationCode, getLatestMailId, getTempEmailAddress } from '../helpers/email.js'
@@ -14,8 +19,10 @@ import {
   RestartVerificationAlert,
   tapHelpMenuRow,
 } from '../helpers/help-menu.js'
-import { describeCurrentScreen, reachCameraScreen } from '../helpers/screens.js'
+import { describeCurrentScreen, reachCameraScreen, type ScreenProbe, waitForAnyScreen } from '../helpers/screens.js'
 import { BaseScreen } from '../screens/core/BaseScreen.js'
+import type { ScreenPresence } from '../screens/core/defineScreen.js'
+import { AppErrorModal } from '../screens/errors.js'
 import { HomeNotificationCard, HomeScreen } from '../screens/main.js'
 import { VerifyPromptScreen } from '../screens/onboarding.js'
 import {
@@ -53,6 +60,7 @@ import {
   VideoReviewScreen,
   VideoTooLongScreen,
 } from '../screens/verify.js'
+import { clearQueuedSubmission, hasQueuedSubmission, markSubmissionQueued } from '../support/send-video-queue.js'
 
 /**
  * Verify-stack arranges: the entry spine plus the per-step arranges that mirror the app's
@@ -96,13 +104,24 @@ export async function leaveVerificationToHome(): Promise<void> {
 }
 
 /**
- * Re-enter an interrupted verification from Home's verification card — the only route back in, since
- * the in-progress flag is in-memory. The stack mounts at `getResumeStepRoute`; which screen that is,
- * is the caller's assertion.
+ * Re-enter an interrupted verification. In-session, Home's verification card is the only route back
+ * in (the in-progress flag is in-memory); across a relaunch the app resumes a user who chose to
+ * verify straight onto their step, so pass `resumedOnto` to accept that landing too. Either way the
+ * stack mounts at `getResumeStepRoute`; which screen that is stays the caller's assertion.
  */
-export async function resumeVerification(): Promise<void> {
-  await HomeNotificationCard.expectVisible(Timeouts.SCREEN_TRANSITION)
-  await HomeNotificationCard.tapToNavigate('primary')
+export async function resumeVerification(
+  resumedOnto?: ScreenPresence,
+  timeoutMs: number = Timeouts.SCREEN_TRANSITION
+): Promise<void> {
+  const candidates: Record<string, ScreenProbe> = { card: HomeNotificationCard }
+  if (resumedOnto) {
+    candidates.resumed = resumedOnto
+  }
+  if ((await waitForAnyScreen(candidates, timeoutMs)) === 'card') {
+    await HomeNotificationCard.tapToNavigate('primary')
+    return
+  }
+  console.log('[verify] Already inside verification — the app resumed onto the step itself')
 }
 
 /**
@@ -268,6 +287,7 @@ export async function submitSendVideoVerification(user: TestUser): Promise<void>
 
   await VideoReviewScreen.tapWhenEnabled('primary') // UseVideo → RESETS to EvidenceUploading, which uploads on mount
   await SuccessfullySentScreen.expectVisible(Timeouts.VIDEO_UPLOAD)
+  markSubmissionQueued() // from here until the scripted review claims it, a failure leaves an orphan behind
   await SuccessfullySentScreen.tapToNavigate('primary') // Go to home — the screen's only way out
 
   await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
@@ -321,24 +341,100 @@ async function recordPromptedVideo(): Promise<void> {
   )
 }
 
-/** VideoInstructions → an armed recorder, with the prompt set the recording will be judged against. */
+/** Attempts at arming the recorder before the journey gives up on the device's camera stack. */
+const RECORDING_START_ATTEMPTS = 3
+
+/** How long StartRecording gets to leave the screen after its tap before the tap is called swallowed. */
+const RECORDING_START_LEAVE_MS = 5_000
+
+type RecorderArmOutcome = 'armed' | 'error' | 'bounced'
+
+/**
+ * VideoInstructions → an armed recorder, with the prompt set the recording will be judged against.
+ *
+ * Arming fails transiently on rack devices — the recorder errors at 00:00 behind the app's
+ * "Recording error" modal, or the thumbnail snapshot fails and the app bounces back to the
+ * instructions — so it is retried from VideoInstructions, whose StartRecording issues a fresh prompt
+ * set each time. The final failure carries the modal's details rather than a timeout.
+ */
 async function startVideoRecording(): Promise<void> {
+  let lastFailure = ''
+  for (let attempt = 1; attempt <= RECORDING_START_ATTEMPTS; attempt++) {
+    const outcome = await armRecorder()
+    if (outcome === 'armed') {
+      return
+    }
+    lastFailure = outcome === 'error' ? await recoverFromRecordingError() : await recoverFromRecorderBounce()
+    console.warn(`[verify] The recorder did not arm (attempt ${attempt}/${RECORDING_START_ATTEMPTS}): ${lastFailure}`)
+  }
+  throw new Error(`The recording failed to start after ${RECORDING_START_ATTEMPTS} attempts. Last: ${lastFailure}`)
+}
+
+/** Tap StartRecording and wait for the recorder to arm, the app to error, or the instructions to come back. */
+async function armRecorder(): Promise<RecorderArmOutcome> {
   await VideoInstructionsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   // Disabled until a fresh prompt set lands — the wait for it IS the wait for the fetch.
   await VideoInstructionsScreen.tapWhenEnabled('primary')
+  // A swallowed tap leaves the instructions up — the same recovery as a bounce.
+  if (!(await waitForInstructionsToLeave())) {
+    return 'bounced'
+  }
 
   // No start button: recording arms itself after a 3-2-1 countdown, behind camera AND microphone
   // dialogs, so the first prompt button gets a camera budget rather than a transition one.
   //
   // The error modal counts as "we got somewhere": iOS drops the covered recorder out of the
   // accessibility tree, so a recording that fails on arm would otherwise spend the whole camera budget
-  // waiting for a screen that is already there and unreachable. Ending the wait on either outcome lets
-  // the assert below name the app's error instead of a 45s timeout.
-  await reachCameraScreen(
-    'TakeVideo',
-    async () => (await TakeVideoScreen.isPresent(1_000)) || (await isAppErrorShowing())
-  )
-  await throwIfAppErrorShowing('The recording failed to start')
+  // waiting for a screen that is already there and unreachable. The instructions coming back is the
+  // snapshot-failure path (a native alert, then goBack).
+  const arm: { outcome: RecorderArmOutcome | null } = { outcome: null }
+  await reachCameraScreen('TakeVideo', async () => {
+    if (await TakeVideoScreen.isPresent(1_000)) {
+      arm.outcome = 'armed'
+    } else if (await isAppErrorShowing()) {
+      arm.outcome = 'error'
+    } else if (await VideoInstructionsScreen.isPresent(500)) {
+      arm.outcome = 'bounced'
+    }
+    return arm.outcome !== null
+  })
+  return arm.outcome ?? 'bounced'
+}
+
+async function waitForInstructionsToLeave(): Promise<boolean> {
+  const deadline = Date.now() + RECORDING_START_LEAVE_MS
+  while (Date.now() < deadline) {
+    if (!(await VideoInstructionsScreen.isPresent(500))) {
+      return true
+    }
+  }
+  return false
+}
+
+/** Close the app's error modal and back out of the dead recorder to VideoInstructions; returns what it said. */
+async function recoverFromRecordingError(): Promise<string> {
+  const failure = await describeAppError()
+  await AppErrorModal.tap('primary') // close
+  // Cancel is TakeVideo's only way back; it pops to VideoInstructions, which refetches prompts on focus.
+  if (await TakeVideoScreen.isPresent(Timeouts.ELEMENT_VISIBLE)) {
+    await TakeVideoScreen.tap('secondary')
+  }
+  await VideoInstructionsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  return failure
+}
+
+/** The app came back to VideoInstructions on its own (snapshot failure → native alert → goBack): clear the alert. */
+async function recoverFromRecorderBounce(): Promise<string> {
+  const failure = `bounced back to VideoInstructions. On screen: ${await describeCurrentScreen()}`
+  // The RN Alert is an app dialog on Android (never matched by the permission probe) and a system-style
+  // alert on iOS; both are best-effort here — a swallowed tap raised none.
+  if (driver.isAndroid) {
+    await acceptAppAlert(1_000).catch(() => undefined)
+  } else {
+    await acceptSystemAlert(1_000).catch(() => undefined)
+  }
+  await VideoInstructionsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+  return failure
 }
 
 /**
@@ -439,7 +535,10 @@ function assertExpectedDecision(actual: 'verified' | 'cancelled', expected: 'ver
  * foregrounding would NOT do — the Home-side status check runs once per stack mount, not per resume.
  * The push notification is advisory and never navigates, so it is not waited on either.
  */
-export async function waitForSendVideoDecision(expected: 'verified' | 'cancelled'): Promise<void> {
+export async function waitForSendVideoDecision(
+  expected: 'verified' | 'cancelled',
+  options: { reviewed?: ClaimedRequestSummary } = {}
+): Promise<void> {
   const deadline = Date.now() + REVIEW_DECISION_TIMEOUT_MS
   for (;;) {
     await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
@@ -452,14 +551,54 @@ export async function waitForSendVideoDecision(expected: 'verified' | 'cancelled
     }
 
     if (Date.now() + REVIEW_DECISION_POLL_MS >= deadline) {
+      const reviewed = options.reviewed
+        ? `The scripted review decided ${options.reviewed.queue} request ${options.reviewed.requestIdentifier} ` +
+          `(${options.reviewed.claimedName}, serial ${options.reviewed.claimedSerial}, ${options.reviewed.claimedOs || 'os unknown'})`
+        : 'The scripted review reported success'
       throw new Error(
         `The agent decision (${expected}) did not reach the app within ${REVIEW_DECISION_TIMEOUT_MS}ms of re-checking. ` +
-          'The scripted review reported success, so suspect the status endpoint or a submission other than this one.'
+          `${reviewed}, so suspect the status endpoint or a submission other than this one — ` +
+          'a stale same-persona upload at the head of the queue is the usual cause.'
       )
     }
     // Back does not pop here: it marks the account unverified, which swaps the stack back to Home.
     await PendingReviewScreen.back.tap()
     await driver.pause(REVIEW_DECISION_POLL_MS)
+  }
+}
+
+/**
+ * Journey setup: the review claims the queue HEAD blindly, so this journey's upload only reaches it
+ * once the queue is empty. A drain that stops early leaves a foreign request in front of ours — fail
+ * here, rather than twenty minutes later on a decision wait that never settles.
+ */
+export async function clearReviewQueueBeforeSubmit(): Promise<void> {
+  const { stoppedReason, queuesWithWork } = await drainSendVideoQueue()
+  if (stoppedReason) {
+    throw new Error(
+      `The review queue is not empty, so this journey's upload would not be the request the review claims: ` +
+        `${stoppedReason}. Queues still holding work: ${queuesWithWork.join(', ') || 'none reported'}.`
+    )
+  }
+}
+
+/**
+ * Journey teardown: drain the review queue when this session's upload was never claimed — a failure
+ * between the upload and the scripted review would otherwise leave it for the next run, or the
+ * morning. Best-effort by design: a hook that throws is reported as a failure of its own.
+ */
+export async function cleanUpQueuedSubmission(): Promise<void> {
+  if (!hasQueuedSubmission()) {
+    return
+  }
+  console.warn('[verify] This journey left its send-video upload in the review queue — draining it')
+  try {
+    await drainSendVideoQueue({ maxClaims: 5, timeoutMs: 120_000 })
+  } catch (err) {
+    console.warn(`[verify] The post-journey queue drain failed: ${(err as Error).message ?? err}`)
+  } finally {
+    // Cleared however the drain went: the orphan is this teardown's to deal with, once.
+    clearQueuedSubmission()
   }
 }
 

--- a/e2e/src/helpers/alerts.ts
+++ b/e2e/src/helpers/alerts.ts
@@ -15,6 +15,12 @@ const ANDROID_PERM_DENY_REGEX = '.*:id/permission_deny.*'
 const ANDROID_PERM_ANY_REGEX = '.*:id/permission_(allow|deny).*'
 const ANDROID_RESET_APP_SELECTOR = 'android=new UiSelector().textMatches("(?i)^reset app$")'
 const ANDROID_ALERT_OK_SELECTOR = 'android=new UiSelector().textMatches("(?i)^ok$")'
+// Android 12+ sensor-privacy toggle (SystemUI) — raised when the mic/camera is blocked device-wide. Not a
+// permission-controller dialog, so the resourceId probes never see it; matched by its title copy.
+const ANDROID_SENSOR_PRIVACY_TITLE_SELECTOR =
+  String.raw`android=new UiSelector().textMatches("(?i)^unblock( device)? (microphone|camera|camera and microphone)\?$")`
+const ANDROID_SENSOR_PRIVACY_ACCEPT_SELECTOR = 'android=new UiSelector().textMatches("(?i)^unblock$")'
+const ANDROID_SENSOR_PRIVACY_DISMISS_SELECTOR = 'android=new UiSelector().textMatches("(?i)^cancel$")'
 
 const webdriverLogger = logger('webdriver')
 
@@ -57,8 +63,17 @@ async function hasAndroidPermissionDialog(): Promise<boolean> {
   return btn.isDisplayed().catch(() => false)
 }
 
+async function hasAndroidSensorPrivacyDialog(): Promise<boolean> {
+  return $(ANDROID_SENSOR_PRIVACY_TITLE_SELECTOR)
+    .isDisplayed()
+    .catch(() => false)
+}
+
 async function hasNativePopup(): Promise<boolean> {
-  return driver.isAndroid ? hasAndroidPermissionDialog() : hasIosNativePopup()
+  if (driver.isAndroid) {
+    return (await hasAndroidPermissionDialog()) || (await hasAndroidSensorPrivacyDialog())
+  }
+  return hasIosNativePopup()
 }
 
 async function waitForPopup(timeoutMs: number): Promise<boolean> {
@@ -171,6 +186,17 @@ async function resolveAndroidPermissionDialog(action: 'accept' | 'dismiss', appe
     return
   }
 
+  // Unblocking flips a device-wide toggle, so the next session on this rack device starts clean.
+  if (await hasAndroidSensorPrivacyDialog()) {
+    const selector = action === 'accept' ? ANDROID_SENSOR_PRIVACY_ACCEPT_SELECTOR : ANDROID_SENSOR_PRIVACY_DISMISS_SELECTOR
+    await $(selector).click()
+    if (await waitForDismissal(DEFAULT_DISMISS_TIMEOUT_MS)) {
+      console.log(`[alerts] ${action === 'accept' ? 'Unblocked' : 'Left blocked'} the device sensor (sensor-privacy dialog)`)
+      return
+    }
+    throw new Error(`[alerts] Tapped the sensor-privacy dialog's ${action} button but it did not dismiss`)
+  }
+
   const resourceIdRegex = action === 'accept' ? ANDROID_PERM_ALLOW_REGEX : ANDROID_PERM_DENY_REGEX
   const btn = $(`android=new UiSelector().resourceIdMatches("${resourceIdRegex}")`)
   if (!(await btn.isDisplayed().catch(() => false))) {
@@ -194,7 +220,9 @@ async function resolveAndroidPermissionDialog(action: 'accept' | 'dismiss', appe
  *
  * Android: the system permission controller renders the dialog with stable
  * `permission_allow*` resourceIds — we match those with a regex to cover
- * "Allow", "While using the app", "Only this time" across OS versions.
+ * "Allow", "While using the app", "Only this time" across OS versions. The
+ * Android 12+ "Unblock device microphone/camera?" sensor-privacy dialog is
+ * handled too (matched by title; "Unblock" accepts it).
  */
 export async function acceptSystemAlert(appearTimeoutMs = DEFAULT_APPEAR_TIMEOUT_MS): Promise<void> {
   if (driver.isAndroid) {

--- a/e2e/src/helpers/app-error.ts
+++ b/e2e/src/helpers/app-error.ts
@@ -1,3 +1,4 @@
+import { Timeouts } from '../constants.js'
 import { AppErrorModal } from '../screens/errors.js'
 import { describeCurrentScreen } from './screens.js'
 
@@ -7,9 +8,34 @@ import { describeCurrentScreen } from './screens.js'
  */
 const PROBE_TIMEOUT_MS = 1_000
 
+/** Cap on the details carried into a failure message — the modal can hold a stack. */
+const DETAILS_MAX_CHARS = 400
+
 /** Is the app's error modal up? Cheap probe — never scrolls, never throws. */
 export async function isAppErrorShowing(timeoutMs: number = PROBE_TIMEOUT_MS): Promise<boolean> {
   return AppErrorModal.isPresent(timeoutMs)
+}
+
+/**
+ * The modal's expandable details ("Error code N - message"), or '' when it carries none. Best-effort:
+ * a details read must never mask the failure it decorates.
+ */
+export async function readAppErrorDetails(): Promise<string> {
+  try {
+    if (!(await AppErrorModal.isVisible('showDetails'))) return ''
+    await AppErrorModal.link('showDetails')
+    const details = await AppErrorModal.read('details', Timeouts.ELEMENT_VISIBLE)
+    return details.replaceAll(/\s+/g, ' ').trim().slice(0, DETAILS_MAX_CHARS)
+  } catch {
+    return ''
+  }
+}
+
+/** The screen dump plus the modal's details — what a recorder or camera failure should carry. */
+export async function describeAppError(): Promise<string> {
+  const details = await readAppErrorDetails()
+  const screen = await describeCurrentScreen()
+  return details ? `${screen} | details: ${details}` : screen
 }
 
 /**
@@ -19,5 +45,5 @@ export async function isAppErrorShowing(timeoutMs: number = PROBE_TIMEOUT_MS): P
  */
 export async function throwIfAppErrorShowing(context: string): Promise<void> {
   if (!(await isAppErrorShowing())) return
-  throw new Error(`${context}: the app raised an error modal. On screen: ${await describeCurrentScreen()}`)
+  throw new Error(`${context}: the app raised an error modal. On screen: ${await describeAppError()}`)
 }

--- a/e2e/src/helpers/approval.ts
+++ b/e2e/src/helpers/approval.ts
@@ -1,5 +1,7 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { TestUsers } from '../constants.js'
+import { clearQueuedSubmission } from '../support/send-video-queue.js'
 
 /**
  * Normalizes BIRTH_DATE to YYYY-MM-DD regardless of input format.
@@ -14,6 +16,12 @@ function normalizeBirthdate(value: string): string {
 }
 
 const loginModuleUrl = pathToFileURL(resolve(dirname(fileURLToPath(import.meta.url)), '../../scripts/login.mjs')).href
+
+/** Appium idles a session out at `newCommandTimeout` (180 s); a cheap command this often keeps it alive through Node-only work. */
+const KEEPALIVE_INTERVAL_MS = 45_000
+
+/** Default budget for a drain: generous for a full queue, well inside mocha's 600 s test/hook timeout. */
+const DRAIN_TIMEOUT_MS = 150_000
 
 export interface RegistrationDocument {
   typeId: string
@@ -42,6 +50,108 @@ type ApproveInPersonLoginInput = ApproveInPersonInput extends infer T
     ? T & { flow: F; userCode: string }
     : never
   : never
+
+/** Who the claimed request must be for. Checked before any decision, and never guessed at. */
+export interface SendVideoReviewIdentity {
+  /** Guards the claim. A cardless registration has no card, and the portal shows 'N/A' for it. */
+  cardSerialNumber: string
+  /** The real guard for a cardless request, where every serial reads the same. */
+  surname: string
+  /** Also picks the identity match, on the flows where the portal asks for one. */
+  firstName: string
+  /** The submitting device's platform: the personas are shared, so the other platform's upload of the same person is foreign. */
+  platform?: 'ios' | 'android'
+}
+
+export type SendVideoReviewInput =
+  | ({
+      decision: 'approve'
+    } & SendVideoReviewIdentity)
+  | ({
+      decision: 'reject'
+      /** Reason text the app shows the user on the cancelled-review screen — tests assert it verbatim. */
+      verificationComment: string
+      /** Internal portal note; defaults to verificationComment. */
+      comment?: string
+      /** Portal reject-reason id; defaults to '22' (additional person in photo or video). */
+      typeReasonId?: string
+    } & SendVideoReviewIdentity)
+
+/** What the scripted review claimed and decided — for the journey's logs and its decision-timeout message. */
+export interface ClaimedRequestSummary {
+  requestIdentifier: string
+  queue: 'cardholder' | 'cardless'
+  claimedName: string
+  claimedSerial: string
+  /** "iOS 18.6" / "Android 15" as the portal renders it; '' when the page did not say. */
+  claimedOs: string
+  claimedAppVersion: string
+  videoDate: string
+}
+
+/** 'all' rejects every queued request; 'e2e' only the journeys' personas, stopping at a foreign head. */
+export type DrainScope = 'all' | 'e2e'
+
+export interface DrainSendVideoQueueOptions {
+  /** Defaults to E2E_QUEUE_DRAIN_SCOPE, else 'all'. */
+  scope?: DrainScope
+  maxClaims?: number
+  /** The reason the portal records against each rejected request. */
+  reason?: string
+  /** Budget for the WHOLE drain — login plus ~5 round trips per queued request. */
+  timeoutMs?: number
+  /** Log in and read which queues hold work; claim nothing. */
+  dryRun?: boolean
+}
+
+export interface DrainSendVideoQueueResult {
+  rejected: ClaimedRequestSummary[]
+  released: ClaimedRequestSummary[]
+  /** Queues still showing a claim button when the drain ended ('cardholder' / 'cardless'). */
+  queuesWithWork: ('cardholder' | 'cardless')[]
+  /** Set when work was still queued: a foreign head under 'e2e', the claim cap, or a decision that did not stick. */
+  stoppedReason?: string
+}
+
+type LoginModule = {
+  approveInPersonLogin: (input: ApproveInPersonLoginInput, options?: { signal?: AbortSignal }) => Promise<void>
+  reviewSendVideoLogin: (
+    input: SendVideoReviewInput,
+    options?: { signal?: AbortSignal; claimTimeoutMs?: number }
+  ) => Promise<ClaimedRequestSummary>
+  drainSendVideoQueue: (options: {
+    scope: DrainScope
+    personas: SendVideoReviewIdentity[]
+    reason?: string
+    maxClaims?: number
+    dryRun?: boolean
+    signal?: AbortSignal
+  }) => Promise<DrainSendVideoQueueResult>
+}
+
+/** The SiteMinder/IDcheck script, loaded lazily so a journey only pays for it at the approval step. */
+async function loadLoginModule(): Promise<LoginModule> {
+  return (await import(loginModuleUrl)) as LoginModule
+}
+
+/** The submitting device's platform when this runs inside a wdio session; the CLI has none. */
+function currentPlatform(): 'ios' | 'android' | undefined {
+  if (typeof driver === 'undefined') return undefined
+  return driver.isIOS ? 'ios' : 'android'
+}
+
+/** Run portal round trips without the Appium session idling out underneath them. */
+async function withDriverKeepalive<T>(work: () => Promise<T>): Promise<T> {
+  if (typeof driver === 'undefined') return work()
+  const timer = setInterval(() => {
+    driver.getWindowSize().catch(() => undefined)
+  }, KEEPALIVE_INTERVAL_MS)
+  try {
+    return await work()
+  } finally {
+    clearInterval(timer)
+  }
+}
 
 /**
  * Approve an in-person verification request by running the SM login flow in-process.
@@ -72,9 +182,7 @@ export async function approveInPersonRequest(
       ? { ...input, userCode: code }
       : { ...input, cardBirthdate: normalizeBirthdate(input.cardBirthdate), userCode: code }
 
-  const { approveInPersonLogin } = (await import(loginModuleUrl)) as {
-    approveInPersonLogin: (input: ApproveInPersonLoginInput, options?: { signal?: AbortSignal }) => Promise<void>
-  }
+  const { approveInPersonLogin } = await loadLoginModule()
 
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
@@ -96,59 +204,45 @@ export async function approveInPersonRequest(
   }
 }
 
-/** Who the claimed request must be for. Checked before any decision, and never guessed at. */
-export interface SendVideoReviewIdentity {
-  /** Guards the claim. A cardless registration has no card, and the portal shows 'N/A' for it. */
-  cardSerialNumber: string
-  /** The real guard for a cardless request, where every serial reads the same. */
-  surname: string
-  /** Also picks the identity match, on the flows where the portal asks for one. */
-  firstName: string
-}
-
-export type SendVideoReviewInput =
-  | ({
-      decision: 'approve'
-    } & SendVideoReviewIdentity)
-  | ({
-      decision: 'reject'
-      /** Reason text the app shows the user on the cancelled-review screen — tests assert it verbatim. */
-      verificationComment: string
-      /** Internal portal note; defaults to verificationComment. */
-      comment?: string
-      /** Portal reject-reason id; defaults to '22' (additional person in photo or video). */
-      typeReasonId?: string
-    } & SendVideoReviewIdentity)
-
 /**
  * Review (approve or reject) a queued send-video verification request by running the SM login flow
- * in-process.
+ * in-process, and say which request that was.
  *
  * The portal's queue is a blind FIFO claim, so the script polls until the submission appears and
- * refuses to review one that is not for the expected person. It works for every card type: the review
- * form is echoed back as rendered, which covers the extra document and name fields an added photo ID
- * or a cardless registration brings, and the identity-match step a cardless one inserts.
+ * refuses to review one that is not for the expected person on the expected platform. It works for
+ * every card type: the review form is echoed back as rendered, which covers the extra document and
+ * name fields an added photo ID or a cardless registration brings, and the identity-match step a
+ * cardless one inserts.
  *
  * @param input - Decision + who the request must be for (reject adds the reason fields)
  * @param timeoutMs - Budget for the WHOLE chain — dominated by the claim polling (up to 120s in the
  *   script) plus SM login and the decision round trips, so a thin budget expires mid-poll.
  */
-export async function reviewSendVideoRequest(input: SendVideoReviewInput, timeoutMs = 180_000): Promise<void> {
-  console.log(`[approval] Reviewing send-video request (decision=${input.decision}, serial=${input.cardSerialNumber})`)
+export async function reviewSendVideoRequest(
+  input: SendVideoReviewInput,
+  timeoutMs = 180_000
+): Promise<ClaimedRequestSummary> {
+  const platform = input.platform ?? currentPlatform()
+  console.log(
+    `[approval] Reviewing send-video request (decision=${input.decision}, serial=${input.cardSerialNumber}, platform=${platform ?? 'any'})`
+  )
 
-  const { reviewSendVideoLogin } = (await import(loginModuleUrl)) as {
-    reviewSendVideoLogin: (
-      input: SendVideoReviewInput,
-      options?: { signal?: AbortSignal; claimTimeoutMs?: number }
-    ) => Promise<{ requestIdentifier: string; claimedSerial: string; claimedName: string }>
-  }
+  const { reviewSendVideoLogin } = await loadLoginModule()
 
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
   const startedAt = Date.now()
 
   try {
-    await reviewSendVideoLogin(input, { signal: controller.signal })
+    const claimed = await withDriverKeepalive(() =>
+      reviewSendVideoLogin({ ...input, platform }, { signal: controller.signal })
+    )
+    clearQueuedSubmission()
+    console.log(
+      `[approval] Decided ${claimed.queue} request ${claimed.requestIdentifier}: ${claimed.claimedName} ` +
+        `(serial ${claimed.claimedSerial}, ${claimed.claimedOs || 'os unknown'})`
+    )
+    return claimed
   } catch (error: unknown) {
     const elapsedMs = Date.now() - startedAt
     const message = error instanceof Error ? error.message : String(error)
@@ -163,4 +257,96 @@ export async function reviewSendVideoRequest(input: SendVideoReviewInput, timeou
   } finally {
     clearTimeout(timeoutId)
   }
+}
+
+/** The personas the journeys submit as — what `scope: 'e2e'` keeps a drain to. */
+export const E2E_SEND_VIDEO_PERSONAS: SendVideoReviewIdentity[] = Object.values(TestUsers).map((user) => ({
+  cardSerialNumber: user.cardSerial,
+  surname: user.lastName,
+  firstName: user.firstName,
+}))
+
+/** The drain scope to use: an explicit one, else E2E_QUEUE_DRAIN_SCOPE, else 'all'. */
+export function resolveDrainScope(scope?: DrainScope): DrainScope {
+  if (scope) return scope
+  const fromEnv = process.env.E2E_QUEUE_DRAIN_SCOPE
+  if (fromEnv === 'all' || fromEnv === 'e2e') return fromEnv
+  if (fromEnv) console.warn(`[queue] Unknown E2E_QUEUE_DRAIN_SCOPE "${fromEnv}" — draining with scope 'all'`)
+  return 'all'
+}
+
+/**
+ * Empty the SIT send-video review queue by rejecting whatever is queued, so the next upload is the
+ * head the scripted review claims. The queue is shared with the UAT team and the other platform's
+ * run, which is why the journeys never run send-video on two platforms at once, and why `scope`
+ * exists: 'e2e' keeps a daytime run to the journeys' own personas.
+ */
+export async function drainSendVideoQueue(options: DrainSendVideoQueueOptions = {}): Promise<DrainSendVideoQueueResult> {
+  const scope = resolveDrainScope(options.scope)
+  const timeoutMs = options.timeoutMs ?? DRAIN_TIMEOUT_MS
+  console.log(`[queue] ${options.dryRun ? 'Inspecting' : 'Draining'} the send-video review queue (scope=${scope})`)
+
+  const { drainSendVideoQueue: drain } = await loadLoginModule()
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  const startedAt = Date.now()
+
+  try {
+    const result = await withDriverKeepalive(() =>
+      drain({
+        scope,
+        personas: E2E_SEND_VIDEO_PERSONAS,
+        reason: options.reason,
+        maxClaims: options.maxClaims,
+        dryRun: options.dryRun,
+        signal: controller.signal,
+      })
+    )
+    const stopped = result.stoppedReason ? ` — ${result.stoppedReason}` : ''
+    console.log(
+      `[queue] Drained in ${Date.now() - startedAt}ms: ${result.rejected.length} rejected, ${result.released.length} released${stopped}`
+    )
+    return result
+  } catch (error: unknown) {
+    const elapsedMs = Date.now() - startedAt
+    const message = error instanceof Error ? error.message : String(error)
+    const detail = controller.signal.aborted
+      ? `the ${timeoutMs}ms budget for the whole drain ran out (see the per-step [sm-login] timings for where it went)`
+      : message
+    throw new Error(`Queue drain failed after ${elapsedMs}ms (scope=${scope}): ${detail}`)
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+/** Markdown for a drain result — what the CI step summary and the CLI print. */
+export function renderDrainSummary(result: DrainSendVideoQueueResult, scope: DrainScope): string {
+  const lines = [`### Send-video review queue drain (scope: ${scope})`, '']
+  const rows = [
+    ...result.rejected.map((request) => ({ action: 'rejected', ...request })),
+    ...result.released.map((request) => ({ action: 'released', ...request })),
+  ]
+  if (rows.length === 0) {
+    lines.push(
+      result.queuesWithWork.length === 0
+        ? 'Queue already empty — nothing to do.'
+        : `Nothing touched; work still queued in: ${result.queuesWithWork.join(', ')}.`
+    )
+  } else {
+    lines.push(
+      '| Action | Queue | Request | Name | Serial | Device | App | Video date |',
+      '| --- | --- | --- | --- | --- | --- | --- | --- |'
+    )
+    for (const row of rows) {
+      lines.push(
+        `| ${row.action} | ${row.queue} | ${row.requestIdentifier} | ${row.claimedName} | ${row.claimedSerial} | ` +
+          `${row.claimedOs || '?'} | ${row.claimedAppVersion || '?'} | ${row.videoDate || '?'} |`
+      )
+    }
+  }
+  if (result.stoppedReason) {
+    lines.push('', `⚠️ Stopped early: ${result.stoppedReason}`)
+  }
+  return lines.join('\n')
 }

--- a/e2e/src/helpers/screens.ts
+++ b/e2e/src/helpers/screens.ts
@@ -1,4 +1,5 @@
 import { Timeouts } from '../constants.js'
+import type { ScreenPresence } from '../screens/core/defineScreen.js'
 import { acceptSystemAlertsUntil } from './alerts.js'
 
 /**
@@ -49,4 +50,34 @@ export async function reachCameraScreen(
 ): Promise<void> {
   if (await acceptSystemAlertsUntil(isReady, { timeoutMs })) return
   throw new Error(`${name} did not become ready within ${timeoutMs}ms. On screen: ${await describeCurrentScreen()}`)
+}
+
+/** A screen object, or a cheap non-throwing probe for anything a screen object cannot name. */
+export type ScreenProbe = ScreenPresence | (() => Promise<boolean>)
+
+/** Per-candidate sampling budget inside {@link waitForAnyScreen} — polled, so an interval, not a wait. */
+const ANY_SCREEN_PROBE_MS = 500
+
+/**
+ * Wait until one of `candidates` is on screen and say which — for the seams where the app may
+ * legitimately land on either of two screens (a relaunch that resumes into verification, or Home).
+ * Never scrolls; on timeout the thrown error names what was actually on screen.
+ */
+export async function waitForAnyScreen<K extends string>(
+  candidates: Record<K, ScreenProbe>,
+  timeoutMs: number = Timeouts.SCREEN_TRANSITION
+): Promise<K> {
+  const deadline = Date.now() + timeoutMs
+  const entries = Object.entries(candidates) as [K, ScreenProbe][]
+  for (;;) {
+    for (const [key, probe] of entries) {
+      const present = typeof probe === 'function' ? await probe() : await probe.isPresent(ANY_SCREEN_PROBE_MS)
+      if (present) return key
+    }
+    if (Date.now() > deadline) {
+      throw new Error(
+        `None of [${entries.map(([key]) => key).join(', ')}] appeared within ${timeoutMs}ms. On screen: ${await describeCurrentScreen()}`
+      )
+    }
+  }
 }

--- a/e2e/src/screens/errors.ts
+++ b/e2e/src/screens/errors.ts
@@ -20,7 +20,10 @@ const { errorModal } = TestIds
 export const AppErrorModal = defineScreen({
   self: bcsc(errorModal.close),
   primary: bcsc(errorModal.close),
-  elements: {
+  links: {
     showDetails: bcsc(errorModal.showDetails),
+  },
+  elements: {
+    details: bcsc(errorModal.details), // the error code + message, only after ShowDetails
   },
 })

--- a/e2e/src/support/send-video-queue.ts
+++ b/e2e/src/support/send-video-queue.ts
@@ -1,0 +1,19 @@
+/**
+ * Whether this journey's send-video upload is still sitting in the SIT review queue: set once the
+ * upload is acknowledged, cleared once the scripted review has claimed it or the teardown has drained
+ * it. The journeys' teardown reads it to drain an orphan a mid-journey failure would otherwise leave
+ * for the next run.
+ */
+let queuedSubmission = false
+
+export function markSubmissionQueued(): void {
+  queuedSubmission = true
+}
+
+export function clearQueuedSubmission(): void {
+  queuedSubmission = false
+}
+
+export function hasQueuedSubmission(): boolean {
+  return queuedSubmission
+}

--- a/e2e/src/test-ids/registry.ts
+++ b/e2e/src/test-ids/registry.ts
@@ -48,6 +48,7 @@ export const TestIds = {
   errorModal: {
     close: 'CloseButton',
     showDetails: 'ShowDetails',
+    details: 'DetailsText', // "Error code N - message", rendered only once ShowDetails is pressed
     title: 'HeaderText',
     body: 'BodyText',
   },

--- a/e2e/test/bcsc/a11y/accessibility.journey.ts
+++ b/e2e/test/bcsc/a11y/accessibility.journey.ts
@@ -1,5 +1,5 @@
 import { TEST_PIN, TestUsers, Timeouts } from '../../../src/constants.js'
-import { relaunchApp, selectAccountLandingIfPresent } from '../../../src/flows/auth.js'
+import { relaunchApp, selectAccountLandingIfPresent, submitPin } from '../../../src/flows/auth.js'
 import { chooseAddAccount, leaveVerificationToHome, startVerification } from '../../../src/flows/verify.js'
 import { auditScreen, reportA11ySummary } from '../../../src/helpers/a11y-audit.js'
 import { tapAtWindowPercent } from '../../../src/helpers/gestures.js'
@@ -267,12 +267,9 @@ describe('Accessibility journey: automated audits over the core screens', () => 
     await AccountLandingScreen.tap('primary')
     await EnterPINScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
     await auditScreen('EnterPIN')
-    // The PIN auto-submits on the 6th digit; Continue is the fallback when it does not navigate.
-    await EnterPINScreen.fill('pin', TEST_PIN)
-    if (!(await HomeScreen.isPresent(Timeouts.SCREEN_TRANSITION))) {
-      await EnterPINScreen.tapWhenEnabled('primary')
-      await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
-    }
+    // Where the PIN lands is not this audit's business: the session started a verification, which the
+    // app resumes on unlock, so only the departure from EnterPIN is proven.
+    await submitPin(TEST_PIN)
   })
 
   it('reports the accessibility audit roll-up', async () => {

--- a/e2e/test/bcsc/auth/auth-intro.journey.ts
+++ b/e2e/test/bcsc/auth/auth-intro.journey.ts
@@ -1,7 +1,7 @@
 import { TEST_PIN, Timeouts } from '../../../src/constants.js'
 import { relaunchApp, selectAccountLandingIfPresent, unlockWithPin } from '../../../src/flows/auth.js'
 import { skipToHome } from '../../../src/flows/onboarding.js'
-import { openDeveloperMenuFromSettings } from '../../../src/helpers/developer.js'
+import { openDeveloperMenuFromSettings, scrollToSettingsVersionFooter } from '../../../src/helpers/developer.js'
 import { AccountLandingScreen, AuthSettingsScreen } from '../../../src/screens/auth.js'
 import { DeveloperScreen } from '../../../src/screens/developer.js'
 import { HomeScreen, SettingsScreen } from '../../../src/screens/main.js'
@@ -68,6 +68,8 @@ describe('Auth journey: returning-user intro', () => {
     // is persisted, so the row is now offered on every settings surface.
     await HomeScreen.tap('menu')
     await SettingsScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
+    // The row sits at the foot of a list that outruns the default scroll hunt on small phones.
+    await scrollToSettingsVersionFooter()
     await SettingsScreen.waitFor('developerMode', Timeouts.SCREEN_TRANSITION)
   })
 })

--- a/e2e/test/bcsc/migration/migration.spec.ts
+++ b/e2e/test/bcsc/migration/migration.spec.ts
@@ -1,10 +1,14 @@
 // organize-imports-ignore — import order defines test run order
 /**
- * Migration suite: v3 → v4 upgrade flow.
+ * Migration suite: the upgrade from the v3 BC Services Card app to v4.
  *
- * Starts the v3 BC Services Card app, completes onboarding + in-person
- * verification, then upgrades to v4 and verifies the app unlocks with
- * the PIN created in v3.
+ * The same shape as the other two upgrade lanes (previous release → current, 4.0.3 → current):
+ * set up on the old build, install the current one over it, prove the data survived. It keeps its
+ * own suite because the old build is a different app lineage — its own binaries and testIDs
+ * (`src/v3TestIDs.ts`) — and because it runs Android-only in CI.
+ *
+ * Starts the v3 app, completes onboarding + in-person verification, then upgrades to v4 and
+ * verifies the app unlocks with the PIN created in v3.
  *
  * Prerequisites:
  * - V3 app uploaded to Sauce Labs storage (set as initial `appium:app`)
@@ -14,5 +18,5 @@
  * Run with: yarn wdio configs/sauce/wdio.<platform>.sauce.migration.conf.ts --suite migration
  */
 import './v3-onboarding.spec.js'
-import './upgrade.spec.js'
+import './v3-to-v4-upgrade.spec.js'
 import './v4-unlock.spec.js'

--- a/e2e/test/bcsc/migration/v3-onboarding.spec.ts
+++ b/e2e/test/bcsc/migration/v3-onboarding.spec.ts
@@ -99,8 +99,8 @@ async function scrollNumberPickerTo(
   throw new Error(`NumberPicker did not reach "${target}" after ${maxClicks} clicks`)
 }
 
-describe('V3 Add Card', () => {
-  it('should tap the Add Card / Setup button', async () => {
+describe('Upgrade from v3: setting up on the v3 release', () => {
+  it('taps the Add Card / Setup button', async () => {
     await annotate('Migration: V3 onboarding')
     const addCard = await V3.Initial.addCard()
     await addCard.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
@@ -108,7 +108,7 @@ describe('V3 Add Card', () => {
     await addCard.click()
   })
 
-  it('should complete the tutorial carousel', async () => {
+  it('completes the tutorial carousel', async () => {
     const numPages = 3
     for (let i = 0; i < numPages; i++) {
       try {
@@ -123,14 +123,14 @@ describe('V3 Add Card', () => {
   })
 
   // this is the one that it gets stuck on
-  it('should advance past the "New setup" intro page', async () => {
+  it('advances past the "New setup" intro page', async () => {
     const continueBtn = await V3.NewSetup.continue()
     await continueBtn.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     await continueBtn.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await continueBtn.click()
   })
 
-  it('should enable notifications', async () => {
+  it('enables notifications', async () => {
     const enableBtn = await V3.Notifications.continue()
     await enableBtn.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     await enableBtn.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
@@ -141,28 +141,28 @@ describe('V3 Add Card', () => {
     await acceptSystemAlert()
   })
 
-  it('should tap Step 1', async () => {
+  it('taps Step 1', async () => {
     const step1 = await V3.SetupSteps.step1()
     await step1.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     await step1.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await step1.click()
   })
 
-  it('should accept the privacy policy', async () => {
+  it('accepts the privacy policy', async () => {
     const continueBtn = await V3.Privacy.continue()
     await continueBtn.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     await continueBtn.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await continueBtn.click()
   })
 
-  it('should accept terms of use', async () => {
+  it('accepts the terms of use', async () => {
     const acceptBtn = await V3.Terms.acceptAndContinue()
     await acceptBtn.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     await acceptBtn.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await acceptBtn.click()
   })
 
-  it('should enter an account nickname', async () => {
+  it('enters an account nickname', async () => {
     if (driver.isAndroid) {
       const nicknameInput = await V3.Nickname.nicknameInput()
       await nicknameInput.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
@@ -188,14 +188,14 @@ describe('V3 Add Card', () => {
     }
   })
 
-  it('should tap Choose a PIN', async () => {
+  it('taps Choose a PIN', async () => {
     const choosePinBtn = await V3.PINPrep.choosePIN()
     await choosePinBtn.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     await choosePinBtn.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await choosePinBtn.click()
   })
 
-  it('should create a PIN', async () => {
+  it('creates a PIN', async () => {
     const { pin } = migrationContext
 
     if (driver.isAndroid) {
@@ -240,27 +240,27 @@ describe('V3 Add Card', () => {
     }
   })
 
-  it('should tap Step 2', async () => {
+  it('taps Step 2', async () => {
     const step2 = await V3.SetupSteps.step2()
     await step2.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await step2.click()
   })
 
-  it('should select the combined card type', async () => {
+  it('selects the combined card type', async () => {
     const combined = await V3.CardTypeSelection.combinedCard()
     await combined.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     await combined.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await combined.click()
   })
 
-  it('should choose Enter Manually', async () => {
+  it('chooses Enter Manually', async () => {
     const enterManually = await V3.AddCardInstructions.enterManually()
     await enterManually.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     await enterManually.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await enterManually.click()
   })
 
-  it('should enter the card serial number', async () => {
+  it('enters the card serial number', async () => {
     const serialInput = await V3.ManualEntry.serialInput()
     await serialInput.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     await serialInput.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
@@ -273,7 +273,7 @@ describe('V3 Add Card', () => {
     await continueBtn.click()
   })
 
-  it('should enter the birthdate', async () => {
+  it('enters the birthdate', async () => {
     const dob = parseDob(testUser.dob)
 
     if (driver.isAndroid) {
@@ -283,9 +283,13 @@ describe('V3 Add Card', () => {
       await dateField.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
       await dateField.click()
 
-      // Wait for the date picker dialog's NumberPickers to appear
+      // The dialog opens asynchronously — `$$` answers [] until it renders, so wait for a picker first.
+      await $('android.widget.NumberPicker').waitForDisplayed({ timeout: 5_000 })
       const pickers = await $$('android.widget.NumberPicker')
-      await pickers[0].waitForDisplayed({ timeout: 5_000 })
+      const pickerCount = await pickers.length
+      if (pickerCount < 3) {
+        throw new Error(`Expected the day/month/year NumberPickers, found ${pickerCount}`)
+      }
 
       // Detect locale order: if first picker has alphabetic text, it's month-first
       const firstText = await pickers[0].$('android.widget.EditText').getText()
@@ -325,14 +329,14 @@ describe('V3 Add Card', () => {
     }
   })
 
-  it('should tap step 5', async () => {
+  it('taps Step 5', async () => {
     const step5 = await V3.SetupSteps.step5()
     await step5.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     await step5.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })
     await step5.click()
   })
 
-  it('should select in-person verification', async () => {
+  it('selects in-person verification', async () => {
     if (driver.isAndroid) {
       const inPersonOption = await $('android=new UiSelector().textContains("In Person")')
       await inPersonOption.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
@@ -345,7 +349,7 @@ describe('V3 Add Card', () => {
     }
   })
 
-  it('should read the confirmation code and approve via SiteMinder', async () => {
+  it('reads the confirmation code and approves it via SiteMinder', async () => {
     let confirmationCode: string
 
     if (driver.isAndroid) {
@@ -366,7 +370,7 @@ describe('V3 Add Card', () => {
     })
   })
 
-  it('should tap complete button once the verification is approved and tap Ok on the "You\'re all set" screen', async () => {
+  it('completes the approved verification and dismisses the "You\'re all set" screen', async () => {
     const completeBtn = await V3.VerifyInPerson.complete()
     await completeBtn.waitForDisplayed({ timeout: Timeouts.SCREEN_TRANSITION })
     await completeBtn.waitForEnabled({ timeout: Timeouts.SCREEN_TRANSITION })

--- a/e2e/test/bcsc/migration/v3-to-v4-upgrade.spec.ts
+++ b/e2e/test/bcsc/migration/v3-to-v4-upgrade.spec.ts
@@ -13,16 +13,16 @@ import { annotate } from '../../../src/helpers/sauce.js'
  * Runs on Sauce for both platforms — the storage-based mid-session install passes Sauce resigning
  * (iOS validated 2026-08-25).
  */
-describe('Upgrade v3 → v4', () => {
+describe('Upgrade from v3: installing the current build', () => {
   let appId: string | undefined
 
-  it('should install the v4 app over v3', async () => {
+  it('installs the current build over v3', async () => {
     await annotate('Migration: Upgrading v3 → v4')
     appId = await installCurrentBuildOverRunningApp()
     console.log('[migration] Installed v4 app over v3 successfully')
   })
 
-  it('should terminate and relaunch the app as v4', async () => {
+  it('relaunches as the current build', async () => {
     if (!appId) throw new Error('install step did not record the app id')
     await relaunchAfterInstall(appId)
   })

--- a/e2e/test/bcsc/migration/v4-unlock.spec.ts
+++ b/e2e/test/bcsc/migration/v4-unlock.spec.ts
@@ -16,7 +16,7 @@ import { migrationContext } from './migration-context.js'
  * card — so the old `CardButton-<nickname>` step is gone (it referenced a v3 concept that no longer
  * exists in v4).
  */
-describe('V4 Unlock After Migration', () => {
+describe('Upgrade from v3: unlocking with the v3 PIN', () => {
   it('unlocks the migrated account and enters the v3 PIN', async () => {
     await annotate('Migration: V4 unlock')
     await selectAccountLandingIfPresent()

--- a/e2e/test/bcsc/verify/send-video-approved.journey.ts
+++ b/e2e/test/bcsc/verify/send-video-approved.journey.ts
@@ -4,6 +4,8 @@ import { unlockWithPin } from '../../../src/flows/auth.js'
 import { completeOnboarding } from '../../../src/flows/onboarding.js'
 import {
   chooseAddAccount,
+  cleanUpQueuedSubmission,
+  clearReviewQueueBeforeSubmit,
   enterBirthdate,
   enterSerialManually,
   reachVerificationMethod,
@@ -12,7 +14,7 @@ import {
   submitSendVideoVerification,
   waitForSendVideoDecision,
 } from '../../../src/flows/verify.js'
-import { reviewSendVideoRequest } from '../../../src/helpers/approval.js'
+import { type ClaimedRequestSummary, reviewSendVideoRequest } from '../../../src/helpers/approval.js'
 import { HomeScreen, SettingsScreen } from '../../../src/screens/main.js'
 import { PendingReviewScreen, VerificationSuccessScreen } from '../../../src/screens/verify.js'
 import { getTestUser, setTestUser } from '../../../src/support/context.js'
@@ -26,14 +28,25 @@ import { getTestUser, setTestUser } from '../../../src/support/context.js'
  * IDCheck SIT review portal (`reviewSendVideoRequest`; needs `SM_USER`/`SM_PASSWORD` on an allowlisted
  * runner), then the app's own status re-check → VerificationSuccess and verified Home.
  *
- * QUEUE HYGIENE: the portal has no worklist — a review claims the NEXT queued request, blindly. A
- * foreign head (stale or third-party) is CLOSED and the claim retried, so a polluted queue self-heals;
- * that is exactly why no other send-video journey may run CONCURRENTLY with this one — its live
- * request would be closed too (the suite is serial at the default `maxInstances: 1`).
+ * QUEUE HYGIENE: the portal has no worklist — a review claims the NEXT queued request blindly and
+ * matches it by persona, which a stale upload of the same persona also satisfies. So the queue is
+ * drained before this journey submits, drained again by the teardown if the upload is never reviewed,
+ * and the send-video journeys run one platform at a time (CI's `send-video` lane), never concurrently.
  */
 describe('Verified journey: send video, approved', () => {
+  /** What the scripted review claimed — named by the decision wait's failure, should the app never see it. */
+  let reviewed: ClaimedRequestSummary | undefined
+
   before(() => {
     setTestUser(TestUsers.photo)
+  })
+
+  after(async () => {
+    await cleanUpQueuedSubmission()
+  })
+
+  it('clears the review queue before submitting', async () => {
+    await clearReviewQueueBeforeSubmit()
   })
 
   it('onboards to the verify prompt', async () => {
@@ -56,8 +69,8 @@ describe('Verified journey: send video, approved', () => {
     // The one resume-matrix row nothing could reach before a submission existed. A relaunch is what
     // makes it worth asserting: the submitted-video flag has to survive native storage and hydration
     // has to route back to the status screen, rather than the in-memory flag carrying it.
-    await unlockWithPin(TEST_PIN, { relaunch: true })
-    await resumeVerification()
+    await unlockWithPin(TEST_PIN, { relaunch: true, landing: 'any' })
+    await resumeVerification(PendingReviewScreen, Timeouts.APP_LAUNCH)
     await PendingReviewScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
     // Back marks the account unverified rather than popping, which returns the stack to Home — where
     // the decision wait below starts.
@@ -67,7 +80,7 @@ describe('Verified journey: send video, approved', () => {
 
   it('is approved by the agent (scripted against the SIT review portal)', async () => {
     const user = getTestUser()
-    await reviewSendVideoRequest({
+    reviewed = await reviewSendVideoRequest({
       decision: 'approve',
       cardSerialNumber: user.cardSerial,
       surname: user.lastName,
@@ -76,7 +89,7 @@ describe('Verified journey: send video, approved', () => {
   })
 
   it('picks up the approval and lands on verified Home', async () => {
-    await waitForSendVideoDecision('verified')
+    await waitForSendVideoDecision('verified', { reviewed })
     await VerificationSuccessScreen.tap('primary') // Continue → exits the verify stack to Home
     await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })

--- a/e2e/test/bcsc/verify/send-video-cancelled.journey.ts
+++ b/e2e/test/bcsc/verify/send-video-cancelled.journey.ts
@@ -2,6 +2,8 @@ import { TestUsers } from '../../../src/constants.js'
 import { completeOnboarding } from '../../../src/flows/onboarding.js'
 import {
   chooseAddAccount,
+  cleanUpQueuedSubmission,
+  clearReviewQueueBeforeSubmit,
   enterBirthdate,
   enterSerialManually,
   expectCancelledReviewReason,
@@ -11,7 +13,7 @@ import {
   submitSendVideoVerification,
   waitForSendVideoDecision,
 } from '../../../src/flows/verify.js'
-import { reviewSendVideoRequest } from '../../../src/helpers/approval.js'
+import { type ClaimedRequestSummary, reviewSendVideoRequest } from '../../../src/helpers/approval.js'
 import { getTestUser, setTestUser } from '../../../src/support/context.js'
 
 /**
@@ -24,15 +26,27 @@ import { getTestUser, setTestUser } from '../../../src/support/context.js'
  * Deliberately stops at that screen. Its button re-registers the device from scratch to re-enter
  * verification, which is the account-reset journey's story, not this one's.
  *
- * QUEUE HYGIENE: reviews claim the NEXT queued request blindly — a foreign head is CLOSED and the
- * claim retried, so this must not run CONCURRENTLY with another send-video journey, whose live request
- * would be closed too (the suite is serial at the default `maxInstances: 1`).
+ * QUEUE HYGIENE: the portal has no worklist — a review claims the NEXT queued request blindly and
+ * matches it by persona, which a stale upload of the same persona also satisfies. So the queue is
+ * drained before this journey submits, drained again by the teardown if the upload is never reviewed,
+ * and the send-video journeys run one platform at a time (CI's `send-video` lane), never concurrently.
  */
 const AGENT_REASON = 'Automated e2e rejection'
 
 describe('Verified journey: send video, rejected', () => {
+  /** What the scripted review claimed — named by the decision wait's failure, should the app never see it. */
+  let reviewed: ClaimedRequestSummary | undefined
+
   before(() => {
     setTestUser(TestUsers.photo)
+  })
+
+  after(async () => {
+    await cleanUpQueuedSubmission()
+  })
+
+  it('clears the review queue before submitting', async () => {
+    await clearReviewQueueBeforeSubmit()
   })
 
   it('onboards to the verify prompt', async () => {
@@ -59,7 +73,7 @@ describe('Verified journey: send video, rejected', () => {
 
   it('is rejected by the agent, with a reason (scripted against the SIT review portal)', async () => {
     const user = getTestUser()
-    await reviewSendVideoRequest({
+    reviewed = await reviewSendVideoRequest({
       decision: 'reject',
       cardSerialNumber: user.cardSerial,
       surname: user.lastName,
@@ -69,7 +83,7 @@ describe('Verified journey: send video, rejected', () => {
   })
 
   it('shows the cancelled review with the agent reason', async () => {
-    await waitForSendVideoDecision('cancelled')
+    await waitForSendVideoDecision('cancelled', { reviewed })
     await expectCancelledReviewReason(AGENT_REASON)
   })
 })

--- a/e2e/test/bcsc/verify/send-video-non-bcsc.journey.ts
+++ b/e2e/test/bcsc/verify/send-video-non-bcsc.journey.ts
@@ -5,6 +5,8 @@ import {
   captureFirstNonBcscDocument,
   captureSecondNonBcscDocument,
   chooseAddAccount,
+  cleanUpQueuedSubmission,
+  clearReviewQueueBeforeSubmit,
   completeEmailVerification,
   fillResidentialAddress,
   startEmailVerification,
@@ -14,7 +16,7 @@ import {
   submitSendVideoVerification,
   waitForSendVideoDecision,
 } from '../../../src/flows/verify.js'
-import { reviewSendVideoRequest } from '../../../src/helpers/approval.js'
+import { type ClaimedRequestSummary, reviewSendVideoRequest } from '../../../src/helpers/approval.js'
 import { getEmailConfirmationCode } from '../../../src/helpers/email.js'
 import { HomeScreen, SettingsScreen } from '../../../src/screens/main.js'
 import { VerificationSuccessScreen } from '../../../src/screens/verify.js'
@@ -39,13 +41,25 @@ const SECOND_DOC_MATCH = 'Canadian Passport'
  * mandatory for a cardless registration, so this cannot run on a network that intercepts the disposable
  * -inbox providers — see the non-BCSC in-person journey's note.
  *
- * QUEUE HYGIENE: reviews claim the NEXT queued request blindly — a foreign head is CLOSED and the
- * claim retried — so no other send-video journey may run CONCURRENTLY: its live request would be
- * closed too (the suite is serial at the default `maxInstances: 1`).
+ * QUEUE HYGIENE: the portal has no worklist — a review claims the NEXT queued request blindly and
+ * matches it by persona, which a stale upload of the same persona also satisfies. So the queue is
+ * drained before this journey submits, drained again by the teardown if the upload is never reviewed,
+ * and the send-video journeys run one platform at a time (CI's `send-video` lane), never concurrently.
  */
 describe('Verified journey: non-bcsc, send video', () => {
+  /** What the scripted review claimed — named by the decision wait's failure, should the app never see it. */
+  let reviewed: ClaimedRequestSummary | undefined
+
   before(() => {
     setTestUser(TestUsers.na)
+  })
+
+  after(async () => {
+    await cleanUpQueuedSubmission()
+  })
+
+  it('clears the review queue before submitting', async () => {
+    await clearReviewQueueBeforeSubmit()
   })
 
   it('onboards to the verify prompt', async () => {
@@ -85,7 +99,7 @@ describe('Verified journey: non-bcsc, send video', () => {
     const user = getTestUser()
     // Serial is 'N/A' for every cardless request, so the name is what identifies this one — and it also
     // chooses the identity the portal matches against.
-    await reviewSendVideoRequest({
+    reviewed = await reviewSendVideoRequest({
       decision: 'approve',
       cardSerialNumber: user.cardSerial,
       surname: user.lastName,
@@ -94,7 +108,7 @@ describe('Verified journey: non-bcsc, send video', () => {
   })
 
   it('picks up the approval and lands on verified Home', async () => {
-    await waitForSendVideoDecision('verified')
+    await waitForSendVideoDecision('verified', { reviewed })
     await VerificationSuccessScreen.tap('primary') // Continue → exits the verify stack to Home
     await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })

--- a/e2e/test/bcsc/verify/send-video-non-photo.journey.ts
+++ b/e2e/test/bcsc/verify/send-video-non-photo.journey.ts
@@ -4,6 +4,8 @@ import { completeOnboarding } from '../../../src/flows/onboarding.js'
 import {
   captureAdditionalPhotoId,
   chooseAddAccount,
+  cleanUpQueuedSubmission,
+  clearReviewQueueBeforeSubmit,
   enterBirthdate,
   enterSerialManually,
   reachAdditionalPhotoIdList,
@@ -13,7 +15,7 @@ import {
   submitSendVideoVerification,
   waitForSendVideoDecision,
 } from '../../../src/flows/verify.js'
-import { reviewSendVideoRequest } from '../../../src/helpers/approval.js'
+import { type ClaimedRequestSummary, reviewSendVideoRequest } from '../../../src/helpers/approval.js'
 import { HomeScreen, SettingsScreen } from '../../../src/screens/main.js'
 import { VerificationSuccessScreen } from '../../../src/screens/verify.js'
 import { getTestUser, setTestUser } from '../../../src/support/context.js'
@@ -32,13 +34,25 @@ const ADDITIONAL_ID_MATCH = 'Passport'
  *
  * CAMERA-DEPENDENT — both the document and the selfie use Sauce image injection.
  *
- * QUEUE HYGIENE: reviews claim the NEXT queued request blindly — a foreign head is CLOSED and the
- * claim retried — so no other send-video journey may run CONCURRENTLY: its live request would be
- * closed too (the suite is serial at the default `maxInstances: 1`).
+ * QUEUE HYGIENE: the portal has no worklist — a review claims the NEXT queued request blindly and
+ * matches it by persona, which a stale upload of the same persona also satisfies. So the queue is
+ * drained before this journey submits, drained again by the teardown if the upload is never reviewed,
+ * and the send-video journeys run one platform at a time (CI's `send-video` lane), never concurrently.
  */
 describe('Verified journey: non-photo card, send video', () => {
+  /** What the scripted review claimed — named by the decision wait's failure, should the app never see it. */
+  let reviewed: ClaimedRequestSummary | undefined
+
   before(() => {
     setTestUser(TestUsers.nonPhoto)
+  })
+
+  after(async () => {
+    await cleanUpQueuedSubmission()
+  })
+
+  it('clears the review queue before submitting', async () => {
+    await clearReviewQueueBeforeSubmit()
   })
 
   it('onboards to the verify prompt', async () => {
@@ -65,7 +79,7 @@ describe('Verified journey: non-photo card, send video', () => {
 
   it('is approved by the agent (scripted against the SIT review portal)', async () => {
     const user = getTestUser()
-    await reviewSendVideoRequest({
+    reviewed = await reviewSendVideoRequest({
       decision: 'approve',
       cardSerialNumber: user.cardSerial,
       surname: user.lastName,
@@ -74,7 +88,7 @@ describe('Verified journey: non-photo card, send video', () => {
   })
 
   it('picks up the approval and lands on verified Home', async () => {
-    await waitForSendVideoDecision('verified')
+    await waitForSendVideoDecision('verified', { reviewed })
     await VerificationSuccessScreen.tap('primary') // Continue → exits the verify stack to Home
     await HomeScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })

--- a/e2e/test/bcsc/verify/verified-non-photo.journey.ts
+++ b/e2e/test/bcsc/verify/verified-non-photo.journey.ts
@@ -81,8 +81,8 @@ describe('Verified journey: non-photo card', () => {
   it('resumes onto the document-number form after a relaunch', async () => {
     // Photos-but-no-number is the ONE mid-capture state hydration preserves (an evidence with no photos
     // is dropped), so the photos must survive the relaunch and the app must resume here.
-    await unlockWithPin(TEST_PIN, { relaunch: true })
-    await resumeVerification()
+    await unlockWithPin(TEST_PIN, { relaunch: true, landing: 'any' })
+    await resumeVerification(EvidenceIDCollectionScreen, Timeouts.APP_LAUNCH)
     await EvidenceIDCollectionScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })
 

--- a/e2e/test/bcsc/verify/verify-resume.journey.ts
+++ b/e2e/test/bcsc/verify/verify-resume.journey.ts
@@ -30,9 +30,9 @@ const INTERRUPTED_EVIDENCE_MATCH = 'BC Drivers Licence'
  * unfinished verification. That mapping drives the verify stack's initial route and every step-completion
  * navigation, and none of it was covered.
  *
- * The route back in is always Home's verification card: the in-progress flag is in-memory and hydration
- * recomputes it, so leaving the flow AND every relaunch land there. Each checkpoint leaves, returns, and
- * asserts which step the app chose.
+ * Leaving the flow lands on Home, whose verification card is the route back in (the in-progress flag is
+ * in-memory); a relaunch resumes a user who chose to verify straight onto the step. Each checkpoint
+ * leaves, returns, and asserts which step the app chose.
  *
  * Deliberately cheap — nothing is verified and no camera is used. The serial is saved but never submitted
  * (no `authorizeDevice`), and the interrupted capture is a selected ID with zero photos, which the app
@@ -91,9 +91,10 @@ describe('Verify journey: resume routing', () => {
 
   it('still resumes onto the birthdate step after a relaunch', async () => {
     // A relaunch is what the in-memory flag cannot cover: the serial must survive in native storage and
-    // hydration must recompute the step. Landing on Home is part of it — `unlockWithPin` requires it.
-    await unlockWithPin(TEST_PIN, { relaunch: true })
-    await resumeVerification()
+    // hydration must recompute the step. The unlock lands straight on it (the app resumes a user who
+    // chose to verify) or on Home, whose card is the other way in — so the landing is left open.
+    await unlockWithPin(TEST_PIN, { relaunch: true, landing: 'any' })
+    await resumeVerification(EnterBirthdateScreen, Timeouts.APP_LAUNCH)
     await EnterBirthdateScreen.expectVisible(Timeouts.SCREEN_TRANSITION)
   })
 


### PR DESCRIPTION
Closes #4665 

<!-- Add the number above, like "Closes #1234", or link it in the Development
     panel. A bare "#1234" lower down doesn't count.
     No issue? Delete the line and add the `status/no-issue` label. -->

## What changed
Unwraps "FILE_UPLOAD_ERROR" / "Problem with Connection" code: 2404 into seperate distict app errors. 

<!-- Enough context to read the diff. The backstory lives in the issue.
     Drop in a screenshot or a short video if it shows what changed or how
     it's meant to work — often quicker than describing it. -->

## What should the reviewer focus on

<!-- Point at the scary bit — or say there isn't one:
     "Copy change, quick skim is fine."
     "The cancel path in useEvidenceUpload — not sure it clears the timer."
     "iOS only, Android untouched." -->

## How to test

<!-- How someone else checks it. "Covered by unit tests" counts. -->
